### PR TITLE
Feature/private access

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -84,14 +84,14 @@
     <h3 class="pull-right">
       <div class="button contact-button" *ngIf="publicPage && tool?.private_access">
         <p>
-          <a [href]="composeEmail(true)">
+          <a [href]="requestAccessHREF">
             Request Access
           </a>
         </p>
       </div>
-      <div class="button contact-button" *ngIf="publicPage && tool?.email !== null && !tool?.private_access">
+      <div class="button contact-button" *ngIf="publicPage && tool?.email && !tool?.private_access">
         <p>
-          <a [href]="composeEmail(false)">
+          <a [href]="contactAuthorHREF">
             Contact Author
           </a>
         </p>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -13,7 +13,6 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
 <div class="row" *ngIf="error || missingWarning">
   <div class="col-md-12" *ngIf="!isToolPublic">
     <div class="alert alert-warning" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
@@ -35,7 +34,7 @@
         </a>
       </span>
       <span *ngIf="tool?.private_access" class="private-lock" tooltip="Private">
-          <app-private-icon></app-private-icon>
+        <app-private-icon></app-private-icon>
       </span>
       {{ tool?.tool_path }}
       <app-starring *ngIf="isToolPublic" (change)="starGazersChange()"></app-starring>
@@ -52,7 +51,6 @@
         </select>
       </div>
     </div>
-
     <p class="update">
       Last build: {{ tool?.agoMessage || 'n/a' }}
     </p>
@@ -67,7 +65,8 @@
     <h3>
       <div class="pull-right">
         <div class="btn-group" role="group">
-          <button id="publishToolButton" type="button" [ngClass]="{'disabled': publishDisable()}" class="btn btn-warning" (click)="publish()" [(ngModel)]="published" [disabled]="!thisisValid" btnCheckbox>
+          <button id="publishToolButton" type="button" [ngClass]="{'disabled': publishDisable()}" class="btn btn-warning" (click)="publish()" [(ngModel)]="published"
+            [disabled]="!thisisValid" btnCheckbox>
             {{tool?.is_published ? 'Unpublish' : 'Publish'}}
           </button>
           <button *ngIf="tool?.is_published" type="button" [disabled]="tool?.is_published" class="btn btn-danger">
@@ -78,6 +77,24 @@
         <button type="button" class="btn btn-primary" (click)="refresh()" [disabled]="refreshMessage !== null">
           Refresh
         </button>
+      </div>
+    </h3>
+  </div>
+  <div class="col-md-4">
+    <h3 class="pull-right">
+      <div class="button contact-button" *ngIf="!editMode && tool?.private_access">
+        <p>
+          <a [href]="composeEmail(true)">
+            Request Access
+          </a>
+        </p>
+      </div>
+      <div class="button contact-button" *ngIf="!editMode && tool?.email !== null && !tool?.private_access">
+        <p>
+          <a [href]="composeEmail(false)">
+            Contact Author
+          </a>
+        </p>
       </div>
     </h3>
   </div>
@@ -110,7 +127,8 @@
           <div *ngIf="labelsEditMode && !isToolPublic">
             <div class="form-group">
               <label>Tool Labels:</label>
-              <input id="toolLabels" type="text" class="input-sm form-control" name="toolLabels" [(ngModel)]="containerEditData.labels" #name="ngModel" maxlength="512" [pattern]="labelPattern" placeholder="e.g. dockstore, oicr-icgc, pancancer" />
+              <input id="toolLabels" type="text" class="input-sm form-control" name="toolLabels" [(ngModel)]="containerEditData.labels" #name="ngModel" maxlength="512"
+                [pattern]="labelPattern" placeholder="e.g. dockstore, oicr-icgc, pancancer" />
             </div>
             <div *ngIf="name.errors && (name.dirty || name.touched)" class="alert alert-danger">
               <div [hidden]="!name.errors.maxlength">
@@ -148,7 +166,6 @@
         </div>
       </div>
     </div>
-
     <div class="panel panel-default" *ngIf="tool">
       <div class="panel-heading">
         <h3>Docker Pull Command</h3>
@@ -158,7 +175,7 @@
           <input type="text" class="form-control" [(ngModel)]="dockerPullCmd" value="{{dockerPullCmd}}" readonly>
           <span class="input-group-btn">
             <button class="btn btn-default" [ngClass]="{'btn-copy':toolCopyBtn === 'docker_pull_command'}" type="button" ngxClipboard [cbContent]="dockerPullCmd"
