### PR TITLE
Feature/incorrect redirect url handling

### DIFF
--- a/cypress/integration/dropdown.js
+++ b/cypress/integration/dropdown.js
@@ -47,7 +47,16 @@ describe('Dropdown test', function() {
                 .get('h4').contains('GitLab').contains('Link Account')
         });
     });
-
+    var everythingOk = function() {
+        cy
+        .get('h4').contains('GitHub').contains('Unlink Account')
+        cy
+        .get('h4').contains('Quay.io').contains('Unlink Account')
+        cy
+        .get('h4').contains('Bitbucket').contains('Link Account')
+        cy
+        .get('h4').contains('GitLab').contains('Link Account')
+    }
     describe('Go to setup page', function() {
         beforeEach(function() {
             // Select dropdown setup
@@ -57,16 +66,28 @@ describe('Dropdown test', function() {
         });
 
         it('Should show all accounts as linked (except GitLab and Bitbucket)', function() {
-            cy
-                .get('h4').contains('GitHub').contains('Unlink Account')
-            cy
-                .get('h4').contains('Quay.io').contains('Unlink Account')
-            cy
-                .get('h4').contains('Bitbucket').contains('Link Account')
-            cy
-                .get('h4').contains('GitLab').contains('Link Account')
+            everythingOk();
+            cy.visit('http://localhost:4200/auth/gitlab.com?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
+                expect(resp.status).to.eq('')
+            })
+            everythingOk();
+            cy.visit('http://localhost:4200/auth/bitbucket.org?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
+                expect(resp.status).to.eq('')
+            })
+            everythingOk();
+            cy.visit('http://localhost:4200/auth/potato.com?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
+                expect(resp.status).to.eq('')
+            })
+            everythingOk();
+            cy.visit('http://localhost:4200/auth/github.com?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
+                expect(resp.status).to.eq('')
+            })
+            everythingOk();
+            cy.visit('http://localhost:4200/auth/quay.io?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
+                expect(resp.status).to.eq('')
+            })
+            everythingOk();
         });
-
         // TODO: this part of the wizard has been reworked
         // it('Go through steps', function() {
         //     // Should start on step 1

