### PR TITLE
Feature/issue 933

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -45,7 +45,8 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
-        "prod": "environments/environment.prod.ts"
+        "prod": "environments/environment.prod.ts",
+        "qa": "environments/environment.qa.ts"
       }
     }
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 src/app/shared/swagger/
 swagger-codegen-cli.jar
 
+# dev environment only
+src/environments/environment.ts
+
 # dependencies
 /node_modules
 /bower_components

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ before_script:
   - 'sleep 20'
 
 script:
-  - ng build # this does syntax checking, unit testing, and jshint
-  - ng serve --silent &
-  - ng test --watch=false --code-coverage
+  - ng build --environment=qa # this does syntax checking, unit testing, and jshint
+  - ng serve --environment=qa --silent &
+  - ng test --environment=qa --watch=false --code-coverage
   - cypress run --record --config defaultCommandTimeout=10000 #test using cypress for integration testing
 
 after_success:

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row header1">
       <div class="col-md-6 splash">
+        <button *ngIf="prod" type="button" class="pull-left btn btn-info" (click)="goToUI1()">Click here to go back to UI1</button> 
         <h1 class="title">Create, Share, Use</h1>
         <h2 class="title caption">Search Docker Tools and Workflows for the Sciences:</h2>
         <div class="btn-group">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,5 +1,8 @@
