### PR TITLE
Fix noticeable warnings in workflow component html

### DIFF
--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -22,7 +22,6 @@
       </button>
       <span class="glyphicon glyphicon-warning-sign">
       </span>
-      {{ missingContent.length === 1 ? 'Field that is missing from file: ' : 'Fields that are missing from file: '}} {{missingContent}}
     </div>
   </div>
 </div>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -42,7 +42,7 @@ import { UrlResolverService } from './../shared/url-resolver.service';
 })
 export class WorkflowComponent extends Entry {
   workflowEditData: any;
-  public workflow: Workflow;
+  public workflow: ExtendedWorkflow;
   public missingWarning: boolean;
   public title: string;
   private workflowCopyBtn: string;


### PR DESCRIPTION
Fixing all the obvious issues reported by IDE in this workflow component html.

There's a bunch of similar issues across the board introduced during the Angularjs to Angular 2+ migration.  Couldn't find a tslint or codelyzer rules to enforce it so that it can be checked/fixed for everything in one PR but my IDE does in fact report it.  I'll keep an eye out in the future and fix it when in proximity.

- Removed the missingContent variable that's not defined anywhere
- Changed type from Workflow to ExtendedWorkflow due to the properties provider and provider url being available only in ExtendedWorkflow.

For ga4gh/dockstore#1394