### PR TITLE
relaxed tool version validation

### DIFF
--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -41,7 +41,7 @@ export const validationPatterns = {
   'imagePath': '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$',
   'toolName': '^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$',
   'label': '^(| *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)( *, *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))* *)$',
-  'versionTag': '^[a-zA-Z0-9]+([-_\.][a-zA-Z0-9]+)*$',
+  'versionTag': '^[a-zA-Z0-9]+([-_\.]*[a-zA-Z0-9]+)*$',
   'reference': '[\\w-]+((/|.)[\\w-]+)*',
   'workflowDescriptorPath': '^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl|yaml|yml)',
   'workflowName': '[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*',


### PR DESCRIPTION
* relaxes validation for tool version as mentioned in ga4gh/dockstore#776 (allows for consecutive inner - and _ )
