### PR TITLE
Feature/ng after view checked

### DIFF
--- a/src/app/search/advancedsearch/advancedsearch.component.ts
+++ b/src/app/search/advancedsearch/advancedsearch.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnInit } from '@angular/core';
+
 import { AdvancedSearchObject } from './../../shared/models/AdvancedSearchObject';
 import { AdvancedSearchService } from './advanced-search.service';
-import { Component, OnInit, AfterViewChecked } from '@angular/core';
 
 @Component({
   selector: 'app-advancedsearch',

--- a/src/app/search/elastic-search-client.ts
+++ b/src/app/search/elastic-search-client.ts
@@ -1,0 +1,8 @@
+import { Dockstore } from './../shared/dockstore.model';
+import { Client } from 'elasticsearch';
+
+export const ELASTIC_SEARCH_CLIENT = new Client({
+    host: Dockstore.API_URI + '/api/ga4gh/v1/extended',
+    apiVersion: '5.x',
+    log: 'debug'
+  });

--- a/src/app/search/query-builder.service.spec.ts
+++ b/src/app/search/query-builder.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { QueryBuilderService } from './query-builder.service';
+
+describe('Service: QueryBuilder', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [QueryBuilderService]
+    });
+  });
+
+  it('should ...', inject([QueryBuilderService], (service: QueryBuilderService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/search/query-builder.service.spec.ts
+++ b/src/app/search/query-builder.service.spec.ts
@@ -1,3 +1,5 @@
+import { SearchStubService } from './../test/service-stubs';
+import { SearchService } from './search.service';
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
@@ -6,7 +8,7 @@ import { QueryBuilderService } from './query-builder.service';
 describe('Service: QueryBuilder', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [QueryBuilderService]
+      providers: [QueryBuilderService, {provide: SearchService, useClass: SearchStubService}]
     });
   });
 

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -1,7 +1,8 @@
-import { SearchService } from './search.service';
-import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
 import { Injectable } from '@angular/core';
 import bodybuilder from 'bodybuilder';
