### PR TITLE
Run chrome headless

### DIFF
--- a/scripts/run-travis-script.sh
+++ b/scripts/run-travis-script.sh
@@ -16,6 +16,6 @@ else
   ng lint
   ng build --progress false
   ng serve --silent &
-  ng test --watch=false --code-coverage
+  ng test --watch=false --code-coverage --browsers ChromeHeadless
   cypress run --record --config defaultCommandTimeout=10000
 fi


### PR DESCRIPTION
Sometimes `ng test` results in `Karma - Disconnected, because no message in 10000 ms`  .  Run chrome headless appears to help mitigate the issue a bit.  Another option is to increase timeout.