### PR TITLE
Don't refresh on stubbed descriptorType change

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -81,7 +81,7 @@
   <li>
     <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.STUB" class="form-inline">
       <Strong uib-tooltip="Type of descriptor language used">Descriptor Type: </Strong>
-      <select class="form-control input-sm" (change)="save()" [(ngModel)]="workflow.descriptorType">
+      <select class="form-control input-sm" (change)="update()" [(ngModel)]="workflow.descriptorType">
         <option *ngFor="let descriptorLanguage of descriptorLanguages()" value="{{descriptorLanguage | lowercase}}">{{descriptorLanguage | lowercase}}</option>
       </select>
     </div>

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -85,6 +85,10 @@ export class InfoTabComponent implements OnInit {
     this.infoTabService.updateAndRefresh(this.workflow);
   }
 
+  update() {
+    this.infoTabService.update(this.workflow);
+  }
+
  /**
    * Cancel button function
    *

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -86,6 +86,24 @@ export class InfoTabService {
         });
     }
 
+    /**
+     * This updates the workflow without refreshing
+     *
+     * @param {Workflow} workflow The updated workflow to send
+     * @memberof InfoTabService
+     */
+    update(workflow: Workflow) {
+        const message = 'Descriptor Type';
+        this.stateService.setRefreshMessage('Updating ' + message + '...');
+        this.workflowsService.updateWorkflow(this.originalWorkflow.id, workflow).subscribe((updatedWorkflow: Workflow) => {
+            this.workflowService.replaceWorkflow(this.workflows, updatedWorkflow);
+            this.refreshService.handleSuccess(message);
+        }, error => {
+            this.refreshService.handleError(message, error);
+        });
+
+    }
+
     get workflow(): ExtendedWorkflow {
         return this.currentWorkflow;
     }


### PR DESCRIPTION
Simple change to not refresh when changing descriptorType of a stubbed workflow because that will automatically make it a full workflow and we can only change descriptorType of stubbed workflows.