### PR TITLE
Feature/no connection to webservice

### DIFF
--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -72,6 +72,9 @@ export class RegisterToolService {
     setToolRegisterError(error: HttpErrorResponse) {
         let errorObj = null;
         if (error) {
+          if (error.status === 0) {
+            errorObj = { message: 'The webservice is currently down, possibly due to load. Please wait and try again later.', errorDetails: '' }
+          } else {
             errorObj = {
                 message: 'The webservice encountered an error trying to create this ' +
                 'tool, please ensure that the tool attributes are ' +
@@ -79,6 +82,7 @@ export class RegisterToolService {
                 errorDetails: '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
                 error.error
             };
+          }
         }
         this.toolRegisterError.next(errorObj);
     }

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -73,7 +73,10 @@ export class RegisterToolService {
         let errorObj = null;
         if (error) {
           if (error.status === 0) {
-            errorObj = { message: 'The webservice is currently down, possibly due to load. Please wait and try again later.', errorDetails: '' }
+            errorObj = {
+              message: 'The webservice is currently down, possibly due to load. Please wait and try again later.',
+              errorDetails: ''
+            };
           } else {
             errorObj = {
                 message: 'The webservice encountered an error trying to create this ' +

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -93,7 +93,8 @@ export class RegisterWorkflowModalService {
             }, error =>  {
               if (error) {
                 if (error.status === 0) {
-                  this.setWorkflowRegisterError('The webservice is currently down, possibly due to load. Please wait and try again later.', '');
+                  this.setWorkflowRegisterError('The webservice is currently down, possibly due to load. ' +
+                  'Please wait and try again later.', '');
                 } else {
                   this.setWorkflowRegisterError('The webservice encountered an error trying to create this ' +
                     'workflow, please ensure that the workflow attributes are ' +

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -90,10 +90,18 @@ export class RegisterWorkflowModalService {
                     this.setIsModalShown(false);
                     this.clearWorkflowRegisterError();
                 }, error => this.stateService.setRefreshMessage(null));
-            }, error => this.setWorkflowRegisterError('The webservice encountered an error trying to create this ' +
-                'workflow, please ensure that the workflow attributes are ' +
-                'valid and the same image has not already been registered.', '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
-                error.error)
+            }, error =>  {
+              if (error) {
+                if (error.status === 0) {
+                  this.setWorkflowRegisterError('The webservice is currently down, possibly due to load. Please wait and try again later.', '');
+                } else {
+                  this.setWorkflowRegisterError('The webservice encountered an error trying to create this ' +
+                    'workflow, please ensure that the workflow attributes are ' +
+                    'valid and the same image has not already been registered.', '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
+                    error.error);
+                  }
+                }
+              }
             );
     }
 


### PR DESCRIPTION
This deals with the error message shown when you try to edit or add a version in my tools/workflows.

Note that this further deals with https://github.com/ga4gh/dockstore/issues/1321.

Now there are other places where we could have error messages for no connection to webservice, but the scope of this issue seemed to only be for existing error messages.

Most other places on the site will redirect to the maintenance page on a full refresh of the page. When the routes change however there is no redirection, instead you go to the page and there is empty content. For examples going to the /tools page will show an empty table.