-                    (cbOnSuccess)="toolCopyBtnClick('docker_pull_command')">
+              (cbOnSuccess)="toolCopyBtnClick('docker_pull_command')">
               <span class="glyphicon glyphicon-copy"></span>
             </button>
           </span>
@@ -222,7 +239,8 @@
       </div>
       <div class="panel-body">
         <div class="container-sharing">
-          <share-buttons class="withCount" [url]="shareURL" [whatsApp]="false" [stumbleUpOn]="false" [pinterest]="false" [tumblr]="false" [showCount]="true" (count)="sumCounts($event)">
+          <share-buttons class="withCount" [url]="shareURL" [whatsApp]="false" [stumbleUpOn]="false" [pinterest]="false" [tumblr]="false" [showCount]="true"
+            (count)="sumCounts($event)">
           </share-buttons>
         </div>
       </div>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -82,14 +82,14 @@
   </div>
   <div class="col-md-4">
     <h3 class="pull-right">
-      <div class="button contact-button" *ngIf="!editMode && tool?.private_access">
+      <div class="button contact-button" *ngIf="publicPage && tool?.private_access">
         <p>
           <a [href]="composeEmail(true)">
             Request Access
           </a>
         </p>
       </div>
-      <div class="button contact-button" *ngIf="!editMode && tool?.email !== null && !tool?.private_access">
+      <div class="button contact-button" *ngIf="publicPage && tool?.email !== null && !tool?.private_access">
         <p>
           <a [href]="composeEmail(false)">
             Contact Author

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -96,6 +96,53 @@ export class ContainerComponent extends Entry {
     this.containerService.setCopyBtn(null);
   }
 
+  /**
+   * Compose the href for the Request Access button or Contact Author button
+   * @param privateTool true for Request Access button, false for Contact Author button
+   */
+  public composeEmail(privateTool: boolean): string {
+    let email: string;
+    let subject: string;
+    let body: string;
+    if (privateTool) {
+      email = this.getRequestEmailMailTo();
+      subject = this.getRequestEmailSubject();
+      body = this.getRequestEmailBody();
+    } else {
+      email = this.getInquiryEmailMailTo();
+      subject = this.getInquiryEmailSubject();
+      body = this.getInquiryEmailBody();
+    }
+    return `mailto:${email}?subject=${subject}&body=${body}`;
+  }
+
+  // Request Access button
+  private getRequestEmailMailTo(): string {
+    return this.dockstoreService.getRequestAccessEmail(this.tool.tool_maintainer_email, this.tool.email);
+  }
+
+  private getRequestEmailSubject(): string {
+    return encodeURI(`Dockstore Request for Access to ${this.tool.path}`);
+  }
+
+  private getRequestEmailBody(): string {
+    return encodeURI(`I would like to request access to your Docker image ${this.tool.path}. ` +
+    `My user name on ${this.tool.registry} is <username>`);
+  }
+
+  // Contact Author button
+  private getInquiryEmailMailTo(): string {
+    return this.tool.email;
+  }
+
+  private getInquiryEmailSubject(): string {
+    return encodeURI(`Dockstore ${this.tool.path} inquiry`);
+  }
+
+  private getInquiryEmailBody(): string {
+    return '';
+  }
+
   setProperties() {
     let toolRef: ExtendedDockstoreTool = this.tool;
     this.labels = this.dockstoreService.getLabelStrings(this.tool.labels);

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -1,3 +1,4 @@
+import { EmailService } from './email.service';
 import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
 /*
  *    Copyright 2017 OICR
@@ -52,6 +53,8 @@ export class ContainerComponent extends Entry {
   privateOnlyRegistry: boolean;
   containerEditData: any;
   thisisValid = true;
+  public requestAccessHREF: string;
+  public contactAuthorHREF: string;
   public missingWarning: boolean;
   public tool: ExtendedDockstoreTool;
   private toolSubscription: Subscription;
@@ -66,6 +69,7 @@ export class ContainerComponent extends Entry {
     private refreshService: RefreshService,
     private updateContainer: ContainerService,
     private containersService: ContainersService,
+    private emailService: EmailService,
     trackLoginService: TrackLoginService,
     communicatorService: CommunicatorService,
     providerService: ProviderService,
@@ -94,53 +98,6 @@ export class ContainerComponent extends Entry {
 
   public resetCopyBtn(): void {
     this.containerService.setCopyBtn(null);
-  }
-
-  /**
-   * Compose the href for the Request Access button or Contact Author button
-   * @param privateTool true for Request Access button, false for Contact Author button
-   */
-  public composeEmail(privateTool: boolean): string {
-    let email: string;
-    let subject: string;
-    let body: string;
-    if (privateTool) {
-      email = this.getRequestEmailMailTo();
-      subject = this.getRequestEmailSubject();
-      body = this.getRequestEmailBody();
-    } else {
-      email = this.getInquiryEmailMailTo();
-      subject = this.getInquiryEmailSubject();
-      body = this.getInquiryEmailBody();
-    }
-    return `mailto:${email}?subject=${subject}&body=${body}`;
-  }
-
-  // Request Access button
-  private getRequestEmailMailTo(): string {
-    return this.dockstoreService.getRequestAccessEmail(this.tool.tool_maintainer_email, this.tool.email);
-  }
-
-  private getRequestEmailSubject(): string {
-    return encodeURI(`Dockstore Request for Access to ${this.tool.path}`);
-  }
-
-  private getRequestEmailBody(): string {
-    return encodeURI(`I would like to request access to your Docker image ${this.tool.path}. ` +
-    `My user name on ${this.tool.registry} is <username>`);
-  }
-
-  // Contact Author button
-  private getInquiryEmailMailTo(): string {
-    return this.tool.email;
-  }
-
-  private getInquiryEmailSubject(): string {
-    return encodeURI(`Dockstore ${this.tool.path} inquiry`);
-  }
-
-  private getInquiryEmailBody(): string {
-    return '';
   }
 
   setProperties() {
@@ -197,6 +154,8 @@ export class ContainerComponent extends Entry {
       toolRef.buildMode = this.containerService.getBuildMode(toolRef.mode);
       toolRef.buildModeTooltip = this.containerService.getBuildModeTooltip(toolRef.mode);
       this.initTool();
+      this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
+      this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool);
     }
   }
 

