### PR TITLE
changed workflow names from showing in brackets to the same as tools

### DIFF
--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -33,7 +33,7 @@
                 <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
               </a>
             </span>
-            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/'+workflow?.path)">{{ workflow?.repository + (workflow.workflowName ? ' (' + workflow.workflowName + ')' : '') }}</a>
+            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/' + workflow?.path)">{{ workflow?.repository + (workflow.workflowName ? '/' + workflow.workflowName : '') }}</a>
           </td>
           <td>
             {{ workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers.length }}


### PR DESCRIPTION
Now workflows with workflow names are shown in list to be the same as tools.

Ex. OxoG-Dockstore-Tools/pcawg-oxog-full-workflow

https://github.com/ga4gh/dockstore/issues/1143