### PR TITLE
Fix broken DAG #1199

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -35,7 +35,7 @@
         "../node_modules/datatables.net-bs/js/dataTables.bootstrap.js",
         "../node_modules/jquery-colorbox/jquery.colorbox.js",
         "../node_modules/highlightjs-line-numbers.js/dist/highlightjs-line-numbers.min.js",
-        "../node_modules/cytoscape/dist/cytoscape.min.js",
+        "../node_modules/cytoscape/dist/cytoscape.js",
         "../node_modules/dagre/dist/dagre.min.js",
         "../node_modules/cytoscape-dagre/cytoscape-dagre.js",
         "../node_modules/qtip2/dist/jquery.qtip.js",


### PR DESCRIPTION
It was only failing in Angular prod mode.

Using source maps, I saw it was failing in cytoscape.min.js, so then
I tried the non-minified version to see exactly what the problem was,
and the problem went away.

The problem seems to be unrelated to the CWL Viewer DAG work, as I could
still reproduce the problem in prod mode if I rolled back the CWL
Viewer commits locally.

With this change, the generated bundles only seem to contain minified
code; it looks like the difference is that Angular preforms the
minification at build time.

ga4gh/dockstore#1199