+
+import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
+import { SearchService } from './search.service';
 
 /**
  * This service constructs all the querys and should be only class that interacts with the bodybuilder library.

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -12,6 +12,7 @@ import { SearchService } from './search.service';
  */
 @Injectable()
 export class QueryBuilderService {
+    // TODO: Comment on why shard_size is 10,000
     private shard_size = 10000;
     constructor(private searchService: SearchService) { }
 

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import bodybuilder from 'bodybuilder';
+@Injectable()
+export class QueryBuilderService {
+
+constructor() { }
+
+getTagCloudQuery(type: string): string {
+    let body = bodybuilder().size();
+    body = body.query('match', '_type', type);
+    body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
+    const toolQuery = JSON.stringify(body, null, 1);
+    return toolQuery;
+}
+}

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -1,15 +1,22 @@
 import { Injectable } from '@angular/core';
 import bodybuilder from 'bodybuilder';
+
+/**
+ * This service constructs all the querys and should be only class that interacts with the bodybuilder library.
+ *
+ * @export
+ * @class QueryBuilderService
+ */
 @Injectable()
 export class QueryBuilderService {
 
-constructor() { }
+    constructor() { }
 
-getTagCloudQuery(type: string): string {
-    let body = bodybuilder().size();
-    body = body.query('match', '_type', type);
-    body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
-    const toolQuery = JSON.stringify(body, null, 1);
-    return toolQuery;
-}
+    getTagCloudQuery(type: string): string {
+        let body = bodybuilder().size();
+        body = body.query('match', '_type', type);
+        body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
+        const toolQuery = JSON.stringify(body, null, 1);
+        return toolQuery;
+    }
 }

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -1,3 +1,5 @@
+import { SearchService } from './search.service';
+import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
 import { Injectable } from '@angular/core';
 import bodybuilder from 'bodybuilder';
 
@@ -9,8 +11,8 @@ import bodybuilder from 'bodybuilder';
  */
 @Injectable()
 export class QueryBuilderService {
-
-    constructor() { }
+    private shard_size = 10000;
+    constructor(private searchService: SearchService) { }
 
     getTagCloudQuery(type: string): string {
         let body = bodybuilder().size();
@@ -18,5 +20,215 @@ export class QueryBuilderService {
         body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
         const toolQuery = JSON.stringify(body, null, 1);
         return toolQuery;
+    }
+
+    getSidebarQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean,
+        bucketStubs: any, filters: any, sortModeMap: any): string {
+        const count = this.getNumberOfFilters(filters);
+        let sidebarBody = bodybuilder().size(query_size);
+        sidebarBody = this.appendQuery(sidebarBody, values, advancedSearchObject, searchTerm);
+        sidebarBody = this.appendAggregations(count, sidebarBody, bucketStubs, filters, sortModeMap);
+        const builtSideBarBody = sidebarBody.build();
+        const sideBarQuery = JSON.stringify(builtSideBarBody);
+        return sideBarQuery;
+    }
+
+    getNumberOfFilters(filters: any) {
+        let count = 0;
+        filters.forEach(filter => {
+            count += filter.size;
+        });
+        return count;
+    }
+
+    getResultQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean,
+        filters: any): string {
+        let tableBody = bodybuilder().size(query_size);
+        tableBody = this.appendQuery(tableBody, values, advancedSearchObject, searchTerm);
+        tableBody = this.appendFilter(tableBody, null, filters);
+        const builtTableBody = tableBody.build();
+        const tableQuery = JSON.stringify(builtTableBody);
+        return tableQuery;
+    }
+
+    getNonVerifiedQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean, filters: any) {
+        let bodyNotVerified = bodybuilder().size(query_size);
+        bodyNotVerified = this.appendQuery(bodyNotVerified, values, advancedSearchObject, searchTerm);
+        const key = 'tags.verified';
+        bodyNotVerified = bodyNotVerified.filter('term', key, false).notFilter('term', key, true);
+        bodyNotVerified = this.appendFilter(bodyNotVerified, null, filters);
+        const builtBodyNotVerified = bodyNotVerified.build();
+        const queryBodyNotVerified = JSON.stringify(builtBodyNotVerified);
+    }
+
+
+    /**===============================================
+      *                Append Functions
+      * ==============================================
+      */
+    /**
+     * Append filters to a body builder object in order to add filter functionality to the overall elastic search query
+     * This is used to add to query object as well as each individual aggregation
+     * @param {*} body
+     * @returns the new body builder object with filter applied
+     * @memberof SearchComponent
+     */
+    appendFilter(body: any, aggKey: string, filters: any): any {
+        filters.forEach((value: Set<string>, key: string) => {
+            value.forEach(insideFilter => {
+                if (aggKey === key && !this.searchService.exclusiveFilters.includes(key)) {
+                    // Return some garbage filter because we've decided to append a filter, there's no turning back
+                    // return body;  // <--- this does not work
+                    body = body.notFilter('term', 'some garbage term that hopefully never gets matched', insideFilter);
+                } else {
+                    if (value.size > 1) {
+                        body = body.orFilter('term', key, insideFilter);
+                    } else {
+                        if (key === 'tags.verified' && !insideFilter) {
+                            body = body.notFilter('term', key, !insideFilter);
+                        } else {
+                            body = body.filter('term', key, insideFilter);
+                        }
+                    }
+                }
+            });
+        });
+        return body;
+    }
+
+    /**
+      * Append the query to a body builder object in order to add query functionality to the overall elastic search query
+      *
+      * @param {*} body the body build object
+      * @returns {*} the new body builder object
+      * @memberof SearchComponent
+      */
+    appendQuery(body: any, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean): any {
+        if (values.toString().length > 0) {
+            if (advancedSearchObject && !advancedSearchObject.toAdvanceSearch) {
+                advancedSearchObject.ORFilter = values;
+                this.advancedSearchFiles(body, advancedSearchObject);
+                advancedSearchObject.ORFilter = '';
+            }
+        } else {
+            body = body.query('match_all', {});
+        }
+        if (advancedSearchObject) {
+            if (advancedSearchObject.toAdvanceSearch) {
+                if (advancedSearchObject.searchMode === 'description') {
+                    this.advancedSearchDescription(body, advancedSearchObject);
+                } else if (advancedSearchObject.searchMode === 'files') {
+                    this.advancedSearchFiles(body, advancedSearchObject);
+                }
+                values = '';
+                searchTerm = false;
+            }
+        }
+        return body;
+    }
+
+    /**===============================================
+     *                Advanced Search Functions
+     * ===============================================
+     */
+
+    /**
+     * Append aggregations to a body builder object in order to add aggregation functionality to the overall elastic search query
+     *
+     * @param {number} count number of filters
+     * @param {*} body the body builder object
+     * @returns {*} the new body builder object
+     * @memberof SearchComponent
+     */
+    appendAggregations(count: number, body: any, bucketStubs: any, filters: any, sortModeMap: any): any {
+        // go through buckets
+        bucketStubs.forEach(key => {
+            const order = this.searchService.parseOrderBy(key, sortModeMap);
+            if (count > 0) {
+                body = body.agg('filter', key, key, (a) => {
+                    return this.appendFilter(a, key, filters).aggregation('terms', key, key, { size: this.shard_size, order });
+                });
+            } else {
+                body = body.agg('terms', key, key, { size: this.shard_size, order });
+            }
+        });
+        return body;
+    }
+
+    // Advanced search query related functions
+
+    /* TODO: Make this better */
+    advancedSearchFiles(body: any, advancedSearchObject: AdvancedSearchObject) {
+        if (advancedSearchObject.ANDSplitFilter) {
+            const filters = advancedSearchObject.ANDSplitFilter.split(' ');
+            let insideFilter_tool = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_tool = insideFilter_tool.filter('match_phrase', 'tags.sourceFiles.content', filter);
+            });
+            let insideFilter_workflow = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_workflow = insideFilter_workflow.filter('match_phrase', 'workflowVersions.sourceFiles.content', filter);
+            });
+            body = body.filter('bool', filter => filter
+                .orFilter('bool', toolfilter => toolfilter = insideFilter_tool)
+                .orFilter('bool', workflowfilter => workflowfilter = insideFilter_workflow));
+        }
+        if (advancedSearchObject.ANDNoSplitFilter) {
+            body = body.filter('bool', filter => filter
+                .orFilter('bool', toolfilter => toolfilter
+                    .filter('match_phrase', 'tags.sourceFiles.content', advancedSearchObject.ANDNoSplitFilter))
+                .orFilter('bool', workflowfilter => workflowfilter
+                    .filter('match_phrase', 'workflowVersions.sourceFiles.content', advancedSearchObject.ANDNoSplitFilter)));
+        }
+        if (advancedSearchObject.ORFilter) {
+            const filters = advancedSearchObject.ORFilter.split(' ');
+            let insideFilter_tool = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_tool = insideFilter_tool.orFilter('match_phrase', 'tags.sourceFiles.content', filter);
+            });
+            let insideFilter_workflow = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_workflow = insideFilter_workflow.orFilter('match_phrase', 'workflowVersions.sourceFiles.content', filter);
+            });
+            body = body.filter('bool', filter => filter
+                .orFilter('bool', toolfilter => toolfilter = insideFilter_tool)
+                .orFilter('bool', workflowfilter => workflowfilter = insideFilter_workflow));
+        }
+        if (advancedSearchObject.NOTFilter) {
+            const filters = advancedSearchObject.NOTFilter.split(' ');
+            let insideFilter_tool = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_tool = insideFilter_tool.notFilter('match_phrase', 'tags.sourceFiles.content', filter);
+            });
+            let insideFilter_workflow = bodybuilder();
+            filters.forEach(filter => {
+                insideFilter_workflow = insideFilter_workflow.notFilter('match_phrase', 'workflowVersions.sourceFiles.content', filter);
+            });
+            body = body.filter('bool', filter => filter
+                .filter('bool', toolfilter => toolfilter = insideFilter_tool)
+                .filter('bool', workflowfilter => workflowfilter = insideFilter_workflow));
+        }
+    }
+
+    advancedSearchDescription(body: any, advancedSearchObject: AdvancedSearchObject) {
+        if (advancedSearchObject.ANDSplitFilter) {
+            const filters = advancedSearchObject.ANDSplitFilter.split(' ');
+            filters.forEach(filter => body = body.filter('match_phrase', 'description', filter));
+        }
+        if (advancedSearchObject.ANDNoSplitFilter) {
+            body = body.query('match_phrase', 'description', advancedSearchObject.ANDNoSplitFilter);
+        }
+        if (advancedSearchObject.ORFilter) {
+            const filters = advancedSearchObject.ORFilter.split(' ');
+            filters.forEach(filter => {
+                body = body.orFilter('match_phrase', 'description', filter);
+            });
+        }
+        if (advancedSearchObject.NOTFilter) {
+            const filters = advancedSearchObject.NOTFilter.split(' ');
+            filters.forEach(filter => {
+                body = body.notQuery('match_phrase', 'description', filter);
+            });
+        }
     }
 }

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -1,0 +1,49 @@
+<tabset class="homeComponent" type="tabs">
+  <tab id="toolTab" [active] = "activeToolBar" [customClass]="browseToolsTab" [disabled]="haveNoHits(toolHits)">
+    <ng-template tabHeading>
+      <img class="site-icons-tab" src="assets/images/dockstore/dockstore-tools-blue.png">
+      Browse Tools
+    </ng-template>
+    <div *ngIf="toolTagCloudData">
+      <button type="button" class="btn btn-info tagCloud-btn tool" (click)="clickTagCloudBtn('tool')">
+        <i [class]="showToolTagCloud ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'" aria-hidden="true"></i>
+        <span>Tag Cloud</span>
+      </button>
+      <div class="tagCloud tool" *ngIf="showToolTagCloud">
+        <angular-tag-cloud
+          [data]="toolTagCloudData"
+          [width]="options.width"
+          [height]="options.height"
+          [overflow]="options.overflow"
+          (clicked)="tagClicked($event)">
+        </angular-tag-cloud>
+      </div>
+    </div>
+    <p>A tool is a docker container with an associated descriptor describing how to run it.</p>
+    <app-listentry (userUpdated)="saveSearchFilter($event)" [entryType]="'tool'"></app-listentry>
+  </tab>
+
+  <tab id="workflowTab" [active] = "!activeToolBar" [customClass]="browseWorkflowsTab" [disabled]="haveNoHits(workflowHits)">
+    <div *ngIf="workflowTagCloudData">
+      <button type="button" class="btn btn-info tagCloud-btn workflow" (click)="clickTagCloudBtn('workflow')">
+        <i [class]="showWorkflowTagCloud ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'" aria-hidden="true"></i>
+        <span>Tag Cloud</span>
+      </button>
+      <div class="tagCloud workflow" *ngIf="showWorkflowTagCloud">
+        <angular-tag-cloud
+          [data]="workflowTagCloudData"
+          [width]="options.width"
+          [height]="options.height"
+          [overflow]="options.overflow"
+          (clicked)="tagClicked($event)">
+        </angular-tag-cloud>
+      </div>
+    </div>
+    <ng-template tabHeading>
+      <img class="site-icons-tab" src="assets/images/dockstore/dockstore-workflows-green.png">
+      Browse Workflows
+    </ng-template>
+    <p> A workflow is a series of tools strung together, with an associated descriptor describing how to run it.</p>
+    <app-listentry (userUpdated)="saveSearchFilter($event)" [entryType]="'workflow'"></app-listentry>
+  </tab>
+</tabset>

