### PR TITLE
Require at least one of the two descriptors, change placeholder

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -64,8 +64,8 @@
         <div class="form-group">
           <strong tooltip="Path in Git repository to main CWL descriptor file">CWL Path: </strong>
           <span *ngIf="!cwlPathEditing"> {{ tool?.default_cwl_path || 'n/a' }}</span>
-          <input *ngIf="cwlPathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.cwlPath" type="text" class="input-default form-control"
-            name="contCWLPath" [(ngModel)]="tool.default_cwl_path" placeholder="e.g. /Dockerfile" />
+          <input *ngIf="cwlPathEditing" [required]="!tool?.default_wdl_path" minlength="3" maxlength="256" [pattern]="validationPatterns.cwlPath" type="text" class="input-default form-control"
+            name="contCWLPath" [(ngModel)]="tool.default_cwl_path" [placeholder]="exampleDescriptorPatterns.cwl" />
         </div>
         <div class="btn-group push-right" role="group" aria-label="Basic example">
           <button *ngIf="!isPublic && cwlPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
@@ -84,8 +84,8 @@
         <div class="form-group">
           <strong tooltip="Path in Git repository to main WDL descriptor file">WDL Path:</strong>
           <span *ngIf="!wdlPathEditing">{{ tool?.default_wdl_path || 'n/a' }}</span>
-          <input *ngIf="wdlPathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.wdlPath" type="text" class="input-default form-control"
-            name="contWDLPath" [(ngModel)]="tool.default_wdl_path" placeholder="e.g. /Dockerfile" />
+          <input *ngIf="wdlPathEditing" [required]="!tool?.default_cwl_path" minlength="3" maxlength="256" [pattern]="validationPatterns.wdlPath" type="text" class="input-default form-control"
+            name="contWDLPath" [(ngModel)]="tool.default_wdl_path" [placeholder]="exampleDescriptorPatterns.wdl" />
         </div>
         <div class="btn-group push-right" role="group" aria-label="Basic example">
           <button *ngIf="!isPublic && wdlPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -1,5 +1,4 @@
-import { ExtendedDockstoreTool } from './../../shared/models/ExtendedDockstoreTool';
-/*
+/**
  *    Copyright 2017 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +13,14 @@ import { ExtendedDockstoreTool } from './../../shared/models/ExtendedDockstoreTo
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { Component, Input, OnInit } from '@angular/core';
 
-import { ContainersService } from './../../shared/swagger/api/containers.service';
-import { StateService } from './../../shared/state.service';
-import { validationDescriptorPatterns } from './../../shared/validationMessages.model';
-import { InfoTabService } from './info-tab.service';
 import { ContainerService } from './../../shared/container.service';
-import { Component, OnInit, Input } from '@angular/core';
+import { ExtendedDockstoreTool } from './../../shared/models/ExtendedDockstoreTool';
+import { StateService } from './../../shared/state.service';
+import { ContainersService } from './../../shared/swagger/api/containers.service';
+import { exampleDescriptorPatterns, validationDescriptorPatterns } from './../../shared/validationMessages.model';
+import { InfoTabService } from './info-tab.service';
 
 @Component({
   selector: 'app-info-tab',
@@ -30,6 +30,7 @@ import { Component, OnInit, Input } from '@angular/core';
 export class InfoTabComponent implements OnInit {
   @Input() selectedVersion;
   public validationPatterns = validationDescriptorPatterns;
+  public exampleDescriptorPatterns = exampleDescriptorPatterns;
   dockerFileEditing: boolean;
   cwlPathEditing: boolean;
   wdlPathEditing: boolean;


### PR DESCRIPTION
For issue ga4gh/dockstore#1187

Require one of the two descriptor paths in the info tab of mytools.

Also fixed tooltips and imports