### PR TITLE
Comment out goo.gl url shortener code

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -436,14 +436,6 @@ export class SearchComponent implements OnInit {
   // TODO: Find another method for shortening URLs
   setShortUrl(url: string) {
     this.shortUrl = url;
-    // const googleUrlShortenerBase = 'https://www.googleapis.com/urlshortener/v1/url?key=';
-    // const body = {'longUrl': url};
-    // const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body);
-    //
-    // const sub = req.subscribe(
-    //   data => { this.shortUrl = data['id']; },
-    //   err => { this.shortUrl = url; }
-    // );
   }
 
   /**===============================================

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -433,15 +433,17 @@ export class SearchComponent implements OnInit {
   }
 
   // Given a URL, will attempt to shorten it
+  // TODO: Find another method for shortening URLs
   setShortUrl(url: string) {
-    const googleUrlShortenerBase = 'https://www.googleapis.com/urlshortener/v1/url?key=';
-    const body = {'longUrl': url};
-    const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body);
-
-    const sub = req.subscribe(
-      data => { this.shortUrl = data['id']; },
-      err => { this.shortUrl = url; }
-    );
+    this.shortUrl = url;
+    // const googleUrlShortenerBase = 'https://www.googleapis.com/urlshortener/v1/url?key=';
+    // const body = {'longUrl': url};
+    // const req = this.http.post(googleUrlShortenerBase + Dockstore.GOOGLE_SHORTENER_KEY, body);
+    //
+    // const sub = req.subscribe(
+    //   data => { this.shortUrl = data['id']; },
+    //   err => { this.shortUrl = url; }
+    // );
   }
 
   /**===============================================

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -28,9 +28,6 @@ export class Dockstore {
   // Discourse URL MUST end with a slash (/)
   static readonly DISCOURSE_URL = 'http://localhost/';
 
-  // Google Shortener API key (https://developers.google.com/url-shortener/v1/getting_started#APIKey)
-  static readonly GOOGLE_SHORTENER_KEY = 'fill_this_in';
-
   static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;
   static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
   static readonly DNASTACK_IMPORT_URL= 'https://app.dnastack.com/#/app/workflow/import/dockstore';


### PR DESCRIPTION
Removed code to use the google URL shortener. Now the function to shorten the URL will just return the regular URL. We will need to find something else to replace google in the future.

https://github.com/ga4gh/dockstore/issues/1263

Note: I still have to test this locally. Having trouble setting up elastic search. I'll notify people once this is ready for review.