### PR TITLE
Feature/1301/search name

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -173,7 +173,7 @@ export class QueryBuilderService {
         if (values.toString().length > 0) {
             if (advancedSearchObject && !advancedSearchObject.toAdvanceSearch) {
                 advancedSearchObject.ORFilter = values;
-                this.advancedSearchFiles(body, advancedSearchObject);
+                this.searchEverything(body, values);
                 advancedSearchObject.ORFilter = '';
             }
         } else {
@@ -191,6 +191,29 @@ export class QueryBuilderService {
             }
         }
         return body;
+    }
+
+    /**
+     * Appends search-everything filter to the query
+     * Currently searches sourcefiles, description, labels, author, and path
+     * @param {*} body The original body
+     * @param {string} searchString the search string
+     * @memberof QueryBuilderService
+     */
+    searchEverything(body: any, searchString: string): void {
+        body = body.filter('bool', filter => filter
+        .orFilter('bool', workflowVersionsFileContent => workflowVersionsFileContent
+            .filter('match_phrase', 'workflowVersions.sourceFiles.content', searchString))
+        .orFilter('bool', tagsFileContent => tagsFileContent
+            .filter('match_phrase', 'tags.sourceFiles.content', searchString))
+        .orFilter('bool', descriptionFilter => descriptionFilter
+            .filter('match_phrase', 'description', searchString))
+        .orFilter('bool', labelsFilter => labelsFilter
+            .filter('match_phrase', 'labels', searchString))
+        .orFilter('bool', authorFilter => authorFilter
+            .filter('match_phrase', 'author', searchString))
+        .orFilter('bool', pathFilter => pathFilter
+            .filter('match_phrase', 'path', searchString)));
     }
 
     /**===============================================

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -106,7 +106,7 @@ export class SearchResultsComponent implements OnInit {
           count--;
         }
       );
-    });
+    }).catch(error => console.log(error));
   }
 
   // Tells the search service to tell the search filters to save its data

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -34,7 +34,7 @@
             </span>
           </div>
           <div>
-            <input  tooltip="Find tools and workflows with files that have at least one of these terms"
+            <input  tooltip="Find tools and workflows"
                     type="text" list="suggestions" class="search-box form-control" [(ngModel)]="values"
                     (ngModelChange)="onKey()" placeholder="Enter search term" />
             <datalist id="suggestions" *ngIf="autocompleteTerms.length > 0">

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -314,8 +314,8 @@ export class SearchComponent implements OnInit {
     const aggregations = hits.aggregations;
     Object.entries(aggregations).forEach(
       ([key, value]) => {
-        if (value.buckets != null) {
-          this.setupBuckets(this.searchService.aggregationNameToTerm(key), value.buckets);
+        if (value['buckets'] != null) {
+          this.setupBuckets(this.searchService.aggregationNameToTerm(key), value['buckets']);
         }
         // look for second level buckets (with filtering)
         // If there are second level buckets,
@@ -402,7 +402,7 @@ export class SearchComponent implements OnInit {
     }).then(hits => {
       this.setupAllBuckets(hits);
       this.setupOrderBuckets();
-    });
+    }).catch(error => console.log(error));
   }
 
   /**
@@ -429,7 +429,7 @@ export class SearchComponent implements OnInit {
       if (this.searchTerm && this.hits.length === 0) {
         this.suggestKeyTerm();
       }
-    });
+    }).catch(error => console.log(error));
   }
 
   // Given a URL, will attempt to shorten it
@@ -498,7 +498,7 @@ export class SearchComponent implements OnInit {
           this.autocompleteTerms.push(term.key);
         }
       );
-    });
+    }).catch(error => console.log(error));
     if (!this._timeout) {
       this.advancedSearchObject.toAdvanceSearch = false;
       this.searchTerm = true;
@@ -533,7 +533,7 @@ export class SearchComponent implements OnInit {
       } else {
         this.suggestTerm = '';
       }
-    });
+    }).catch(error => console.log(error));
   }
 
   searchSuggestTerm() {


### PR DESCRIPTION
- Fix for page catastrophically failing when no results are returned (this is already merged into develop)
- Fix for TS2.7 because it was bugging me (even though we're supposed to use TS2.4 right now)
- As before, advanced search searches description and files but non-advanced-search now searches everything (path, author, labels, file contents, description) instead of just file contents (not sure how people were supposed to know it searched file contents previously).

For ga4gh/dockstore#1301