### PR TITLE
Add Feature Flags #268

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -16,6 +16,9 @@
 
 import { Provider } from './enum/provider.enum';
 
+// If you add new properties to this class, you need to also update
+// dockstore.model.ts.template at https://github.com/dockstore/compose_setup
+
 export class Dockstore {
   // Please fill in HOSTNAME with your address
   static readonly HOSTNAME = 'http://localhost';
@@ -51,4 +54,8 @@ export class Dockstore {
   static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITLAB;
 
   static readonly CWL_VISUALIZER_URI = 'https://view.commonwl.org';
+
+  static readonly FEATURES = {
+    enableCwlViewer: false
+  }
 }

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -57,5 +57,5 @@ export class Dockstore {
 
   static readonly FEATURES = {
     enableCwlViewer: false
-  }
+  };
 }

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -23,6 +23,7 @@ import { CommunicatorService } from './../../shared/communicator.service';
 import { WorkflowService } from './../../shared/workflow.service';
 import { DagService } from './dag.service';
 import { Component, OnInit, Input, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
+import { Dockstore } from '../../shared/dockstore.model';
 @Component({
   selector: 'app-dag',
   templateUrl: './dag.component.html',
@@ -56,7 +57,7 @@ export class DagComponent implements OnInit, AfterViewChecked {
   private refresh = false;
 
   public dagType: 'classic' | 'cwlviewer' = 'classic';
-  public enableCwlViewer = false;
+  public enableCwlViewer = Dockstore.FEATURES.enableCwlViewer;
   public refreshCounter = 1;
 
   setDagResult(dagResult: any) {


### PR DESCRIPTION
Add a "feature flags" property in dockstore.model.ts, so that
features can be turned on/off without doing new Git commits.
EnableCwlViewer is the only flag in there so far.

Also added a comment to dockstore.model.ts warning to keep it in sync
with the template in the dockstore/compose_setup repo, as I was
previously unaware of the need.

Not sure if this approach is overkill, but it does seem like it would be nice to be able to turn on a feature with doing a new commit, and it looks like another feature, Launch with FireCloud, may only get turned on in staging, but not prod, at first.