### PR TITLE
Fix stubbed workflows showing description and CLI commands

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -89,7 +89,7 @@
       <Strong uib-tooltip="Type of descriptor language used">Descriptor Type: </Strong>{{ workflow?.descriptorType }}</div>
   </li>
 </ul>
-<div *ngIf="workflow">
+<div *ngIf="workflow && workflow?.mode === WorkflowType.ModeEnum.FULL">
   <div *ngIf="workflow?.description || !isPublic">
     <label tooltip="Description of workflow obtained from workflow descriptor">
       Description


### PR DESCRIPTION
Simple fix for ga4gh/dockstore#1250 and also a bigger issue...  Going from FULL workflow to a STUB workflow showed the CLI commands of the previous FULL workflow.