### PR TITLE
added loading screen

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,57 @@
 </head>
 
 <body data-spy="scroll" data-target="#toc">
-  <app-root>Loading...</app-root>
+  <app-root>
+    <style>
+      app-root {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        color: white;
+        font-family: -apple-system,
+            BlinkMacSystemFont,
+            "Segoe UI",
+            Roboto,
+            Oxygen-Sans,
+            Ubuntu,
+            Cantarell,
+            Helvetica,
+            sans-serif;
+        font-size: 2.5em;
+        text-shadow: 2px 2px 10px rgba(0,0,0,0.2);
+      }
+      body {
+        background: #21335B;
+        margin: 0;
+        padding: 0;
+      }
+      .loader {
+          border: 8px solid #f3f3f3;
+          border-top: 8px solid #487980;
+          border-radius: 50%;
+          width: 50px;
+          height: 50px;
+          animation: spin 2s linear infinite;
+          margin-top:10px;
+      }
+
+      @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+      }
+
+      .tagline {
+        font-size: 18px;
+      }
+    </style>
+
+    Dockstore
+    <p class="tagline">Create, Share, Use</p>
+    <div class="loader"></div>
+
+  </app-root>
 </body>
 
 </html>


### PR DESCRIPTION
Adds a simple loading screen on initial page load. Much nicer than the current Loading... text.

Note that the CSS stuff has to be in the index.html as during the loading the screen the other CSS files don't seem to have been initialised.

On app load the contents of the app-root are cleared, so these classes shouldn't impact the actual site.

https://github.com/ga4gh/dockstore/issues/893