### PR TITLE
Feature/modal fix easy

### DIFF
--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -13,7 +13,8 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<div *ngIf="isModalShown" [config]="{ show: true }" (onHidden)="onHidden()" bsModal #registerToolModal="bs-modal" class="modal fade" tabindex="-1"
+<div *ngIf="isModalShown">
+<div [config]="{ show: true }" (onHidden)="hideModal()" bsModal #registerToolModal="bs-modal" class="modal fade" tabindex="-1"
   role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -178,4 +179,5 @@
       </form>
     </div>
   </div>
+</div>
 </div>

--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -13,8 +13,8 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
-<div *ngIf="isModalShown" [config]="{ show: true }" (onHidden)="onHidden()" bsModal #autoShownModal="bs-modal" class="modal fade" tabindex="-1"
+<div *ngIf="isModalShown">
+<div [config]="{ show: true }" (onHidden)="onHidden()" bsModal #autoShownModal="bs-modal" class="modal fade" tabindex="-1"
   role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -216,4 +216,5 @@
       </form>
     </div>
   </div>
+</div>
 </div>

--- a/src/app/workflow/launch/workflow-launch.service.spec.ts
+++ b/src/app/workflow/launch/workflow-launch.service.spec.ts
@@ -32,7 +32,7 @@ describe('LaunchService', () => {
     expect(service.getParamsString('a/b', 'latest', 'cwl')).toContain(
       'dockstore workflow convert entry2json --entry a/b:latest > Dockstore.json');
     expect(service.getParamsString('a/b', 'latest', 'wdl')).toContain(
-      'dockstore workflow convert entry2json --entry --descriptor wdl a/b:latest > Dockstore.json');
+      'dockstore workflow convert entry2json --entry a/b:latest > Dockstore.json');
   }));
   it('should getCliString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {
     expect(service.getCliString('a/b', 'latest', 'cwl')).toContain(

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -18,12 +18,7 @@ import { LaunchService } from '../../shared/launch.service';
 import { Dockstore } from '../../shared/dockstore.model';
 export class WorkflowLaunchService extends LaunchService {
   getParamsString(path: string, versionName: string, currentDescriptor: string) {
-    let descriptor = '';
-
-    if (currentDescriptor === 'wdl') {
-      descriptor = WorkflowLaunchService.descriptorWdl;
-    }
-    return '$ dockstore workflow convert entry2json --entry' + descriptor + ` ${ path }:${ versionName } > Dockstore.json
+    return `$ dockstore workflow convert entry2json --entry ${ path }:${ versionName } > Dockstore.json
             \n$ vim Dockstore.json`;
   }
 

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -13,8 +13,8 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
-<div *ngIf="isModalShown" [config]="{ show: true }" (onHidden)="hideModal()" bsModal #registerWorkflowModal="bs-modal" class="modal fade" tabindex="-1"
+<div *ngIf="isModalShown">
+<div [config]="{ show: true }" (onHidden)="hideModal()" bsModal #registerWorkflowModal="bs-modal" class="modal fade" tabindex="-1"
   role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -116,4 +116,5 @@
       </form>
     </div>
   </div>
+</div>
 </div>

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -13,8 +13,8 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
-<div *ngIf="isModalShown" [config]="{ show: true }" (onHidden)="onHidden()" bsModal #autoShownModal="bs-modal" class="modal fade" tabindex="-1"
+<div *ngIf="isModalShown">
+<div [config]="{ show: true }" (onHidden)="hideModal()" bsModal #autoShownModal="bs-modal" class="modal fade" tabindex="-1"
   role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -129,4 +129,5 @@
       </form>
     </div>
   </div>
+</div>
 </div>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -66,7 +66,6 @@
           Actions
         </label>
       </th>
-      <app-version-modal></app-version-modal>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
For issue ga4gh/dockstore#952,  ga4gh/dockstore#947

Basically moving the *ngIf to the parent of the modal fixes it.
Removed a redundant modal.

Also removed '--descriptor wdl' from wdl workflows because apparently it's not needed.