### PR TITLE
Feature/validation fixes

### DIFF
--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -136,7 +136,8 @@
               Docker Registry Path:
             </label>
             <div class="col-sm-9">
-              <input id="dockerRegistryPathInput" class="form-control" name="customDockerRegistryPath" [(ngModel)]="customDockerRegistryPath" maxlength="256" tooltip="Custom Docker registry path" placeholder="e.g. registry.hub.docker.com" [disabled]="!showCustomDockerRegistryPath" />
+              <input id="dockerRegistryPathInput" class="form-control" name="customDockerRegistryPath" [(ngModel)]="customDockerRegistryPath" maxlength="256" tooltip="Custom Docker registry path" placeholder="e.g. registry.hub.docker.com" [disabled]="!showCustomDockerRegistryPath" [pattern]="validationPatterns.alphanumericInternalUHP"/>
+              <div *ngIf="formErrors.customDockerRegistryPath" class="alert alert-danger"> {{ formErrors.customDockerRegistryPath}} </div>  
             </div>
           </div>
           <div class="form-group form-group-sm">

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -142,6 +142,7 @@ export const validationMessages = {
   },
   'customDockerRegistryPath': {
     'maxlength': 'Custom docker registry path is too long. (Max 256 characters.)',
-    'pattern': 'A custom docker registry path may only consist of alphanumeric characters, internal underscores, internal hyphens, and internal periods.'
+    'pattern': 'A custom docker registry path may only consist of ' +
+    'alphanumeric characters, internal underscores, internal hyphens, and internal periods.'
   }
 };

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -29,7 +29,8 @@ export const formErrors = {
   'reference': '',
   'versionTag': '',
   'workflow_path': '',
-  'workflowName': ''
+  'workflowName': '',
+  'customDockerRegistryPath': ''
 };
 
 export const validationPatterns = {
@@ -47,7 +48,9 @@ export const validationPatterns = {
   'workflowName': '[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*',
   'cwlTestParameterFilePath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.(json|yml|yaml)$',
   'wdlTestParameterFilePath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.(json|yml|yaml)$',
-  'testParameterFilePath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.(json|yml|yaml)$'
+  'testParameterFilePath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.(json|yml|yaml)$',
+  // This should be used for all validation patterns that are alphanumeric with internal underscores, hyphens, and periods.
+  'alphanumericInternalUHP': '^[a-zA-Z0-9]+([-_\.]*[a-zA-Z0-9]+)*$'
 };
 
 export const validationMessages = {
@@ -81,11 +84,11 @@ export const validationMessages = {
     'minlength': 'Image Path is too short. (Min. 3 characters.)',
     'maxlength': 'Image Path is too long. (Max 128 characters.)',
     'pattern': 'The namespace and name of the image repository, separated by a \'/\'. ' +
-    'Use \'_\' for an empty namespace. Currently, only Quay.io and Docker Hub are supported third-party platforms.'
+    'Use \'_\' for an empty namespace.'
   },
   'label': {
     'maxlength': 'Labels string is too long. (Max 512 characters.)',
-    'pattern': 'Labels are comma-delimited, and may only contain alphanumerical characters and internal hyphens.'
+    'pattern': 'Labels are comma-delimited, and may only consist of alphanumerical characters and internal hyphens.'
   },
   'cwlTestParameterFilePath': {
     'required': 'This field cannot be empty.',
@@ -110,7 +113,7 @@ export const validationMessages = {
   },
   'toolName': {
     'maxlength': 'Tool Name is too long. (Max 256 characters.)',
-    'pattern': 'A Tool Name may only consist of alphanumeric characters and internal underscores or hyphens.'
+    'pattern': 'A Tool Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.'
   },
   'email': {
     'maxlength': 'Email is too long. (Max 256 characters.)'
@@ -125,7 +128,7 @@ export const validationMessages = {
   'versionTag': {
     'required': 'This field cannot be empty.',
     'maxlength': 'Version Tag is too long. (Max 128 characters.)',
-    'pattern': 'A Version Tag may only consist of alphanumeric characters, internal hyphens, periods and underscores.'
+    'pattern': 'A Version Tag may only consist of alphanumeric characters, internal underscores, internal hyphens, and internal periods.'
   },
   'workflow_path': {
     'required': 'This field cannot be empty.',
@@ -136,6 +139,10 @@ export const validationMessages = {
   },
   'workflowName': {
     'maxlength': 'Workflow Name is too long. (Max 256 characters.)',
-    'pattern': 'A Workflow Name may only consist of alphanumeric characters and internal underscores or hyphens.'
+    'pattern': 'A Workflow Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.'
+  },
+  'customDockerRegistryPath': {
+    'maxlength': 'Custom docker registry path is too long. (Max 256 characters.)',
+    'pattern': 'A custom docker registry path may only consist of alphanumeric characters, internal underscores, internal hyphens, and internal periods.'
   }
 };

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -76,8 +76,7 @@ export const validationMessages = {
     'required': 'This field cannot be empty.',
     'minlength': 'Source Code Repository Path is too short. (Min. 3 characters.)',
     'maxlength': 'Source Code Repository Path is too long. (Max 128 characters.)',
-    'pattern': 'The namespace and name of the Git repository, separated by a \'/\'. ' +
-    'Currently, only GitHub, Bitbucket and GitLab are supported third-party platforms.'
+    'pattern': 'The namespace and name of the Git repository, separated by a \'/\'. '
   },
   'imagePath': {
     'required': 'This field cannot be empty.',

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -55,7 +55,7 @@ export const validationMessages = {
     'required': 'This field cannot be empty.',
     'minlength': 'Descriptor Path is too short. (Min. 3 characters.)',
     'maxlength': 'Descriptor Path is too long. (Max 256 characters.)',
-    'pattern': 'Invalid Descriptor Path format. Descriptor Path must begin with \'/\' and end with \'*.cwl\', \'*.yml\', or\'*.yaml\'.'
+    'pattern': 'Invalid Descriptor Path format. Descriptor Path must begin with \'/\' and end with \'*.cwl\', \'*.yml\', or \'*.yaml\'.'
   },
   'wdlPath': {
     'required': 'This field cannot be empty.',
@@ -120,12 +120,12 @@ export const validationMessages = {
     'minlength': 'Git reference is too short. (Min. 3 characters.)',
     'maxlength': 'Git reference is too long. (Max 128 characters.)',
     'pattern': 'Invalid Git Reference format. ' +
-    'An Git Reference path may only consist of alphanumeric characters, \'-\' and \'_\', with interior \'/\' and \'.\' separators.'
+    'A Git Reference path may only consist of alphanumeric characters, \'-\' and \'_\', with interior \'/\' and \'.\' separators.'
   },
   'versionTag': {
     'required': 'This field cannot be empty.',
-    'maxlength': 'Tag Name is too long. (Max 128 characters.)',
-    'pattern': 'A Tag Name may only consist of alphanumeric characters and internal hyphens, periods and underscores.'
+    'maxlength': 'Version Tag is too long. (Max 128 characters.)',
+    'pattern': 'A Version Tag may only consist of alphanumeric characters, internal hyphens, periods and underscores.'
   },
   'workflow_path': {
     'required': 'This field cannot be empty.',


### PR DESCRIPTION
For validation changes mentioned in ga4gh/dockstore#767

Notes:
- Validation message renamed to match field name.  In the future, if changing from Version Tag to something else, change both of them.
- asterisks kept until group consensus
- Dropdown info is obvious so removed additional info from messages.
- Toolname appears to have validation already
- Added validation to custom and non-custom docker registry path (the non-custom ones pass already) validation.  The pattern is alphanumeric with internal hyphen, period, and underscores (based on what I've seen in Amazon ECR examples).  Although we can probably leave this out if unneeded.

