### PR TITLE
Display view.commonwl.org visualization #1058

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -49,4 +49,6 @@ export class Dockstore {
   static readonly GITLAB_AUTH_URL = 'https://gitlab.com/oauth/authorize';
   static readonly GITLAB_CLIENT_ID = 'fill_this_in';
   static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITLAB;
+
+  static readonly CWL_VISUALIZER_URI = 'https://view.commonwl.org';
 }

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
@@ -17,6 +17,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { CwlViewerDescriptor, CwlViewerService } from './cwl-viewer.service';
 import { WorkflowVersion } from '../../../shared/swagger/model/workflowVersion';
+import { ExtendedWorkflow } from "../../../shared/models/ExtendedWorkflow";
 
 @Component({
   selector: 'app-cwl-viewer',
@@ -27,10 +28,10 @@ import { WorkflowVersion } from '../../../shared/swagger/model/workflowVersion';
 
 export class CwlViewerComponent implements OnInit {
 
-  @Input() workflow: any;
+  @Input() workflow: ExtendedWorkflow;
   @Input() set selectedVersion(value: WorkflowVersion) {
     if (value != null) {
-      this._selectedVersion = value;
+      this.version = value;
       this.onChange();
     }
   }
@@ -44,7 +45,7 @@ export class CwlViewerComponent implements OnInit {
   public cwlViewerDescriptor: CwlViewerDescriptor;
   public loading = false;
 
-  private _selectedVersion;
+  private version;
 
   constructor(private cwlViewerService: CwlViewerService) {
   }
@@ -58,11 +59,11 @@ export class CwlViewerComponent implements OnInit {
   }
 
   onChange() {
-    if (this._selectedVersion) {
+    if (this.version) {
       this.loading = true;
       this.cwlViewerDescriptor = null;
-      this.cwlViewerService.getVisualizationUrls(this.workflow.providerUrl, this._selectedVersion.reference,
-        this._selectedVersion.workflow_path)
+      this.cwlViewerService.getVisualizationUrls(this.workflow.providerUrl, this.version.reference,
+        this.version.workflow_path)
         .subscribe(
           cwlViewerDescriptor => {
             this.cwlViewerDescriptor = cwlViewerDescriptor;

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
@@ -17,7 +17,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { CwlViewerDescriptor, CwlViewerService } from './cwl-viewer.service';
 import { WorkflowVersion } from '../../../shared/swagger/model/workflowVersion';
-import { ExtendedWorkflow } from "../../../shared/models/ExtendedWorkflow";
+import { ExtendedWorkflow } from '../../../shared/models/ExtendedWorkflow';
 
 @Component({
   selector: 'app-cwl-viewer',

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
@@ -1,0 +1,90 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the 'License');
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an 'AS IS' BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import { Component, Input, OnInit } from '@angular/core';
+import { CwlViewerDescriptor, CwlViewerService } from './cwl-viewer.service';
+import { WorkflowVersion } from '../../../shared/swagger/model/workflowVersion';
+
+@Component({
+  selector: 'app-cwl-viewer',
+  templateUrl: './cwl-viewer.html',
+  providers: [CwlViewerService],
+  styleUrls: ['./cwl-viewer.scss']
+})
+
+export class CwlViewerComponent implements OnInit {
+
+  @Input() workflow: any;
+  @Input() set selectedVersion(value: WorkflowVersion) {
+    if (value != null) {
+      this._selectedVersion = value;
+      this.onChange();
+    }
+  }
+  @Input() set refresh(value: any) {
+    this.resetZoom();
+  }
+  @Input() expanded: boolean;
+
+  public cwlViewerError = false;
+  public cwlViewerPercentageZoom = 100;
+  public cwlViewerDescriptor: CwlViewerDescriptor;
+  public loading = false;
+
+  private _selectedVersion;
+
+  constructor(private cwlViewerService: CwlViewerService) {
+  }
+
+  ngOnInit(): void {
+    this.cwlViewerDescriptor = null;
+  }
+
+  resetZoom() {
+    this.cwlViewerPercentageZoom = 100;
+  }
+
+  onChange() {
+    if (this._selectedVersion) {
+      this.loading = true;
+      this.cwlViewerDescriptor = null;
+      this.cwlViewerService.getVisualizationUrls(this.workflow.providerUrl, this._selectedVersion.reference,
+        this._selectedVersion.workflow_path)
+        .subscribe(
+          cwlViewerDescriptor => {
+            this.cwlViewerDescriptor = cwlViewerDescriptor;
+            this.cwlViewerError = false;
+            this.loading = false;
+            this.resetZoom();
+          },
+          () => {
+            this.cwlViewerDescriptor = null;
+            this.cwlViewerError = true;
+            this.loading = false;
+          });
+    }
+  }
+
+  onWheel(event: WheelEvent) {
+    const offset = event.deltaY > 0 ? -10 : 10;
+    const newWidth = this.cwlViewerPercentageZoom + offset;
+    if (newWidth >= 1) {
+      this.cwlViewerPercentageZoom = newWidth;
+    }
+    event.preventDefault();
+  }
+
+}

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
@@ -5,7 +5,7 @@
       branches and does not support tags.</span>
   </div>
   <div>
-    <span *ngIf="!cwlViewerError">See on <a [href]="cwlViewerDescriptor?.webPageUrl" target="_blank">https://view.commonwl.org <span class="glyphicon glyphicon-new-window"></span></a></span>
+    <span *ngIf="!cwlViewerError">See on <a [href]="cwlViewerDescriptor?.webPageUrl" target="_blank">Common Workflow Language Viewer <span class="glyphicon glyphicon-new-window"></span></a></span>
   </div>
   <div class="mini-dag image" [ngClass]="{'fullscreen-element large-dag': expanded}">
     <div *ngIf="loading" class="text-center viewer-loading">

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
@@ -1,0 +1,16 @@
+<div [ngClass]="{'fullscreen-element large-dag': expanded}" class="cwl-viewer" >
+  <div *ngIf="cwlViewerError" class="alert alert-warning">
+    <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
+    <span>The Common Workflow Language Viewer was unable to process the CWL. Note that the viewer only supports
+      branches and does not support tags.</span>
+  </div>
+  <div>
+    <span *ngIf="!cwlViewerError">See on <a [href]="cwlViewerDescriptor?.webPageUrl" target="_blank">https://view.commonwl.org <span class="glyphicon glyphicon-new-window"></span></a></span>
+  </div>
+  <div class="mini-dag image" [ngClass]="{'fullscreen-element large-dag': expanded}">
+    <div *ngIf="loading" class="text-center viewer-loading">
+      <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate" ></span>
+    </div>
+    <img [hidden]="!cwlViewerDescriptor" [style.width.%]="cwlViewerPercentageZoom" [style.height.%]="cwlViewerPercentageZoom" [src]="cwlViewerDescriptor?.svgUrl" (wheel)="onWheel($event)">
+  </div>
+</div>

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.scss
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.scss
@@ -1,0 +1,30 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+.cwl-viewer {
+
+  border: none;
+
+  .viewer-loading {
+    width: 100%;
+    font-size: 48px;
+  }
+
+  .image {
+    overflow: hidden;
+  }
+
+}

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
@@ -3,7 +3,7 @@ import { CwlViewerService } from './cwl-viewer.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Dockstore } from '../../../shared/dockstore.model';
 
-describe('Service: commonwl', () => {
+describe('Service: CWLViewer', () => {
 
   let cwlViewerService: CwlViewerService;
   let httpMock: HttpTestingController;

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
@@ -1,0 +1,89 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { CwlViewerService } from './cwl-viewer.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Dockstore } from '../../../shared/dockstore.model';
+
+describe('Service: commonwl', () => {
+
+  let cwlViewerService: CwlViewerService;
+  let httpMock: HttpTestingController;
+  let commonWlEndpoint: string;
+  const providerUrl = 'https://github.com/dockstore-testing/Metaphlan-ISBCGC';
+  const reference = 'master';
+  const workflowPath = '/metaphlan_wfl.cwl';
+
+  const cwlViewerResponse
+    = {
+    'retrievedFrom': {
+      'repoUrl': 'https://github.com/dockstore-testing/Metaphlan-ISBCGC.git',
+      'branch': 'master',
+      'path': 'metaphlan_wfl.cwl',
+      'packedId': null,
+      'url': 'https://github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl',
+      'rawUrl': 'https://raw.githubusercontent.com/dockstore-testing/Metaphlan-ISBCGC/master/metaphlan_wfl.cwl',
+      'type': 'GITHUB'
+    },
+    'retrievedOn': 1518199020779,
+    'lastCommit': '9283b35ae651477f5e722111b07c8128aa66c0ea',
+    'label': 'metaphlan_wfl.cwl',
+    'permalink': 'https://w3id.org/cwl/view/git/9283b35ae651477f5e722111b07c8128aa66c0ea/metaphlan_wfl.cwl',
+    'visualisationXdot': '/graph/xdot/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl',
+    'visualisationPng': '/graph/png/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl',
+    'visualisationSvg': '/graph/svg/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl',
+    'roBundle': '/robundle/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl'
+  };
+
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule ],
+      providers: [ CwlViewerService ]
+    });
+    cwlViewerService = TestBed.get(CwlViewerService);
+    commonWlEndpoint = cwlViewerService.cwlViewerEndpoint(providerUrl, reference, workflowPath);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it ('should work if POST returns 200', (done) => {
+    cwlViewerService.getVisualizationUrls(providerUrl, reference, workflowPath).subscribe(
+      (resp) => {
+        expect(resp.svgUrl).toBe(Dockstore.CWL_VISUALIZER_URI +
+          '/graph/svg/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl');
+        expect(resp.webPageUrl).toBe(commonWlEndpoint);
+        done();
+      },
+      () => {
+      });
+    const response200 = httpMock.expectOne(commonWlEndpoint);
+    response200.flush(cwlViewerResponse);
+    httpMock.verify();
+  });
+
+  it ('should work if POST returns 202', fakeAsync(() => {
+    cwlViewerService.getVisualizationUrls(providerUrl, reference, workflowPath).subscribe(
+      (resp) => {
+        expect(resp.svgUrl).toBe(Dockstore.CWL_VISUALIZER_URI +
+          '/graph/svg/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl');
+      },
+      () => {
+      });
+    const response202 = httpMock.expectOne(commonWlEndpoint);
+    response202.flush(null, {
+      headers: {
+        Location: '/queue/1'
+      },
+      status: 202, statusText: 'Accepted'});
+    tick(400);
+    const poll = httpMock.expectOne(Dockstore.CWL_VISUALIZER_URI + '/queue/1');
+    poll.flush(cwlViewerResponse);
+    httpMock.verify();
+  }));
+
+  it ('should fail if POST returns 400', (done) => {
+    cwlViewerService.getVisualizationUrls(providerUrl, reference, workflowPath).subscribe(null,
+      () => done());
+    const response400 = httpMock.expectOne(commonWlEndpoint);
+    response400.flush(null, {status: 400, statusText: 'Bad Request'});
+    httpMock.verify();
+  });
+});

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.ts
@@ -1,0 +1,119 @@
+/*
+ *    Copyright 2017 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the 'License');
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an 'AS IS' BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Dockstore } from '../../../shared/dockstore.model';
+import { Observable } from 'rxjs/Observable';
+
+interface WorkflowDetails {
+  /**
+   * A relative path link to the svg format visualisation image
+   */
+  visualisationSvg: string;
+}
+
+/**
+ * A descriptor for some of the urls available from view.commonwl.org for a CWL visualization.
+ */
+export interface CwlViewerDescriptor {
+  /**
+   * The url of the SVG file
+   */
+  svgUrl: string;
+  /**
+   * The url of the web page on view.commonwl.org
+   */
+  webPageUrl: string;
+}
+
+/**
+ * This service is responsible for generating visualizations, if they haven't already been generated, from
+ * https://view.commonwl.org, and returning the urls of those visualizations.
+ */
+@Injectable()
+export class CwlViewerService {
+
+  constructor(private httpClient: HttpClient) {
+  }
+
+  /**
+   *
+   * Returns visualization urls for a workflow.
+   *
+   * 1. POSTs to https://view.commonwl.org/workflows?url=<cwl on GitHub>
+   *    1. If visualization has already been generated, or generation is quick, response is 200 with details in response body.
+   *    Actually, the POST returns a 303, but Angular HttpClient follows the redirect so from the client perspective
+   *    it's as if it returned a 200.
+   *    2. If image generation needs to be queued up, response is 202 with link to job in Location header
+   *      1. Follow location header and poll job queue
+   *      2. When job is finished, polling job queue redirects and returns a response with details in body
+   *
+   * @param {string} providerUrl, e.g., `https://github.com/dockstore-testing/Metaphlan-ISBCGC`
+   * @param {string} reference, a branch name, e.g., `master`
+   * @param {string} workflow_path, path to CWL, e.g., `/metaphlan_wfl.cwl`
+   * @returns {Observable<CwlViewerDescriptor>}
+   */
+  getVisualizationUrls(providerUrl: string, reference: string, workflow_path: string): Observable<CwlViewerDescriptor> {
+
+    const url = this.cwlViewerEndpoint(providerUrl, reference, workflow_path);
+
+    return this.httpClient.post(url, null, {observe: 'response'})
+      .switchMap((res: HttpResponse<WorkflowDetails>) => {
+        if (res.status === 200) {
+          return Observable.of(<CwlViewerDescriptor>{
+            svgUrl: Dockstore.CWL_VISUALIZER_URI + res.body.visualisationSvg,
+            webPageUrl: res.url});
+        } else if (res.status === 202) {
+          const locationHeader = res.headers.get('Location');
+          if (locationHeader) {
+            const queueUrl = locationHeader.startsWith('/') ? Dockstore.CWL_VISUALIZER_URI + locationHeader : locationHeader;
+            return this.pollJobQueue(queueUrl);
+          }
+        }
+        throw new Error(`Error posting ${workflow_path}`);
+      });
+  }
+
+  /**
+   * Returns the CommonWL endpoint to request a visualization.
+   *
+   * @param {string} providerUrl
+   * @param {string} reference
+   * @param {string} workflow_path
+   * @returns {string}
+   */
+  cwlViewerEndpoint(providerUrl: string, reference: string, workflow_path: string) {
+    return Dockstore.CWL_VISUALIZER_URI + '/workflows?url='
+      + encodeURIComponent(providerUrl + '/blob/' + reference
+        + workflow_path);
+  }
+
+  private pollJobQueue(queueUrl: string) {
+    const pollFrequencyMs = 250;
+    const maxPolls = 30000 / pollFrequencyMs; // Poll for a maximum of 30 seconds
+    return Observable.interval(pollFrequencyMs)
+      .switchMap(() => this.httpClient.get(queueUrl, {observe: 'response'}))
+      .take(maxPolls)
+      // When the job is complete, polling the job sends a 302 which Angular Http client follows, giving the job output
+      .filter((p: HttpResponse<any>) => p.body && p.body.visualisationSvg)
+      .take(1)
+      .map((resp: HttpResponse<WorkflowDetails>) => (<CwlViewerDescriptor>{
+        svgUrl: Dockstore.CWL_VISUALIZER_URI + resp.body.visualisationSvg,
+        webPageUrl: resp.url
+      }));
+  }
+}

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.ts
@@ -96,13 +96,13 @@ export class CwlViewerService {
    * @param {string} workflow_path
    * @returns {string}
    */
-  cwlViewerEndpoint(providerUrl: string, reference: string, workflow_path: string) {
+  cwlViewerEndpoint(providerUrl: string, reference: string, workflow_path: string): string {
     return Dockstore.CWL_VISUALIZER_URI + '/workflows?url='
       + encodeURIComponent(providerUrl + '/blob/' + reference
         + workflow_path);
   }
 
-  private pollJobQueue(queueUrl: string) {
+  private pollJobQueue(queueUrl: string): Observable<CwlViewerDescriptor> {
     const pollFrequencyMs = 250;
     const maxPolls = 30000 / pollFrequencyMs; // Poll for a maximum of 30 seconds
     return Observable.interval(pollFrequencyMs)

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -16,16 +16,26 @@
 <div class="row" id="dag-holder" [ngClass]="{'fullscreen': expanded}">
   <div class="col-md-12" id="dag-col" [ngClass]="{'fullscreen-element': expanded}">
     <div [ngClass]="{'fullscreen-dropdown': expanded}" *ngIf="dagResult && !notFound && !missingTool">
-      <a href id="exportLink" (click)="download()">
-      <span class="glyphicon glyphicon-export"></span>Export to PNG</a>
-      <div class="btn-group pull-right" role="group" style="width:auto">
-        <button id="dag_fullscreen" (click)="toggleExpand()" tooltip="Toggle fullscreen" class="dag-button btn btn-default">
-          <span *ngIf="!expanded" class="glyphicon glyphicon-resize-full" id="resize-full-button"></span>
-          <span *ngIf="expanded" class="glyphicon glyphicon-resize-small" id="resize-small-button"></span>
-        </button>
-        <button id="dag_reload" (click)="refreshDocument()" class="dag-button btn btn-default" tooltip="Reset">
-          <span class="glyphicon glyphicon-screenshot"></span>
-        </button>
+      <div *ngIf="enableCwlViewer && workflow?.descriptorType === 'cwl'" style="line-height: 20px;">
+        <label class="radio-inline">
+          <input type="radio" name="dagType" [(ngModel)]="dagType" value="classic">Classic
+        </label>
+        <label class="radio-inline">
+          <input type="radio" name="dagType" [(ngModel)]="dagType" value="cwlviewer">Common Workflow Language Viewer
+        </label>
+      </div>
+      <div>
+        <a *ngIf="dagType === 'classic'" href id="exportLink" (click)="download()">
+          <span *ngIf="dagType === 'classic'" class="glyphicon glyphicon-export"></span>Export to PNG</a>
+        <div class="btn-group pull-right" role="group" style="width:auto">
+          <button id="dag_fullscreen" (click)="toggleExpand()" tooltip="Toggle fullscreen" class="dag-button btn btn-default">
+            <span *ngIf="!expanded" class="glyphicon glyphicon-resize-full" id="resize-full-button"></span>
+            <span  *ngIf="expanded" class="glyphicon glyphicon-resize-small" id="resize-small-button"></span>
+          </button>
+          <button id="dag_reload" (click)="reset()" class="dag-button btn btn-default" tooltip="Reset">
+            <span class="glyphicon glyphicon-screenshot"></span>
+          </button>
+        </div>
       </div>
     </div>
     <div class="alert alert-warning" role="alert" *ngIf="notFound || !dagResult">
@@ -37,9 +47,17 @@
         Please ensure that the Descriptor is a valid CWL 1.0 workflow.
       </span>
     </div>
+
     <div class="alert alert-warning" role="alert" *ngIf="workflow?.descriptorType === 'cwl' && missingTool">
       <span class="glyphicon glyphicon-warning-sign"></span>&nbsp; DAG cannot be created because some required tools are missing from Github repo.
     </div>
-    <div #cy id="cy" *ngIf="dagResult !== null && !missingTool" [ngClass]="{'fullscreen-element large-dag': expanded}" class="mini-dag"></div>
+
+
+    <app-cwl-viewer *ngIf="enableCwlViewer && workflow?.descriptorType === 'cwl'" [hidden]="dagType !== 'cwlviewer'"
+                    [workflow]="workflow" [selectedVersion]="_selectedVersion" [refresh]="refreshCounter" [expanded]="expanded">
+
+    </app-cwl-viewer>
+
+    <div #cy id="cy" *ngIf="dagResult !== null && !missingTool" [hidden]="dagType !== 'classic'" [ngClass]="{'fullscreen-element large-dag': expanded}" class="mini-dag"></div>
   </div>
 </div>

--- a/src/app/workflow/dag/dag.component.spec.ts
+++ b/src/app/workflow/dag/dag.component.spec.ts
@@ -22,6 +22,7 @@ import { Workflow } from './../../shared/swagger/model/workflow';
 import { WorkflowService } from './../../shared/workflow.service';
 import { WorkflowsStubService, WorkflowStubService } from './../../test/service-stubs';
 import { DagComponent } from './dag.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 /* tslint:disable:no-unused-variable */
 declare var cytoscape: any;
@@ -33,9 +34,11 @@ describe('DagComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ DagComponent ],
+      imports: [ HttpClientTestingModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [ {provide: WorkflowsService, useClass: WorkflowsStubService },
-        {provide: WorkflowService, useClass: WorkflowStubService}]
+        {provide: WorkflowService, useClass: WorkflowStubService},
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -203,6 +203,7 @@ export class DagComponent implements OnInit, AfterViewChecked {
   download() {
     if (this.cy) {
       const pngDAG = this.cy.png({ full: true, scale: 2 });
+      const name = this.workflow.repository + '_' + this._selectedVersion.name + '.png';
       $('#exportLink').attr('href', pngDAG).attr('download', name);
     }
   }

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -34,7 +34,6 @@ export class DagComponent implements OnInit, AfterViewChecked {
   @Input() defaultVersion: any;
   @Input() id: number;
   _selectedVersion: WorkflowVersion;
-  @Input() theWorkflow: any;
   @Input() set selectedVersion(value: WorkflowVersion) {
     if (value != null) {
       this._selectedVersion = value;
@@ -59,7 +58,6 @@ export class DagComponent implements OnInit, AfterViewChecked {
   public dagType: 'classic' | 'cwlviewer' = 'classic';
   public enableCwlViewer = false;
   public refreshCounter = 1;
-  public cwlViewerError: boolean;
 
   setDagResult(dagResult: any) {
     this.dagResult = dagResult;

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -1,14 +1,14 @@
 /*
  *    Copyright 2017 OICR
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    Licensed under the Apache License, Version 2.0 (the 'License');
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
  *
  *        http://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    distributed under the License is distributed on an 'AS IS' BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
@@ -34,6 +34,7 @@ export class DagComponent implements OnInit, AfterViewChecked {
   @Input() defaultVersion: any;
   @Input() id: number;
   _selectedVersion: WorkflowVersion;
+  @Input() theWorkflow: any;
   @Input() set selectedVersion(value: WorkflowVersion) {
     if (value != null) {
       this._selectedVersion = value;
@@ -54,9 +55,21 @@ export class DagComponent implements OnInit, AfterViewChecked {
   private tooltip: string;
   public missingTool;
   private refresh = false;
+
+  public dagType: 'classic' | 'cwlviewer' = 'classic';
+  public enableCwlViewer = false;
+  public refreshCounter = 1;
+  public cwlViewerError: boolean;
+
   setDagResult(dagResult: any) {
     this.dagResult = dagResult;
   }
+
+  reset() {
+    this.refreshCounter++;
+    this.refreshDocument();
+  }
+
   refreshDocument() {
     const self = this;
     if (this.dagResult) {
@@ -190,7 +203,6 @@ export class DagComponent implements OnInit, AfterViewChecked {
   download() {
     if (this.cy) {
       const pngDAG = this.cy.png({ full: true, scale: 2 });
-      const name = this.workflow.repository + '_' + this._selectedVersion.name + '.png';
       $('#exportLink').attr('href', pngDAG).attr('download', name);
     }
   }

--- a/src/app/workflow/dag/dag.module.ts
+++ b/src/app/workflow/dag/dag.module.ts
@@ -1,14 +1,14 @@
 /*
  *    Copyright 2017 OICR
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    Licensed under the Apache License, Version 2.0 (the 'License');
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
  *
  *        http://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    distributed under the License is distributed on an 'AS IS' BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
@@ -22,6 +22,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { getTooltipConfig } from './../../shared/tooltip';
 import { DagComponent } from './dag.component';
+import { CwlViewerComponent } from './cwl-viewer/cwl-viewer.component';
 
 @NgModule({
   imports: [
@@ -29,7 +30,7 @@ import { DagComponent } from './dag.component';
     FormsModule,
     TooltipModule
   ],
-  declarations: [DagComponent],
+  declarations: [DagComponent, CwlViewerComponent],
   exports: [DagComponent],
   providers: [
     {provide: TooltipConfig, useFactory: getTooltipConfig},

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -132,7 +132,7 @@
         <app-tool-tab [selectedVersion]="selectedVersion"></app-tool-tab>
       </tab>
       <tab id="dagTab" [disabled]="isStub()" heading="DAG" *ngIf="validVersions" (select)="setTab('DAG')">
-        <app-dag *ngIf="checkMode('DAG')" [id]="workflow?.id" [validVersions]="validVersions" [defaultVersion]="defaultVersion" [selectedVersion]="selectedVersion" [theWorkflow]="workflow"></app-dag>
+        <app-dag *ngIf="checkMode('DAG')" [id]="workflow?.id" [validVersions]="validVersions" [defaultVersion]="defaultVersion" [selectedVersion]="selectedVersion"></app-dag>
       </tab>
     </tabset>
   </div>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -132,7 +132,7 @@
         <app-tool-tab [selectedVersion]="selectedVersion"></app-tool-tab>
       </tab>
       <tab id="dagTab" [disabled]="isStub()" heading="DAG" *ngIf="validVersions" (select)="setTab('DAG')">
-        <app-dag *ngIf="checkMode('DAG')" [id]="workflow?.id" [validVersions]="validVersions" [defaultVersion]="defaultVersion" [selectedVersion]="selectedVersion"></app-dag>
+        <app-dag *ngIf="checkMode('DAG')" [id]="workflow?.id" [validVersions]="validVersions" [defaultVersion]="defaultVersion" [selectedVersion]="selectedVersion" [theWorkflow]="workflow"></app-dag>
       </tab>
     </tabset>
   </div>


### PR DESCRIPTION
For CWL workflows, display an SVG created by view.commonwl.org. This
is in addition to the current DAG visualization, and the change
includes radiobuttons that let the user select which visualization
to see.

This feature is off by default, as view.commonwl.org does not
support CORS. Two issues were filed and fixed in that repo, but they
have not yet been deployed. This was tested by running an instance of
the viewer locally.

To turn on the feature, initialize enableCwlViewer to true in
src/app/workflow/dag/dag.component.ts. Ideally a more fancy feature
flag feature should have been implemented that doesn't require
changing the source code to toggle the feature, but it didn't seem worth
the effort unless this is a need we anticipate coming up more often.

Todo:

The zooming in/out is pretty crude -- it doesn't let you pick which
part of the image you to see.

![screen shot 2018-02-14 at 10 14 51 am](https://user-images.githubusercontent.com/1049340/36272540-ac6ee32e-1236-11e8-846c-0c09390baab6.png)
