### PR TITLE
Feature/use models

### DIFF
--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -1,3 +1,4 @@
+import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
 /*
  *    Copyright 2017 OICR
  *
@@ -49,7 +50,7 @@ export class ContainerComponent extends Entry {
   containerEditData: any;
   thisisValid = true;
   public missingWarning: boolean;
-  public tool;
+  public tool: ExtendedDockstoreTool;
   private toolSubscription: Subscription;
   private toolCopyBtnSubscription: Subscription;
   public toolCopyBtn: string;
@@ -85,16 +86,16 @@ export class ContainerComponent extends Entry {
   }
 
   setProperties() {
-    let toolRef: any = this.tool;
+    let toolRef: ExtendedDockstoreTool = this.tool;
     this.labels = this.dockstoreService.getLabelStrings(this.tool.labels);
     this.dockerPullCmd = this.listContainersService.getDockerPullCmd(this.tool.path);
     this.privateOnlyRegistry = this.imageProviderService.checkPrivateOnlyRegistry(this.tool);
     this.shareURL = window.location.href;
     this.labelsEditMode = false;
-    toolRef.agoMessage = this.dateService.getAgoMessage(toolRef.lastBuild);
-    toolRef.email = this.dockstoreService.stripMailTo(toolRef.email);
-    toolRef.lastBuildDate = this.dateService.getDateTimeMessage(toolRef.lastBuild);
-    toolRef.lastUpdatedDate = this.dateService.getDateTimeMessage(toolRef.lastUpdated);
+    toolRef.agoMessage = this.dateService.getAgoMessage(new Date(this.tool.lastBuild).getTime());
+    toolRef.email = this.dockstoreService.stripMailTo(this.tool.email);
+    toolRef.lastBuildDate = this.dateService.getDateTimeMessage(new Date(this.tool.lastBuild).getTime());
+    toolRef.lastUpdatedDate = this.dateService.getDateTimeMessage(new Date(this.tool.lastBuild).getTime());
     toolRef.versionVerified = this.dockstoreService.getVersionVerified(toolRef.tags);
     toolRef.verifiedSources = this.dockstoreService.getVerifiedSources(toolRef);
     toolRef.verifiedLinks = this.dateService.getVerifiedLink();
@@ -126,14 +127,14 @@ export class ContainerComponent extends Entry {
     this.toolCopyBtnSubscription.unsubscribe();
   }
 
-  protected setUpTool(tool: any) {
+  protected setUpTool(tool: ExtendedDockstoreTool) {
     if (tool) {
       this.tool = tool;
       if (!tool.providerUrl) {
         this.providerService.setUpProvider(tool);
       }
       this.tool = Object.assign(tool, this.tool);
-      const toolRef: any = this.tool;
+      const toolRef: ExtendedDockstoreTool = this.tool;
       toolRef.buildMode = this.containerService.getBuildMode(toolRef.mode);
       toolRef.buildModeTooltip = this.containerService.getBuildModeTooltip(toolRef.mode);
       this.initTool();

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -1,3 +1,4 @@
+import { ExtendedDockstoreTool } from './../../shared/models/ExtendedDockstoreTool';
 /*
  *    Copyright 2017 OICR
  *
@@ -29,7 +30,7 @@ import { Component, OnInit, Input } from '@angular/core';
 export class InfoTabComponent implements OnInit {
   @Input() validVersions;
   @Input() defaultVersion;
-  tool: any;
+  tool: ExtendedDockstoreTool;
   public validationPatterns = validationPatterns;
   dockerFileEditing: boolean;
   cwlPathEditing: boolean;

--- a/src/app/shared/container.service.spec.ts
+++ b/src/app/shared/container.service.spec.ts
@@ -71,18 +71,16 @@ describe('ContainerService', () => {
     }));
 
     it('should get build mode', inject([ContainerService], (service: ContainerService) => {
-        expect(service.getBuildMode('AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS')).toEqual('Fully-Automated');
-        expect(service.getBuildMode('AUTO_DETECT_QUAY_TAGS_WITH_MIXED')).toEqual('Partially-Automated');
-        expect(service.getBuildMode('MANUAL_IMAGE_PATH')).toEqual('Manual');
-        expect(service.getBuildMode('mmmrrrggglll')).toEqual('Unknown');
+        expect(service.getBuildMode(DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS)).toEqual('Fully-Automated');
+        expect(service.getBuildMode(DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSWITHMIXED)).toEqual('Partially-Automated');
+        expect(service.getBuildMode(DockstoreTool.ModeEnum.MANUALIMAGEPATH)).toEqual('Manual');
     }));
 
     it('should get build mode tooltip', inject([ContainerService], (service: ContainerService) => {
-        expect(service.getBuildModeTooltip('AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS'))
+        expect(service.getBuildModeTooltip(DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS))
             .toEqual('Fully-Automated: All versions are automated builds');
-        expect(service.getBuildModeTooltip('AUTO_DETECT_QUAY_TAGS_WITH_MIXED'))
+        expect(service.getBuildModeTooltip(DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSWITHMIXED))
             .toEqual('Partially-Automated: At least one version is an automated build');
-        expect(service.getBuildModeTooltip('MANUAL_IMAGE_PATH')).toEqual('Manual: No versions are automated builds');
-        expect(service.getBuildModeTooltip('mmmrrrggglll')).toEqual('Unknown: Build information not known');
+        expect(service.getBuildModeTooltip(DockstoreTool.ModeEnum.MANUALIMAGEPATH)).toEqual('Manual: No versions are automated builds');
     }));
 });

--- a/src/app/shared/container.service.ts
+++ b/src/app/shared/container.service.ts
@@ -1,3 +1,4 @@
+import { DockstoreTool } from './swagger/model/dockstoreTool';
 /*
  *    Copyright 2017 OICR
  *
@@ -60,26 +61,26 @@ export class ContainerService {
     this.copyBtnSource.next(copyBtn);
   }
 
-  getBuildMode(mode: string) {
+  getBuildMode(mode: DockstoreTool.ModeEnum) {
     switch (mode) {
-      case 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS':
+      case DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS:
         return 'Fully-Automated';
-      case 'AUTO_DETECT_QUAY_TAGS_WITH_MIXED':
+      case DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSWITHMIXED:
         return 'Partially-Automated';
-      case 'MANUAL_IMAGE_PATH':
+      case DockstoreTool.ModeEnum.MANUALIMAGEPATH:
         return 'Manual';
       default:
         return 'Unknown';
     }
   }
 
-  getBuildModeTooltip(mode: string) {
+  getBuildModeTooltip(mode: DockstoreTool.ModeEnum) {
     switch (mode) {
-      case 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS':
+      case DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS:
         return 'Fully-Automated: All versions are automated builds';
-      case 'AUTO_DETECT_QUAY_TAGS_WITH_MIXED':
+      case DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSWITHMIXED:
         return 'Partially-Automated: At least one version is an automated build';
-      case 'MANUAL_IMAGE_PATH':
+      case DockstoreTool.ModeEnum.MANUALIMAGEPATH:
         return 'Manual: No versions are automated builds';
       default:
         return 'Unknown: Build information not known';

--- a/src/app/shared/models/ExtendedDockstoreTool.ts
+++ b/src/app/shared/models/ExtendedDockstoreTool.ts
@@ -1,0 +1,18 @@
+import { DockstoreTool } from './../swagger/model/dockstoreTool';
+export interface ExtendedDockstoreTool extends DockstoreTool {
+    agoMessage?: string;
+    // Stripped of 'mailto:'
+    email?: string;
+    // Build date in string format
+    lastBuildDate?: string;
+    // Update in string format
+    lastUpdatedDate?: string;
+    versionVerified?: any;
+    verifiedSources?: any;
+    verifiedLinks?: any;
+    imgProviderUrl?: string;
+    // The transformed git url
+    providerUrl?: string;
+    buildMode?: string;
+    buildModeTooltip?: string;
+}


### PR DESCRIPTION
Start taking advantage of swagger models and types.  There should be many more changes like this at some later date. 

This also uses the swagger DockstoreTool.ModeEnum.