--- a/src/app/container/email.service.spec.ts
+++ b/src/app/container/email.service.spec.ts
@@ -1,0 +1,39 @@
+import { DockstoreService } from './../shared/dockstore.service';
+import { sampleTool1 } from '../test/mocked-objects';
+import { DockstoreTool } from './../shared/swagger/model/dockstoreTool';
+import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { EmailService } from './email.service';
+
+describe('Service: Email', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [EmailService, DockstoreService]
+    });
+  });
+
+  const tool: ExtendedDockstoreTool = sampleTool1;
+  tool.tool_maintainer_email = 'fake@maintainer.email.ca';
+  tool.email = 'fake@email.ca';
+  tool.path = 'registry.hub.docker.com/postgres/postgres';
+  tool.registry = DockstoreTool.RegistryEnum.DOCKERHUB;
+  tool.imgProvider = 'Docker Hub';
+
+  it('should get the right request access email href', inject([EmailService], (service: EmailService) => {
+    expect(service).toBeTruthy();
+    expect(service.composeRequestAccessEmail(tool)).toEqual('mailto:fake@maintainer.email.ca' +
+    '?subject=Dockstore%20Request%20for%20Access%20to%20registry.hub.docker.com/postgres/postgres' +
+    '&body=I%20would%20like%20to%20request%20access%20to%20your%20Docker%20image%20registry.hub.docker.com/postgres/postgres.%20' +
+    'My%20user%20name%20on%20Docker%20Hub%20is%20%3Cusername%3E');
+  }));
+
+  it('should get the right contact author email href', inject([EmailService], (service: EmailService) => {
+    expect(service).toBeTruthy();
+    expect(service.composeContactAuthorEmail(tool)).toEqual('mailto:fake@email.ca' +
+    '?subject=Dockstore%20registry.hub.docker.com/postgres/postgres%20inquiry' +
+    '&body=');
+  }));
+
+});

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -1,0 +1,94 @@
+import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
+import { DockstoreService } from './../shared/dockstore.service';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class EmailService {
+
+constructor(private dockstoreService: DockstoreService) { }
+  /**
+   * Compose the href for an email
+   * @param email The mailto address
+   * @param subject The subject of the email
+   * @param body The body of the the email
+   */
+  private composeEmail(email: string, subject: string, body: string): string {
+    return `mailto:${email}?subject=${subject}&body=${body}`;
+  }
+
+  /**
+   * Composes the href for the Request Access email
+   * @param tool The tool to request access for
+   */
+  public composeRequestAccessEmail(tool: ExtendedDockstoreTool): string {
+    const email = this.getRequestEmailMailTo(tool.tool_maintainer_email, tool.email);
+    const subject = this.getRequestEmailSubject(tool.path);
+    const body = this.getRequestEmailBody(tool.path, tool.imgProvider);
+    return this.composeEmail(email, subject, body);
+  }
+
+  /**
+   * Composes the href for the Contact Author email
+   * @param tool The tool to contact author for
+   */
+  public composeContactAuthorEmail(tool: ExtendedDockstoreTool): string {
+    const email = this.getInquiryEmailMailTo(tool.email);
+    const subject = this.getInquiryEmailSubject(tool.path);
+    const body = this.getInquiryEmailBody();
+    return this.composeEmail(email, subject, body);
+  }
+
+  // Request Access button methods
+  /**
+   * This gets the mailto address when the Request Access button is clicked
+   * @param maintainerEmail The maintainer email
+   * @param email The tool author's email address
+   */
+  private getRequestEmailMailTo(maintainerEmail: string, email: string): string {
+    return this.dockstoreService.getRequestAccessEmail(maintainerEmail, email);
+  }
+
+  /**
+   * This gets the email subject when the Request Access button is clicked
+   * @param path The path of the tool whose access is being requested
+   */
+  private getRequestEmailSubject(path: string): string {
+    return encodeURI(`Dockstore Request for Access to ${path}`);
+  }
+
+  /**
+   * This gets the email body when the Request Access button is clicked
+   * @param path The path of the tool whose access is being requested
+   * @param toolRegistry The tool registry (Quay.io, GitLab, etc) of the tool whose access is being requested
+   */
+  private getRequestEmailBody(path: string, toolRegistry: string): string {
+    return encodeURI(`I would like to request access to your Docker image ${path}. ` +
+    `My user name on ${toolRegistry} is <username>`);
+  }
+
+  // Contact Author button methods
+  /**
+   * This gets the mailto address when the Contact Author button is clicked.    console.log(tool);
+   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
+   * @param email The tool author's email address
+   */
+  private getInquiryEmailMailTo(email): string {
+    return email;
+  }
+
+  /**
+   * This gets the email subject when the Contact Author button is clicked
+   * @param path The path of the tool whose access is being requested
+   */
+  private getInquiryEmailSubject(path: string): string {
+    return encodeURI(`Dockstore ${path} inquiry`);
+  }
+
+  /**
+   * This gets the email body when the Contact Author button is clicked
+   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
+   */
+  private getInquiryEmailBody(): string {
+    return '';
+  }
+}

