### PR TITLE
Add and select tool to view

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ngx-sharebuttons": "^3.0.0",
     "rxjs": "^5.1.0",
     "ts-md5": "^1.2.0",
-    "typescript": "^2.3.2",
+    "typescript": "2.3.4",
     "zone.js": "^0.8.9"
   },
   "devDependencies": {

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -58,6 +58,7 @@ export class ContainerComponent extends Tool {
     toolRef.versionVerified = this.dockstoreService.getVersionVerified(toolRef.tags);
     toolRef.verifiedSources = this.dockstoreService.getVerifiedSources(toolRef);
     toolRef.verifiedLinks = this.dateService.getVerifiedLink();
+    toolRef.isPublic = this.isToolPublic;
     if (!toolRef.imgProviderUrl) {
       toolRef = this.imageProviderService.setUpImageProvider(toolRef);
     }

--- a/src/app/container/view/view.component.html
+++ b/src/app/container/view/view.component.html
@@ -144,7 +144,7 @@
                         <div class="col-sm-9 col-md-9 col-lg-9">
                             <div>
                             <div class="checkbox">
-                                <input type="checkbox" name="checkbox" [(ngModel)]="unsavedVersion.hidden" title="Hide tag from public view."/>
+                                <input type="checkbox" name="checkbox" [disabled]="editMode" [(ngModel)]="unsavedVersion.hidden" title="Hide tag from public view."/>
                             </div>
                             </div>
                         </div>

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -15,17 +15,15 @@ import { ViewService } from './view.service';
 @Component({
   selector: 'app-view-container',
   templateUrl: './view.component.html',
-  styleUrls: ['./view.component.css'],
-  providers: [ViewService]
+  styleUrls: ['./view.component.css']
 })
 // This is actually the tag edtior
 export class ViewContainerComponent extends View implements OnInit, AfterViewChecked {
-
   // Enumss
   public TagEditorMode = TagEditorMode;
   public DescriptorType = DescriptorType;
 
-  private editMode = true;
+  private editMode;
   private mode: TagEditorMode;
   private tool: any;
   private unsavedVersion;
@@ -199,8 +197,20 @@ export class ViewContainerComponent extends View implements OnInit, AfterViewChe
         this.mode = mode;
       }
     );
+
     this.unsavedVersion = Object.assign({}, this.version);
-    this.containerService.tool$.subscribe(tool => this.tool = tool);
+    this.containerService.tool$.subscribe(tool => {
+    this.tool = tool;
+      if (tool) {
+        if (this.tool.isPublic) {
+          this.editMode = false;
+        } else {
+          this.editMode = true;
+        }
+      } else {
+        console.log('Tool is not truthy');
+      }
+    });
     this.viewService.unsavedTestCWLFile.subscribe(
       (file: string) => {
         this.unsavedTestCWLFile = file;

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit, ViewChild, AfterViewChecked } from '@angular/core';
 import { NgForm, Validators } from '@angular/forms';
 
-import { CommunicatorService } from './../../shared/communicator.service';
+import { ContainerService } from './../../shared/container.service';
 import { ContainerTagsService } from './../../shared/containerTags.service';
-import { ContainerService } from '../../shared/container.service';
 import { DateService } from '../../shared/date.service';
 import { DescriptorType } from '../../shared/enum/descriptorType.enum';
 import { ParamfilesService } from './../paramfiles/paramfiles.service';
@@ -48,7 +47,7 @@ export class ViewContainerComponent extends View implements OnInit, AfterViewChe
     private viewService: ViewService,
     private listContainersService: ListContainersService,
     dateService: DateService,
-    private communicatorService: CommunicatorService,
+    private containerService: ContainerService,
     private containerTagsService: ContainerTagsService) {
     super(dateService);
   }
@@ -201,7 +200,7 @@ export class ViewContainerComponent extends View implements OnInit, AfterViewChe
       }
     );
     this.unsavedVersion = Object.assign({}, this.version);
