### PR TITLE
Fix login to create tokens of the same scope as account linking

### DIFF
--- a/src/app/shared/auth.model.ts
+++ b/src/app/shared/auth.model.ts
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
 import { CustomConfig } from 'ng2-ui-auth';
 
 import { Dockstore } from '../shared/dockstore.model';
@@ -24,7 +23,8 @@ export class AuthConfig extends CustomConfig {
   providers = {
     github: {
       url: Dockstore.API_URI + '/auth/tokens/github',
-      clientId: Dockstore.GITHUB_CLIENT_ID
+      clientId: Dockstore.GITHUB_CLIENT_ID,
+      scope: Dockstore.GITHUB_SCOPE
     }
   };
 }


### PR DESCRIPTION
This one line/error took entirely too long to discover. 
The issue was that logging in would create a token of completely different scope from the linking account button, causing newly logged in users to be unable to refresh workflows out of the box. 
  