### PR TITLE
Feature/register workflow fix

### DIFF
--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.spec.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.spec.ts
@@ -65,14 +65,18 @@ describe('Service: paramFiles.service.ts', () => {
     }));
     it('should set register error and clear refreshing state', inject([RegisterWorkflowModalService, StateService],
         (service: RegisterWorkflowModalService, stateService: StateService) => {
-        service.setWorkflowRegisterError('oh no!', 'oh yes');
-        service.workflowRegisterError$.subscribe(error => expect(error).toEqual(expectedError));
-        stateService.refreshMessage$.subscribe(refreshMessage => expect(refreshMessage).toBeFalsy());
-    }));
+            service.setWorkflowRegisterError('oh no!', 'oh yes');
+            service.workflowRegisterError$.subscribe(error => expect(error).toEqual(expectedError));
+            stateService.refreshMessage$.subscribe(refreshMessage => expect(refreshMessage).toBeFalsy());
+        }));
     it('should set register workflow and clear refreshing state and error', inject([RegisterWorkflowModalService, StateService],
         (service: RegisterWorkflowModalService, stateService: StateService) => {
-        service.registerWorkflow();
-        service.isModalShown$.subscribe(isModalShown => expect(isModalShown).toEqual(false));
-        service.workflowRegisterError$.subscribe(isModalShown => expect(isModalShown).toBeFalsy);
-    }));
+            service.registerWorkflow();
+            service.isModalShown$.subscribe(isModalShown => expect(isModalShown).toEqual(false));
+            service.workflowRegisterError$.subscribe(isModalShown => expect(isModalShown).toBeFalsy);
+        }));
+    it('should have not error on getDescriptorLanguageKeys()',
+        inject([RegisterWorkflowModalService], (service: RegisterWorkflowModalService) => {
+            service.getDescriptorLanguageKeys();
+        }));
 });

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.spec.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.spec.ts
@@ -77,6 +77,8 @@ describe('Service: paramFiles.service.ts', () => {
         }));
     it('should have not error on getDescriptorLanguageKeys()',
         inject([RegisterWorkflowModalService], (service: RegisterWorkflowModalService) => {
-            service.getDescriptorLanguageKeys();
+            const descriptorLanguageKeys: Array<String> = service.getDescriptorLanguageKeys();
+            expect(descriptorLanguageKeys.includes('CWL'));
+            expect(descriptorLanguageKeys.includes('WDL'));
         }));
 });

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -105,7 +105,7 @@ export class RegisterWorkflowModalService {
 
     getDescriptorLanguageKeys(): Array<string> {
       if (this.descriptorLanguageMap) {
-        return this.descriptorLanguageMap.map((a) => a.enum.toString());
+        return this.descriptorLanguageMap.map((a) => a.value);
       }
     }
 }


### PR DESCRIPTION
Simple fix for the console error that appears when "Register Workflow" button is clicked.

A test to accompany getDescriptorLanguageKeys()