--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+import { SearchResultsComponent } from './search-results.component';
+
+describe('SearchResultsComponent', () => {
+  let component: SearchResultsComponent;
+  let fixture: ComponentFixture<SearchResultsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchResultsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchResultsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -1,7 +1,13 @@
+import { QueryBuilderService } from './../query-builder.service';
+import { SearchStubService, QueryBuilderStubService } from './../../test/service-stubs';
+import { SearchService } from './../search.service';
+import { FormsModule } from '@angular/forms';
+import { TagCloudModule } from 'angular-tag-cloud-module/dist';
+import { TabsModule } from 'ngx-bootstrap/tabs';
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SearchResultsComponent } from './search-results.component';
 
@@ -11,7 +17,13 @@ describe('SearchResultsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SearchResultsComponent ]
+      declarations: [ SearchResultsComponent ],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [TabsModule.forRoot(), TagCloudModule],
+      providers: [
+        {provide: SearchService, useClass: SearchStubService},
+        { provide: QueryBuilderService, useClass: QueryBuilderStubService }
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -102,9 +102,6 @@ export class SearchResultsComponent implements OnInit {
     this.searchService.searchTerm$.next(true);
     this.searchService.values$.next(clicked.text);
     this.searchService.tagClicked$.next(true);
-    // this.searchTerm = true;
-    // this.values = clicked.text;
-    // this.updateQuery();
   }
 
   /**

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -1,8 +1,9 @@
-import { QueryBuilderService } from './../query-builder.service';
-import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
-import { CloudData, CloudOptions } from 'angular-tag-cloud-module';
-import { SearchService } from './../search.service';
 import { Component, OnInit } from '@angular/core';
+import { CloudData, CloudOptions } from 'angular-tag-cloud-module';
+
+import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
+import { QueryBuilderService } from './../query-builder.service';
+import { SearchService } from './../search.service';
 
 @Component({
   selector: 'app-search-results',

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -1,8 +1,8 @@
+import { QueryBuilderService } from './../query-builder.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
 import { CloudData, CloudOptions } from 'angular-tag-cloud-module';
 import { SearchService } from './../search.service';
 import { Component, OnInit } from '@angular/core';
-import bodybuilder from 'bodybuilder';
 
 @Component({
   selector: 'app-search-results',
@@ -24,7 +24,7 @@ export class SearchResultsComponent implements OnInit {
     height: 200,
     overflow: false,
   };
-  constructor(private searchService: SearchService) {
+  constructor(private searchService: SearchService, private queryBuilderService: QueryBuilderService) {
 
   }
 
@@ -42,10 +42,7 @@ export class SearchResultsComponent implements OnInit {
   }
 
   createTagCloud(type: string) {
-    let body = bodybuilder().size();
-    body = body.query('match', '_type', type);
-    body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
-    const toolQuery = JSON.stringify(body, null, 1);
+    const toolQuery = this.queryBuilderService.getTagCloudQuery(type);
     this.createToolTagCloud(toolQuery, type);
   }
 

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -1,0 +1,135 @@
+import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
+import { CloudData, CloudOptions } from 'angular-tag-cloud-module';
+import { SearchService } from './../search.service';
+import { Component, OnInit } from '@angular/core';
+import bodybuilder from 'bodybuilder';
+
+@Component({
+  selector: 'app-search-results',
+  templateUrl: './search-results.component.html',
+  styleUrls: ['./search-results.component.css']
+})
+export class SearchResultsComponent implements OnInit {
+  public activeToolBar = true;
+  public workflowHits: any;
+  public toolHits: any;
+  public browseToolsTab = 'browseToolsTab';
+  public browseWorkflowsTab = 'browseWorkflowsTab';
+  toolTagCloudData: Array<CloudData>;
+  workflowTagCloudData: Array<CloudData>;
+  showToolTagCloud = false;
+  showWorkflowTagCloud = false;
+  options: CloudOptions = {
+    width: 600,
+    height: 200,
+    overflow: false,
+  };
+  constructor(private searchService: SearchService) {
+
+  }
+
+  ngOnInit() {
+    this.searchService.workflowhit$.subscribe(workflowHits => {
+      this.workflowHits = workflowHits;
+      this.setTabActive();
+    });
+    this.searchService.toolhit$.subscribe(toolHits => {
+      this.toolHits = toolHits;
+      this.setTabActive();
+    });
+    this.createTagCloud('tool');
+    this.createTagCloud('workflow');
+  }
+
+  createTagCloud(type: string) {
+    let body = bodybuilder().size();
+    body = body.query('match', '_type', type);
+    body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
+    const toolQuery = JSON.stringify(body, null, 1);
+    this.createToolTagCloud(toolQuery, type);
+  }
+
+  clickTagCloudBtn(type: string) {
+    if (type === 'tool') {
+      this.showToolTagCloud = !this.showToolTagCloud;
+    } else {
+      this.showWorkflowTagCloud = !this.showWorkflowTagCloud;
+    }
+  }
+
+  createToolTagCloud(toolQuery, type) {
+    ELASTIC_SEARCH_CLIENT.search({
+      index: 'tools',
+      type: 'entry',
+      body: toolQuery
+    }).then(hits => {
+      let weight = 10;
+      let count = 0;
+      hits.aggregations.tagcloud.buckets.forEach(
+        tag => {
+          const theTag = {
+            text: tag.key,
+            weight: weight
+          };
+          if (weight === 10) {
+            /** just for fun...**/
+            theTag['color'] = '#ffaaee';
+          }
+          if (count % 2 !== 0) {
+            weight--;
+          }
+          if (type === 'tool') {
+            if (!this.toolTagCloudData) {
+              this.toolTagCloudData = new Array<CloudData>();
+            }
+            this.toolTagCloudData.push(theTag);
+          } else {
+            if (!this.workflowTagCloudData) {
+              this.workflowTagCloudData = new Array<CloudData>();
+            }
+            this.workflowTagCloudData.push(theTag);
+          }
+          count--;
+        }
+      );
+    });
+  }
+
+  // Tells the search service to tell the search filters to save its data
+  saveSearchFilter() {
+    this.searchService.toSaveSearch$.next(true);
+  }
+
+  tagClicked(clicked: CloudData) {
+    this.searchService.searchTerm$.next(true);
+    this.searchService.values$.next(clicked.text);
+    this.searchService.tagClicked$.next(true);
+    // this.searchTerm = true;
+    // this.values = clicked.text;
+    // this.updateQuery();
+  }
+
+  /**
+   * This handles the which tab (tool or workflow) is set to active based on hits.
+   * The default is tool if both have hits
+   *
+   * @memberof SearchResultsComponent
+   */
+  setTabActive(): void {
+    if (!this.toolHits || !this.workflowHits) {
+      this.activeToolBar = true;
+      return;
+    }
+    if (this.toolHits.length === 0 && this.workflowHits.length > 0) {
+      this.activeToolBar = false;
+    } else if (this.workflowHits.length === 0 && this.toolHits.length > 0) {
+      this.activeToolBar = true;
+    } else {
+      this.activeToolBar = true;
+    }
+  }
+
+  haveNoHits(object: Object[]): boolean {
+    return this.searchService.haveNoHits(object);
+  }
+}

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -1,9 +1,6 @@
 <app-header>
   <span class="glyphicon glyphicon-search"></span>
   Search
