### PR TITLE
Feature/swagger endpoint parameter order check

### DIFF
--- a/cypress/integration/toolDetails.js
+++ b/cypress/integration/toolDetails.js
@@ -1,4 +1,4 @@
-describe('Dockstore Tool Details', function() {
+describe('Dockstore Tool Details of quay.io/A2/a', function() {
     require('./helper.js')
     beforeEach(function() {
         cy.visit(String(global.baseUrl) + "/containers/quay.io/A2/a")
@@ -79,6 +79,74 @@ describe('Dockstore Tool Details', function() {
                     .should("not.be.visible")
                 cy
                     .contains('A Test Parameter File associated with this Docker container, descriptor type and version could not be found.')
+            });
+        });
+    });
+})
+
+describe('Dockstore Tool Details of quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut', function() {
+    require('./helper.js')
+    beforeEach(function() {
+        cy.visit(String(global.baseUrl) + "/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut")
+        cy
+            .get('tab')
+            .should('have.length', 7)
+    });
+
+
+    describe('Change tab to files', function() {
+        beforeEach(function() {
+            cy
+                .get('.nav-link')
+                .contains('Files')
+                .parent()
+                .click()
+        });
+
+        it('Should have Dockerfile tab selected', function() {
+            cy
+                .get('.nav-link')
+                .contains('Dockerfile')
+                .parent()
+                .click()
+                .should("have.class", "active")
+
+            it('Should have content in file viewer', function() {
+                cy
+                    .get(".hljs.yaml")
+                    .should("be.visible")
+            });
+        });
+
+        describe('Change tab to Descriptor files', function() {
+            beforeEach(function() {
+                cy
+                    .get('.nav-link')
+                    .contains('Descriptor Files')
+                    .parent()
+                    .click()
+            });
+
+            it('Should have content in file viewer', function() {
+                cy
+                    .get(".hljs.yaml")
+                    .should("be.visible")
+            });
+        });
+
+        describe('Change tab to Test Parameters', function() {
+            beforeEach(function() {
+                cy
+                    .get('.nav-link')
+                    .contains('Test Parameter Files')
+                    .parent()
+                    .click()
+            });
+
+            it('Should have content in file viewer', function() {
+                cy
+                    .get(".hljs.yaml")
+                    .should("be.visible")
             });
         });
     });

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -32,7 +32,7 @@ export class ParamfilesService {
     if (type === 'workflows') {
       return this.workflowsService.getTestParameterFiles(id, versionName);
     } else {
-      return this.containersService.getTestParameterFiles(id, versionName, descriptor);
+      return this.containersService.getTestParameterFiles(id, descriptor, versionName);
     }
   }
 

--- a/src/app/paramfiles/paramfiles.service.ts
+++ b/src/app/paramfiles/paramfiles.service.ts
@@ -24,7 +24,7 @@ export class ParamFilesService {
   constructor(private containersService: ContainersService) { }
 
   getContainerTestParamFiles(toolId: number, tagName?: string, descriptorType?: string) {
-    return this.containersService.getTestParameterFiles(toolId, tagName, descriptorType);
+    return this.containersService.getTestParameterFiles(toolId, descriptorType, tagName);
   }
 
   getTagsWithParam(toolId: number, validTags) {

--- a/travisci/db_dump.sql
+++ b/travisci/db_dump.sql
@@ -585,6 +585,7 @@ INSERT INTO databasechangeloglock (id, locked, lockgranted, lockedby) VALUES (1,
 --
 
 INSERT INTO enduser (id, avatarurl, bio, company, email, isadmin, location, username) VALUES (1, NULL, NULL, NULL, NULL, false, NULL, 'user_A');
+INSERT INTO enduser (id, isadmin, username, avatarurl, bio, company, email, location) VALUES (2, false, 'potato', '', NULL, '', '', NULL);
 
 
 --


### PR DESCRIPTION
Parameter order generated by swagger has swapped.  Swagger generates the parameters in the order presented by swagger.yaml but with required parameters listed in front and optional ones after.

Between 1.3.0-rc.0 and 1.4.0-alpha.5, it appears the "descriptorType" query parameter has changed from optional to required.  This caused swagger codegen to generate a different parameter order.

This PR:
- adds a test that shows the test parameter endpoint failing.
- adds a fix that shows the previous test passing.
- It also adds the missing enduser that was supposed to be in the db update for the docker pull fix (the hotfix already has it)