+import { Dockstore } from './../shared/dockstore.model';
+import { environment } from './../../environments/environment';
 import {AfterViewInit, Component, OnInit} from '@angular/core';
 import { TwitterService } from '../shared/twitter.service';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -8,6 +11,7 @@ import { TwitterService } from '../shared/twitter.service';
 export class HomeComponent implements OnInit, AfterViewInit {
   public browseToolsTab = 'browseToolsTab';
   public browseWorkflowsTab = 'browseWorkflowsTab';
+  public prod = environment.production;
   constructor(private twitterService: TwitterService) {
   }
 
@@ -20,5 +24,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
   goToSearch(searchValue: string) {
     window.location.href = '/search?search=' + searchValue;
+  }
+
+  goToUI1() {
+    window.location.href = Dockstore.UI1_URI;
   }
 }

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -1,29 +1,27 @@
+import { environment } from './../../environments/environment';
+// Do not change
 export class Dockstore {
-  // Please fill in HOSTNAME with your address
-  static readonly HOSTNAME = 'http://localhost';
-  static readonly API_PORT = '8080';
-  static readonly UI_PORT = '4200';
+  static readonly UI1_URI = environment.HOSTNAME + ':' + environment.UI1_PORT;
+  static readonly LOCAL_URI = environment.HOSTNAME + ':' + environment.UI_PORT;
+  static readonly API_URI = environment.HOSTNAME + ':' + environment.API_PORT;
 
-  static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;
-  static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
-  static readonly DNASTACK_IMPORT_URL= 'https://app.dnastack.com/#/app/workflow/import/dockstore';
+  static readonly DNASTACK_IMPORT_URL = 'https://app.dnastack.com/#/app/workflow/import/dockstore';
 
-  static readonly GITHUB_CLIENT_ID = 'fill this in';
+  static readonly GITHUB_CLIENT_ID = environment.GITHUB_CLIENT_ID;
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
-
-  static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/github.com';
+  static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/github';
   static readonly GITHUB_SCOPE = 'read:org,user,user:email';
 
   static readonly QUAYIO_AUTH_URL = 'https://quay.io/oauth/authorize';
   static readonly QUAYIO_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/quay';
+
   static readonly QUAYIO_SCOPE = 'repo:read,user:read';
-  static readonly QUAYIO_CLIENT_ID = 'fill this in';
+  static readonly QUAYIO_CLIENT_ID = environment.QUAYIO_CLIENT_ID;
 
   static readonly BITBUCKET_AUTH_URL = 'https://bitbucket.org/site/oauth2/authorize';
-  static readonly BITBUCKET_CLIENT_ID = 'fill this in';
+  static readonly BITBUCKET_CLIENT_ID = environment.BITBUCKET_CLIENT_ID;
 
   static readonly GITLAB_AUTH_URL = 'https://gitlab.com/oauth/authorize';
-  static readonly GITLAB_CLIENT_ID = 'fill this in';
+  static readonly GITLAB_CLIENT_ID = environment.GITLAB_CLIENT_ID;
   static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/gitlab';
-
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,14 @@
+// This is for production only
+
 export const environment = {
-  production: true
+  production: true,
+  HOSTNAME: 'http://localhost fill this in for production',
+  API_PORT: '8080 fill this in for production',
+  UI_PORT: '4200 fill this in for production',
+  UI1_PORT: '9000 fill this in for production',
+
+  GITHUB_CLIENT_ID: 'fill this in for production',
+  QUAYIO_CLIENT_ID: 'fille this in for production',
+  BITBUCKET_CLIENT_ID: 'fill this in for production',
+  GITLAB_CLIENT_ID: 'fill this in for production',
 };

--- a/src/environments/environment.qa.ts
+++ b/src/environments/environment.qa.ts
@@ -1,0 +1,19 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=qa` then `environment.qa.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+// This is for Travis
+
+export const environment = {
+  production: true,
+  HOSTNAME: 'http://localhost',
+  API_PORT: '8080',
+  UI_PORT: '4200',
+  UI1_PORT: '9000',
+
+  GITHUB_CLIENT_ID: 'maybe fill this in',
+  QUAYIO_CLIENT_ID: 'maybe fill this in',
+  BITBUCKET_CLIENT_ID: 'maybe fill this in',
+  GITLAB_CLIENT_ID: 'maybe fill this in',
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,13 +7,13 @@
 
 export const environment = {
   production: false,
-  HOSTNAME: 'http://##.##.##.## change this to your own IP',
-  API_PORT: '8080 change this to your own port',
-  UI_PORT: '4200 change this to your own port',
-  UI1_PORT: '9000 change this to your own port',
+  HOSTNAME: 'fill this in',
+  API_PORT: 'fil this in',
+  UI_PORT: 'fil this in ',
+  UI1_PORT: 'fil this in',
 
-  GITHUB_CLIENT_ID: 'fill this in with your own',
-  QUAYIO_CLIENT_ID: 'fill this in with your own',
-  BITBUCKET_CLIENT_ID: 'fill this in with your own',
-  GITLAB_CLIENT_ID: 'fill this in with your own',
+  GITHUB_CLIENT_ID: 'fil this in',
+  QUAYIO_CLIENT_ID: 'fil this in',
+  BITBUCKET_CLIENT_ID: 'fill this in',
+  GITLAB_CLIENT_ID: 'fill this in',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,6 +3,17 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
+// This is for development, do not commit
+
 export const environment = {
-  production: false
+  production: false,
+  HOSTNAME: 'http://##.##.##.## change this to your own IP',
+  API_PORT: '8080 change this to your own port',
+  UI_PORT: '4200 change this to your own port',
+  UI1_PORT: '9000 change this to your own port',
+
+  GITHUB_CLIENT_ID: 'fill this in with your own',
+  QUAYIO_CLIENT_ID: 'fill this in with your own',
+  BITBUCKET_CLIENT_ID: 'fill this in with your own',
+  GITLAB_CLIENT_ID: 'fill this in with your own',
 };


### PR DESCRIPTION
This implements ga4gh/dockstore#933 

There is now a bootstrap info style button at the top left corner above the heading where clicking on it will redirect to the old UI (dropdown would block top right).  This is present depending on the build environment.  There are several things done to achieve this.

- dockstore.model.ts was heavily modified and does not need changes per environment (dev, qa, prod)
- environment.ts and environment.prod.ts is now utilized (prod for production, the former for development)
- environment.qa.ts has been added and is used for Travis testing

For development, only environment.ts should be modified and is ignored but git.  See .travis.yml for how to run in different environments.

Also, I can't spell "fill" apparently.