-  <div class="pull-right">
-  </div>
-
 </app-header>
 <div class="container search-container">
   <div class="row">
@@ -172,56 +169,7 @@
           <p><strong>Notice: </strong>Your search has returned greater than {{ query_size - 1 }} results, however only {{ query_size - 1 }} results are shown.
             We recommend that you narrow your search to find more relevant results.</p>
         </div>
-
-        <tabset class="homeComponent" type="tabs">
-          <tab id="toolTab" [active] = "activeToolBar" [customClass]="browseToolsTab" [disabled]="haveNoHits(toolHits)">
-            <ng-template tabHeading>
-              <img class="site-icons-tab" src="assets/images/dockstore/dockstore-tools-blue.png">
-              Browse Tools
-            </ng-template>
-            <div *ngIf="toolTagCloudData">
-              <button type="button" class="btn btn-info tagCloud-btn tool" (click)="clickTagCloudBtn('tool')">
-                <i [class]="showToolTagCloud ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'" aria-hidden="true"></i>
-                <span>Tag Cloud</span>
-              </button>
-              <div class="tagCloud tool" *ngIf="showToolTagCloud">
-                <angular-tag-cloud
-                  [data]="toolTagCloudData"
-                  [width]="options.width"
-                  [height]="options.height"
-                  [overflow]="options.overflow"
-                  (clicked)="tagClicked($event)">
-                </angular-tag-cloud>
-              </div>
-            </div>
-            <p>A tool is a docker container with an associated descriptor describing how to run it.</p>
-            <app-listentry (userUpdated)="saveSearchFilter($event)" [entryType]="'tool'"></app-listentry>
-          </tab>
-
-          <tab id="workflowTab" [active] = "!activeToolBar" [customClass]="browseWorkflowsTab" [disabled]="haveNoHits(workflowHits)">
-            <div *ngIf="workflowTagCloudData">
-              <button type="button" class="btn btn-info tagCloud-btn workflow" (click)="clickTagCloudBtn('workflow')">
-                <i [class]="showWorkflowTagCloud ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'" aria-hidden="true"></i>
-                <span>Tag Cloud</span>
-              </button>
-              <div class="tagCloud workflow" *ngIf="showWorkflowTagCloud">
-                <angular-tag-cloud
-                  [data]="workflowTagCloudData"
-                  [width]="options.width"
-                  [height]="options.height"
-                  [overflow]="options.overflow"
-                  (clicked)="tagClicked($event)">
-                </angular-tag-cloud>
-              </div>
-            </div>
-            <ng-template tabHeading>
-              <img class="site-icons-tab" src="assets/images/dockstore/dockstore-workflows-green.png">
-              Browse Workflows
-            </ng-template>
-            <p> A workflow is a series of tools strung together, with an associated descriptor describing how to run it.</p>
-            <app-listentry (userUpdated)="saveSearchFilter($event)" [entryType]="'workflow'"></app-listentry>
-          </tab>
-        </tabset>
+        <app-search-results></app-search-results>
       </div>
     </div>
   </div>

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -33,7 +33,7 @@
           </button>
           <app-advancedsearch></app-advancedsearch>
         </accordion-group>
