### PR TITLE
Feature/864/split file formats

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -15,7 +15,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import bodybuilder from 'bodybuilder';
+import * as bodybuilder from 'bodybuilder';
 
 import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
 import { SearchService } from './search.service';
@@ -33,11 +33,12 @@ export class QueryBuilderService {
     constructor(private searchService: SearchService) { }
 
     getTagCloudQuery(type: string): string {
-        let body = bodybuilder().size();
+        const tagCloudSize = 20;
+        let body = bodybuilder().size(tagCloudSize);
         body = this.excludeContent(body);
         body = body.query('match', '_type', type);
-        body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: 20 }).build();
-        const toolQuery = JSON.stringify(body, null, 1);
+        body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: tagCloudSize });
+        const toolQuery = JSON.stringify(body.build(), null, 1);
         return toolQuery;
     }
 

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -210,8 +210,8 @@ export class SearchService {
       ['Language', 'descriptorType'],
       ['Registry', 'registry'],
       ['Source Control', 'source_control_provider.keyword'],
-      ['Input File Formats', 'input_file_formats.keyword'],
-      ['Output File Formats', 'output_file_formats.keyword'],
+      ['Input File Formats', 'input_file_formats.value.keyword'],
+      ['Output File Formats', 'output_file_formats.value.keyword'],
       ['Private Access', 'private_access'],
       ['VerifiedTool', 'tags.verified'],
       ['Author', 'author'],
@@ -235,8 +235,8 @@ export class SearchService {
       ['namespace', 'Tool: Namespace'],
       ['labels.value.keyword', 'Labels'],
       ['tags.verifiedSource', 'Tool: Verified Source'],
-      ['input_file_formats.keyword', 'Input File Formats'],
-      ['output_file_formats.keyword', 'Output File Formats'],
+      ['input_file_formats.value.keyword', 'Input File Formats'],
+      ['output_file_formats.value.keyword', 'Output File Formats'],
       ['workflowVersions.verifiedSource.keyword', 'Workflow: Verified Source'],
       ['organization', 'Workflow: Organization']
     ]);
@@ -256,8 +256,8 @@ export class SearchService {
       ['tags.verified', new SubBucket],
       ['tags.verifiedSource', new SubBucket],
       ['workflowVersions.verifiedSource.keyword', new SubBucket],
-      ['input_file_formats.keyword', new SubBucket],
-      ['output_file_formats.keyword', new SubBucket]
+      ['input_file_formats.value.keyword', new SubBucket],
+      ['output_file_formats.value.keyword', new SubBucket]
     ]);
   }
 

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -210,7 +210,8 @@ export class SearchService {
       ['Language', 'descriptorType'],
       ['Registry', 'registry'],
       ['Source Control', 'source_control_provider.keyword'],
-      ['File Formats', 'file_formats.keyword'],
+      ['Input File Formats', 'input_file_formats.keyword'],
+      ['Output File Formats', 'output_file_formats.keyword'],
       ['Private Access', 'private_access'],
       ['VerifiedTool', 'tags.verified'],
       ['Author', 'author'],
@@ -234,7 +235,8 @@ export class SearchService {
       ['namespace', 'Tool: Namespace'],
       ['labels.value.keyword', 'Labels'],
       ['tags.verifiedSource', 'Tool: Verified Source'],
-      ['file_formats.keyword', 'File Formats'],
+      ['input_file_formats.keyword', 'Input File Formats'],
+      ['output_file_formats.keyword', 'Output File Formats'],
       ['workflowVersions.verifiedSource.keyword', 'Workflow: Verified Source'],
       ['organization', 'Workflow: Organization']
     ]);
@@ -254,7 +256,8 @@ export class SearchService {
       ['tags.verified', new SubBucket],
       ['tags.verifiedSource', new SubBucket],
       ['workflowVersions.verifiedSource.keyword', new SubBucket],
-      ['file_formats.keyword', new SubBucket]
+      ['input_file_formats.keyword', new SubBucket],
+      ['output_file_formats.keyword', new SubBucket]
     ]);
   }
 

--- a/src/app/starring/starring.component.html
+++ b/src/app/starring/starring.component.html
@@ -16,7 +16,7 @@
 
 <div class="btn-group" role="group">
   <button id="starringButton" type="button" (click)="setStarring()"
-          [disabled]="!isLoggedIn" class="btn btn-default"
+          [disabled]="!isLoggedIn || disable" class="btn btn-default"
           [ngClass]="(rate)?'btn btn-default active':'btn btn-default'">
     <span id="starringButtonIcon"
           [ngClass]="(rate)?'glyphicon glyphicon-star':'glyphicon glyphicon-star-empty'"

--- a/src/app/starring/starring.component.ts
+++ b/src/app/starring/starring.component.ts
@@ -39,6 +39,7 @@ export class StarringComponent implements OnInit {
   public isLoggedIn: boolean;
   public rate = false;
   public total_stars = 0;
+  public disable = false;
   private starredUsers: User[];
   private workflowSubscription: Subscription;
   private toolSubscription: Subscription;
@@ -100,12 +101,13 @@ export class StarringComponent implements OnInit {
    * @memberof StarringComponent
    */
   setStarring() {
+    this.disable = true;
     if (this.isLoggedIn) {
       this.setStar().subscribe(
         data => {
           // update total_stars
           this.getStarredUsers();
-        });
+        }, error => this.disable = false);
     }
   }
   setStar(): any {
@@ -121,7 +123,10 @@ export class StarringComponent implements OnInit {
         (starring: User[]) => {
           this.total_stars = starring.length;
           this.rate = this.calculateRate(starring);
-        });
+          this.disable = false;
+        }, error => this.disable = false);
+    } else {
+      this.disable = false;
     }
   }
   getStargazers() {


### PR DESCRIPTION
Part 2 of ga4gh/dockstore#864

- Splits file format into two seperate buckets (Input and Output)
- Also fixes search that was apparently broken since Angular 5 update (elasticsearch not running in UI2 Travis, hard to tell search page is broken vs empty)
- Modifications to tag cloud query building in prep for new bodybuilder which correctly type-checks