### PR TITLE
Feature/1327/encode url

### DIFF
--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -26,14 +26,14 @@
     </span>
   </span>
 
-  <div *ngIf="nullDescriptors || !_selectedVersion?.valid">
+  <div *ngIf="!content">
     <alert type="warning">
       <span class="glyphicon glyphicon-warning-sign"></span>
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </alert>
   </div>
 
-  <div *ngIf="!nullDescriptors && _selectedVersion?.valid" class="code-copy">
+  <div *ngIf="content" class="code-copy">
     <div class="code-copy-button btn-group">
       <a *ngIf="(published$ | async)" download [href]="descriptorPath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -55,12 +55,15 @@ export class DockerfileComponent implements AfterViewChecked {
   reactToVersion(): void {
     if (this._selectedVersion) {
       this.nullContent = false;
-      this.containersService.dockerfile(this.id, this._selectedVersion.name)
+      this.containersService.dockerfile(this.id, this._selectedVersion.name).first()
         .subscribe(file => {
             this.content = file.content;
             this.contentHighlighted = true;
             this.filepath = file.path;
             this.containerFilePath = this.getContainerfilePath();
+          }, error => {
+            this.nullContent = true;
+            this.content = null;
           }
         );
     } else {
@@ -77,7 +80,8 @@ export class DockerfileComponent implements AfterViewChecked {
 
   private getContainerfilePath(): string {
     const basepath = Dockstore.API_URI + ga4ghPath + '/tools/';
-    const customPath = encodeURIComponent(this.entrypath) + '/versions/' + encodeURIComponent(this._selectedVersion.name) + '/containerfile';
+    const customPath = encodeURIComponent(this.entrypath) + '/versions/' + encodeURIComponent(this._selectedVersion.name)
+       + '/containerfile';
     return basepath + customPath;
   }
 

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -77,7 +77,7 @@ export class DockerfileComponent implements AfterViewChecked {
 
   private getContainerfilePath(): string {
     const basepath = Dockstore.API_URI + ga4ghPath + '/tools/';
-    const customPath = encodeURIComponent(this.entrypath) + '/versions/' + this._selectedVersion.name + '/containerfile';
+    const customPath = encodeURIComponent(this.entrypath) + '/versions/' + encodeURIComponent(this._selectedVersion.name) + '/containerfile';
     return basepath + customPath;
   }
 

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -39,7 +39,7 @@ export class FileService {
           entry = encodeURIComponent(entrypath);
         }
 
-        const customPath =  entry + '/versions/' + currentVersion.name + '/'
+        const customPath =  entry + '/versions/' + encodeURIComponent(currentVersion.name) + '/'
           + descriptorType + '/descriptor/' + encodeURIComponent(currentFile.path);
         return basepath + customPath;
       } else {


### PR DESCRIPTION
Leftover from ga4gh/dockstore#1327 and more

- Encode the version name for the GA4GH endpoints (case where version is "feature/thing")
- Handle get dockerfile errors to suppress console.logs
- Fixes the highlight.js going crazy by giving it the thing to highlight when it thinks it needs to highlight (by always showing content when there is content even though version may not be a valid)