### PR TITLE
Feature/version modal fix

### DIFF
--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -104,7 +104,7 @@
           <div class="form-group form-group-sm" style="clear:both;">
             <div class="col-sm-offset-3 col-sm-9 col-md-9 col-lg-9 test_parameter_div" *ngFor="let item of unsavedCWLTestParameterFilePaths; let i = index;trackBy:trackByIndex;">
               <div class="input-group">
-                <input type="text" class="form-control" name="unsavedCWLTestParameterFilePaths[{{i}}]" [(ngModel)]="unsavedCWLTestParameterFilePaths[i]" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''" />
+                <input type="text" class="form-control" name="unsavedCWLTestParameterFilePaths[{{i}}]" [(ngModel)]="unsavedCWLTestParameterFilePaths[i]" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" disabled ng-class="editMode ? 'test_parameter_input' : ''" />
                 <button title="Remove CWL test parameter file" type="button" class="btn btn-danger test_parameter_remove_button" *ngIf="editMode" (click)="removeTestParameterFile(i, DescriptorType.CWL)">
                   <span class="glyphicon glyphicon-minus"></span>
                 </button>
@@ -130,7 +130,7 @@
           <div class="form-group form-group-sm" style="clear:both;">
             <div class="col-sm-offset-3 col-sm-9 col-md-9 col-lg-9 test_parameter_div" *ngFor="let item of unsavedWDLTestParameterFilePaths; let i = index;">
               <div class="input-group">
-                <input type="text" class="form-control" name="unsavedWDLTestParameterFilePaths[{{i}}]" [(ngModel)]="unsavedWDLTestParameterFilePaths[i]" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''" />
+                <input type="text" class="form-control" name="unsavedWDLTestParameterFilePaths[{{i}}]" [(ngModel)]="unsavedWDLTestParameterFilePaths[i]" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" disabled ng-class="editMode ? 'test_parameter_input' : ''" />
                 <button title="Remove WDL test parameter file" type="button" class="btn btn-danger test_parameter_remove_button" ng-hide="!editMode" (click)="removeTestParameterFile(i, DescriptorType.WDL)">
                   <span class="glyphicon glyphicon-minus"></span>
                 </button>

--- a/src/app/container/version-modal/version-modal.component.ts
+++ b/src/app/container/version-modal/version-modal.component.ts
@@ -109,26 +109,30 @@ export class VersionModalComponent implements OnInit, AfterViewChecked {
   }
 
   editTag() {
+    const message = 'Updating tag';
+    this.stateService.setRefreshMessage(message + '...');
     const id = this.tool.id;
     const tagName = this.version.name;
     const newCWL = this.unsavedCWLTestParameterFilePaths.filter(x => !this.savedCWLTestParameterFilePaths.includes(x));
     if (newCWL && newCWL.length > 0) {
-      this.containersService.addTestParameterFiles(id, newCWL, null, tagName, 'CWL').subscribe();
+      this.containersService.addTestParameterFiles(id, newCWL, null, tagName, 'CWL').subscribe(response => {},
+        err => this.refreshService.handleError(message, err) );
     }
     const missingCWL = this.savedCWLTestParameterFilePaths.filter(x => !this.unsavedCWLTestParameterFilePaths.includes(x));
     if (missingCWL && missingCWL.length > 0) {
-      this.containersService.deleteTestParameterFiles(id, missingCWL, tagName, 'CWL').subscribe();
+      this.containersService.deleteTestParameterFiles(id, missingCWL, tagName, 'CWL').subscribe(response => {},
+        err => this.refreshService.handleError(message, err) );
     }
     const newWDL = this.unsavedWDLTestParameterFilePaths.filter(x => !this.savedWDLTestParameterFilePaths.includes(x));
     if (newWDL && newWDL.length > 0) {
-      this.containersService.addTestParameterFiles(id, newWDL, null, tagName, 'WDL').subscribe();
+      this.containersService.addTestParameterFiles(id, newWDL, null, tagName, 'WDL').subscribe(response => {},
+        err => this.refreshService.handleError(message, err) );
     }
     const missingWDL = this.savedWDLTestParameterFilePaths.filter(x => !this.unsavedWDLTestParameterFilePaths.includes(x));
     if (missingWDL && missingWDL.length > 0) {
-      this.containersService.deleteTestParameterFiles(id, missingWDL, tagName, 'WDL').subscribe();
+      this.containersService.deleteTestParameterFiles(id, missingWDL, tagName, 'WDL').subscribe(response => {},
+        err => this.refreshService.handleError(message, err) );
     }
-    const message = 'Updating tag';
-    this.stateService.setRefreshMessage(message + '...');
     this.containertagsService.updateTags(id, [this.unsavedVersion]).subscribe(response => {
       this.tool.tags = response;
       this.containerService.setTool(this.tool);

--- a/src/app/container/version-modal/version-modal.component.ts
+++ b/src/app/container/version-modal/version-modal.component.ts
@@ -209,11 +209,17 @@ export class VersionModalComponent implements OnInit, AfterViewChecked {
       this.version = version;
       this.unsavedVersion = Object.assign({}, this.version);
     });
-    this.versionModalService.isModalShown.subscribe(isModalShown => this.isModalShown = isModalShown);
+    this.versionModalService.isModalShown.subscribe(isModalShown => {
+      if (this.tool) {
+        this.isModalShown = isModalShown;
+      } else {
+        this.versionModalService.setIsModalShown(false);
+      }
+    });
     this.versionModalService.mode.subscribe(
       (mode: TagEditorMode) => {
         this.mode = mode;
-        if (mode !== null) {
+        if (mode !== null && this.tool) {
           this.setMode(mode);
         }
       }


### PR DESCRIPTION
- Null check
- Disable editing of previous tool test parameter files for consistency (enable once we figure out form validation)
- Hook tool version editing to notifications (will need to chain the api calls similar to workflows)
- Handle some errors