### PR TITLE
Feature/issue 723

### DIFF
--- a/src/app/container/versions/versions.component.css
+++ b/src/app/container/versions/versions.component.css
@@ -14,3 +14,7 @@
  *    limitations under the License.
  */
 
+ .break {
+    word-break: break-word
+ }
+

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 
-<div>
+<div class="table-responsive">
   <table class="table versions-grid table-bordered table-condensed table-striped">
     <thead>
       <tr>
@@ -62,15 +62,15 @@
         </th>
       </tr>
     </thead>
-    <tbody>
+    <tbody >
       <tr *ngIf="versions.length === 0">
         <td colspan="7">
           <div class="text-center">No Records Found</div>
         </td>
       </tr>
       <tr *ngFor="let version of versions | orderBy : convertSorting()">
-        <td>
-          <input class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
+        <td style="word-break: break-word" >
+          <input  class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
             [value]="version.name" (click)="updateDefaultVersion(version.name)" [disabled]="publicPage" tooltip="Set as default branch"/> {{ version.name }}
         </td>
         <td>

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -69,7 +69,7 @@
         </td>
       </tr>
       <tr *ngFor="let version of versions | orderBy : convertSorting()">
-        <td style="word-break: break-word" >
+        <td class="break">
           <input  class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
             [value]="version.name" (click)="updateDefaultVersion(version.name)" [disabled]="publicPage" tooltip="Set as default branch"/> {{ version.name }}
         </td>

--- a/src/app/container/view/view.component.css
+++ b/src/app/container/view/view.component.css
@@ -13,8 +13,3 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-td {
-  word-wrap:break-word;
-  word-break:break-all;
-}

--- a/src/app/starring/starring.component.ts
+++ b/src/app/starring/starring.component.ts
@@ -96,7 +96,7 @@ export class StarringComponent implements OnInit {
   calculateRate(starredUsers: User[]) {
     if (!this.user) {
       this.rate = false;
-    }
+    } else {
     let matchingUser: User;
     matchingUser = starredUsers.find(user => user.id === this.user.id);
     if (matchingUser) {
@@ -104,6 +104,7 @@ export class StarringComponent implements OnInit {
     } else {
       this.rate = false;
     }
+  }
   }
 
   setStarring() {


### PR DESCRIPTION
For ga4gh/dockstore#723 .  The version table was protruding outside the tab contents for certain tools.  This is caused by the table contents simply being too long.  This is first bandage fixed by word-wrapping the version column when it gets too long.  It is then fixed with table-responsive so that whenever the table contents are too long, the table will be horizontally scroll-able.

This also fixes the starring component trying to use the user object when it already knows it cant' get it.