### PR TITLE
Feature/1094/my entry sidebar

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,6 @@
 {
-  "projectId": "1ya4vj"
+  "projectId": "1ya4vj",
+  "viewportHeight": 1080,
+  "viewportWidth": 1920
+ 
 }

--- a/cypress/integration/checkerWorkflowFromMyTools.js
+++ b/cypress/integration/checkerWorkflowFromMyTools.js
@@ -6,17 +6,16 @@ describe('Checker workflow test from my-tools', function() {
         cy.visit(String(global.baseUrl) + "/my-tools")
     });
 
-
+    function goToB3() {
+        cy.wait(5000)
+        cy.contains('quay.io/A2')
+            .parentsUntil('accordion-group')
+            .contains('div .no-wrap', /\bb3\b/)
+            .should('be.visible').click()
+    }
     describe('Should be able to register and publish a checker workflow from a tool', function() {
         it('visit a tool and have the correct buttons and be able to register a checker workflow', function() {
-            cy
-                .get('accordion')
-                .children(':nth-child(2)')
-                .click()
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'b3')
-                .click()
+            goToB3();
 
             cy.get('#viewCheckerWorkflowButton').should('not.be.visible')
             cy.get('#viewParentEntryButton').should('not.be.visible')
@@ -34,15 +33,7 @@ describe('Checker workflow test from my-tools', function() {
             cy.get('#submitButton').click()
         });
         it('visit the tool and its checker workflow and have the correct buttons', function() {
-            cy
-                .get('accordion')
-                .children(':nth-child(2)')
-                .click()
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'b3')
-                .click()
-
+           goToB3();
             // In the parent tool right now
             // Didn't change the tool path upon entry or select
             // cy.url().should('eq', 'http://localhost:4200/my-tools/quay.io/A2/b3')
@@ -66,15 +57,7 @@ describe('Checker workflow test from my-tools', function() {
             cy.get('#viewCheckerWorkflowButton').should('visible')
         })
         it('visit the tool and have its publish/unpublish reflected in the checker workflow', function() {
-            cy
-                .get('accordion')
-                .children(':nth-child(2)')
-                .click()
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'b3')
-                .click()
-
+            goToB3();
             // In the parent tool right now
             // Didn't change the tool path upon entry or select
             // cy.url().should('eq', 'http://localhost:4200/my-tools/quay.io/A2/b3')

--- a/cypress/integration/checkerWorkflowFromMyWorkflow.js
+++ b/cypress/integration/checkerWorkflowFromMyWorkflow.js
@@ -6,6 +6,9 @@ describe('Checker workflow test from my-workflows', function() {
         cy.visit(String(global.baseUrl) + "/my-workflows")
     });
 
+    /**
+     * This specifically gets the 'l' workflow, not something containing the 'l', but exactly 'l'
+     */
     function getWorkflow() {
         cy.contains('github.com')
         // Apparently you need to click the accordion in order for the other components inside

--- a/cypress/integration/checkerWorkflowFromMyWorkflow.js
+++ b/cypress/integration/checkerWorkflowFromMyWorkflow.js
@@ -6,16 +6,25 @@ describe('Checker workflow test from my-workflows', function() {
         cy.visit(String(global.baseUrl) + "/my-workflows")
     });
 
+    function getWorkflow() {
+        cy.contains('github.com')
+        // Apparently you need to click the accordion in order for the other components inside
+        // to become click-able
+        cy
+            .get('accordion')
+            .click()
+        cy.get('accordion')
+            .contains('div .no-wrap', /\l\b/)
+            .should('be.visible')
+            .parent()
+            .should('be.visible').click()
+    }
+
 
     describe('Should be able to register and publish a checker workflow from a workflow', function() {
-        it('visit a tool and have the correct buttons and be able to register a checker workflow', function() {        
-            cy
-            .get('accordion')
-            .get('.panel')
-            .children(':nth-child(2)')
-            .contains('a', 'l')
-            .click()
-
+        it('visit a tool and have the correct buttons and be able to register a checker workflow', function() {
+            getWorkflow();
+            cy.url().should('eq', 'http://localhost:4200/my-workflows/github.com/A/l')
             cy.get('#viewCheckerWorkflowButton').should('not.be.visible')
             cy.get('#viewParentEntryButton').should('not.be.visible')
             cy.get('#addCheckerWorkflowButton').should('be.visible').click()
@@ -31,13 +40,7 @@ describe('Checker workflow test from my-workflows', function() {
             cy.get('#submitButton').click()
         });
         it('visit the workflow and its checker workflow and have the correct buttons', function() {
-            cy
-                .get('accordion')
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'l')
-                .click()
-
+            getWorkflow();
             // In the parent workflow right now
             cy.url().should('eq', 'http://localhost:4200/my-workflows/github.com/A/l')
             cy.get('#viewParentEntryButton').should('not.be.visible')
@@ -60,13 +63,10 @@ describe('Checker workflow test from my-workflows', function() {
             cy.get('#viewCheckerWorkflowButton').should('visible')
         })
         it('visit the workflow and have its publish/unpublish reflected in the checker workflow', function() {
-            cy
-                .get('accordion')
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'l')
-                .click()
-
+            // The url should automatically change to include the workflow full path
+            cy.url().should('eq', 'http://localhost:4200/my-workflows/github.com/A/l')
+            getWorkflow();
+            // The url should automatically change to include the workflow full path
             // In the parent tool right now
             cy.url().should('eq', 'http://localhost:4200/my-workflows/github.com/A/l')
             cy.get('#publishButton').should('be.visible').should('contain', 'Unpublish').click()
@@ -76,7 +76,7 @@ describe('Checker workflow test from my-workflows', function() {
 
             // In the checker workflow right now
             cy.url().should('eq', 'http://localhost:4200/my-workflows/github.com/A/l/_cwl_checker')
-            cy.get('#publishButton').should('be.visible').should('contain', 'Publish')            
+            cy.get('#publishButton').should('be.visible').should('contain', 'Publish')
             cy.get('#viewParentEntryButton').should('be.visible').click()
 
             // In the parent tool right now

--- a/cypress/integration/mytools.js
+++ b/cypress/integration/mytools.js
@@ -1,150 +1,152 @@
 describe('Dockstore my tools', function() {
-  require('./helper.js')
+    require('./helper.js')
 
-	beforeEach(function () {
-     cy.visit(String(global.baseUrl) + "/my-tools")
-  });
-
-  describe('Should contain extended DockstoreTool properties', function() {
-    it('visit another page then come back', function() {
-      cy.get('a#home-nav-button').click()
-      cy.contains('Browse Tools')
-      cy.get('a#my-tools-nav-button').click()
-      cy
-      .get('accordion')
-        .children(':nth-child(2)')
-        .click()
-        .get('.panel')
-        .children(':nth-child(2)')
-        .contains('a', 'b1')
-        .click()
-        cy.contains('GitHub')
-        cy.contains('https://github.com/A2/b1')
-        cy.contains('Quay.io')
-        cy.contains('quay.io/A2/b1')
-        cy.contains('Last Build')
-        cy.contains('Last Updated')
-        cy.contains('Build Mode')
-        cy.contains('Fully-Automated')
-    });
-  });
-
-  describe('publish a tool', function() {
-    it("publish and unpublish", function() {
-      cy
-        .get('accordion')
-          .children(':nth-child(2)')
-          .click()
-          .get('.panel')
-          .children(':nth-child(2)')
-          .find('a')
-          .contains('b')
-          .first()
-          .click()
-          .get('#publishToolButton')
-          .should('contain', 'Publish')
-          .click()
-          .should('contain', 'Unpublish')
-          .click()
-          .should('contain', 'Publish')
-    });
-  });
-
-  describe('Publish an existing Amazon ECR tool', function() {
-    it('publish', function() {
-      cy
-        .get('#publishToolButton')
-        .click()
-    });
-  });
-
-  describe('manually register an Amazon ECR tool', function() {
-    it("register tool", function() {
-      cy
-        .server()
-        .route({
-            method: "GET",
-            url: /refresh/,
-            response: {"id": 40000, "author":null,"description":null,"labels":[],"users":[{"id":1,"username":"user_A","isAdmin":false,"name":"user_A"}],"email":null,"defaultVersion":null,"lastUpdated":1482334377743,"gitUrl":"git@github.com:testnamespace/testname.git","mode":"MANUAL_IMAGE_PATH","name":"testname","toolname":"","namespace":"testnamespace","registry":"AMAZON_ECR","lastBuild":null,"tags":[],"is_published":false,"last_modified":null,"default_dockerfile_path":"/Dockerfile","defaultCWLTestParameterFile":"/test.cwl.json", "defaultWDLTestParameterFile":"/test.cwl.json","default_cwl_path":"/Dockstore.cwl","default_wdl_path":"/Dockstore.wdl","tool_maintainer_email":"test@email.com","private_access":true,"path":"amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname","tool_path":"amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname", "custom_docker_registry_path": "amazon.dkr.ecr.test.amazonaws.com"}
-
-          })
-        .route({
-            method: "GET",
-            url: /dockerfile/,
-            response: {"content":"FROM ubuntu:16.10"}
-          })
-        .route({
-            method: "GET",
-            url: /cwl/,
-            response: {"content":"#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n","path":"/Dockstore.cwl"}
-          })
-      cy
-        .get('#register_tool_button')
-        .click()
-
-      cy
-        .get('#sourceCodeRepositoryInput')
-        .type("testnamespace/testname")
-        .wait(1000)
-
-      cy
-        .get('#imageRegistrySpinner')
-        .click()
-      cy
-        .contains('Amazon ECR')
-        .click()
-
-      cy
-        .get('#dockerRegistryPathInput')
-        .type('amazon.dkr.ecr.test.amazonaws.com')
-
-      cy
-        .get('#toolMaintainerEmailInput')
-        .type('test@email.com')
-
-      cy
-        .get('#imageRegistryInput')
-        .type('testnamespace/testname')
-
-      cy
-        .get('#submitButton')
-        .click()
-
-      cy
-        .get('#tool-path')
-        .should('contain', 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname')
-
-      cy
-        .contains('Versions')
-        .click()
-
-      cy
-        .get('#addTagButton')
-        .click()
-
-      cy
-        .get('#versionTagInput')
-        .type('master')
-      cy
-        .get('#gitReferenceInput')
-        .type('master')
-
-      cy
-        .get('#addVersionTagButton')
-        .click()
-
-      cy
-        .get('#deregisterButton')
-        .click()
-      cy
-        .get('#deregisterConfirmButton')
-        .click()
-
-        // This should be activated later
-        // cy
-        // .get('#tool-path')
-        // .should('not.contain', 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname')
+    beforeEach(function() {
+        cy.visit(String(global.baseUrl) + "/my-tools")
     });
 
-  });
+    function goToB1() {
+      cy.wait(5000)
+        cy.contains('quay.io/A2')
+            .parentsUntil('accordion-group')
+            .contains('Unpublished')
+            .should('be.visible')
+            .click()
+        cy.contains('quay.io/A2')
+            .parentsUntil('accordion-group')
+            .contains('div .no-wrap', /\bb1\b/)
+            .should('be.visible').click()
+    }
+
+    describe('Should contain extended DockstoreTool properties', function() {
+        it('visit another page then come back', function() {
+            cy.get('a#home-nav-button').click()
+            cy.contains('Browse Tools')
+            cy.get('a#my-tools-nav-button').click()
+            cy.contains('github.com')
+            // Apparently you need to click the accordion in order for the other components inside
+            // to become click-able
+            goToB1();
+            cy.contains('GitHub')
+            cy.contains('https://github.com/A2/b1')
+            cy.contains('Quay.io')
+            cy.contains('quay.io/A2/b1')
+            cy.contains('Last Build')
+            cy.contains('Last Updated')
+            cy.contains('Build Mode')
+            cy.contains('Fully-Automated')
+        });
+    });
+
+    describe('publish a tool', function() {
+        it("publish and unpublish", function() {
+            goToB1();
+            cy
+                .get('#publishToolButton')
+                .should('contain', 'Publish')
+                .click()
+                .should('contain', 'Unpublish')
+                .click()
+                .should('contain', 'Publish')
+        });
+    });
+
+    describe('Publish an existing Amazon ECR tool', function() {
+        it('publish', function() {
+          cy.visit(String(global.baseUrl) + "/my-tools/amazon.dkr.ecr.test.amazonaws.com/A/a")
+            cy
+                .get('#publishToolButton')
+                .click()
+        });
+    });
+
+    describe('manually register an Amazon ECR tool', function() {
+        it("register tool", function() {
+            cy
+                .server()
+                .route({
+                    method: "GET",
+                    url: /refresh/,
+                    response: { "id": 40000, "author": null, "description": null, "labels": [], "users": [{ "id": 1, "username": "user_A", "isAdmin": false, "name": "user_A" }], "email": null, "defaultVersion": null, "lastUpdated": 1482334377743, "gitUrl": "git@github.com:testnamespace/testname.git", "mode": "MANUAL_IMAGE_PATH", "name": "testname", "toolname": "", "namespace": "testnamespace", "registry": "AMAZON_ECR", "lastBuild": null, "tags": [], "is_published": false, "last_modified": null, "default_dockerfile_path": "/Dockerfile", "defaultCWLTestParameterFile": "/test.cwl.json", "defaultWDLTestParameterFile": "/test.cwl.json", "default_cwl_path": "/Dockstore.cwl", "default_wdl_path": "/Dockstore.wdl", "tool_maintainer_email": "test@email.com", "private_access": true, "path": "amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname", "tool_path": "amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname", "custom_docker_registry_path": "amazon.dkr.ecr.test.amazonaws.com" }
+
+                })
+                .route({
+                    method: "GET",
+                    url: /dockerfile/,
+                    response: { "content": "FROM ubuntu:16.10" }
+                })
+                .route({
+                    method: "GET",
+                    url: /cwl/,
+                    response: { "content": "#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n", "path": "/Dockstore.cwl" }
+                })
+            cy
+                .get('#register_tool_button')
+                .click()
+
+            cy
+                .get('#sourceCodeRepositoryInput')
+                .type("testnamespace/testname")
+                .wait(1000)
+
+            cy
+                .get('#imageRegistrySpinner')
+                .click()
+            cy
+                .contains('Amazon ECR')
+                .click()
+
+            cy
+                .get('#dockerRegistryPathInput')
+                .type('amazon.dkr.ecr.test.amazonaws.com')
+
+            cy
+                .get('#toolMaintainerEmailInput')
+                .type('test@email.com')
+
+            cy
+                .get('#imageRegistryInput')
+                .type('testnamespace/testname')
+
+            cy
+                .get('#submitButton')
+                .click()
+
+            cy
+                .get('#tool-path')
+                .should('contain', 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname')
+
+            cy
+                .contains('Versions')
+                .click()
+
+            cy
+                .get('#addTagButton')
+                .click()
+
+            cy
+                .get('#versionTagInput')
+                .type('master')
+            cy
+                .get('#gitReferenceInput')
+                .type('master')
+
+            cy
+                .get('#addVersionTagButton')
+                .click()
+
+            cy
+                .get('#deregisterButton')
+                .click()
+            cy
+                .get('#deregisterConfirmButton')
+                .click()
+
+            // This should be activated later
+            // cy
+            // .get('#tool-path')
+            // .should('not.contain', 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname')
+        });
+
+    });
 });

--- a/cypress/integration/myworkflows.js
+++ b/cypress/integration/myworkflows.js
@@ -7,18 +7,28 @@ describe('Dockstore my workflows', function() {
 
     describe('Should contain extended Workflow properties', function() {
         it('visit another page then come back', function() {
-          cy.get('a#home-nav-button').click()
-          cy.contains('Browse Tools')
-          cy.get('a#my-workflows-nav-button').click()
+            cy.get('a#home-nav-button').click()
+            cy.contains('Browse Tools')
+            cy.get('a#my-workflows-nav-button').click()
 
         });
         it('Should contain the extended properties', function() {
+            cy.contains('github.com')
+            // Apparently you need to click the accordion in order for the other components inside
+            // to become click-able
             cy
                 .get('accordion')
-                .get('.panel')
-                .children(':nth-child(2)')
-                .contains('a', 'g')
                 .click()
+            cy
+                .get('accordion')
+                .contains('a', 'Unpublished')
+                .should('be.visible')
+                .click()
+            cy.get('accordion')
+                .contains('div .no-wrap', /\g\b/)
+                .should('be.visible')
+                .parent()
+                .should('be.visible').click()
             cy.contains('GitHub')
             cy.contains('https://github.com/A/g')
         });
@@ -26,6 +36,7 @@ describe('Dockstore my workflows', function() {
 
     describe('Look at an invalid workflow', function() {
         it('Invalid workflow should not be publishable', function() {
+            cy.visit(String(global.baseUrl) + "/my-workflows/github.com/A/g")
             cy
                 .get('#publishButton')
                 .should('have.class', 'disabled')
@@ -35,6 +46,7 @@ describe('Dockstore my workflows', function() {
         });
 
         it('Only Info and Labels tab should be enabled', function() {
+            cy.visit(String(global.baseUrl) + "/my-workflows/github.com/A/g")
             cy
                 .get('.nav-link')
                 .contains('Info')
@@ -71,13 +83,7 @@ describe('Dockstore my workflows', function() {
 
     describe('Look at a published workflow', function() {
         it('Look at each tab', function() {
-            cy
-                .get('accordion')
-                .children(':nth-child(1)')
-                .find('a')
-                .contains('l')
-                .first()
-                .click()
+            cy.visit(String(global.baseUrl) + "/my-workflows/github.com/A/l")
             cy
                 .get('.nav-link')
                 .contains('Info')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,9 +2098,9 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "cypress": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-1.4.1.tgz",
-      "integrity": "sha1-YvQHSgDm8S4t/jiKf06BaknOsD8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-2.1.0.tgz",
+      "integrity": "sha512-EKXGjKFKUkhXXfAkYixBN2Lo2Gji4ZGC+ezWflRf/co49+OyHarZaXp7Y/n826WjmMdpHTmkOw4wUWBgyFHEHQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -2148,9 +2148,9 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -2168,7 +2168,7 @@
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
           },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "codelyzer": "~3.2.0",
-    "cypress": "^1.4.1",
+    "cypress": "^2.1.0",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -195,7 +195,9 @@ export class ContainerComponent extends Entry {
         publish: this.published
       };
       this.containersService.publish(this.tool.id, request).subscribe(
-        response => this.tool.is_published = response.is_published, err => {
+        response => {
+          this.containerService.upsertToolToTools(response);
+        }, err => {
           this.published = !this.published;
           this.refreshService.handleError('publish error', err);
         });

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -52,24 +52,32 @@
     <div class="row">
       <div class="col-md-3 containers-rsb">
         <accordion [closeOthers]="oneAtATime">
-          <accordion-group *ngFor="let nsObj of nsContainers" panelClass="containers-accordion" [heading]="nsObj?.namespace" [isOpen]="nsObj?.isFirstOpen">
-            <div *ngFor="let containerObj of nsObj?.containers">
-              <div class="panel-container-label" [ngClass]="{selected: tool.id === containerObj.id}">
-                <div class="container-name-oflw pull-left" title="{{containerObj.name + (containerObj?.toolname ? '/' + containerObj?.toolname : '')}}">
-                  <a style="cursor: pointer;" (click)="goToTool(containerObj)">
-                    {{containerObj.name + (containerObj.toolname ? '/' + containerObj.toolname : '')}}
-                  </a>
-                </div>
-                <div class="pull-right">
-                  <span class="label" [ngClass]="containerObj?.is_published ? 'label-primary' : 'label-warning'">
-                    {{ containerObj?.is_published ? 'PUB' : 'UNPUB'}}
-                  </span>
-                </div>
-              </div>
-            </div>
+          <accordion-group *ngFor="let orgObj of orgToolsObject" panelClass="containers-accordion" [heading]="orgObj?.namespace" [isOpen]="orgObj?.isFirstOpen">
+              <tabset [justified]="true">
+                  <tab heading="Published" [active]="orgObj.activeTab === 'published'">
+                    <div *ngFor="let entryObj of orgObj?.published">
+                      <div class="panel-container-label" [ngClass]="{selected: tool?.id === entryObj?.id}">
+                        <div style="cursor:pointer" class="no-wrap" title="{{entryObj?.repository + (entryObj?.toolName ? '/' + entryObj?.toolName : '')}}"
+                          (click)="selectContainer(entryObj)">
+                          {{entryObj?.name + (entryObj?.toolName ? '/' + entryObj?.toolName : '')}}
+                        </div>
+                      </div>
+                    </div>
+                  </tab>
+                  <tab heading="Unpublished" [active]="orgObj.activeTab === 'unpublished'">
+                      <div *ngFor="let entryObj of orgObj?.unpublished">
+                        <div class="panel-container-label" [ngClass]="{selected: tool?.id === entryObj?.id}">
+                          <div style="cursor:pointer" class="no-wrap" title="{{entryObj?.repository + (entryObj?.toolName ? '/' + entryObj?.toolName : '')}}"
+                            (click)="selectContainer(entryObj)">
+                            {{entryObj?.name + (entryObj?.toolName ? '/' + entryObj?.toolName : '')}}
+                          </div>
+                        </div>
+                      </div>
+                    </tab>
+                </tabset>
             <hr class="accordion-hr">
-            <app-refresh-tool-organization class="pull-right" [organization]="nsObj.namespace"></app-refresh-tool-organization>
-            <button type="button" class="btn btn-primary btn-xs pull-right add-container-ns" (click)="setModalGitPathAndImgPath(nsObj?.namespace); showRegisterToolModal()">
+            <app-refresh-tool-organization class="pull-right" [organization]="orgObj.namespace"></app-refresh-tool-organization>
+            <button type="button" class="btn btn-primary btn-xs pull-right add-container-ns" (click)="setModalGitPathAndImgPath(orgObj?.namespace); showRegisterToolModal()">
               <span class="glyphicon glyphicon-plus"></span>
             </button>
           </accordion-group>

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -24,7 +24,7 @@
   <div class="container padding-top">
     <app-alert></app-alert>
     <!--Msg/Warning Page, this should be a Component-->
-    <div class="row" *ngIf="nsContainers?.length == 0">
+    <div class="row" *ngIf="orgToolsObject?.length == 0">
       <div class="col-md-12">
         <div class="alert alert-info" role="alert">
           <p>

--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -99,7 +99,7 @@ export class MyToolComponent implements OnInit, OnDestroy {
             if (publishedWorkflow) {
               this.selectContainer(publishedWorkflow);
             } else {
-              const theFirstWorkflow = sortedContainers[0].workflows[0];
+              const theFirstWorkflow = sortedContainers[0].containers[0];
               this.selectContainer(theFirstWorkflow);
             }
           }

--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -13,9 +13,10 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from 'ng2-ui-auth';
+import { Subject } from 'rxjs/Subject';
 
 import { RegisterToolService } from '../../container/register-tool/register-tool.service';
 import { AccountsService } from '../../loginComponents/accounts/external/accounts.service';
@@ -25,6 +26,7 @@ import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
 import { RefreshService } from '../../shared/refresh.service';
 import { StateService } from '../../shared/state.service';
+import { DockstoreTool } from '../../shared/swagger';
 import { UrlResolverService } from '../../shared/url-resolver.service';
 import { MytoolsService } from '../mytools.service';
 import { Tool } from './../../container/register-tool/tool';
@@ -40,15 +42,16 @@ import { Configuration } from './../../shared/swagger/configuration';
   styleUrls: ['./my-tool.component.scss'],
   providers: [MytoolsService, DockstoreService]
 })
-export class MyToolComponent implements OnInit {
-  nsContainers: any;
+export class MyToolComponent implements OnInit, OnDestroy {
   oneAtATime = true;
   tools: any;
   user: any;
   tool: any;
   public hasGitHubToken = true;
+  private ngUnsubscribe: Subject<{}> = new Subject();
   public refreshMessage: string;
   private registerTool: Tool;
+  public orgToolsObject: Array<OrgToolObject>;
   constructor(private mytoolsService: MytoolsService, private configuration: Configuration,
     private communicatorService: CommunicatorService, private usersService: UsersService,
     private userService: UserService, private authService: AuthService, private stateService: StateService,
@@ -57,95 +60,192 @@ export class MyToolComponent implements OnInit {
     private registerToolService: RegisterToolService, private tokenService: TokenService,
     private urlResolverService: UrlResolverService, private router: Router) { }
 
+  link() {
+    this.accountsService.link(TokenSource.GITHUB);
+  }
+
   ngOnInit() {
     localStorage.setItem('page', '/my-tools');
     this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
-    this.containerService.setTool(null);
-    this.containerService.tool$.subscribe(selectedTool => {
-      this.tool = selectedTool;
-      this.communicatorService.setTool(selectedTool);
-      this.setIsFirstOpen();
-    });
     this.tokenService.hasGitHubToken$.subscribe(hasGitHubToken => this.hasGitHubToken = hasGitHubToken);
+    this.containerService.setTool(null);
+    this.containerService.tool$.subscribe(tool => {
+      this.tool = tool;
+      if (tool) {
+      this.setIsFirstOpen();
+      this.updateActiveTab();
+    }
+    });
     this.userService.user$.subscribe(user => {
       if (user) {
         this.user = user;
-        this.usersService.userContainers(user.id).subscribe(tools => {
+        this.usersService.userContainers(user.id).first().subscribe(tools => {
           this.containerService.setTools(tools);
         });
       }
     });
-    this.containerService.tools$.subscribe(tools => {
-      this.tools = tools;
-      if (this.user) {
+    this.containerService.tools$.takeUntil(this.ngUnsubscribe).subscribe(tools => {
+      if (tools) {
+        this.tools = tools;
         const sortedContainers = this.mytoolsService.sortNSContainers(tools, this.user.username);
-        this.containerService.setNsContainers(sortedContainers);
-      }
-    });
-    this.containerService.nsContainers.subscribe(containers => {
-      this.nsContainers = containers;
-      /* For the first initial time, set the first tool to be the selected one */
-      if (this.nsContainers && this.nsContainers.length > 0) {
-        const theFirstTool = this.nsContainers[0].containers[0];
-        const foundWorkflow = this.findToolFromPath(this.urlResolverService.getEntryPathFromUrl(), this.nsContainers);
-        if (foundWorkflow) {
-          this.selectContainer(foundWorkflow);
+        /* For the first initial time, set the first tool to be the selected one */
+        if (sortedContainers && sortedContainers.length > 0) {
+          this.orgToolsObject = this.convertNamespaceWorkflowsToOrgWorkflowsObject(sortedContainers);
+          const foundWorkflow = this.findToolFromPath(this.urlResolverService.getEntryPathFromUrl(), this.orgToolsObject);
+          if (foundWorkflow) {
+            this.selectContainer(foundWorkflow);
+          } else {
+            const publishedWorkflow = this.getFirstPublishedEntry(sortedContainers);
+            if (publishedWorkflow) {
+              this.selectContainer(publishedWorkflow);
+            } else {
+              const theFirstWorkflow = sortedContainers[0].workflows[0];
+              this.selectContainer(theFirstWorkflow);
+            }
+          }
         } else {
-          this.selectContainer(theFirstTool);
+          this.selectContainer(null);
         }
-      } else {
-        this.selectContainer(null);
       }
     });
     this.stateService.refreshMessage$.subscribe(refreshMessage => this.refreshMessage = refreshMessage);
     this.registerToolService.tool.subscribe(tool => this.registerTool = tool);
   }
 
-  link() {
-      this.accountsService.link(TokenSource.GITHUB);
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 
-  private findToolFromPath(path: string, nsContainers: any[]): ExtendedDockstoreTool {
-    let matchingWorkflow: ExtendedDockstoreTool;
-    nsContainers.forEach((nsContainer)  => {
-      nsContainer.containers.forEach((container: ExtendedDockstoreTool) => {
-        if (container.tool_path === path) {
-          matchingWorkflow = container;
+/**
+   * This figures out which tab (Published/Unpublished) is active
+   * In order of priority:
+   * 1. If the selected entry is published/unpublished, the tab selected will published/unpublished to reflect it
+   * 2. If there are published entries, the published tab will be selected
+   * 3. Unpublished otherwise
+   * @private
+   * @memberof MyToolComponent
+   */
+  private updateActiveTab() {
+    if (this.orgToolsObject) {
+      for (let i = 0; i < this.orgToolsObject.length; i++) {
+        if (this.tool) {
+          if (this.orgToolsObject[i].unpublished.find((workflow: DockstoreTool) => workflow.id === this.tool.id)) {
+            this.orgToolsObject[i].activeTab = 'unpublished';
+            continue;
+          }
+          if (this.orgToolsObject[i].published.find((workflow: DockstoreTool) => workflow.id === this.tool.id)) {
+            this.orgToolsObject[i].activeTab = 'published';
+            continue;
+          }
+          if (this.orgToolsObject[i].published.length > 0) {
+            this.orgToolsObject[i].activeTab = 'published';
+          } else {
+            this.orgToolsObject[i].activeTab = 'unpublished';
+          }
         }
+      }
+    }
+  }
+
+  /**
+ * Converts the deprecated nsWorkflows object to the new OrgWorkflowsObject contains:
+ * an array of published and unpublished workflows
+ * and which tab should be opened (published or unpublished)
+ * Main reason to convert to the new object is because figuring it out which tab should be active on
+ * the fly will result in function being executed far too many times (150 times)
+ * @private
+ * @param {Array<any>} nsWorkflows The original nsWorkflows object
+ * @returns {Array<OrgWorkflowObject>} The new object with more properties
+ * @memberof MyWorkflowComponent
+ */
+
+  private convertNamespaceWorkflowsToOrgWorkflowsObject(nsWorkflows: Array<any>): Array<OrgToolObject> {
+    const orgWorkflowsObject: Array<OrgToolObject> = [];
+    for (let i = 0; i < nsWorkflows.length; i++) {
+      const orgWorkflowObject: OrgToolObject = {
+        namespace: '',
+        isFirstOpen: false,
+        organization: '',
+        published: [],
+        unpublished: [],
+        activeTab: 'published'
+      };
+      const nsWorkflow: Array<DockstoreTool> = nsWorkflows[i].containers;
+      orgWorkflowObject.isFirstOpen = nsWorkflows[i].isFirstOpen;
+      orgWorkflowObject.namespace = nsWorkflows[i].namespace;
+      orgWorkflowObject.organization = nsWorkflows[i].organization;
+      orgWorkflowObject.published = nsWorkflow.filter((workflow: DockstoreTool) => {
+        return workflow.is_published;
       });
-    });
-    return matchingWorkflow;
-
+      orgWorkflowObject.unpublished = nsWorkflow.filter((workflow: DockstoreTool) => {
+        return !workflow.is_published;
+      });
+      orgWorkflowsObject.push(orgWorkflowObject);
+    }
+    return orgWorkflowsObject;
   }
-  goToTool(tool: ExtendedDockstoreTool) {
-    this.containerService.setTool(tool);
-    this.router.navigateByUrl('/my-tools/' + tool.tool_path);
+
+  /**
+   * Find the first published workflow in all of the organizations
+   *
+   * @private
+   * @param {*} orgEntries The deprecated object containing all the workflows
+   * @returns {DockstoreTool} The first published workflow found, null if there aren't any
+   * @memberof MyToolComponent
+   */
+  private getFirstPublishedEntry(orgEntries: any): DockstoreTool {
+    for (let i = 0; i < orgEntries.length; i++) {
+      const foundWorkflow = orgEntries[i]['containers'].find((entry: DockstoreTool) => {
+        return entry.is_published === true;
+      });
+      if (foundWorkflow) {
+        return foundWorkflow;
+      }
+    }
+    return null;
   }
 
+  private findToolFromPath(path: string, orgWorkflows: Array<OrgToolObject>): ExtendedDockstoreTool {
+    let matchingWorkflow: ExtendedDockstoreTool;
+    for (let i = 0; i < orgWorkflows.length; i++) {
+      matchingWorkflow = orgWorkflows[i].published.find((workflow: DockstoreTool) => workflow.tool_path === path);
+      if (matchingWorkflow) {
+        return matchingWorkflow;
+      }
+      matchingWorkflow = orgWorkflows[i].unpublished.find((workflow: DockstoreTool) => workflow.tool_path === path);
+      if (matchingWorkflow) {
+        return matchingWorkflow;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Determines which accordion is expanded on the workflow selector sidebar
+   *
+   * @memberof MyToolComponent
+   */
   setIsFirstOpen() {
-    if (this.nsContainers && this.tool) {
-      for (const nsObj of this.nsContainers) {
-        if (this.containSelectedTool(nsObj)) {
-          nsObj.isFirstOpen = true;
+    if (this.orgToolsObject && this.tool) {
+      for (let i = 0; i < this.orgToolsObject.length; i++) {
+        if (this.orgToolsObject[i].published.find((entry: DockstoreTool) => entry.id === this.tool.id)) {
+          this.orgToolsObject[i].isFirstOpen = true;
+          break;
+        }
+        if (this.orgToolsObject[i].unpublished.find((entry: DockstoreTool) => entry.id === this.tool.id)) {
+          this.orgToolsObject[i].isFirstOpen = true;
           break;
         }
       }
     }
   }
-  containSelectedTool(nsObj) {
-    let containTool = false;
-    for (const tool of nsObj.containers) {
-      if (tool.id === this.tool.id) {
-        containTool = true;
-        break;
-      }
-    }
-    return containTool;
-  }
+
   selectContainer(tool) {
-    this.tool = tool;
     this.containerService.setTool(tool);
-    this.communicatorService.setTool(tool);
+    if (tool) {
+      this.router.navigateByUrl('/my-tools/' + tool.tool_path);
+    }
   }
 
   setModalGitPathAndImgPath(namespace: string) {
@@ -163,4 +263,13 @@ export class MyToolComponent implements OnInit {
   refreshAllTools() {
     this.refreshService.refreshAllTools(this.user.id);
   }
+}
+
+interface OrgToolObject {
+  namespace: string;
+  organization: string;
+  isFirstOpen: boolean;
+  published: Array<ExtendedDockstoreTool>;
+  unpublished: Array<ExtendedDockstoreTool>;
+  activeTab: 'unpublished' | 'published';
 }

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -51,12 +51,12 @@
   <div class="row">
     <div class="col-md-3 containers-rsb">
       <accordion [closeOthers]="oneAtATime">
-        <accordion-group *ngFor="let orgObj of orgWorkflows" [heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="no-wrap containers-accordion"
+        <accordion-group *ngFor="let orgObj of orgWorkflowsObject" [heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="no-wrap containers-accordion"
           [isOpen]="orgObj?.isFirstOpen">
           <tabset [justified]="true">
-            <tab heading="Published">
-              <div *ngFor="let workflowObj of orgObj?.workflows">
-                <div *ngIf="workflowObj?.is_published" class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
+            <tab heading="Published" [active]="orgObj.activeTab === 'published'">
+              <div *ngFor="let workflowObj of orgObj?.published">
+                <div class="panel-container-label" [ngClass]="{selected: workflow?.id === workflowObj?.id}">
                   <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
                     (click)="goToWorkflow(workflowObj)">
                     {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
@@ -64,9 +64,9 @@
                 </div>
               </div>
             </tab>
-            <tab heading="Unpublished" [active]="orgObjContainsWorkflow(false, orgObj.workflows, workflow)">
-              <div *ngFor="let workflowObj of orgObj?.workflows">
-                <div *ngIf="!workflowObj?.is_published" class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
+            <tab heading="Unpublished" [active]="orgObj.activeTab === 'unpublished'">
+              <div *ngFor="let workflowObj of orgObj?.unpublished">
+                <div class="panel-container-label" [ngClass]="{selected: workflow?.id === workflowObj?.id}">
                   <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
                     (click)="goToWorkflow(workflowObj)">
                     {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -58,7 +58,7 @@
               <div *ngFor="let workflowObj of orgObj?.published">
                 <div class="panel-container-label" [ngClass]="{selected: workflow?.id === workflowObj?.id}">
                   <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
-                    (click)="goToWorkflow(workflowObj)">
+                    (click)="selectWorkflow(workflowObj)">
                     {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
                   </div>
                 </div>
@@ -68,7 +68,7 @@
               <div *ngFor="let workflowObj of orgObj?.unpublished">
                 <div class="panel-container-label" [ngClass]="{selected: workflow?.id === workflowObj?.id}">
                   <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
-                    (click)="goToWorkflow(workflowObj)">
+                    (click)="selectWorkflow(workflowObj)">
                     {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
                   </div>
                 </div>

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -23,7 +23,7 @@
 </app-header>
 <div class="container padding-top">
   <app-alert></app-alert>
-  <div class="row" *ngIf="orgWorkflows?.length == 0">
+  <div class="row" *ngIf="orgWorkflowsObject?.length == 0">
     <div class="col-md-12">
       <div class="alert alert-info" role="alert">
         <p>

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -53,20 +53,28 @@
       <accordion [closeOthers]="oneAtATime">
         <accordion-group *ngFor="let orgObj of orgWorkflows" [heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="containers-accordion"
           [isOpen]="orgObj?.isFirstOpen">
-          <div *ngFor="let workflowObj of orgObj?.workflows">
-            <div class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
-              <div class="container-name-oflw pull-left" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}">
-                <a style="cursor: pointer;" (click)="goToWorkflow(workflowObj)">
-                  {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
-                </a>
+          <tabset [justified]="true">
+            <tab heading="Published">
+              <div *ngFor="let workflowObj of orgObj?.workflows">
+                <div *ngIf="workflowObj?.is_published" class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
+                  <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
+                    (click)="goToWorkflow(workflowObj)">
+                    {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
+                  </div>
+                </div>
               </div>
-              <div class="pull-right">
-                <span class="label" [ngClass]="workflowObj?.is_published ? 'label-primary' : 'label-warning'">
-                  {{ workflowObj?.is_published ? 'PUB' : 'UNPUB'}}
-                </span>
+            </tab>
+            <tab heading="Unpublished" [active]="orgObjContainsWorkflow(false, orgObj.workflows, workflow)">
+              <div *ngFor="let workflowObj of orgObj?.workflows">
+                <div *ngIf="!workflowObj?.is_published" class="panel-container-label" [ngClass]="{selected: workflow.id === workflowObj.id}">
+                  <div style="cursor:pointer" class="no-wrap" title="{{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}"
+                    (click)="goToWorkflow(workflowObj)">
+                    {{workflowObj?.repository + (workflowObj?.workflowName ? '/' + workflowObj?.workflowName : '')}}
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </tab>
+          </tabset>
           <hr class="accordion-hr">
           <app-refresh-workflow-organization class="pull-right" [organization]="orgObj?.organization"></app-refresh-workflow-organization>
           <button type="button" class="glyphicon glyphicon-plus btn btn-primary btn-xs pull-right add-container-ns" (click)="setModalGitURL(orgObj?.organization + '/new_workflow'); showModal()">

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -51,7 +51,7 @@
   <div class="row">
     <div class="col-md-3 containers-rsb">
       <accordion [closeOthers]="oneAtATime">
-        <accordion-group *ngFor="let orgObj of orgWorkflows" [heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="containers-accordion"
+        <accordion-group *ngFor="let orgObj of orgWorkflows" [heading]="orgObj?.sourceControl + '/' + orgObj?.organization" panelClass="no-wrap containers-accordion"
           [isOpen]="orgObj?.isFirstOpen">
           <tabset [justified]="true">
             <tab heading="Published">

--- a/src/app/myworkflows/my-workflow/my-workflow.component.scss
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.scss
@@ -1,0 +1,6 @@
+
+.no-wrap {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -33,6 +33,7 @@ import { UrlResolverService } from './../../shared/url-resolver.service';
 import { WorkflowService } from './../../shared/workflow.service';
 import { RegisterWorkflowModalService } from './../../workflow/register-workflow-modal/register-workflow-modal.service';
 import { MyWorkflowsService } from './../myworkflows.service';
+import { Workflow } from '../../shared/swagger';
 
 @Component({
   selector: 'app-my-workflow',
@@ -112,6 +113,25 @@ export class MyWorkflowComponent implements OnInit {
   private goToWorkflow(workflow: ExtendedWorkflow): void {
     this.workflowService.setWorkflow(workflow);
     this.router.navigateByUrl('/my-workflows/' + workflow.full_workflow_path);
+  }
+
+  /**
+   * Determines whether the given workflow is present in the list of workflows and is in the desired published state
+   * @param {boolean} published Whether we're looking for a published workflow or not
+   * @param {Array<Workflow>} workflows The current list of workflows in an organization
+   * @param {Workflow} selectedWorkflow The current selected workflow
+   * @returns Whether the workflow is present or not
+   * @memberof MyWorkflowComponent
+   */
+  public orgObjContainsWorkflow(published: boolean, workflows: Array<Workflow>, selectedWorkflow: Workflow): boolean {
+    console.log('executed');
+    const filteredWorkflows = workflows.filter(workflow => (workflow.is_published === published));
+    const foundWorkflow = filteredWorkflows.find(workflow => workflow.id === selectedWorkflow.id);
+    if (foundWorkflow) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   private findWorkflowFromPath(path: string, orgWorkflows: any[]): ExtendedWorkflow {

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -101,7 +101,12 @@ export class MyWorkflowComponent implements OnInit {
         if (foundWorkflow) {
           this.selectWorkflow(foundWorkflow);
         } else {
-          this.selectWorkflow(theFirstWorkflow);
+          const publishedWorkflow = this.getFirstPublishedWorkflow(this.orgWorkflows);
+          if (publishedWorkflow) {
+            this.selectWorkflow(publishedWorkflow);
+          } else {
+            this.selectWorkflow(theFirstWorkflow);
+          }
         }
       } else {
         this.selectWorkflow(null);
@@ -110,9 +115,23 @@ export class MyWorkflowComponent implements OnInit {
     this.stateService.refreshMessage$.subscribe(refreshMessage => this.refreshMessage = refreshMessage);
   }
 
+  private getFirstPublishedWorkflow(orgWorkflows: any): Workflow {
+    for (let i = 0; i < orgWorkflows.length; i++) {
+      const foundWorkflow = orgWorkflows[i]['workflows'].find((workflow: Workflow) => {
+        return workflow.is_published === true;
+      });
+      if (foundWorkflow) {
+        return foundWorkflow;
+      }
+    }
+    return null;
+  }
+
   private goToWorkflow(workflow: ExtendedWorkflow): void {
     this.workflowService.setWorkflow(workflow);
-    this.router.navigateByUrl('/my-workflows/' + workflow.full_workflow_path);
+    if (workflow) {
+      this.router.navigateByUrl('/my-workflows/' + workflow.full_workflow_path);
+    }
   }
 
   /**
@@ -164,7 +183,7 @@ export class MyWorkflowComponent implements OnInit {
     }
   }
   selectWorkflow(workflow: ExtendedWorkflow) {
-    this.workflowService.setWorkflow(workflow);
+    this.goToWorkflow(workflow);
   }
 
   setModalGitURL(gitURL: string) {

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -15,7 +15,7 @@
  */
 import { Location } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router/';
+import { NavigationEnd, Router } from '@angular/router/';
 import { AuthService } from 'ng2-ui-auth/commonjs/auth.service';
 import { Subject } from 'rxjs/Subject';
 
@@ -46,7 +46,6 @@ import { MyWorkflowsService } from './../myworkflows.service';
 
 export class MyWorkflowComponent implements OnInit, OnDestroy {
   hasGitHubToken = true;
-  orgWorkflows = [];
   oneAtATime = true;
   workflow: any;
   user: any;
@@ -66,6 +65,9 @@ export class MyWorkflowComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    /**
+     * This handles when the router changes url due to when the user clicks the 'view checker workflow' or 'view parent entry' buttons
+     */
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         const foundWorkflow = this.findWorkflowFromPath(this.urlResolverService.getEntryPathFromUrl(), this.orgWorkflowsObject);
@@ -97,18 +99,18 @@ export class MyWorkflowComponent implements OnInit, OnDestroy {
       if (workflows) {
         this.workflows = workflows;
         const sortedWorkflows = this.myworkflowService.sortORGWorkflows(workflows, this.user.username);
-        this.orgWorkflows = sortedWorkflows;
-        if (this.orgWorkflows && this.orgWorkflows.length > 0) {
+        /* For the first initial time, set the first tool to be the selected one */
+        if (sortedWorkflows && sortedWorkflows.length > 0) {
           this.orgWorkflowsObject = this.convertNamespaceWorkflowsToOrgWorkflowsObject(sortedWorkflows);
           const foundWorkflow = this.findWorkflowFromPath(this.urlResolverService.getEntryPathFromUrl(), this.orgWorkflowsObject);
-          const theFirstWorkflow = this.orgWorkflows[0].workflows[0];
           if (foundWorkflow) {
             this.selectWorkflow(foundWorkflow);
           } else {
-            const publishedWorkflow = this.getFirstPublishedWorkflow(this.orgWorkflows);
+            const publishedWorkflow = this.getFirstPublishedWorkflow(sortedWorkflows);
             if (publishedWorkflow) {
               this.selectWorkflow(publishedWorkflow);
             } else {
+              const theFirstWorkflow = sortedWorkflows[0].workflows[0];
               this.selectWorkflow(theFirstWorkflow);
             }
           }

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -124,7 +124,6 @@ export class MyWorkflowComponent implements OnInit {
    * @memberof MyWorkflowComponent
    */
   public orgObjContainsWorkflow(published: boolean, workflows: Array<Workflow>, selectedWorkflow: Workflow): boolean {
-    console.log('executed');
     const filteredWorkflows = workflows.filter(workflow => (workflow.is_published === published));
     const foundWorkflow = filteredWorkflows.find(workflow => workflow.id === selectedWorkflow.id);
     if (foundWorkflow) {

--- a/src/app/myworkflows/myworkflows.component.spec.ts
+++ b/src/app/myworkflows/myworkflows.component.spec.ts
@@ -100,16 +100,4 @@ describe('MyWorkflowComponent', () => {
     component.refreshAllWorkflows();
     expect(refreshService.refreshAllWorkflows).toHaveBeenCalled();
   });
-  it('should check if it contains workflows', () => {
-    component.workflow = {
-      id: 5
-    };
-    fixture.detectChanges();
-    expect(component.containSelectedWorkflow({workflows: [sampleWorkflow1, sampleWorkflow2, sampleWorkflow3]})).toBeFalsy();
-    component.workflow = {
-      id: 3
-    };
-    fixture.detectChanges();
-    expect(component.containSelectedWorkflow({workflows: [sampleWorkflow1, sampleWorkflow2, sampleWorkflow3]})).toBeTruthy();
-  });
 });

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -314,8 +314,8 @@ export class SearchComponent implements OnInit {
     const aggregations = hits.aggregations;
     Object.entries(aggregations).forEach(
       ([key, value]) => {
-        if (value.buckets != null) {
-          this.setupBuckets(this.searchService.aggregationNameToTerm(key), value.buckets);
+        if (value['buckets'] != null) {
+          this.setupBuckets(this.searchService.aggregationNameToTerm(key), value['buckets']);
         }
         // look for second level buckets (with filtering)
         // If there are second level buckets,


### PR DESCRIPTION
Leaving this here for now for issue ga4gh/dockstore#1094

Changes the my-tools/my-workflows' select entries component to have a toggle between published and unpublished entries.  Tests currently use `wait` in order for the rendering to finish before clicking.  Ideally, another should function should be used to determine when it's done rendering.  Additionally, change it so that the rendering can be easily detected and done once.

Try reverting the Cypress update (to autoscroll to component) and resolution change (just in case it's not visible)