### PR TITLE
Feature/search

### DIFF
--- a/src/app/listentry/listentry.component.html
+++ b/src/app/listentry/listentry.component.html
@@ -87,7 +87,7 @@
         <span *ngIf="getVerifiedWorkflow(hit?._source)">
             <a style="text-decoration: none" tooltip="Verified" class="glyphicon glyphicon-ok"></a>
         </span>
-        <a (click)="sendToolInfo(hit?._source)" [routerLink]="('/workflows/' + hit?._source.path )">
+        <a (click)="sendToolInfo(hit?._source)" [routerLink]="('/workflows/' + hit?._source.full_workflow_path )">
           {{ hit?._source.repository + (hit?._source.workflowName ? '/' + hit?._source.workflowName : '') }}
         </a>
       </td>

--- a/src/app/listentry/listentry.component.ts
+++ b/src/app/listentry/listentry.component.ts
@@ -13,18 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import { SearchService } from './../search/search.service';
-import { AfterViewInit, Component, Input, OnInit, ViewChild,  Output, EventEmitter} from '@angular/core';
-import { Subject } from 'rxjs/Subject';
-import { Subscription } from 'rxjs/Subscription';
 import 'rxjs/add/operator/takeUntil';
-import { SearchComponent } from '../search/search.component';
+
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { DataTableDirective } from 'angular-datatables';
+import { Subject } from 'rxjs/Subject';
+
 import { ListContainersService } from '../containers/list/list.service';
-import { PagenumberService } from '../shared/pagenumber.service';
-import { OnDestroy } from '@angular/core';
 import { DockstoreService } from '../shared/dockstore.service';
+import { ExtendedDockstoreTool } from '../shared/models/ExtendedDockstoreTool';
+import { ExtendedWorkflow } from '../shared/models/ExtendedWorkflow';
+import { SearchService } from './../search/search.service';
 
 @Component({
   selector: 'app-listentry',
@@ -103,11 +102,25 @@ export class ListentryComponent implements OnInit, AfterViewInit, OnDestroy {
     }).catch(error => console.log(error));
   }
 
-  getVerifiedTool(tool) {
+  /**
+   * Determines whether a DockstoreTool is considered verified
+   *
+   * @param {ExtendedDockstoreTool} tool The DockstoreTool to be looked at
+   * @returns {boolean} Whether or not the DockstoreTool is considered verified
+   * @memberof ListentryComponent
+   */
+  getVerifiedTool(tool: ExtendedDockstoreTool) {
     return this.dockstoreService.getVersionVerified(tool.tags);
   }
 
-  getVerifiedWorkflow(workflow) {
+  /**
+   * Determines whether a Workflow is considered verified
+   *
+   * @param {ExtendedWorkflow} workflow The Workflow to be looked at
+   * @returns {boolean} Whether or not the Workflow is considered verified
+   * @memberof ListentryComponent
+   */
+  getVerifiedWorkflow(workflow: ExtendedWorkflow): boolean {
     return this.dockstoreService.getVersionVerified(workflow.workflowVersions);
   }
 }

--- a/src/app/shared/dockstore.service.ts
+++ b/src/app/shared/dockstore.service.ts
@@ -26,6 +26,9 @@ export class DockstoreService {
   }
 
   getVersionVerified(versions) {
+    if (!versions) {
+      return false;
+    }
     const verifiedVersion = versions.find(version => version.verified);
     if (verifiedVersion) {
       return true;

--- a/src/app/shared/dockstore.service.ts
+++ b/src/app/shared/dockstore.service.ts
@@ -13,8 +13,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 import { Injectable } from '@angular/core';
+
+import { Tag, WorkflowVersion } from './swagger';
 
 @Injectable()
 export class DockstoreService {
@@ -25,7 +26,14 @@ export class DockstoreService {
     return versions.filter(version => version.valid);
   }
 
-  getVersionVerified(versions) {
+  /**
+   * Determines whether any of the versions of the entry are verified
+   *
+   * @param {(Array<WorkflowVersion|Tag>)} versions  an entry's versions
+   * @returns {boolean} Whether or not one of the versions are verified
+   * @memberof DockstoreService
+   */
+  getVersionVerified(versions: Array<WorkflowVersion|Tag>): boolean {
     if (!versions) {
       return false;
     }


### PR DESCRIPTION
This contains 2 fixes.

1.  Return the full workflow path for the workflows listed in search results  ga4gh/dockstore#1097
2.  Workfaround the major console.log issue that occurs when there's no versions for specific tool/workflow in search.  Side note, figure out why elasticsearch doesn't return an empty array for workflowVersions.

Note:
The getVersionVerified() function is being executed a bajillion times and should be fixed at some point.