### PR TITLE
Feature/toast notifcation

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -349,6 +349,11 @@
       "from": "angular2-markdown@1.6.0",
       "resolved": "https://registry.npmjs.org/angular2-markdown/-/angular2-markdown-1.6.0.tgz"
     },
+    "angular2-notifications": {
+      "version": "0.7.8",
+      "from": "angular2-notifications@>=0.7.8 <0.8.0",
+      "resolved": "https://registry.npmjs.org/angular2-notifications/-/angular2-notifications-0.7.8.tgz"
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "from": "ansi-escapes@>=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "angular-datatables": "4.2.0",
     "angular-tag-cloud-module": "^1.4.0",
     "angular2-markdown": "1.6.0",
+    "angular2-notifications": "^0.7.8",
     "bodybuilder": "^2.2.0",
     "bootstrap": "^3.3.7",
     "bootstrap-social": "^5.1.1",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,3 +7,4 @@
   <app-sponsors></app-sponsors>
   <app-footer></app-footer>
 </div>
+<app-toaster></app-toaster>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { ToasterModule } from './shared/toaster/toaster.module';
 import { RouterLinkStubDirective, RouterOutletStubComponent } from './test/router-stubs';
 import { TestBed, async } from '@angular/core/testing';
 
@@ -21,6 +22,7 @@ describe('AppComponent', () => {
         NavbarStubComponent, SponsorsStubComponent, FooterStubComponent,
         RouterLinkStubDirective, RouterOutletStubComponent
       ],
+      imports: [ToasterModule]
     }).compileComponents();
   }));
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { ToasterModule } from './shared/toaster/toaster.module';
 /*
  *    Copyright 2017 OICR
  *
@@ -22,10 +23,10 @@ import { Configuration } from './shared/swagger/configuration';
 import { ApiModule } from './shared/swagger/api.module';
 import { StateService } from './shared/state.service';
 /* Angular Modules */
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { BrowserModule } from '@angular/platform-browser';
 import { FlexLayoutModule } from '@angular/flex-layout';
 
 /* Bootstrap */
@@ -111,7 +112,7 @@ import { SearchModule } from './search/search.module';
     RefreshOrganizationComponent // Have to add this extended component to appease compiler
 ],
   imports: [
-    BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     HttpModule,
     DataTablesModule.forRoot(),
@@ -125,6 +126,7 @@ import { SearchModule } from './search/search.module';
     TooltipModule.forRoot(),
     ClipboardModule,
     OrderByModule,
+    ToasterModule,
     FlexLayoutModule,
     StarringModule,
     routing,

--- a/src/app/container/info-tab/info-tab.service.ts
+++ b/src/app/container/info-tab/info-tab.service.ts
@@ -1,3 +1,4 @@
+import { RefreshService } from './../../shared/refresh.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -28,7 +29,7 @@ export class InfoTabService {
     private tool;
     private tools;
     constructor(private containersService: ContainersService, private stateService: StateService,
-        private containerService: ContainerService) {
+        private containerService: ContainerService, private refreshService: RefreshService) {
         this.containerService.tool$.subscribe(tool => this.tool = tool);
         this.containerService.tools$.subscribe(tools => this.tools = tools);
     }
@@ -45,13 +46,14 @@ export class InfoTabService {
     }
 
     updateAndRefresh(tool: any) {
+        const message = 'Tool Info';
         this.containersService.updateContainer(this.tool.id, tool).subscribe(response => {
-            this.stateService.setRefreshMessage('Updating tool info...');
+            this.stateService.setRefreshMessage('Updating ' + message + '...');
             this.containersService.refresh(this.tool.id).subscribe(refreshResponse => {
                 this.containerService.replaceTool(this.tools, refreshResponse);
                 this.containerService.setTool(refreshResponse);
-                this.stateService.setRefreshMessage(null);
-            });
+                this.refreshService.handleSuccess(message);
+            }, error => this.refreshService.handleError(message, error));
         });
     }
 }

