### PR TITLE
Fix for descriptorLanguage being pre-mapped already

### DIFF
--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -26,7 +26,7 @@ import { WorkflowService } from './../../shared/workflow.service';
 @Injectable()
 export class RegisterWorkflowModalService {
     workflowRegisterError$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
-    private descriptorLanguageMap = [];
+    private descriptorLanguageMap: Array<string> = [];
     sampleWorkflow: Workflow = <Workflow>{};
     actualWorkflow: Workflow;
     private sourceControlMap = [];

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -104,8 +104,6 @@ export class RegisterWorkflowModalService {
     }
 
     getDescriptorLanguageKeys(): Array<string> {
-      if (this.descriptorLanguageMap) {
-        return this.descriptorLanguageMap.map((a) => a.value);
-      }
+      return this.descriptorLanguageMap;
     }
 }


### PR DESCRIPTION
There was a descriptorLanguage$ observable that was mapped from the bean to contain the array of strings.  This PR fixes what was left out (by not trying to map a 2nd time).

For ga4gh/dockstore#1253