-        <accordion-group *ngFor="let key of orderedBuckets.keys();" #bucket panelClass="containers-accordion" [isOpen]="expandAll">
+        <accordion-group *ngFor="let key of getKeys(orderedBuckets)" #bucket panelClass="containers-accordion" [isOpen]="expandAll">
           <div accordion-heading>
             {{friendlyNames.get(key)}}
             <span>
@@ -65,7 +65,7 @@
               </div>
             </div>
           </div>
-          <div *ngFor='let subBucket of orderedBuckets.get(key).Items.keys(); let i = index'>
+          <div *ngFor='let subBucket of getKeys(orderedBuckets.get(key).Items); let i = index'>
             <div class="panel-container-label">
               <div *ngIf="i < 5">
                 <div class="container-name-oflw pull-left">

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -1,34 +1,45 @@
-import { AdvancedSearchStubService } from './../test/service-stubs';
+import { AccordionModule } from 'ngx-bootstrap';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AdvancedSearchService } from './advancedsearch/advanced-search.service';
-import { SearchStubService } from '../test/service-stubs';
+import { ProviderService } from '../shared/provider.service';
+import { QueryBuilderStubService, SearchStubService, AdvancedSearchStubService } from './../test/service-stubs';
+import { QueryBuilderService } from './query-builder.service';
 import { SearchService } from './search.service';
