### PR TITLE
Feature/cypress types

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "baseUrl": "../node_modules",
+    "target": "es5",
+    "lib": [
+      "es5",
+      "dom"
+    ],
+    "types": [
+      "cypress"
+    ]
+  },
+  "include": [
+    "**/*.*"
+  ]
+}

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -1,4 +1,4 @@
-<li *ngIf="(checkerWorkflow$ | async) || (!(checkerWorkflow$ | async) && !(hasParentEntry$ | async) && !(isStub$ | async))">
+<li *ngIf="(checkerWorkflow$ | async) || (!(checkerWorkflow$ | async) && !(hasParentEntry$ | async) && !(isStub$ | async)) && !(isPublic$ | async)">
   <form #editCheckerWorkflowPathForm="ngForm" class="form-inline">
     <div class="form-group">
       <strong tooltip="Checker workflow of this tool/workflow that tests it">Checker Workflow</strong>:

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -1,4 +1,4 @@
-<li *ngIf="(checkerWorkflow$ | async) || (!(checkerWorkflow$ | async) && !(hasParentEntry$ | async) && !(isStub$ | async)) && !(isPublic$ | async)">
+<li *ngIf="(checkerWorkflow$ | async) || (!(checkerWorkflow$ | async) && !(hasParentEntry$ | async) && !(isStub$ | async))">
   <form #editCheckerWorkflowPathForm="ngForm" class="form-inline">
     <div class="form-group">
       <strong tooltip="Checker workflow of this tool/workflow that tests it">Checker Workflow</strong>:


### PR DESCRIPTION
- Activate Cypress intellisense
- Empty checker workflow path is no longer displayed in public entries