### PR TITLE
Updated README and package.json for setting up angular-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Angular CLI requires Node 6.9.0 or higher, together with NPM 3 or higher.
 curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
 sudo apt-get install -y nodejs
 nodejs -v
-v7.9.0
+v7.10.0
 npm -v
 4.2.0
 ```
@@ -43,7 +43,7 @@ Until bootstrap-toc moves to npm or a better table of contents(toc) library come
 sudo npm install -g bower
 bower -v
 1.8.0
-sudo npm install -g @angular/cli@latest
+sudo npm install -g @angular/cli@1.0.3
 bower update
 ```
 
@@ -68,19 +68,21 @@ $ ng -v
  / ___ \| | | | (_| | |_| | | (_| | |      | |___| |___ | |
 /_/   \_\_| |_|\__, |\__,_|_|\__,_|_|       \____|_____|___|
                |___/
-@angular/cli: 1.0.0
-node: 7.9.0
+@angular/cli: 1.0.3
+node: 7.10.0
 os: linux x64
-@angular/common: 2.4.10
-@angular/compiler: 2.4.10
-@angular/core: 2.4.10
-@angular/forms: 2.4.10
-@angular/http: 2.4.10
-@angular/platform-browser: 2.4.10
-@angular/platform-browser-dynamic: 2.4.10
-@angular/router: 3.4.10
-@angular/cli: 1.0.0
-@angular/compiler-cli: 2.4.10
+@angular/animations: 4.1.2
+@angular/common: 4.1.2
+@angular/compiler: 4.1.2
+@angular/compiler-cli: 4.1.2
+@angular/core: 4.1.2
+@angular/forms: 4.1.2
+@angular/http: 4.1.2
+@angular/platform-browser: 4.1.2
+@angular/platform-browser-dynamic: 4.1.2
+@angular/platform-server: 4.1.2
+@angular/router: 4.1.2
+@angular/cli: 1.0.3
 ```
 
 If you wish to serve the dist folder in a VM, make sure you have nginx and security rules set up properly.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "zone.js": "^0.8.9"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.1",
+    "@angular/cli": "1.0.3",
     "@angular/compiler-cli": "^4.1.0",
     "@types/datatables.net": "^1.10.1",
     "@types/jasmine": "2.5.38",


### PR DESCRIPTION
Issue ga4gh/dockstore#715 has been updated.

So I tested this with different dockers, the global cil version is now same as the local cil.
Note that "angular/cli" in the package.json should always matches the version of the sudo npm install command:
sudo npm install -g @angular/cli@**1.0.3**

ie: make sure its 1.0.3 for both package.json and the install command. 