### PR TITLE
Use google url shortener on permalinks if possible

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -134,9 +134,9 @@
             <ng-template #popTemplate>
               <div class="row">
                 <div class="input-group" style="padding:5px;">
-                  <input type="text" class="form-control" [(ngModel)]="permalink" value="{{permalink}}" readonly>
+                  <input type="text" class="form-control" [(ngModel)]="shortUrl" value="{{shortUrl}}" readonly>
                   <span class="input-group-btn">
-                    <button class="btn btn-default" [ngClass]="{'btn-copy': isCopied}" type="button" ngxClipboard [cbContent]="permalink"
+                    <button class="btn btn-default" [ngClass]="{'btn-copy': isCopied}" type="button" ngxClipboard [cbContent]="shortUrl"
                       (cbOnSuccess)="isCopied = true">
                       <span class="glyphicon glyphicon-copy"></span>
                     </button>

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -25,6 +25,7 @@ import { SearchComponent } from './search.component';
 import { FormsModule } from '@angular/forms';
 import { TagCloudModule } from 'angular-tag-cloud-module/dist';
 import { TabsModule } from 'ngx-bootstrap/tabs';
+import { HttpClientModule } from '@angular/common/http';
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -38,7 +39,7 @@ describe('SearchComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SearchComponent ],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [RouterTestingModule, AccordionModule.forRoot()],
+      imports: [RouterTestingModule, AccordionModule.forRoot(), HttpClientModule],
       providers: [
         {provide: SearchService, useClass: SearchStubService},
         { provide: QueryBuilderService, useClass: QueryBuilderStubService },

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -17,9 +17,10 @@
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router/';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
-
+import { Dockstore } from './../shared/dockstore.model';
 import { CategorySort } from '../shared/models/CategorySort';
 import { SubBucket } from '../shared/models/SubBucket';
 import { ProviderService } from '../shared/provider.service';
@@ -37,7 +38,7 @@ import { SearchService } from './search.service';
 export class SearchComponent implements OnInit {
   public advancedSearchObject: AdvancedSearchObject;
   private routeSub: Subscription;
-  public permalink: string;
+  public shortUrl: string;
   /** current set of search results
    * TODO: this stores all results, but the real implementation should limit results
    * and paginate to be scalable
@@ -117,7 +118,8 @@ export class SearchComponent implements OnInit {
     public searchService: SearchService,
     private advancedSearchService: AdvancedSearchService,
     private router: Router,
-    private Location: Location) {
+    private Location: Location,
+    private http: HttpClient) {
     this.location = Location;
     // Initialize mappings
     this.bucketStubs = this.searchService.initializeBucketStubs();
@@ -344,8 +346,8 @@ export class SearchComponent implements OnInit {
     };
 
     const linkArray = this.searchService.createPermalinks(searchInfo);
-    this.permalink = linkArray[0] + '?' + linkArray[1];
     this.location.go('search?' + linkArray[1]);
+    this.setShortUrl(linkArray[0] + '?' + linkArray[1]);
   }
 
   /**===============================================
@@ -410,6 +412,18 @@ export class SearchComponent implements OnInit {
         this.suggestKeyTerm();
       }
     });
+  }
+
+  // Given a URL, will attempt to shorten it
+  setShortUrl(url: string) {
+    const googleUrlShortenerBase = 'https://www.googleapis.com/urlshortener/v1/url?key=';
+    const body = {'longUrl': url};
+    const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body)
+
+    const sub = req.subscribe(
+      data => { this.shortUrl = data['id'];},
+      err => { this.shortUrl = url; }
+    );
   }
 
   /**===============================================
@@ -568,6 +582,7 @@ export class SearchComponent implements OnInit {
     this.orderedBuckets.get(category).Items = orderedMap2;
     this.sortModeMap.get(category).SortBy = sortMode;
   }
+
   /**===============================================
    *                Helper Functions
    * ===============================================

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -418,10 +418,10 @@ export class SearchComponent implements OnInit {
   setShortUrl(url: string) {
     const googleUrlShortenerBase = 'https://www.googleapis.com/urlshortener/v1/url?key=';
     const body = {'longUrl': url};
-    const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body)
+    const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body);
 
     const sub = req.subscribe(
-      data => { this.shortUrl = data['id'];},
+      data => { this.shortUrl = data['id']; },
       err => { this.shortUrl = url; }
     );
   }

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -17,6 +17,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import { TagCloudModule } from 'angular-tag-cloud-module';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -57,7 +58,8 @@ import { SearchService } from './search.service';
     BsDropdownModule.forRoot(),
     PopoverModule.forRoot(),
     ClipboardModule,
-    searchRouting
+    searchRouting,
+    HttpClientModule
   ],
   providers: [AdvancedSearchService, SearchService, QueryBuilderService, {provide: TooltipConfig, useFactory: getTooltipConfig}],
   exports: [SearchComponent]

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -67,7 +67,7 @@ export class SearchService {
   // Given a search info object, will create the permalink for the current search
   createPermalinks(searchInfo) {
     // For local testing, use LOCAL_URI, else use HOSTNAME
-    let url = `${ Dockstore.HOSTNAME }/search`;
+    const url = `${ Dockstore.HOSTNAME }/search`;
     const params = new URLSearchParams();
     const filter = searchInfo.filter;
     filter.forEach(

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -66,7 +66,8 @@ export class SearchService {
   }
   // Given a search info object, will create the permalink for the current search
   createPermalinks(searchInfo) {
-    const url = `${ Dockstore.LOCAL_URI }/search`;
+    // For local testing, use LOCAL_URI, else use HOSTNAME
+    let url = `${ Dockstore.HOSTNAME }/search`;
     const params = new URLSearchParams();
     const filter = searchInfo.filter;
     filter.forEach(

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -25,6 +25,9 @@ export class Dockstore {
   // Discourse URL MUST end with a slash (/)
   static readonly DISCOURSE_URL = 'http://localhost/';
 
+  // Google Shortener API key
+  static readonly GOOGLE_SHORTENER_KEY = 'fill_this_in';
+
   static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;
   static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
   static readonly DNASTACK_IMPORT_URL= 'https://app.dnastack.com/#/app/workflow/import/dockstore';

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -25,7 +25,7 @@ export class Dockstore {
   // Discourse URL MUST end with a slash (/)
   static readonly DISCOURSE_URL = 'http://localhost/';
 
-  // Google Shortener API key
+  // Google Shortener API key (https://developers.google.com/url-shortener/v1/getting_started#APIKey)
   static readonly GOOGLE_SHORTENER_KEY = 'fill_this_in';
 
   static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;


### PR DESCRIPTION
Uses URL shortener for permalinks.
Note dockstore.model.ts has new field GOOGLE_SHORTENER_KEY, we will need to generate an API key with a new dockstore email address

[Issue #924](https://github.com/ga4gh/dockstore/issues/924)