### PR TITLE
Used main descriptor as relative path

### DIFF
--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -110,7 +110,7 @@ export class LaunchComponent {
   private changeMessages(toolPath: string, versionName: string) {
     this.params = this.launchService.getParamsString(toolPath, versionName, this.currentDescriptor);
     this.cli = this.launchService.getCliString(toolPath, versionName, this.currentDescriptor);
-    this.cwl = this.launchService.getCwlString(toolPath, versionName);
+    this.cwl = this.launchService.getCwlString(toolPath, versionName, '');
     this.dockstoreSupportedCwlLaunch = this.launchService.getDockstoreSupportedCwlLaunchString(toolPath, versionName);
     this.dockstoreSupportedCwlMakeTemplate = this.launchService.getDockstoreSupportedCwlMakeTemplateString(toolPath, versionName);
     this.consonance = this.launchService.getConsonanceString(toolPath, versionName);

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -110,7 +110,7 @@ export class LaunchComponent {
   private changeMessages(toolPath: string, versionName: string) {
     this.params = this.launchService.getParamsString(toolPath, versionName, this.currentDescriptor);
     this.cli = this.launchService.getCliString(toolPath, versionName, this.currentDescriptor);
-    this.cwl = this.launchService.getCwlString(toolPath, versionName, '');
+    this.cwl = this.launchService.getCwlString(toolPath, versionName, encodeURIComponent(this._selectedVersion.cwl_path));
     this.dockstoreSupportedCwlLaunch = this.launchService.getDockstoreSupportedCwlLaunchString(toolPath, versionName);
     this.dockstoreSupportedCwlMakeTemplate = this.launchService.getDockstoreSupportedCwlMakeTemplateString(toolPath, versionName);
     this.consonance = this.launchService.getConsonanceString(toolPath, versionName);

--- a/src/app/container/launch/tool-launch.service.spec.ts
+++ b/src/app/container/launch/tool-launch.service.spec.ts
@@ -18,7 +18,7 @@ import { TestBed, inject } from '@angular/core/testing';
 
 import { ToolLaunchService } from './tool-launch.service';
 
-describe('LaunchService', () => {
+describe('ToolLaunchService', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [ToolLaunchService]
@@ -40,14 +40,14 @@ describe('LaunchService', () => {
     }));
 
     it('should getCWLString', inject([ToolLaunchService], (service: ToolLaunchService) => {
-        expect(service.getCwlString('quay.io/a/b', 'c', ''))
+        expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato'))
             .toContain('cwl-runner');
-        expect(service.getCwlString('quay.io/a/b', 'c', ''))
+        expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato'))
             .not.toContain('non-strict');
-        expect(service.getCwlString('quay.io/a/b', 'c', ''))
-            .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor Dockstore.json');
-        expect(service.getCwlString('quay.io/a/b/d', 'c', ''))
-            .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor Dockstore.json');
+        expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato'))
+            .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json');
+        expect(service.getCwlString('quay.io/a/b/d', 'c', '%2Fpotato'))
+            .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json');
     }));
     it('should getConsonanceString', inject([ToolLaunchService], (service: ToolLaunchService) => {
         expect(service.getDockstoreSupportedCwlLaunchString('quay.io/briandoconnor/dockstore-tool-bamstats', '1.25-11')).toContain(

--- a/src/app/container/launch/tool-launch.service.spec.ts
+++ b/src/app/container/launch/tool-launch.service.spec.ts
@@ -40,13 +40,13 @@ describe('LaunchService', () => {
     }));
 
     it('should getCWLString', inject([ToolLaunchService], (service: ToolLaunchService) => {
-        expect(service.getCwlString('quay.io/a/b', 'c'))
+        expect(service.getCwlString('quay.io/a/b', 'c', ''))
             .toContain('cwl-runner');
-        expect(service.getCwlString('quay.io/a/b', 'c'))
+        expect(service.getCwlString('quay.io/a/b', 'c', ''))
             .not.toContain('non-strict');
-        expect(service.getCwlString('quay.io/a/b', 'c'))
+        expect(service.getCwlString('quay.io/a/b', 'c', ''))
             .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor Dockstore.json');
-        expect(service.getCwlString('quay.io/a/b/d', 'c'))
+        expect(service.getCwlString('quay.io/a/b/d', 'c', ''))
             .toContain('api/ga4gh/v1/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor Dockstore.json');
     }));
     it('should getConsonanceString', inject([ToolLaunchService], (service: ToolLaunchService) => {

--- a/src/app/container/launch/tool-launch.service.ts
+++ b/src/app/container/launch/tool-launch.service.ts
@@ -41,6 +41,6 @@ export class ToolLaunchService extends LaunchService {
   getCwlString(path: string, versionName: string, mainDescriptor: string) {
     return '$ cwl-runner ' +
       `${Dockstore.API_URI}/api/ga4gh/v1/tools/${encodeURIComponent(path)}` +
-      `/versions/${encodeURIComponent(versionName)}/plain-CWL/descriptor Dockstore.json`;
+      `/versions/${encodeURIComponent(versionName)}/plain-CWL/descriptor/${mainDescriptor} Dockstore.json`;
   }
 }

--- a/src/app/container/launch/tool-launch.service.ts
+++ b/src/app/container/launch/tool-launch.service.ts
@@ -38,7 +38,7 @@ export class ToolLaunchService extends LaunchService {
     return `$ dockstore tool launch --entry ${path}:${versionName} --json Dockstore.json` + descriptor;
   }
 
-  getCwlString(path: string, versionName: string) {
+  getCwlString(path: string, versionName: string, mainDescriptor: string) {
     return '$ cwl-runner ' +
       `${Dockstore.API_URI}/api/ga4gh/v1/tools/${encodeURIComponent(path)}` +
       `/versions/${encodeURIComponent(versionName)}/plain-CWL/descriptor Dockstore.json`;

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -29,7 +29,7 @@ export abstract class LaunchService {
     constructor() { }
     abstract getParamsString(path: string, versionName: string, currentDescriptor: string);
     abstract getCliString(path: string, versionName: string, currentDescriptor: string);
-    abstract getCwlString(path: string, versionName: string);
+    abstract getCwlString(path: string, versionName: string, mainDescriptor: string);
     getConsonanceString(path: string, versionName: string) {
         return `$ consonance run --tool-dockstore-id ${path}:${versionName} ` +
             '--run-descriptor Dockstore.json --flavour \<AWS instance-type\>';

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -58,7 +58,7 @@ export class LaunchWorkflowComponent {
   private changeMessages(workflowPath: string, versionName: string) {
     this.params = this.launchService.getParamsString(workflowPath, versionName, this.currentDescriptor);
     this.cli = this.launchService.getCliString(workflowPath, versionName, this.currentDescriptor);
-    this.cwl = this.launchService.getCwlString(workflowPath, versionName, '/' + encodeURIComponent(this._selectedVersion.workflow_path));
+    this.cwl = this.launchService.getCwlString(workflowPath, versionName, encodeURIComponent(this._selectedVersion.workflow_path));
     this.dockstoreSupportedCwlLaunch = this.launchService.getDockstoreSupportedCwlLaunchString(workflowPath, versionName);
     this.dockstoreSupportedCwlMakeTemplate = this.launchService.getDockstoreSupportedCwlMakeTemplateString(workflowPath, versionName);
     this.consonance = this.launchService.getConsonanceString(workflowPath, versionName);

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -58,7 +58,7 @@ export class LaunchWorkflowComponent {
   private changeMessages(workflowPath: string, versionName: string) {
     this.params = this.launchService.getParamsString(workflowPath, versionName, this.currentDescriptor);
     this.cli = this.launchService.getCliString(workflowPath, versionName, this.currentDescriptor);
-    this.cwl = this.launchService.getCwlString(workflowPath, versionName);
+    this.cwl = this.launchService.getCwlString(workflowPath, versionName, '/' + encodeURIComponent(this._selectedVersion.workflow_path));
     this.dockstoreSupportedCwlLaunch = this.launchService.getDockstoreSupportedCwlLaunchString(workflowPath, versionName);
     this.dockstoreSupportedCwlMakeTemplate = this.launchService.getDockstoreSupportedCwlMakeTemplateString(workflowPath, versionName);
     this.consonance = this.launchService.getConsonanceString(workflowPath, versionName);

--- a/src/app/workflow/launch/workflow-launch.service.spec.ts
+++ b/src/app/workflow/launch/workflow-launch.service.spec.ts
@@ -40,12 +40,12 @@ describe('LaunchService', () => {
   }));
 
   it('should getCWLString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {
-    expect(service.getCwlString('a/b', 'c'))
+    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
       .toContain('cwl-runner');
-    expect(service.getCwlString('a/b', 'c'))
+    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
       .not.toContain('non-strict');
-    expect(service.getCwlString('a/b', 'c'))
-      .toContain('api/ga4gh/v1/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor Dockstore.json');
+    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
+      .toContain('api/ga4gh/v1/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json');
   }));
   it('should getConsonanceString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {
     expect(service.getConsonanceString('a/b', 'latest')).toContain(

--- a/src/app/workflow/launch/workflow-launch.service.spec.ts
+++ b/src/app/workflow/launch/workflow-launch.service.spec.ts
@@ -18,7 +18,7 @@ import { TestBed, inject } from '@angular/core/testing';
 
 import { WorkflowLaunchService } from './workflow-launch.service';
 
-describe('LaunchService', () => {
+describe('WorkflowLaunchService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [WorkflowLaunchService]
@@ -40,11 +40,11 @@ describe('LaunchService', () => {
   }));
 
   it('should getCWLString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {
-    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
+    expect(service.getCwlString('a/b', 'c', '%2Fpotato'))
       .toContain('cwl-runner');
-    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
+    expect(service.getCwlString('a/b', 'c', '%2Fpotato'))
       .not.toContain('non-strict');
-    expect(service.getCwlString('a/b', 'c', '/%2Fpotato'))
+    expect(service.getCwlString('a/b', 'c', '%2Fpotato'))
       .toContain('api/ga4gh/v1/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json');
   }));
   it('should getConsonanceString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -28,6 +28,6 @@ export class WorkflowLaunchService extends LaunchService {
 
   getCwlString(path: string, versionName: string, mainDescriptor: string) {
     return `$ cwl-runner ${ Dockstore.API_URI }/api/ga4gh/v1/tools/${ encodeURIComponent('#workflow/' + path) }` +
-      `/versions/${ encodeURIComponent(versionName) }/plain-CWL/descriptor${mainDescriptor} Dockstore.json`;
+      `/versions/${ encodeURIComponent(versionName) }/plain-CWL/descriptor/${mainDescriptor} Dockstore.json`;
   }
 }

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -26,8 +26,8 @@ export class WorkflowLaunchService extends LaunchService {
     return `$ dockstore workflow launch --entry ${ path }:${ versionName } --json Dockstore.json`;
   }
 
-  getCwlString(path: string, versionName: string) {
+  getCwlString(path: string, versionName: string, mainDescriptor: string) {
     return `$ cwl-runner ${ Dockstore.API_URI }/api/ga4gh/v1/tools/${ encodeURIComponent('#workflow/' + path) }` +
-      `/versions/${ encodeURIComponent(versionName) }/plain-CWL/descriptor Dockstore.json`;
+      `/versions/${ encodeURIComponent(versionName) }/plain-CWL/descriptor${mainDescriptor} Dockstore.json`;
   }
 }


### PR DESCRIPTION
For issue ga4gh/dockstore#844

Substitute the workflow cwl-runner launch string's descriptor with the relative paths endpoint instead.  Tool is also changed.