--- a/cypress/integration/dropdown.js
+++ b/cypress/integration/dropdown.js
@@ -37,25 +37,14 @@ describe('Dropdown test', function() {
         });
 
         it('Should show all accounts as linked (except GitLab and Bitbucket)', function() {
-            cy
-                .get('h4').contains('GitHub').contains('Unlink Account')
-            cy
-                .get('h4').contains('Quay.io').contains('Unlink Account')
-            cy
-                .get('h4').contains('Bitbucket').contains('Link Account')
-            cy
-                .get('h4').contains('GitLab').contains('Link Account')
+            everythingOk();
         });
     });
     var everythingOk = function() {
-        cy
-        .get('h4').contains('GitHub').contains('Unlink Account')
-        cy
-        .get('h4').contains('Quay.io').contains('Unlink Account')
-        cy
-        .get('h4').contains('Bitbucket').contains('Link Account')
-        cy
-        .get('h4').contains('GitLab').contains('Link Account')
+            cy.get('#unlink-GitHub').should('be.visible')
+            cy.get('#unlink-Quay').should('be.visible')
+            cy.get('#link-Bitbucket').should('be.visible')
+            cy.get('#link-GitLab').should('be.visible')
     }
     describe('Go to setup page', function() {
         beforeEach(function() {

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -4,7 +4,7 @@
     <div *ngFor="let row of accountsInfo">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h4 class="panel-title">{{ row.name }}
+          <h4 class="panel-title">{{ row.name }} Account
             <span *ngIf="row.isLinked">
               <span class="label label-success">
                 <span class="glyphicon glyphicon-link"></span>
@@ -24,12 +24,12 @@
                   </span>
                 </span>
               </span>
-              <button class="pull-right btn btn-default btn-sm" (click)="unlink(row.source)">
+              <button [attr.id]="'unlink-' + row.name" class="pull-right btn btn-default btn-sm" (click)="unlink(row.source)">
                 <span class="text-danger glyphicon glyphicon-link"></span>
                 <span class="text-danger">Unlink Account</span>
               </button>
             </span>
-            <button *ngIf="!row.isLinked" class="pull-right btn btn-primary btn-sm" (click)="link(row.source)">
+            <button [attr.id]="'link-' + row.name" *ngIf="!row.isLinked" class="pull-right btn btn-primary btn-sm" (click)="link(row.source)">
               <span class="glyphicon glyphicon-link"></span>
               <span>Link Account</span>
             </button>

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -24,28 +24,28 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
 
   accountsInfo: Array<any> = [
     {
-      name: 'GitHub Account',
+      name: 'GitHub',
       source: TokenSource.GITHUB,
       bold: 'Required',
       message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub.',
       show: false
     },
     {
-      name: 'Quay.io Account',
+      name: 'Quay',
       source: TokenSource.QUAY,
       bold: 'Optional',
       message: 'Quay.io credentials are used for pulling information about Docker images and automated builds.',
       show: false
     },
     {
-      name: 'Bitbucket Account',
+      name: 'Bitbucket',
       source: TokenSource.BITBUCKET,
       bold: 'Optional',
       message: 'Bitbucket credentials are used for pulling source code from Bitbucket.',
       show: false
     },
     {
-      name: 'GitLab Account',
+      name: 'GitLab',
       source: TokenSource.GITLAB,
       bold: 'Optional',
       message: 'GitLab credentials are used for pulling source code from GitLab.',

--- a/src/app/loginComponents/auth/auth.component.spec.ts
+++ b/src/app/loginComponents/auth/auth.component.spec.ts
@@ -1,0 +1,30 @@
+import { RouterTestingModule } from '@angular/router/testing';
+import { TokensStubService, TokenStubService } from './../../test/service-stubs';
+import { TokenService } from '../token.service';
+import { AuthComponent } from './auth.component';
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+
+
+describe('AuthComponent', () => {
+  let component: AuthComponent;
+  let fixture: ComponentFixture<AuthComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AuthComponent],
+      imports: [ RouterTestingModule ],
+      providers: [{provide: TokenService, useClass: TokenStubService}]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/loginComponents/auth/auth.component.ts
+++ b/src/app/loginComponents/auth/auth.component.ts
@@ -58,7 +58,7 @@ export class AuthComponent implements OnInit, OnDestroy {
             return addGitLabToken;
           default: {
             console.log('Unknown provider: ' + provider);
-            return null;
+            return Observable.of(null);
           }
         }
       });
@@ -68,7 +68,9 @@ export class AuthComponent implements OnInit, OnDestroy {
     const prevPage = localStorage.getItem('page');
 
     this.tokenSubscription = this.addToken().subscribe(token => {
-      this.tokenService.updateTokens();
+      if (token) {
+        this.tokenService.updateTokens();
+      }
       this.router.navigate([`${ prevPage }`]);
     });
   }

--- a/src/app/loginComponents/auth/auth.component.ts
+++ b/src/app/loginComponents/auth/auth.component.ts
@@ -72,6 +72,8 @@ export class AuthComponent implements OnInit, OnDestroy {
         this.tokenService.updateTokens();
       }
       this.router.navigate([`${ prevPage }`]);
+    }, error => {
+      this.router.navigate([`${ prevPage }`]);
     });
   }
 

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -302,6 +302,11 @@ export class UserStubService {
     user$ = Observable.of({});
 }
 
+export class TokenStubService {
+    updateTokens(): void {
+    }
+}
+
 export class TokensStubService {
     public addQuayToken(accessToken?: string, extraHttpRequestParams?: any): Observable<Token> {
         return Observable.of(quayToken);


### PR DESCRIPTION
For issue ga4gh/dockstore#985.  Returning null causing an error leading to page being stuck.  Fixed by returning Observable.of(null). 

Can't test with Cypress due to `Cypress does not allow you to change superdomains within a single test.`

An option would be to:

`Alternatively you can also disable Chrome Web Security which will turn off this restriction by setting { chromeWebSecurity: false } in your 'cypress.json' file.`  which I don't really recommend.

Currently using karma to test this fix.  It correctly fails with the error prior to the fix.  It correctly passes with the fix.