### PR TITLE
Use the swagger apiKey for authentication

### DIFF
--- a/script
+++ b/script
@@ -1,9 +1,4 @@
 sed -i 's/-//g' src/app/shared/swagger/model/tool.ts && sed -i 's/-//g' src/app/shared/swagger/model/toolVersion.ts && sed -i 's/-//g' src/app/shared/swagger/model/metadata.ts
-sed -i "s/let headers = new Headers(this\.defaultHeaders\.toJSON());/let headers = new Headers(this\.defaultHeaders\.toJSON()); headers\.set('Authorization', 'Bearer ' + this\.configuration\.accessToken);/g" src/app/shared/swagger/api/users.service.ts
-sed -i "s/let headers = new Headers(this\.defaultHeaders\.toJSON());/let headers = new Headers(this\.defaultHeaders\.toJSON()); headers\.set('Authorization', 'Bearer ' + this\.configuration\.accessToken);/g" src/app/shared/swagger/api/containertags.service.ts
-sed -i "s/let headers = new Headers(this\.defaultHeaders\.toJSON());/let headers = new Headers(this\.defaultHeaders\.toJSON()); headers\.set('Authorization', 'Bearer ' + this\.configuration\.accessToken);/g" src/app/shared/swagger/api/workflows.service.ts
-sed -i "s/let headers = new Headers(this\.defaultHeaders\.toJSON());/let headers = new Headers(this\.defaultHeaders\.toJSON()); headers\.set('Authorization', 'Bearer ' + this\.configuration\.accessToken);/g" src/app/shared/swagger/api/containers.service.ts
-sed -i "s/let headers = new Headers(this\.defaultHeaders\.toJSON());/let headers = new Headers(this\.defaultHeaders\.toJSON()); headers\.set('Authorization', 'Bearer ' + this\.configuration\.accessToken);/g" src/app/shared/swagger/api/tokens.service.ts
 ORIGINAL="const jsonMime: RegExp = new RegExp('(?i)^(application/json|\[^;/ \\\t\]+/\[^;/ \\\t\]+\[+\]json)\[ \\\t\]\*(;\.\*)?$');"
 NEW="const jsonMime: RegExp = new RegExp('(application/json|\[^;/ \\\t\]+/\[^;/ \\\t\]+\[+\]json)\[ \\\t\]\*(;\.\*)?$', 'i');"
 for i in src/app/shared/swagger/api/*; do

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -145,7 +145,6 @@ export class AppModule {
 }
 
 export const apiConfig = new Configuration({
-  accessToken: '',
   apiKeys: {},
   basePath: Dockstore.API_URI
 });

--- a/src/app/loginComponents/token.service.ts
+++ b/src/app/loginComponents/token.service.ts
@@ -29,8 +29,7 @@ export class TokenService {
         this.updateTokens();
       }
     });
-    this.configuration.accessToken = this.authService.getToken();
-    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.configuration.accessToken;
+    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
     this.tokens$.subscribe(tokens => this.tokens = tokens);
   }
 

--- a/src/app/loginComponents/user.service.ts
+++ b/src/app/loginComponents/user.service.ts
@@ -33,7 +33,7 @@ export class UserService {
   }
 
   updateUser() {
-    this.configuration.accessToken = this.authService.getToken();
+    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
     this.usersService.getUser().subscribe(
       (user: User) => this.setUser(user),
       error => {

--- a/src/app/mytools/mytools.component.ts
+++ b/src/app/mytools/mytools.component.ts
@@ -32,8 +32,7 @@ export class MyToolsComponent implements OnInit {
     private refreshService: RefreshService,
     private registerToolService: RegisterToolService) { }
   ngOnInit() {
-    this.configuration.accessToken = this.authService.getToken();
-    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.configuration.accessToken;
+    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
     this.containerService.setTool(null);
     this.containerService.tool$.subscribe(selectedTool => {
       this.tool = selectedTool;

--- a/src/app/myworkflows/myworkflows.component.ts
+++ b/src/app/myworkflows/myworkflows.component.ts
@@ -33,7 +33,7 @@ export class MyWorkflowsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.configuration.accessToken = this.authService.getToken();
+    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
     this.workflowService.setWorkflow(null);
     this.workflowService.workflow$.subscribe(
       workflow => {


### PR DESCRIPTION
This removes some commands in 'script' that inject the access token into the generated swagger api classes.  The security definitions present in the dockstore develop's swagger.yaml allows swagger codegen to see which endpoints require authentications and which ones don't.