--- a/src/app/shared/dockstore.service.ts
+++ b/src/app/shared/dockstore.service.ts
@@ -104,4 +104,12 @@ export class DockstoreService {
       return 'glyphicon-sort';
     }
   }
+
+  getRequestAccessEmail(tool_maintainer_email: string, email: string) {
+    if (!tool_maintainer_email) {
+      return this.stripMailTo(tool_maintainer_email);
+    } else {
+      return this.stripMailTo(email);
+    }
+  }
 }

--- a/src/app/shared/dockstore.service.ts
+++ b/src/app/shared/dockstore.service.ts
@@ -106,7 +106,7 @@ export class DockstoreService {
   }
 
   getRequestAccessEmail(tool_maintainer_email: string, email: string) {
-    if (!tool_maintainer_email) {
+    if (tool_maintainer_email) {
       return this.stripMailTo(tool_maintainer_email);
     } else {
       return this.stripMailTo(email);

--- a/src/app/shared/models/ExtendedDockstoreTool.ts
+++ b/src/app/shared/models/ExtendedDockstoreTool.ts
@@ -9,6 +9,7 @@ export interface ExtendedDockstoreTool extends DockstoreTool {
     lastUpdatedDate?: string;
     versionVerified?: any;
     verifiedSources?: any;
+    imgProvider?: string;
     imgProviderUrl?: string;
     // The transformed git url
     provider?: string;

--- a/src/app/shared/modules/container.module.ts
+++ b/src/app/shared/modules/container.module.ts
@@ -1,3 +1,4 @@
+import { EmailService } from '../../container/email.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -107,6 +108,7 @@ import { SelectModule } from './select.module';
     {provide: TooltipConfig, useFactory: getTooltipConfig},
     HighlightJsService,
     ErrorService,
+    EmailService,
     DateService,
     FileService,
     ToolLaunchService,


### PR DESCRIPTION
This puts the missing request access and contact author from UI1 back to UI2.  For issue ga4gh/dockstore#1099

Also officially added imgProvider to the ExtendedDockstoreTool type since the property was already being added to it anyways.