-import { ProviderService } from './../shared/provider.service';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SearchComponent } from './search.component';
+import { FormsModule } from '@angular/forms';
+import { TagCloudModule } from 'angular-tag-cloud-module/dist';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('SearchComponent', () => {
-  // let component: SearchComponent;
-  // let fixture: ComponentFixture<SearchComponent>;
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
 
-  // beforeEach(async(() => {
-  //   TestBed.configureTestingModule({
-  //     declarations: [ SearchComponent ],
-  //     schemas: [ NO_ERRORS_SCHEMA ],
-  //     providers: [ProviderService, {provide: SearchService, useClass: SearchStubService },
-  //     {provide: AdvancedSearchService, useClass: AdvancedSearchStubService }]
-  //   })
-  //   .compileComponents();
-  // }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchComponent ],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [RouterTestingModule, AccordionModule.forRoot()],
+      providers: [
+        {provide: SearchService, useClass: SearchStubService},
+        { provide: QueryBuilderService, useClass: QueryBuilderStubService },
+        ProviderService,
+        { provide: AdvancedSearchService, useClass: AdvancedSearchStubService}
+      ]
+    })
+    .compileComponents();
+  }));
 
-  // beforeEach(() => {
-  //   fixture = TestBed.createComponent(SearchComponent);
-  //   component = fixture.componentInstance;
-  //   fixture.detectChanges();
-  // });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-  // it('should create', () => {
-  //   expect(component).toBeTruthy();
-  // });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -17,7 +17,7 @@ import { Subscription } from 'rxjs/Subscription';
 /** TODO: ExpressionChangedAfterItHasBeenCheckedError is indicator that something is wrong with the bindings,
  *  so you shouldn't just dismiss it, but try to figure out why it's happening...
  **/
