### PR TITLE
Add short instructions for Python 3

### DIFF
--- a/cypress/integration/starTool.js
+++ b/cypress/integration/starTool.js
@@ -72,6 +72,9 @@ describe('Tool starring', function() {
         .should('exist')
 
       cy.visit(String(global.baseUrl) + "/containers/quay.io/A2/a")
+      cy
+        .get('#starringButtonIcon')
+        .should("have.class", "glyphicon-star")
 
       cy
         .get('#starringButton')

--- a/cypress/integration/starWorkflow.js
+++ b/cypress/integration/starWorkflow.js
@@ -72,6 +72,9 @@ describe('Workflow starring', function() {
         .should('exist')
 
       cy.visit(String(global.baseUrl) + "/workflows/github.com/A/l")
+      cy
+        .get('#starringButtonIcon')
+        .should("have.class", "glyphicon-star")
 
       cy
         .get('#starringButton')

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -1,9 +1,11 @@
 // tslint:disable:max-line-length
-import { Metadata } from './../../../shared/swagger/model/metadata';
-import { GA4GHService } from './../../../shared/swagger/api/gA4GH.service';
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from 'ng2-ui-auth';
+
 import { Dockstore } from '../../../shared/dockstore.model';
+import { GA4GHService } from './../../../shared/swagger/api/gA4GH.service';
+import { Metadata } from './../../../shared/swagger/model/metadata';
+import { pipRequirements } from './pipRequirement';
 
 @Component({
   selector: 'app-downloadcliclient',
@@ -14,13 +16,11 @@ export class DownloadCLIClientComponent implements OnInit {
   public downloadCli = 'dummy-start-value';
   public dockstoreVersion = 'dummy-start-value';
   public dsToken = 'dummy-token';
-  public cwltoolVersion = '1.0.20170828135420';
   public dsServerURI: any;
   public isCopied2: boolean;
   public textData1 = '';
   public textData2 = '';
   public textData3 = '';
-
   constructor(private authService: AuthService,
     private gA4GHService: GA4GHService) { }
 
@@ -80,10 +80,11 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 1. Run this to verify that pip has been installed \`pip --version\`
 2. Run these commands to install cwltool
 \`\`\`
-pip install setuptools==36.5.0
-pip install cwl-runner cwltool==${this.cwltoolVersion} schema-salad==2.6.20170806163416 avro==1.8.1 ruamel.yaml==0.14.12 requests==2.18.4
+pip install setuptools==${pipRequirements.setupToolsVersion}
+pip install cwl-runner cwltool==${pipRequirements.cwltoolVersion} schema-salad==${pipRequirements.schemaSaladVersion} avro==${pipRequirements.avroVersion} ruamel.yaml==${pipRequirements.ruamelYamlVersion} requests==${pipRequirements.requestsVersion}
 \`\`\`
-If using Python 3, install cwl-avro==1.8.3 instead of avro==1.8.1.
+<!-- Workaround until https://github.com/common-workflow-language/cwltool/issues/524 is resolved -->
+If using Python 3, install cwl-avro==${pipRequirements.cwlAvroVersion} instead of avro==${pipRequirements.avroVersion}.
 
 3. Install Docker following the instructions on [Docker's website](https://docs.docker.com/engine/installation/linux/ubuntulinux/).
 Ensure that you are able to run Docker without using sudo directly with the
@@ -103,7 +104,7 @@ java version "1.8.0_144"
 Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
 Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)
 $ cwltool --version
-/usr/local/bin/cwltool ${this.cwltoolVersion}
+/usr/local/bin/cwltool ${pipRequirements.cwltoolVersion}
 $ docker run hello-world
 Hello from Docker!
 ...

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -83,6 +83,8 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 pip install setuptools==36.5.0
 pip install cwl-runner cwltool==${this.cwltoolVersion} schema-salad==2.6.20170806163416 avro==1.8.1 ruamel.yaml==0.14.12 requests==2.18.4
 \`\`\`
+If using Python 3, install cwl-avro==1.8.3 instead of avro==1.8.1.
+
 3. Install Docker following the instructions on [Docker's website](https://docs.docker.com/engine/installation/linux/ubuntulinux/).
 Ensure that you are able to run Docker without using sudo directly with the
 [post install instructions](https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user).

--- a/src/app/loginComponents/onboarding/downloadcliclient/pipRequirement.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/pipRequirement.ts
@@ -1,0 +1,24 @@
+/*
+ *     Copyright 2018 OICR
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+export const pipRequirements = {
+    setupToolsVersion: '36.5.0',
+    cwltoolVersion: '1.0.20170828135420',
+    schemaSaladVersion: '2.6.20170806163416',
+    avroVersion: '1.8.1',
+    ruamelYamlVersion: '0.14.12',
+    requestsVersion: '2.18.4',
+    cwlAvroVersion: '1.8.3'
+};


### PR DESCRIPTION
Short instructions for what to do when using Python 3

For issue ga4gh/dockstore#1242

Also added an additional check in the starring tests to make sure everything looks ok before starring.  In the future, it should be done properly instead (disable the button until it's ready to be pressed)

Moved all the pip dependencies versions to another constant in another file.