### PR TITLE
Fix for capital language descriptor bean

### DIFF
--- a/src/app/container/launch/tool-launch.service.spec.ts
+++ b/src/app/container/launch/tool-launch.service.spec.ts
@@ -28,13 +28,13 @@ describe('ToolLaunchService', () => {
         expect(service).toBeTruthy();
     }));
     it('should getParamsString', inject([ToolLaunchService], (service: ToolLaunchService) => {
-        expect(service.getParamsString('quay.io/a/b', 'latest', 'wdl'))
+        expect(service.getParamsString('quay.io/a/b', 'latest', 'WDL'))
             .toContain('$ dockstore tool convert entry2json --descriptor wdl --entry quay.io/a/b:latest > Dockstore.json');
     }));
     it('should getCliString', inject([ToolLaunchService], (service: ToolLaunchService) => {
-        expect(service.getCliString('a/b', 'latest', 'cwl'))
+        expect(service.getCliString('a/b', 'latest', 'CWL'))
             .toContain('dockstore tool launch --entry a/b:latest --json Dockstore.json');
-        expect(service.getCliString('quay.io/a/b', 'c', 'wdl'))
+        expect(service.getCliString('quay.io/a/b', 'c', 'WDL'))
             .toContain('dockstore tool launch --entry quay.io/a/b:c --json Dockstore.json --descriptor wdl');
     }));
 

--- a/src/app/container/launch/tool-launch.service.ts
+++ b/src/app/container/launch/tool-launch.service.ts
@@ -22,7 +22,7 @@ export class ToolLaunchService extends LaunchService {
   getParamsString(path: string, versionName: string, currentDescriptor: string) {
     let descriptor = '';
 
-    if (currentDescriptor === 'wdl') {
+    if (currentDescriptor === 'WDL') {
       descriptor = ToolLaunchService.descriptorWdl;
     }
 
@@ -32,8 +32,7 @@ export class ToolLaunchService extends LaunchService {
 
   getCliString(path: string, versionName: string, currentDescriptor: string) {
     let descriptor = '';
-
-    if (currentDescriptor === 'wdl') {
+    if (currentDescriptor === 'WDL') {
       descriptor = ToolLaunchService.descriptorWdl;
     }
 


### PR DESCRIPTION
Fix for DescriptorLanguageBean returning all caps...which leads to Dockstore command being broken.

Didn't use an enum because DescriptorLanguageBean doesn't have enum.

ga4gh/dockstore#1304