### PR TITLE
Fix for subscription

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -36,8 +36,7 @@ export class DownloadCLIClientComponent implements OnInit {
         apiVersion = resultFromApi.version;
         this.dockstoreVersion = `${apiVersion}`;
         this.downloadCli = `https://github.com/ga4gh/dockstore/releases/download/${apiVersion}/dockstore`;
-      });
-    this.textData1 = `
+        this.textData1 = `
 ### Setup Command Line Interface
 ------------------------------
 #### Part 1
@@ -57,8 +56,8 @@ source ~/.bashrc
 \`\`\`
 4. Alternatively, click here to download and configure the cli yourself
 
-      `;
-    this.textData2 = `
+`;
+        this.textData2 = `
 #### Part 2
 1. Create the folder <code>~/.dockstore</code> and create a configuration file \`~/.dockstore/config\`:
 \`\`\`
@@ -66,8 +65,8 @@ mkdir -p ~/.dockstore
 printf "token: ${this.dsToken}\\nserver-url: ${this.dsServerURI}\\n" > ~/.dockstore/config
 \`\`\`
 2. Alternatively, copy this content to your config file directly
-    `;
-    this.textData3 = `
+`;
+        this.textData3 = `
 #### Part 3
 If you want to launch CWL tools and workflows, Dockstore relies upon [cwltool](https://github.com/common-workflow-language/cwltool) being available on your PATH.  This will require [pip](https://pip.pypa.io/en/latest/installing/)" if it is not already installed.
 
@@ -102,6 +101,7 @@ Hello from Docker!
 ...
 \`\`\`
 In addition to the tools mentioned above you can install an editor capable of syntax highlighting Dockerfiles such as [Atom](https://atom.io/).
-      `;
+`;
+      });
   }
 }

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -17,9 +17,9 @@ export class DownloadCLIClientComponent implements OnInit {
   public cwltoolVersion = '1.0.20170828135420';
   public dsServerURI: any;
   public isCopied2: boolean;
-  public textData1;
-  public textData2;
-  public textData3;
+  public textData1 = '';
+  public textData2 = '';
+  public textData3 = '';
 
   constructor(private authService: AuthService,
     private gA4GHService: GA4GHService) { }
@@ -36,7 +36,13 @@ export class DownloadCLIClientComponent implements OnInit {
         apiVersion = resultFromApi.version;
         this.dockstoreVersion = `${apiVersion}`;
         this.downloadCli = `https://github.com/ga4gh/dockstore/releases/download/${apiVersion}/dockstore`;
-        this.textData1 = `
+        this.generateMarkdown();
+      }, error => {
+        this.generateMarkdown();
+      });
+  }
+  generateMarkdown(): void {
+    this.textData1 = `
 ### Setup Command Line Interface
 ------------------------------
 #### Part 1
@@ -57,7 +63,7 @@ source ~/.bashrc
 4. Alternatively, click here to download and configure the cli yourself
 
 `;
-        this.textData2 = `
+    this.textData2 = `
 #### Part 2
 1. Create the folder <code>~/.dockstore</code> and create a configuration file \`~/.dockstore/config\`:
 \`\`\`
@@ -66,7 +72,7 @@ printf "token: ${this.dsToken}\\nserver-url: ${this.dsServerURI}\\n" > ~/.dockst
 \`\`\`
 2. Alternatively, copy this content to your config file directly
 `;
-        this.textData3 = `
+    this.textData3 = `
 #### Part 3
 If you want to launch CWL tools and workflows, Dockstore relies upon [cwltool](https://github.com/common-workflow-language/cwltool) being available on your PATH.  This will require [pip](https://pip.pypa.io/en/latest/installing/)" if it is not already installed.
 
@@ -102,6 +108,5 @@ Hello from Docker!
 \`\`\`
 In addition to the tools mentioned above you can install an editor capable of syntax highlighting Dockerfiles such as [Atom](https://atom.io/).
 `;
-      });
   }
 }

--- a/src/app/loginComponents/onboarding/quickstart.component.html
+++ b/src/app/loginComponents/onboarding/quickstart.component.html
@@ -15,7 +15,7 @@
   -->
 
 <app-header>
-  <span class="glyphicon glyphicon-tasks"></span>
+  <span class="glyphicon glyphicon-flash"></span>
   QuickStart Wizard
 </app-header>
 <div class="container">


### PR DESCRIPTION
Fix for the dockstore version and api version not showing up on slow networks.  Simply initializing within the subscription instead of outside it.   Formatting is responsible for 6/7 lines added/deleted.

Also might as well fix the ga4gh/dockstore#1010