### PR TITLE
Feature/default version indicator

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -30,7 +30,7 @@
   <div class="col-md-7">
     <h3 id="tool-path">
       <span id="verifiedIcon" *ngIf="tool?.versionVerified">
-        <a href= {{tool?.verifiedLinks}} class="verified-check">
+        <a href= {{getVerifiedLink()}} class="verified-check">
           <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
         </a>
       </span>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -35,7 +35,7 @@
         </a>
       </span>
       <span *ngIf="tool?.private_access" class="private-lock" tooltip="Private">
-          <span class="glyphicon glyphicon-lock"></span>
+          <app-private-icon></app-private-icon>
       </span>
       {{ tool?.tool_path }}
       <app-starring *ngIf="isToolPublic" (change)="starGazersChange()"></app-starring>

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -56,7 +56,7 @@ export class ContainerComponent extends Entry {
   private toolCopyBtnSubscription: Subscription;
   public toolCopyBtn: string;
   constructor(private dockstoreService: DockstoreService,
-    private dateService: DateService,
+    dateService: DateService,
     private imageProviderService: ImageProviderService,
     private listContainersService: ListContainersService,
     private refreshService: RefreshService,
@@ -70,7 +70,7 @@ export class ContainerComponent extends Entry {
     stateService: StateService,
     errorService: ErrorService) {
     super(trackLoginService, providerService, router,
-      stateService, errorService);
+      stateService, errorService, dateService);
     this._toolType = 'containers';
 
     // Initialize discourse urls
@@ -105,7 +105,6 @@ export class ContainerComponent extends Entry {
     toolRef.lastUpdatedDate = this.dateService.getDateTimeMessage(new Date(this.tool.lastBuild).getTime());
     toolRef.versionVerified = this.dockstoreService.getVersionVerified(toolRef.tags);
     toolRef.verifiedSources = this.dockstoreService.getVerifiedSources(toolRef);
-    toolRef.verifiedLinks = this.dateService.getVerifiedLink();
     if (!toolRef.imgProviderUrl) {
       toolRef = this.imageProviderService.setUpImageProvider(toolRef);
     }

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -19,15 +19,15 @@
     <thead>
       <tr>
         <th>
-          <label tooltip="Tags from Docker repository">
+          <label tooltip="Tags from Docker repository: The selected tag will be used
+          to populate the Info tab including 'Launch With'">
             Version
           </label>
           <span class="glyphicon pull-right" [ngClass]="getIconClass('name')" (click)="clickSortColumn('name')">
           </span>
         </th>
         <th>
-          <label tooltip="Git branches/tags: The selected reference and tag will be used
-                       to populate the info tab including 'launch with'">
+          <label tooltip="Git branches/tags">
             Git Reference
           </label>
           <span class="glyphicon pull-right" [ngClass]="getIconClass('reference')" (click)="clickSortColumn('reference')">

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -71,7 +71,7 @@
       <tr *ngFor="let version of versions | orderBy : convertSorting()">
         <td>
           <input class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
-            [value]="version.name" (click)="updateDefaultVersion(version.name)" [disabled]="publicPage" tooltip="Set as default branch"/> {{ version.name }}
+            [value]="version.name" (click)="updateDefaultVersion(version.name)" [tooltip]="getDefaultTooltip()"/> {{ version.name }}
         </td>
         <td>
           {{ version.reference || 'n/a' }}</td>

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -71,7 +71,7 @@
       <tr *ngFor="let version of versions | orderBy : convertSorting()">
         <td>
           <input class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
-            [value]="version.name" (click)="updateDefaultVersion(version.name)" [tooltip]="getDefaultTooltip()"/> {{ version.name }}
+            [value]="version.name" (click)="updateDefaultVersion(version.name)" [tooltip]="getDefaultTooltip(publicPage)"/> {{ version.name }}
         </td>
         <td>
           {{ version.reference || 'n/a' }}</td>

--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -64,7 +64,10 @@ export class VersionsContainerComponent extends Versions implements OnInit {
     return [5, 6];
   }
 
-  updateDefaultVersion(newDefaultVersion: string) {
+  updateDefaultVersion(newDefaultVersion: string): void {
+    if (this.publicPage) {
+      return;
+    }
     const message = 'Updating default tool version';
     this.tool.defaultVersion = newDefaultVersion;
     this.stateService.setRefreshMessage(message + '...');

--- a/src/app/containers/list/list.component.html
+++ b/src/app/containers/list/list.component.html
@@ -32,7 +32,7 @@
                 <a style="text-decoration: none" tooltip="Verified" class="glyphicon glyphicon-ok" href={{verifiedLink}}></a>
             </span>
             <span *ngIf="tool.private_access">
-                <span class="glyphicon glyphicon-lock"></span>
+                <app-private-icon></app-private-icon>
             </span>
             <a (click)="sendToolInfo(tool)" [routerLink]="['/containers', tool?.tool_path ]">{{ tool?.name +
               (tool?.toolname ? '/' + tool?.toolname : '') }}</a>

--- a/src/app/listentry/listentry.component.html
+++ b/src/app/listentry/listentry.component.html
@@ -31,7 +31,7 @@
             <a style="text-decoration: none" tooltip="Verified" class="glyphicon glyphicon-ok"></a>
         </span>
         <span *ngIf="(hit?._source).private_access" class="private-lock">
-            <span class="glyphicon glyphicon-lock"></span>
+            <app-private-icon></app-private-icon>
         </span>
         <a (click)="sendToolInfo(hit._source)" [routerLink]="['/containers', hit?._source.tool_path ]">{{ hit?._source.name +
           (hit?._source.toolname ? '/' + hit?._source.toolname : '') }}

--- a/src/app/listentry/listentry.module.ts
+++ b/src/app/listentry/listentry.module.ts
@@ -14,19 +14,22 @@
  *    limitations under the License.
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ListentryComponent } from './listentry.component';
-import { DataTablesModule } from 'angular-datatables';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { DataTablesModule } from 'angular-datatables';
 import { ClipboardModule } from 'ngx-clipboard';
+
+import { PrivateIconModule } from '../shared/private-icon/private-icon.module';
+import { ListentryComponent } from './listentry.component';
 
 @NgModule({
   imports: [
     CommonModule,
     RouterModule,
     DataTablesModule.forRoot(),
-    ClipboardModule
+    ClipboardModule,
+    PrivateIconModule
   ],
   declarations: [ListentryComponent],
   exports: [ListentryComponent]

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -1,3 +1,4 @@
+import { DateService } from './date.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -53,7 +54,7 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
     public providerService: ProviderService,
     public router: Router,
     private stateService: StateService,
-    private errorService: ErrorService) {
+    private errorService: ErrorService, public dateService: DateService) {
   }
 
   ngOnInit() {
@@ -67,6 +68,10 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
     this.stateService.publicPage$.subscribe(publicPage => this.publicPage = publicPage);
     this.stateService.refreshMessage$.subscribe(refreshMessage => this.refreshMessage = refreshMessage);
     this.loginSubscription = this.trackLoginService.isLoggedIn$.subscribe(state => this.isLoggedIn = state);
+  }
+
+  getVerifiedLink(): string {
+    return this.dateService.getVerifiedLink();
   }
 
   closeError(): void {

--- a/src/app/shared/models/ExtendedDockstoreTool.ts
+++ b/src/app/shared/models/ExtendedDockstoreTool.ts
@@ -9,7 +9,6 @@ export interface ExtendedDockstoreTool extends DockstoreTool {
     lastUpdatedDate?: string;
     versionVerified?: any;
     verifiedSources?: any;
-    verifiedLinks?: any;
     imgProviderUrl?: string;
     // The transformed git url
     providerUrl?: string;

--- a/src/app/shared/modules/container.module.ts
+++ b/src/app/shared/modules/container.module.ts
@@ -14,57 +14,54 @@
  *    limitations under the License.
  */
 
-import { ToolDescriptorService } from '../../container/descriptors/tool-descriptor.service';
-import { ErrorService } from './../../shared/error.service';
-import { InfoTabService } from './../../container/info-tab/info-tab.service';
-import { InfoTabComponent } from './../../container/info-tab/info-tab.component';
-import { VersionModalService } from './../../container/version-modal/version-modal.service';
-import { VersionModalComponent } from './../../container/version-modal/version-modal.component';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
-
-import { ClipboardModule } from 'ngx-clipboard';
+import { FormsModule } from '@angular/forms';
 import { DataTablesModule } from 'angular-datatables';
-import { HighlightJsModule, HighlightJsService } from '../angular2-highlight-js/lib/highlight-js.module';
 import { MarkdownModule } from 'angular2-markdown';
-import { StarringModule } from '../../starring/starring.module';
-
-/* External Library */
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { ShareButtonsModule } from 'ngx-sharebuttons';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ClipboardModule } from 'ngx-clipboard';
+import { ShareButtonsModule } from 'ngx-sharebuttons';
 
-import { AddTagComponent } from './../../container/add-tag/add-tag.component';
 import { ContainerComponent } from '../../container/container.component';
-import { ContainerService } from '../container.service';
-import { DateService } from '../date.service';
 import { DescriptorsComponent } from '../../container/descriptors/descriptors.component';
+import { ToolDescriptorService } from '../../container/descriptors/tool-descriptor.service';
 import { DockerfileComponent } from '../../container/dockerfile/dockerfile.component';
 import { FilesContainerComponent } from '../../container/files/files.component';
-import { FileService } from '../file.service';
-import { HeaderModule } from './header.module';
 import { LaunchComponent } from '../../container/launch/launch.component';
 import { ToolLaunchService } from '../../container/launch/tool-launch.service';
-import { ListContainersModule } from './list-containers.module';
-import { ModalComponent } from './../../container/deregister-modal/deregister-modal.component';
-import { OrderByModule } from '../../shared/modules/orderby.module';
 import { ParamfilesComponent } from '../../container/paramfiles/paramfiles.component';
-import { ParamfilesModule } from './paramfiles.module';
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
-import { RefreshService } from './../refresh.service';
-import { RegisterToolService } from './../../container/register-tool/register-tool.service';
-import { SelectModule } from './select.module';
 import { VersionsContainerComponent } from '../../container/versions/versions.component';
 import { ViewContainerComponent } from '../../container/view/view.component';
-import { WorkflowService } from '../workflow.service';
-import { StarringService } from '../../starring/starring.service';
-
+import { OrderByModule } from '../../shared/modules/orderby.module';
 import { StargazersModule } from '../../stargazers/stargazers.module';
+import { StarringModule } from '../../starring/starring.module';
+import { StarringService } from '../../starring/starring.service';
+import { HighlightJsModule, HighlightJsService } from '../angular2-highlight-js/lib/highlight-js.module';
+import { DateService } from '../date.service';
+import { FileService } from '../file.service';
+import { WorkflowService } from '../workflow.service';
+import { AddTagComponent } from './../../container/add-tag/add-tag.component';
+import { ModalComponent } from './../../container/deregister-modal/deregister-modal.component';
+import { InfoTabComponent } from './../../container/info-tab/info-tab.component';
+import { InfoTabService } from './../../container/info-tab/info-tab.service';
+import { RegisterToolService } from './../../container/register-tool/register-tool.service';
+import { VersionModalComponent } from './../../container/version-modal/version-modal.component';
+import { VersionModalService } from './../../container/version-modal/version-modal.service';
+import { ErrorService } from './../../shared/error.service';
+import { PrivateIconModule } from './../private-icon/private-icon.module';
+import { RefreshService } from './../refresh.service';
+import { HeaderModule } from './header.module';
+import { ListContainersModule } from './list-containers.module';
+import { ParamfilesModule } from './paramfiles.module';
+import { SelectModule } from './select.module';
+
 @NgModule({
   declarations: [
     ContainerComponent,
@@ -98,6 +95,7 @@ import { StargazersModule } from '../../stargazers/stargazers.module';
     FormsModule,
     ShareButtonsModule.forRoot(),
     OrderByModule,
+    PrivateIconModule,
     StarringModule,
     ModalModule,
     StargazersModule

--- a/src/app/shared/modules/list-containers.module.ts
+++ b/src/app/shared/modules/list-containers.module.ts
@@ -22,10 +22,9 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 
 import { ListContainersComponent } from '../../containers/list/list.component';
-
 import { ListContainersService } from '../../containers/list/list.service';
+import { PrivateIconModule } from '../private-icon/private-icon.module';
 import { HeaderModule } from './header.module';
-import { ContainerService } from '../container.service';
 
 @NgModule({
   declarations: [
@@ -38,6 +37,7 @@ import { ContainerService } from '../container.service';
     ClipboardModule,
     HeaderModule,
     TooltipModule.forRoot(),
+    PrivateIconModule
   ],
   providers: [
     ListContainersService

--- a/src/app/shared/private-icon/private-icon.component.css
+++ b/src/app/shared/private-icon/private-icon.component.css
@@ -1,0 +1,3 @@
+.no-underline {
+    text-decoration: none
+}

--- a/src/app/shared/private-icon/private-icon.component.html
+++ b/src/app/shared/private-icon/private-icon.component.html
@@ -1,0 +1,3 @@
+<a [href]="privateDocsLink" class="verified-check no-underline">
+  <span class="glyphicon glyphicon-lock"></span>
+</a>

--- a/src/app/shared/private-icon/private-icon.component.ts
+++ b/src/app/shared/private-icon/private-icon.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-private-icon',
+  templateUrl: './private-icon.component.html',
+  styleUrls: ['./private-icon.component.css']
+})
+export class PrivateIconComponent {
+
+  // Change this link if necessary
+  readonly privateDocsLink = '/docs/public_private_tools';
+  constructor() { }
+}

--- a/src/app/shared/private-icon/private-icon.module.ts
+++ b/src/app/shared/private-icon/private-icon.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PrivateIconComponent } from './private-icon.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [PrivateIconComponent],
+  exports: [PrivateIconComponent]
+})
+export class PrivateIconModule { }

--- a/src/app/shared/versions.ts
+++ b/src/app/shared/versions.ts
@@ -28,6 +28,8 @@ export abstract class Versions {
   defaultVersion: string;
   verifiedLink: string;
   dtOptions;
+  readonly defaultBranchDescription = 'The default branch uniquely identifies the branch of a tool/workflow. ' +
+  'Determines what is displayed in the Info tab (Description, Launch With, etc)';
 
   abstract setNoOrderCols(): Array<number>;
 
@@ -42,11 +44,11 @@ export abstract class Versions {
     this.stateService.publicPage$.subscribe(publicPage => this.publicPage = publicPage);
   }
 
-  getDefaultTooltip(): string {
-    if (this.publicPage) {
-      return 'Default branch';
+  getDefaultTooltip(publicPage: boolean): string {
+    if (publicPage) {
+      return 'Default branch: ' + this.defaultBranchDescription;
     } else {
-      return 'Set as default branch';
+      return 'Set as default branch. ' + this.defaultBranchDescription;
     }
   }
 

--- a/src/app/shared/versions.ts
+++ b/src/app/shared/versions.ts
@@ -42,6 +42,14 @@ export abstract class Versions {
     this.stateService.publicPage$.subscribe(publicPage => this.publicPage = publicPage);
   }
 
+  getDefaultTooltip(): string {
+    if (this.publicPage) {
+      return 'Default branch';
+    } else {
+      return 'Set as default branch';
+    }
+  }
+
   clickSortColumn(columnName) {
     if (this.sortColumn === columnName) {
       this.sortReverse = !this.sortReverse;

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -76,8 +76,8 @@
     </tr>
     <tr *ngFor="let version of versions">
       <td><input class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion"
-                     [(ngModel)]="defaultVersion" [value]="version.reference" (click)="updateDefaultVersion(version.reference)" [disabled]="publicPage"
-                     tooltip="Set as default branch"/>{{ version.reference || 'n/a' }}</td>
+                     [(ngModel)]="defaultVersion" [value]="version.reference" (click)="updateDefaultVersion(version.reference)"
+                     [tooltip]="getDefaultTooltip()"/>{{ version.reference || 'n/a' }}</td>
       <td>{{ version.workflow_path }}</td>
       <td>{{ getDateTimeString(version.last_modified) }}</td>
       <td>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -77,7 +77,7 @@
     <tr *ngFor="let version of versions">
       <td><input class="radio-button-reference" *ngIf="version.name !== 'latest' && (!publicPage || (publicPage && defaultVersion ===version.name)) " type="radio" name="defaultVersion"
                      [(ngModel)]="defaultVersion" [value]="version.reference" (click)="updateDefaultVersion(version.reference)"
-                     [tooltip]="getDefaultTooltip()"/>{{ version.reference || 'n/a' }}</td>
+                     [tooltip]="getDefaultTooltip(publicPage)"/>{{ version.reference || 'n/a' }}</td>
       <td>{{ version.workflow_path }}</td>
       <td>{{ getDateTimeString(version.last_modified) }}</td>
       <td>

--- a/src/app/workflow/versions/versions.component.spec.ts
+++ b/src/app/workflow/versions/versions.component.spec.ts
@@ -63,6 +63,7 @@ describe('VersionsWorkflowComponent', () => {
   });
   it('should update default version and then set current workflow based on response', () => {
     const workflowVersion: WorkflowVersion = {id: 5, reference: 'stuff', name: 'name'};
+    component.publicPage = false;
     component.updateDefaultVersion('name');
     fixture.detectChanges();
     workflowService.workflow$.subscribe(workflow => expect(workflow).toEqual(updatedWorkflow));

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -67,7 +67,10 @@ export class VersionsWorkflowComponent extends Versions implements OnInit {
     });
   }
 
-  updateDefaultVersion(newDefaultVersion: string) {
+  updateDefaultVersion(newDefaultVersion: string): void {
+    if (this.publicPage) {
+      return;
+    }
     const message = 'Updating default workflow version';
     this.workflow.defaultVersion = newDefaultVersion;
     this.stateService.setRefreshMessage(message + '...');

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -30,7 +30,7 @@
   <div class="col-md-7">
     <h3 id="workflow-path">
       <span id="verifiedIcon" *ngIf="workflow?.versionVerified">
-        <a href= {{workflow?.verifiedLinks}} class="verified-check">
+        <a href= {{getVerifiedLink()}} class="verified-check">
           <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
         </a>
       </span>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -53,12 +53,12 @@ export class WorkflowComponent extends Entry {
   private workflowSubscription: Subscription;
   private workflowCopyBtnSubscription: Subscription;
   private workflowCopyBtn: string;
-  constructor(private dockstoreService: DockstoreService, private dateService: DateService, private refreshService: RefreshService,
+  constructor(private dockstoreService: DockstoreService, dateService: DateService, private refreshService: RefreshService,
     private workflowsService: WorkflowsService, trackLoginService: TrackLoginService, providerService: ProviderService,
     router: Router, private workflowService: WorkflowService,
     stateService: StateService, errorService: ErrorService) {
     super(trackLoginService, providerService, router,
-      stateService, errorService);
+      stateService, errorService, dateService);
     this._toolType = 'workflows';
 
     // Initialize discourse urls
@@ -92,7 +92,6 @@ export class WorkflowComponent extends Entry {
     workflowRef.agoMessage = this.dateService.getAgoMessage(workflowRef.last_modified);
     workflowRef.versionVerified = this.dockstoreService.getVersionVerified(workflowRef.workflowVersions);
     workflowRef.verifiedSources = this.dockstoreService.getVerifiedWorkflowSources(workflowRef);
-    workflowRef.verifiedLinks = this.dateService.getVerifiedLink();
     this.resetWorkflowEditData();
     if (workflowRef.path && workflowRef.descriptorType === 'wdl') {
       const myParams = new URLSearchParams();


### PR DESCRIPTION
A few changes to the default version indicator:
- Never disabled.  Apparently chrome disables the tooltip when the radio button is disabled, but firefox doesn't.  Clicking the radio button does nothing on a public page.
- Change tooltip of the radio button so that it is different between public vs private page.  Also add lengthy descripton to tooltip indicating what default branch does.
- Moved the tooltip from the git reference column header to the version column header to indicate that the version column is used to select the default branch.

Removed the property 'verifiedLink' from the tool/workflow ref objects because the link is always the same.

Created a private icon component and module to link to private docs

Also reformatted some imports