### PR TITLE
Use strings only

### DIFF
--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -161,6 +161,9 @@ export class SearchService {
    * @param filter
    */
   handleFilters(category: string, categoryValue: string, filters: any) {
+    if (typeof(categoryValue) === 'number') {
+      categoryValue = String(categoryValue);
+    }
     if (filters.has(category) && filters.get(category).has(categoryValue)) {
       filters.get(category).delete(categoryValue);
       // wipe out the category if empty


### PR DESCRIPTION
For ga4gh/dockstore#1134  

Clicking on verified facet alters the filters by adding a number as the categoryValue (0 for public, 1 for private).
However, using the search path with parameters alters the filters by adding a string as the categoryValue ("0" for public, "1" for private).   This difference causes problems.  Now changing it all to strings (apparently elasticsearch doesn't care).  Also, not sure how a function with typed input parameters do not throw an error when it gets a different type.