--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -1,3 +1,5 @@
+import { RefreshService } from '../../shared/refresh.service';
+import { NotificationsService } from 'angular2-notifications/dist';
 /*
  *    Copyright 2017 OICR
  *
@@ -37,7 +39,7 @@ export class VersionsContainerComponent extends Versions implements OnInit {
   tool: any;
 
   constructor(dockstoreService: DockstoreService, private containersService: ContainersService,
-    dateService: DateService,
+    dateService: DateService, private refreshService: RefreshService,
               private stateService: StateService,
               private containerService: ContainerService) {
     super(dockstoreService, dateService);
@@ -59,8 +61,14 @@ export class VersionsContainerComponent extends Versions implements OnInit {
   }
 
   updateDefaultVersion(newDefaultVersion: string) {
+    const message = 'Default Tool Version';
     this.tool.defaultVersion = newDefaultVersion;
-    this.containersService.updateContainer(this.tool.id, this.tool).subscribe(response => this.containerService.setTool(response));
+    this.stateService.setRefreshMessage('Refreshing ' + message);
+    this.containersService.updateContainer(this.tool.id, this.tool).subscribe(response => {
+      this.containerService.setTool(response);
+      this.refreshService.handleSuccess(message);
+    }, error => this.refreshService.handleError(message, error)
+  );
   }
 
   getVerifiedSource(name: string) {

--- a/src/app/shared/refresh.service.spec.ts
+++ b/src/app/shared/refresh.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotificationsService } from 'angular2-notifications/dist';
 /*
  *    Copyright 2017 OICR
  *
@@ -38,7 +39,7 @@ describe('RefreshService', () => {
                 { provide: WorkflowsService, useClass: WorkflowsStubService },
                 { provide: ContainerService, useClass: ContainerStubService },
                 { provide: WorkflowService, useClass: WorkflowStubService },
-                { provide: UsersService, useClass: UsersStubService }
+                { provide: UsersService, useClass: UsersStubService }, NotificationsService
             ]
         });
     });

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -1,3 +1,4 @@
+import { NotificationsService } from 'angular2-notifications/dist';
 /*
  *    Copyright 2017 OICR
  *
@@ -35,7 +36,7 @@ export class RefreshService {
     private workflows;
     constructor(private WorkflowsService: WorkflowsService, private containerService: ContainerService, private stateService: StateService,
         private workflowService: WorkflowService, private containersService: ContainersService, private usersService: UsersService,
-        private errorService: ErrorService) {
+        private errorService: ErrorService, private notificationsService: NotificationsService) {
         this.containerService.tool$.subscribe(tool => this.tool = tool);
         this.workflowService.workflow$.subscribe(workflow => this.workflow = workflow);
         this.containerService.tools$.subscribe(tools => this.tools = tools);
@@ -47,15 +48,25 @@ export class RefreshService {
      * @memberof RefreshService
      */
     refreshTool() {
+        const message = 'Tool';
         this.stateService.setRefreshMessage('Refreshing ' + this.tool.path + ' ...');
         this.containersService.refresh(this.tool.id).subscribe((response: DockstoreTool) => {
             this.containerService.replaceTool(this.tools, response);
             this.containerService.setTool(response);
-            this.stateService.setRefreshMessage(null);
-        }, error => {
-            this.errorService.setErrorAlert(error);
-            this.stateService.setRefreshMessage(null);
-        });
+            this.handleSuccess(message);
+        }, error => this.handleError(message, error)
+        );
+    }
+
+    handleSuccess(message: string) {
+        this.stateService.setRefreshMessage(null);
+        this.notificationsService.success('Refresh ' + message + ' Succeeded');
+    }
+
+    handleError(message: string, error: any) {
+        this.errorService.setErrorAlert(error);
+        this.stateService.setRefreshMessage(null);
+        this.notificationsService.error('Refresh ' + message + ' Failed');
     }
 
     /**
@@ -63,15 +74,13 @@ export class RefreshService {
      * @memberof RefreshService
      */
     refreshWorkflow() {
+        const message = 'Workflow';
         this.stateService.setRefreshMessage('Refreshing ' + this.workflow.path + ' ...');
         this.WorkflowsService.refresh(this.workflow.id).subscribe((response: Workflow) => {
             this.workflowService.replaceWorkflow(this.workflows, response);
             this.workflowService.setWorkflow(response);
-            this.stateService.setRefreshMessage(null);
-        }, error => {
-            this.errorService.setErrorAlert(error);
-            this.stateService.setRefreshMessage(null);
-        });
+            this.handleSuccess(message);
+        }, error => this.handleError(message, error));
     }
 
 
