### PR TITLE
Update Cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/jasmine": "2.5.38",
     "@types/jasminewd2": "~2.0.2",
     "codelyzer": "~3.1.1",
-    "cypress": "0.20.1",
+    "cypress": "1.0.3",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",


### PR DESCRIPTION
Suppposedly fixes the `TypeError: Cannot read property '0' of null` when running Cypress in CI