### PR TITLE
cannot change workflow type when full

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -79,13 +79,13 @@
     </button>
   </li>
   <li>
-    <div *ngIf="!isPublic" class="form-inline">
+    <div *ngIf="!isPublic && workflow?.mode === WorkflowType.ModeEnum.STUB" class="form-inline">
       <Strong uib-tooltip="Type of descriptor language used">Descriptor Type: </Strong>
       <select class="form-control input-sm" (change)="save()" [(ngModel)]="workflow.descriptorType">
         <option *ngFor="let descriptorLanguage of descriptorLanguages()" value="{{descriptorLanguage | lowercase}}">{{descriptorLanguage | lowercase}}</option>
       </select>
     </div>
-    <div *ngIf="isPublic">
+    <div *ngIf="isPublic || workflow?.mode === WorkflowType.ModeEnum.FULL">
       <Strong uib-tooltip="Type of descriptor language used">Descriptor Type: </Strong>{{ workflow?.descriptorType }}</div>
   </li>
 </ul>


### PR DESCRIPTION
If you are viewing a FULL workflow, you are not able to change the descriptor type.