@@ -81,15 +90,13 @@ export class RefreshService {
      * @memberof RefreshService
      */
     refreshAllTools(userId: number) {
+        const message = 'All Tool';
         this.stateService.setRefreshMessage('Refreshing all tools...');
         this.usersService.refresh(userId).subscribe(
             response => {
                 this.containerService.setTools(response);
-                this.stateService.setRefreshMessage(null);
-            }, error => {
-                this.errorService.setErrorAlert(error);
-                this.stateService.setRefreshMessage(null);
-            });
+                this.handleSuccess(message);
+            }, error => this.handleError(message, error));
     }
 
 
@@ -99,15 +106,13 @@ export class RefreshService {
      * @memberof RefreshService
      */
     refreshAllWorkflows(userId: number) {
+        const message = 'All Workflow';
         this.stateService.setRefreshMessage('Refreshing all workflows...');
         this.usersService.refreshWorkflows(userId).subscribe(
             response => {
                 this.workflowService.setWorkflows(response);
-                this.stateService.setRefreshMessage(null);
-            }, error => {
-                this.errorService.setErrorAlert(error);
-                this.stateService.setRefreshMessage(null);
-            });
+                this.handleSuccess(message);
+            }, error => this.handleError(message, error));
     }
 
     /**

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -47,7 +47,7 @@ export class RefreshService {
      * Handles refreshing of tool and updates the view.
      * @memberof RefreshService
      */
