### PR TITLE
changed how we do workflow names

### DIFF
--- a/src/app/listentry/listentry.component.html
+++ b/src/app/listentry/listentry.component.html
@@ -88,7 +88,7 @@
             <a style="text-decoration: none" tooltip="Verified" class="glyphicon glyphicon-ok"></a>
         </span>
         <a (click)="sendToolInfo(hit?._source)" [routerLink]="['/workflows', hit?._source.path ]">
-          {{ hit?._source.repository + (hit?._source.workflowName ? ' (' + hit?._source.workflowName + ')' : '') }}
+          {{ hit?._source.repository + (hit?._source.workflowName ? '/' + hit?._source.workflowName : '') }}
         </a>
       </td>
       <td>

--- a/src/app/myworkflows/myworkflows.component.html
+++ b/src/app/myworkflows/myworkflows.component.html
@@ -54,9 +54,9 @@
         <accordion-group *ngFor="let orgObj of orgWorkflows"[heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="containers-accordion" [isOpen]="orgObj?.isFirstOpen">
           <div *ngFor="let workflowObj of orgObj?.workflows">
             <div class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
-              <div class="container-name-oflw pull-left" title="{{workflowObj?.repository + (workflowObj?.workflowName ? ' (' + workflowObj?.workflowName + ')' : '')}}">
+              <div class="container-name-oflw pull-left" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}">
                 <a style="cursor: pointer;" (click)="selectWorkflow(workflowObj)">
-                  {{workflowObj?.repository + (workflowObj?.workflowName ? ' (' + workflowObj?.workflowName + ')' : '')}}
+                  {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
                 </a>
               </div>
               <div class="pull-right">

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -63,8 +63,8 @@
               <div class="panel-heading">
                 <h3 class="entry-heading">
                   <a href="/workflows/{{workflow.full_workflow_path}}"
-                     tooltip="{{workflow?.repository + (workflow?.workflowName ? ' (' + workflow?.workflowName + ')' : '')}}">
-                    {{workflow?.repository + (workflow?.workflowName ? ' (' + workflow?.workflowName + ')' : '')}}
+                     tooltip="{{workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')}}">
+                    {{workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')}}
                   </a>
                 </h3>
               </div>

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -33,7 +33,7 @@
                 <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
               </a>
             </span>
-            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/' + workflow.full_workflow_path )">{{ workflow?.repository + (workflow.workflowName ? '/' + workflow.workflowName : '') }}</a>
+            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/' + workflow?.full_workflow_path )">{{ workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}</a>
           </td>
           <td>
             {{ workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers.length }}

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -33,7 +33,7 @@
                 <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
               </a>
             </span>
-            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/' + workflow.full_workflow_path )">{{ workflow?.repository + (workflow.workflowName ? ' (' + workflow.workflowName + ')' : '') }}</a>
+            <a (click)="sendWorkflowInfo(workflow)" [routerLink]="('/workflows/' + workflow.full_workflow_path )">{{ workflow?.repository + (workflow.workflowName ? '/' + workflow.workflowName : '') }}</a>
           </td>
           <td>
             {{ workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers.length }}


### PR DESCRIPTION
Changes workflow names in paths to be listed as path/workflowname instead of path (workflowname). This makes it consistent with tools.

Deals with
https://github.com/ga4gh/dockstore/issues/1143