-    this.tool = this.communicatorService.getTool();
+    this.containerService.tool$.subscribe(tool => this.tool = tool);
     this.viewService.unsavedTestCWLFile.subscribe(
       (file: string) => {
         this.unsavedTestCWLFile = file;

--- a/src/app/container/view/view.service.ts
+++ b/src/app/container/view/view.service.ts
@@ -1,6 +1,9 @@
+import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
+
+@Injectable()
 export class ViewService {
   mode: Subject<TagEditorMode> = new BehaviorSubject<TagEditorMode>(null);
   unsavedTestCWLFile: Subject<string> = new BehaviorSubject<string>('');

--- a/src/app/containers/list/list.component.ts
+++ b/src/app/containers/list/list.component.ts
@@ -1,3 +1,4 @@
+import { ContainerService } from './../../shared/container.service';
 import { Component, Input } from '@angular/core';
 import { CommunicatorService } from '../../shared/communicator.service';
 import { DockstoreService } from '../../shared/dockstore.service';
@@ -30,6 +31,7 @@ export class ListContainersComponent extends ToolLister {
   };
   constructor(private listContainersService: ListContainersService,
               private communicatorService: CommunicatorService,
+              private ContainerService: ContainerService,
               private dockstoreService: DockstoreService,
               private imageProviderService: ImageProviderService,
               private dateService: DateService,
@@ -42,6 +44,7 @@ export class ListContainersComponent extends ToolLister {
 
   sendToolInfo(tool) {
     this.communicatorService.setTool(tool);
+    this.ContainerService.setTool(tool);
   }
 
   getFilteredDockerPullCmd(path: string): string {

--- a/src/app/mytools/mytools.component.html
+++ b/src/app/mytools/mytools.component.html
@@ -9,11 +9,11 @@
 </app-header>
 <div class="container">
   <!--Msg/Warning Page, this should be a Component-->
-  <div class="row" *ngIf="nsContainers.length == 0">
+  <div class="row" *ngIf="nsContainers?.length == 0">
     <div class="col-md-12">
       <div class="alert alert-info"
            role="alert"
-           *ngIf="nsContainers.length == 0">
+           *ngIf="nsContainers?.length == 0">
         <p>
           <span class="glyphicon glyphicon-info-sign"></span>
           There are currently no tools registered under this account, to add your first tool, do one of the following:

--- a/src/app/mytools/mytools.component.ts
+++ b/src/app/mytools/mytools.component.ts
@@ -1,9 +1,9 @@
-import {Component, OnInit} from '@angular/core';
-import {CommunicatorService} from '../shared/communicator.service';
-import {DockstoreService} from '../shared/dockstore.service';
-import {MytoolsService} from './mytools.service';
-import {UserService} from '../loginComponents/user.service';
-import {ContainerService} from '../shared/container.service';
+import { Component, OnInit } from '@angular/core';
+import { CommunicatorService } from '../shared/communicator.service';
+import { DockstoreService } from '../shared/dockstore.service';
+import { MytoolsService } from './mytools.service';
+import { UserService } from '../loginComponents/user.service';
+import { ContainerService } from '../shared/container.service';
 
 @Component({
   selector: 'app-mytools',
@@ -12,23 +12,39 @@ import {ContainerService} from '../shared/container.service';
   providers: [MytoolsService, DockstoreService]
 })
 export class MyToolsComponent implements OnInit {
-  nsContainers = [];
+  nsContainers: any;
   oneAtATime = true;
+  tools: any;
+  user: any;
   constructor(private mytoolsService: MytoolsService,
-              private communicatorService: CommunicatorService,
-              private userService: UserService,
-              private containerService: ContainerService) {
+    private communicatorService: CommunicatorService,
+    private userService: UserService,
+    private containerService: ContainerService) {
 
   }
   ngOnInit() {
     this.userService.getUser().subscribe(user => {
+      this.user = user;
       this.userService.getUserTools(user.id).subscribe(tools => {
-        this.nsContainers = this.mytoolsService.sortNSContainers(tools, user.username);
+        this.containerService.setTools(tools);
+      });
+    });
+    this.containerService.tools.subscribe(tools => {
+      this.tools = tools;
+      if (this.user) {
+        const sortedContainers = this.mytoolsService.sortNSContainers(tools, this.user.username);
+        this.containerService.setNsContainers(sortedContainers);
+        }
+    });
+    this.containerService.nsContainers.subscribe(containers => {
+      this.nsContainers = containers;
+      if (this.nsContainers) {
         const theFirstTool = this.nsContainers[0].containers[0];
         this.selectContainer(theFirstTool);
         this.communicatorService.setTool(theFirstTool);
-      });
-    });
+      }
+    }
+    );
   }
   selectContainer(tool) {
     this.containerService.setTool(tool);

--- a/src/app/mytools/mytools.component.ts
+++ b/src/app/mytools/mytools.component.ts
@@ -41,6 +41,7 @@ export class MyToolsComponent implements OnInit {
       if (this.nsContainers) {
         const theFirstTool = this.nsContainers[0].containers[0];
         this.selectContainer(theFirstTool);
+        this.containerService.setTool(theFirstTool);
         this.communicatorService.setTool(theFirstTool);
       }
     }
@@ -48,5 +49,6 @@ export class MyToolsComponent implements OnInit {
   }
   selectContainer(tool) {
     this.containerService.setTool(tool);
+    this.communicatorService.setTool(tool);
   }
 }

--- a/src/app/shared/container.service.ts
+++ b/src/app/shared/container.service.ts
@@ -9,7 +9,7 @@ import { Subject } from 'rxjs/Subject';
 export class ContainerService {
 
   private static readonly descriptorWdl = ' --descriptor wdl';
-  private toolSource = new Subject<any>();
+  private toolSource = new BehaviorSubject<any>(null);
   tool$ = this.toolSource.asObservable(); // This is the selected tool
   tools = new BehaviorSubject<any>(null); // This contains the list of unsorted tools
   nsContainers: BehaviorSubject<any> = new BehaviorSubject(null); // This contains the list of sorted tool stubs

--- a/src/app/shared/container.service.ts
+++ b/src/app/shared/container.service.ts
@@ -1,3 +1,4 @@
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Injectable } from '@angular/core';
 
 import { Dockstore } from './dockstore.model';
@@ -9,11 +10,27 @@ export class ContainerService {
 
   private static readonly descriptorWdl = ' --descriptor wdl';
   private toolSource = new Subject<any>();
-  tool$ = this.toolSource.asObservable();
+  tool$ = this.toolSource.asObservable(); // This is the selected tool
+  tools = new BehaviorSubject<any>(null); // This contains the list of unsorted tools
+  nsContainers: BehaviorSubject<any> = new BehaviorSubject(null); // This contains the list of sorted tool stubs
   constructor(private dockstoreService: DockstoreService) { }
   setTool(tool: any) {
     this.toolSource.next(tool);
   }
+
+  setTools(tools: any) {
+    this.tools.next(tools);
+  }
+
+  addToTools(tools: any, tool: any) {
+    tools.push(tool);
+    this.tools.next(tools);
+  }
+
+  setNsContainers(tools: any) {
+    this.nsContainers.next(tools);
+  }
+
   getDescriptors(versions, version) {
     if (versions.length && version) {
 

--- a/src/app/shared/modules/container.module.ts
+++ b/src/app/shared/modules/container.module.ts
@@ -77,7 +77,8 @@ import { OrderByModule } from '../../shared/modules/orderby.module';
     LaunchService,
     DockerfileService,
     ParamfilesService,
-    WorkflowService
+    WorkflowService,
+    ViewService
   ],
   exports: [
     ContainerComponent

--- a/src/app/shared/tool.ts
+++ b/src/app/shared/tool.ts
@@ -107,17 +107,19 @@ export abstract class Tool implements OnInit, OnDestroy {
   }
 
   private urlToolChanged(event) {
-    if (!this.tool) {
-      this.title = this.decodedString(event.url.replace(`/${ this._toolType }/`, ''));
-    } else {
-      this.title = this.tool.path;
+    if (event.url) {
+      if (event.url.includes('containers')) {
+        this.title = this.decodedString(event.url.replace(`/${ this._toolType }/`, ''));
+        // Only get published tool if the URI is for a specific tool (/containers/quay.io%2FA2%2Fb3)
+        // as opposed to just /tools or /docs etc.
+        this.toolService.getPublishedToolByPath(this.encodedString(this.title), this._toolType)
+        .subscribe(tool => {
+          this.containerService.setTool(tool);
+        }, error => {
+          this.router.navigate(['../']);
+        });
+      }
     }
-    this.toolService.getPublishedToolByPath(this.encodedString(this.title), this._toolType)
-      .subscribe(tool => {
-        this.containerService.setTool(tool);
-      }, error => {
-        this.router.navigate(['../']);
-      });
   }
 
   private urlWorkflowChanged(event) {

--- a/src/app/shared/tool.ts
+++ b/src/app/shared/tool.ts
@@ -114,7 +114,7 @@ export abstract class Tool implements OnInit, OnDestroy {
     }
     this.toolService.getPublishedToolByPath(this.encodedString(this.title), this._toolType)
       .subscribe(tool => {
-        this.setUpTool(tool);
+        this.containerService.setTool(tool);
       }, error => {
         this.router.navigate(['../']);
       });

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -28,7 +28,7 @@
         </button>
         <button id="dag_fullscreen" *ngIf="dagResult !== null && !notFound && !missingTool" (click)="toggleExpand()" tooltip="Toggle fullscreen" class="dag-button">
           <span *ngIf="!expanded" class="glyphicon glyphicon-resize-full" id="resize-full-button"></span>
-          <span *ngIf="expanded" class="glyphicon glyphicon-resize-small no-display" id="resize-small-button"></span>
+          <span *ngIf="expanded" class="glyphicon glyphicon-resize-small" id="resize-small-button"></span>
         </button>
       </div>
     </div>

--- a/src/app/workflow/dag/dag.service.ts
+++ b/src/app/workflow/dag/dag.service.ts
@@ -154,7 +154,6 @@ export class DagService {
 
     getDockerText(link: string, docker: string) {
         const validLink = !this.isNA(docker);
-        console.log(validLink);
         if (validLink) {
             return `<div><b>Docker:</b> <a href='` + link + `'>` + docker + `</a></div>`;
         } else {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -852,11 +852,6 @@ div.tabs>div:target>div,
   background-color: #303030;
 }
 
-.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
-  background-color: white !important;
-  opacity: 1;
-}
-
 .btn-copy {
   color: white !important;
   background-color: #487980 !important;


### PR DESCRIPTION
Contains a bunch of bug fixes and minor feature updates for tag edtior, DAG, and add tool

- Upon registering tool, add the registered response tool to the list of displayed tools without an additional API call
- Select the tool that just got registered.
- Style fix for DAG
- Bug fix for tag edtior
- Adding DAG refresh on ngAfterViewChecked
- Changes to the routing to grab published tool only when the event.url contains "containers"