-    refreshTool() {
+    refreshTool(): void {
         const message = 'Tool';
         this.stateService.setRefreshMessage('Refreshing ' + this.tool.path + ' ...');
         this.containersService.refresh(this.tool.id).subscribe((response: DockstoreTool) => {
@@ -58,11 +58,25 @@ export class RefreshService {
         );
     }
 
+    /**
+     * This handles what happens after refresh API call returns successfully
+     *
+     * @param {string} message The custom success message that should be displayed
+     * @memberof RefreshService
+     */
     handleSuccess(message: string): void {
         this.stateService.setRefreshMessage(null);
         this.notificationsService.success('Refresh ' + message + ' Succeeded');
     }
 
+
+    /**
+     * This handles what happens after refresh API call returns an error
+     *
+     * @param {string} message The custom error message that should be displayed
+     * @param {*} error The error object returned when refresh failed
+     * @memberof RefreshService
+     */
     handleError(message: string, error: any): void {
         this.errorService.setErrorAlert(error);
         this.stateService.setRefreshMessage(null);
@@ -73,7 +87,7 @@ export class RefreshService {
      * Handles refreshing of the workflow and updates the view.
      * @memberof RefreshService
      */
-    refreshWorkflow() {
+    refreshWorkflow(): void {
         const message = 'Workflow';
         this.stateService.setRefreshMessage('Refreshing ' + this.workflow.path + ' ...');
         this.WorkflowsService.refresh(this.workflow.id).subscribe((response: Workflow) => {
@@ -89,7 +103,7 @@ export class RefreshService {
      * @param {number} userId The user id
      * @memberof RefreshService
      */
-    refreshAllTools(userId: number) {
+    refreshAllTools(userId: number): void {
         const message = 'All Tool';
         this.stateService.setRefreshMessage('Refreshing all tools...');
         this.usersService.refresh(userId).subscribe(
@@ -105,7 +119,7 @@ export class RefreshService {
      * @param {number} userId The user id
      * @memberof RefreshService
      */
-    refreshAllWorkflows(userId: number) {
+    refreshAllWorkflows(userId: number): void {
         const message = 'All Workflow';
         this.stateService.setRefreshMessage('Refreshing all workflows...');
         this.usersService.refreshWorkflows(userId).subscribe(
@@ -121,7 +135,7 @@ export class RefreshService {
      * @param {*} tool  The updated tool
      * @memberof RefreshService
      */
-    replaceTool(tool: DockstoreTool) {
+    replaceTool(tool: DockstoreTool): void {
         this.tools = this.tools.filter(obj => obj.id !== tool.id);
         this.tools.push(tool);
         this.containerService.setTools(this.tools);

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -58,12 +58,12 @@ export class RefreshService {
         );
     }
 
-    handleSuccess(message: string) {
+    handleSuccess(message: string): void {
         this.stateService.setRefreshMessage(null);
         this.notificationsService.success('Refresh ' + message + ' Succeeded');
     }
 
-    handleError(message: string, error: any) {
+    handleError(message: string, error: any): void {
         this.errorService.setErrorAlert(error);
         this.stateService.setRefreshMessage(null);
         this.notificationsService.error('Refresh ' + message + ' Failed');

--- a/src/app/shared/toaster/toaster.component.html
+++ b/src/app/shared/toaster/toaster.component.html
@@ -1,0 +1,1 @@
+<simple-notifications [options]="options"></simple-notifications>

--- a/src/app/shared/toaster/toaster.component.spec.ts
+++ b/src/app/shared/toaster/toaster.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+import { ToasterComponent } from './toaster.component';
+
+describe('ToasterComponent', () => {
+  let component: ToasterComponent;
+  let fixture: ComponentFixture<ToasterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ToasterComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ToasterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/toaster/toaster.component.spec.ts
+++ b/src/app/shared/toaster/toaster.component.spec.ts
@@ -1,3 +1,4 @@
+import { SimpleNotificationsModule } from 'angular2-notifications';
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -11,7 +12,7 @@ describe('ToasterComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ToasterComponent ]
+      declarations: [ ToasterComponent ], imports: [SimpleNotificationsModule]
     })
     .compileComponents();
   }));

--- a/src/app/shared/toaster/toaster.component.ts
+++ b/src/app/shared/toaster/toaster.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-toaster',
+  templateUrl: './toaster.component.html',
+  styleUrls: ['./toaster.component.css']
+})
+export class ToasterComponent implements OnInit {
+
+  constructor() { }
+  public options: any = {timeOut: 1000, showProgressBar: false};
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/shared/toaster/toaster.module.ts
+++ b/src/app/shared/toaster/toaster.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { SimpleNotificationsModule } from 'angular2-notifications';
+
+import { ToasterComponent } from './toaster.component';
+
+@NgModule({
+  imports: [
+    SimpleNotificationsModule.forRoot(),
+  ],
+  declarations: [ToasterComponent],
+  exports: [ToasterComponent]
+})
+export class ToasterModule { }

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -274,6 +274,11 @@ export class WorkflowStubService {
 
 export class RefreshStubService {
     refreshAllWorkflows() { }
+    handleSuccess(message: string): void {
+    }
+
+    handleError(message: string, error: any): void {
+    }
 }
 
 export class RegisterWorkflowModalStubService {

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -45,7 +45,7 @@
         <input *ngIf="workflowPathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.workflowDescriptorPath" type="text" class="input-default form-control"
           name="workflowPath" [(ngModel)]="workflow.workflow_path" placeholder="e.g. /Dockstore.cwl" />
       </div>
-      <button *ngIf="!isPublic" type="button" [disabled]="workflowPathEditing && !editWorkflowPathForm.valid" class="btn btn-link push-right" style="padding: 3px 12px!important;"
+      <button *ngIf="!isPublic" type="button" [disabled]="workflowPathEditing && !editWorkflowPathForm.valid || refreshMessage !== null" class="btn btn-link push-right" style="padding: 3px 12px!important;"
         (click)="toggleEditWorkflowPath()">
         <span class="glyphicon" [ngClass]="{'glyphicon-edit': !workflowPathEditing, 'glyphicon-save': workflowPathEditing }"></span>
         {{ workflowPathEditing ? 'Save' : 'Edit' }}
@@ -54,7 +54,7 @@
   </li>
   <li *ngIf="!isPublic">
     <strong uib-tooltip-html="modeTooltip">Mode</strong>: {{workflow?.mode}}
-    <button class="btn btn-link push-right" type="button" *ngIf="workflow?.mode !== 'STUB' && !workflow?.is_published && !refreshing" (click)="restubWorkflow()">
+    <button class="btn btn-link push-right" type="button" *ngIf="workflow?.mode !== WorkflowType.ModeEnum.STUB && !workflow?.is_published" (click)="restubWorkflow()" [disabled]="refreshMessage !== null">
       <span class="glyphicon glyphicon-remove"></span> Restub
     </button>
   </li>

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -32,9 +32,11 @@ export class InfoTabComponent implements OnInit {
   @Input() defaultVersion;
   public validationPatterns = validationPatterns;
   workflow: Workflow;
+  public WorkflowType = Workflow;
   workflowPathEditing: boolean;
   descriptorTypeEditing: boolean;
   isPublic: boolean;
+  public refreshMessage: string;
   constructor(private workflowService: WorkflowService, private workflowsService: WorkflowsService, private stateService: StateService,
   private infoTabService: InfoTabService) { }
 
@@ -43,6 +45,7 @@ export class InfoTabComponent implements OnInit {
     this.stateService.publicPage$.subscribe(isPublic => this.isPublic = isPublic);
     this.infoTabService.workflowPathEditing$.subscribe(editing => this.workflowPathEditing = editing);
     this.infoTabService.descriptorTypeEditing$.subscribe(editing => this.descriptorTypeEditing = editing);
+    this.stateService.refreshMessage$.subscribe(refreshMessage => this.refreshMessage = refreshMessage);
   }
 
   restubWorkflow() {

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -1,3 +1,4 @@
+import { RefreshService } from '../../shared/refresh.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -30,7 +31,7 @@ export class InfoTabService {
     private workflow: Workflow;
 
     constructor(private workflowsService: WorkflowsService, private workflowService: WorkflowService, private stateService: StateService,
-        private errorService: ErrorService) {
+        private errorService: ErrorService, private refreshService: RefreshService) {
         this.workflowService.workflow$.subscribe(workflow => this.workflow = workflow);
         this.workflowService.workflows$.subscribe(workflows => this.workflows = workflows);
     }
@@ -43,16 +44,14 @@ export class InfoTabService {
     }
 
     updateAndRefresh(workflow: Workflow) {
+        const message = 'Workflow Info';
         this.workflowsService.updateWorkflow(this.workflow.id, workflow).subscribe(response => {
-            this.stateService.setRefreshMessage('Updating workflow info...');
+            this.stateService.setRefreshMessage('Updating ' + message + '...');
             this.workflowsService.refresh(this.workflow.id).subscribe(refreshResponse => {
                 this.workflowService.replaceWorkflow(this.workflows, refreshResponse);
                 this.workflowService.setWorkflow(refreshResponse);
-                this.stateService.setRefreshMessage(null);
-            }, error => {
-                this.errorService.setErrorAlert(error);
-                this.stateService.setRefreshMessage(null);
-            });
+                this.refreshService.handleSuccess(message);
+            }, error => this.refreshService.handleError(message, error));
         });
     }
 }

--- a/src/app/workflow/tool-tab/tool-tab.component.ts
+++ b/src/app/workflow/tool-tab/tool-tab.component.ts
@@ -37,6 +37,9 @@ export class ToolTabComponent implements OnInit {
         this.workflow = workflow;
         if (workflow.workflowVersions) {
           this.selectVersion = this.workflow.workflowVersions.find(x => x.name === this.workflow.defaultVersion);
+          if (!this.selectVersion) {
+            this.selectVersion = this.workflow.workflowVersions[0];
+          }
           this.onChange();
         }
       }

--- a/src/app/workflow/versions/versions.component.spec.ts
+++ b/src/app/workflow/versions/versions.component.spec.ts
@@ -1,3 +1,6 @@
+import { RefreshService } from '../../shared/refresh.service';
+import { ErrorService } from './../../shared/error.service';
+import { StateService } from './../../shared/state.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -19,7 +22,8 @@ import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { WorkflowService } from './../../shared/workflow.service';
 import { DateService } from './../../shared/date.service';
-import { DateStubService, DockstoreStubService, WorkflowStubService, WorkflowsStubService } from './../../test/service-stubs';
+import { DateStubService, ErrorStubService, DockstoreStubService, WorkflowStubService, WorkflowsStubService,
+  StateStubService, RefreshStubService } from './../../test/service-stubs';
 import { DockstoreService } from './../../shared/dockstore.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
@@ -37,7 +41,10 @@ describe('VersionsWorkflowComponent', () => {
       providers: [DockstoreService,
         { provide: DateService, useClass: DateStubService},
         { provide: WorkflowService, useClass: WorkflowStubService},
-        { provide: WorkflowsService, useClass: WorkflowsStubService}
+        { provide: WorkflowsService, useClass: WorkflowsStubService},
+        StateService,
+        { provide: ErrorService, useClass: ErrorStubService },
+        { provide: RefreshService, useClass: RefreshStubService}
       ]
     })
     .compileComponents();

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -1,3 +1,4 @@
+import { RefreshService } from '../../shared/refresh.service';
 import { ErrorService } from '../../shared/error.service';
 import { StateService } from './../../shared/state.service';
 /*
@@ -43,7 +44,8 @@ export class VersionsWorkflowComponent extends Versions {
   }
 
   constructor(dockstoreService: DockstoreService, dateService: DateService, private stateService: StateService,
-    private errorService: ErrorService, private workflowService: WorkflowService, private workflowsService: WorkflowsService) {
+    private errorService: ErrorService, private workflowService: WorkflowService, private workflowsService: WorkflowsService,
+    private refreshService: RefreshService) {
     super(dockstoreService, dateService);
     this.verifiedLink = dateService.getVerifiedLink();
     this.workflowService.workflow$.subscribe(workflow => {
@@ -55,18 +57,15 @@ export class VersionsWorkflowComponent extends Versions {
   }
 
   updateDefaultVersion(newDefaultVersion: string) {
+    const message = 'Default Workflow Version';
     this.workflow.defaultVersion = newDefaultVersion;
     this.stateService.setRefreshMessage('Updating default version...');
     this.workflowsService.updateWorkflow(this.workflowId, this.workflow).subscribe(
       response => {
         this.workflowService.setWorkflow(response);
-        this.stateService.setRefreshMessage(null);
+        this.refreshService.handleSuccess(message);
       },
-    error => {
-      this.stateService.setRefreshMessage(null);
-      this.errorService.setErrorAlert(error);
-    });
-
+      error => this.refreshService.handleError(message, error));
   }
 
   getVerifiedSource(name: string) {

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -1,3 +1,5 @@
+import { ErrorService } from '../../shared/error.service';
+import { StateService } from './../../shared/state.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -40,8 +42,8 @@ export class VersionsWorkflowComponent extends Versions {
     return [4, 5];
   }
 
-  constructor(dockstoreService: DockstoreService, dateService: DateService,
-    private workflowService: WorkflowService, private workflowsService: WorkflowsService) {
+  constructor(dockstoreService: DockstoreService, dateService: DateService, private stateService: StateService,
+    private errorService: ErrorService, private workflowService: WorkflowService, private workflowsService: WorkflowsService) {
     super(dockstoreService, dateService);
     this.verifiedLink = dateService.getVerifiedLink();
     this.workflowService.workflow$.subscribe(workflow => {
@@ -54,8 +56,17 @@ export class VersionsWorkflowComponent extends Versions {
 
   updateDefaultVersion(newDefaultVersion: string) {
     this.workflow.defaultVersion = newDefaultVersion;
+    this.stateService.setRefreshMessage('Updating default version...');
     this.workflowsService.updateWorkflow(this.workflowId, this.workflow).subscribe(
-      response => this.workflowService.setWorkflow(response));
+      response => {
+        this.workflowService.setWorkflow(response);
+        this.stateService.setRefreshMessage(null);
+      },
+    error => {
+      this.stateService.setRefreshMessage(null);
+      this.errorService.setErrorAlert(error);
+    });
+
   }
 
   getVerifiedSource(name: string) {


### PR DESCRIPTION
Anytime something is refreshing, there will be the bootstrap alert notification at the top.  When refresh succeeds or fails, a toast notification will appear briefly (1 second) to indicate it succeeded or failed.  If it failed, the bootstrap alert will show the error details.  

This fixes the issue with the refresh being too fast that people can't tell that it succeeded through the bootstrap alert alone.  The refresh bootstrap alert is still needed when it's so slow (refresh all workflows/tools).