-enableProdMode();
+// enableProdMode();
 @Component({
   selector: 'app-search',
   templateUrl: './search.component.html',
@@ -150,6 +150,9 @@ export class SearchComponent implements OnInit {
   parseParams() {
     let useAdvSearch = false;
     const URIParams = this.searchService.createURIParams(this.curURL);
+    if (!URIParams.paramsMap) {
+      return;
+    }
     URIParams.paramsMap.forEach(((value, key) => {
       if (this.friendlyNames.get(key)) {
         value.forEach(categoryValue => {

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -13,10 +13,6 @@ import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchService } from './search.service';
 
-/** TODO: ExpressionChangedAfterItHasBeenCheckedError is indicator that something is wrong with the bindings,
- *  so you shouldn't just dismiss it, but try to figure out why it's happening...
- **/
-// enableProdMode();
 @Component({
   selector: 'app-search',
   templateUrl: './search.component.html',
@@ -40,6 +36,8 @@ export class SearchComponent implements OnInit {
   public toolHits: Object[] = [];
   public workflowHits: Object[] = [];
   public hits: Object[];
+
+  // TODO: Comment on why shard_size is 10,000
   private shard_size = 10000;
   public suggestTerm = '';
   private firstInit = true;

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -1,18 +1,17 @@
-import { QueryBuilderService } from './query-builder.service';
-import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
-import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
-import { AdvancedSearchService } from './advancedsearch/advanced-search.service';
-import { SearchService } from './search.service';
-import { Component, OnInit, enableProdMode } from '@angular/core';
-import { ProviderService } from '../shared/provider.service';
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router/';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Dockstore } from '../shared/dockstore.model';
-import { CloudData, CloudOptions } from 'angular-tag-cloud-module';
+import { Subscription } from 'rxjs/Subscription';
+
 import { CategorySort } from '../shared/models/CategorySort';
 import { SubBucket } from '../shared/models/SubBucket';
-import { Router } from '@angular/router/';
-import { Location } from '@angular/common';
-import { Subscription } from 'rxjs/Subscription';
+import { ProviderService } from '../shared/provider.service';
+import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
+import { AdvancedSearchService } from './advancedsearch/advanced-search.service';
+import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
+import { QueryBuilderService } from './query-builder.service';
+import { SearchService } from './search.service';
 
 /** TODO: ExpressionChangedAfterItHasBeenCheckedError is indicator that something is wrong with the bindings,
  *  so you shouldn't just dismiss it, but try to figure out why it's happening...

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -106,6 +106,11 @@ export class SearchComponent implements OnInit {
     private Location: Location) {
     this.location = Location;
   }
+
+  getKeys(map: Map<any, any>): Array<string> {
+    return Array.from(map.keys());
+  }
+
   ngOnInit() {
     // Initialize mappings
     this.bucketStubs = this.searchService.initializeBucketStubs();

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -1,3 +1,4 @@
+import { QueryBuilderService } from './query-builder.service';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { SearchService } from './search.service';
 import { TabsModule } from 'ngx-bootstrap/tabs';
@@ -38,7 +39,7 @@ import { SearchResultsComponent } from './search-results/search-results.componen
     ClipboardModule,
     searchRouting
   ],
-  providers: [AdvancedSearchService, SearchService],
+  providers: [AdvancedSearchService, SearchService, QueryBuilderService],
   exports: [SearchComponent]
 
 })

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -16,11 +16,13 @@ import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { ClipboardModule } from 'ngx-clipboard';
 import { searchRouting } from './search.routing';
+import { SearchResultsComponent } from './search-results/search-results.component';
 @NgModule({
   declarations: [
     AdvancedSearchComponent,
-    SearchComponent
-  ],
+    SearchComponent,
+    SearchResultsComponent
+],
   imports: [
     CommonModule,
     ListentryModule,

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -7,6 +7,10 @@ import { SubBucket } from '../shared/models/SubBucket';
 @Injectable()
 export class SearchService {
   private searchInfoSource = new BehaviorSubject<any>(null);
+  public toSaveSearch$ = new BehaviorSubject<boolean>(false);
+  public values$ = new BehaviorSubject<string>('');
+  public searchTerm$ = new BehaviorSubject<boolean>(false);
+  public tagClicked$ = new BehaviorSubject<boolean>(false);
   searchInfo$ = this.searchInfoSource.asObservable();
   /* Observable */
   public toolhit$ = new BehaviorSubject<any>(null);

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -43,6 +43,13 @@ export class DocsStubService {
     }
 }
 
+
+export class QueryBuilderStubService {
+    getTagCloudQuery(type: string): string {
+        return '';
+    }
+}
+
 export class GA4GHStubService {
     metadataGet(): Observable<Metadata> {
         const metadata: Metadata = {
@@ -54,7 +61,16 @@ export class GA4GHStubService {
 }
 
 export class SearchStubService {
+    workflowhit$ = Observable.of([]);
+    toolhit$ = Observable.of([]);
     searchInfo$ = Observable.of({});
+    haveNoHits(object: Object[]): boolean {
+        if (!object || object.length === 0) {
+          return true;
+        } else {
+          return false;
+        }
+      }
 }
 
 export class ListContainersStubService {

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -1,3 +1,5 @@
+import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
+import { SubBucket } from './../shared/models/SubBucket';
 import { Dockstore } from './../shared/dockstore.model';
 import { Token } from './../shared/swagger/model/token';
 import { bitbucketToken, gitHubToken, gitLabToken, quayToken, sampleWorkflow1, updatedWorkflow } from './mocked-objects';
@@ -48,6 +50,17 @@ export class QueryBuilderStubService {
     getTagCloudQuery(type: string): string {
         return '';
     }
+    getSidebarQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean,
+        bucketStubs: any, filters: any, sortModeMap: any): string {
+        return 'thisissomefakequery';
+    }
+    getResultQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean,
+        filters: any): string {
+        return 'thisissomefakequery';
+    }
+    getNonVerifiedQuery(query_size: number, values: string, advancedSearchObject: AdvancedSearchObject, searchTerm: boolean, filters: any) {
+        return 'thisissomefakequery';
+    }
 }
 
 export class GA4GHStubService {
@@ -64,13 +77,96 @@ export class SearchStubService {
     workflowhit$ = Observable.of([]);
     toolhit$ = Observable.of([]);
     searchInfo$ = Observable.of({});
+    toSaveSearch$ = Observable.of(false);
+    values$ = Observable.of('');
+    joinComma(searchTerm: string): string {
+        return searchTerm.trim().split(' ').join(', ');
+    }
     haveNoHits(object: Object[]): boolean {
         if (!object || object.length === 0) {
-          return true;
+            return true;
         } else {
-          return false;
+            return false;
         }
-      }
+    }
+
+    noResults(searchTerm: string, hits: any) {
+        return false;
+    }
+    hasSearchText(advancedSearchObject: any, searchTerm: string, hits: any) {
+        return true;
+    }
+
+    hasFilters(filters: any) {
+        return true;
+    }
+
+    hasResults(searchTerm: string, hits: any) {
+        return true;
+    }
+
+    // Initialization Functions
+    initializeBucketStubs() {
+        return new Map([
+            ['Entry Type', '_type'],
+            ['Registry', 'registry'],
+            ['Private Access', 'private_access'],
+            ['Verified', 'tags.verified'],
+            ['Author', 'author'],
+            ['Organization', 'namespace'],
+            ['Labels', 'labels.value.keyword'],
+            ['Verified Source', 'tags.verifiedSource'],
+        ]);
+    }
+
+    createPermalinks(searchInfo: any) {
+        return 'thisisafakepermalink';
+    }
+
+    createURIParams(cururl) {
+        const url = cururl.substr('/search'.length + 1);
+        const params = new URLSearchParams(url);
+        return params;
+    }
+    initializeFriendlyNames() {
+        return new Map([
+            ['_type', 'Entry Type'],
+            ['registry', 'Registry'],
+            ['private_access', 'Private Access'],
+            ['tags.verified', 'Verified'],
+            ['author', 'Author'],
+            ['namespace', 'Organization'],
+            ['labels.value.keyword', 'Labels'],
+            ['tags.verifiedSource', 'Verified Source'],
+        ]);
+    }
+
+    initializeEntryOrder() {
+        return new Map([
+            ['_type', new SubBucket],
+            ['author', new SubBucket],
+            ['registry', new SubBucket],
+            ['namespace', new SubBucket],
+            ['labels.value.keyword', new SubBucket],
+            ['private_access', new SubBucket],
+            ['tags.verified', new SubBucket],
+            ['tags.verifiedSource', new SubBucket]
+        ]);
+    }
+
+    initializeFriendlyValueNames() {
+        return new Map([
+            ['tags.verified', new Map([
+                ['1', 'verified'], ['0', 'non-verified']
+            ])],
+            ['private_access', new Map([
+                ['1', 'private'], ['0', 'public']
+            ])],
+            ['registry', new Map([
+                ['QUAY_IO', 'Quay.io'], ['DOCKER_HUB', 'Docker Hub'], ['GITLAB', 'GitLab'], ['AMAZON_ECR', 'Amazon ECR']
+            ])]
+        ]);
+    }
 }
 
 export class ListContainersStubService {
@@ -137,7 +233,7 @@ export class HttpStubService {
 
 export class WorkflowStubService {
     nsWorkflows$ = Observable.of([]);
-    workflow$: BehaviorSubject<any> = new BehaviorSubject({sampleWorkflow1}); // This is the selected workflow
+    workflow$: BehaviorSubject<any> = new BehaviorSubject({ sampleWorkflow1 }); // This is the selected workflow
     workflows$: BehaviorSubject<Workflow[]> = new BehaviorSubject([]);  // This contains the list of unsorted workflows
     copyBtn$ = Observable.of({});
     setWorkflow(thing: Workflow) {


### PR DESCRIPTION
This fixes (or works-around) the ExpressionChangedAfterItHasBeenCheckedError errors that we kept getting when enableProd() is removed ga4gh/dockstore#853:

Additionally, several other things were changed:
- all bodybuilder query building functions have been moved to its own query-builder service, no other service or component should be using bodybuilder
- search.component default test have been enabled
- default query-builder test is added
- search table (along with the tag cloud) has been moved to the search-results component

In the future, tag cloud should be its own component.  And the sidebar should also be its own component.