### PR TITLE
Refresh upon default version change

### DIFF
--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -79,8 +79,8 @@ export class VersionsContainerComponent extends Versions implements OnInit {
     this.tool.defaultVersion = newDefaultVersion;
     this.stateService.setRefreshMessage(message + '...');
     this.containersService.updateContainer(this.tool.id, this.tool).subscribe(response => {
-      this.containerService.setTool(response);
       this.refreshService.handleSuccess(message);
+      this.refreshService.refreshTool();
     }, error => this.refreshService.handleError(message, error)
     );
   }

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -255,7 +255,7 @@ export class HttpStubService {
 
 export class WorkflowStubService {
     nsWorkflows$ = Observable.of([]);
-    workflow$: BehaviorSubject<any> = new BehaviorSubject({ sampleWorkflow1 }); // This is the selected workflow
+    workflow$: BehaviorSubject<any> = new BehaviorSubject({ }); // This is the selected workflow
     workflows$: BehaviorSubject<Workflow[]> = new BehaviorSubject([]);  // This contains the list of unsorted workflows
     copyBtn$ = Observable.of({});
     setWorkflow(thing: Workflow) {

--- a/src/app/workflow/versions/versions.component.spec.ts
+++ b/src/app/workflow/versions/versions.component.spec.ts
@@ -17,7 +17,6 @@ import { StateService } from './../../shared/state.service';
  *    limitations under the License.
  */
 
-import { updatedWorkflow } from './../../test/mocked-objects';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { WorkflowService } from './../../shared/workflow.service';
@@ -67,7 +66,9 @@ describe('VersionsWorkflowComponent', () => {
     component.publicPage = false;
     component.updateDefaultVersion('name');
     fixture.detectChanges();
-    workflowService.workflow$.subscribe(workflow => expect(workflow).toEqual(updatedWorkflow));
+    workflowService.workflow$.subscribe(workflow => {
+      expect(workflow).toEqual(jasmine.objectContaining({defaultVersion: 'name'}));
+  });
   });
 
   it('should get verified source', () => {

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -83,8 +83,8 @@ export class VersionsWorkflowComponent extends Versions implements OnInit {
     this.stateService.setRefreshMessage(message + '...');
     this.workflowsService.updateWorkflow(this.workflowId, this.workflow).subscribe(
       response => {
-        this.workflowService.setWorkflow(response);
         this.refreshService.handleSuccess(message);
+        this.refreshService.refreshWorkflow();
       },
       error => this.refreshService.handleError(message, error));
   }


### PR DESCRIPTION
For ga4gh/dockstore#1100
Hooks refresh into the default version change.  Instead of updating the tool/workflow based on the tool/workflow update response, update the tool/workflow based on the refresh response.

