### PR TITLE
Feature/1422/link to test parameter file

### DIFF
--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -34,7 +34,7 @@
   </div>
   <div *ngIf="content && _selectedVersion?.valid" class="row no-margin">
     <div class="btn-group">
-      <a href id="downloadLinkParams" (click)="downloadFile(currentFile, 'downloadLinkParams')" class="btn btn-default" type="button" title="{{filePath}}">
+      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -39,11 +39,14 @@ export class ParamfilesComponent extends EntryFileSelector {
     this.onVersionChange(value);
   }
   public filePath: string;
+  public entryType = 'tool';
+  public downloadFilePath: string;
 
   constructor(private containerService: ContainerService, private containersService: ContainersService,
               private paramfilesService: ParamfilesService,
               public fileService: FileService) {
-    super();
+      super();
+      this.published$ = this.containerService.toolIsPublished$;
   }
   getDescriptors(version): Array<any> {
     return this.paramfilesService.getDescriptors(this._selectedVersion);
@@ -56,11 +59,8 @@ export class ParamfilesComponent extends EntryFileSelector {
   reactToFile(): void {
     this.content = this.currentFile.content;
     this.filePath = this.getFilePath(this.currentFile);
-  }
-
-  // Downloads a file
-  downloadFile(file, id): void {
-    this.fileService.downloadFile(file, id);
+    this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion,
+      this.currentFile, this.currentDescriptor, this.entryType);
   }
 
   // Get the path of the file

--- a/src/app/container/version-modal/version-modal.component.spec.ts
+++ b/src/app/container/version-modal/version-modal.component.spec.ts
@@ -61,7 +61,7 @@ describe('VersionModalComponent', () => {
     const fakeTool = sampleTool1;
     fakeTool.path = 'quay.io\/wtsicgp\/dockstore-cgpmap';
     component.tool = fakeTool;
-    const fakeTag = sampleTag;
+    const fakeTag = Object.assign({}, sampleTag);
     fakeTag.name = '3.0.0-rc8';
     component.version = fakeTag;
     // Manually trigger the update

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -13,9 +13,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import { FileService} from './file.service';
 import { inject, TestBed } from '@angular/core/testing';
+
+import { Dockstore } from './dockstore.model';
+import { FileService } from './file.service';
+import { SourceFile } from './swagger';
+import { sampleTag, sampleSourceFile } from '../test/mocked-objects';
+import { ga4ghPath } from './constants';
 
 describe('FileService', () => {
   beforeEach(() => {
@@ -32,7 +36,13 @@ describe('FileService', () => {
     expect(fileService.escapeEntities('')).toEqual('');
     expect(fileService.escapeEntities(null)).toEqual(null);
   }));
-
-
+  it('should get descriptor path', inject([FileService], (fileService: FileService) => {
+    const tag = sampleTag;
+    const sourceFile = sampleSourceFile;
+    const descriptorType = 'cwl';
+    const entryType = 'tool';
+    const url = fileService.getDescriptorPath('quay.io/org/repo', tag, sourceFile, descriptorType, entryType);
+    expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN-CWL/descriptor//cwl.json');
+  }));
 });
 

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -32,7 +32,7 @@ export class FileService {
      * TODO: Convert to pipe
      * @param {string} entryPath         the entry's path (e.g. "quay.io/pancancer/pcawg-dkfz-workflow")
      * @param {string} entryVersion      the version object of the entry
-     * @param {string} sourceFile        path of the file (e.g. "/Dockstore.cwl")
+     * @param {string} sourceFile        the SourceFile object
      * @param {string} descriptorType    the descriptor type (e.g. "cwl")
      * @param {string} entryType         the entry type, either "tool" or "workflow"
      * @returns {string}                 the url to download the test parameter file

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -15,6 +15,7 @@
  */
 import { ga4ghPath } from './constants';
 import { Dockstore } from './dockstore.model';
+import { WorkflowVersion, Tag, SourceFile } from './swagger';
 
 export class FileService {
     escapeEntities(code: string): string {
@@ -26,41 +27,62 @@ export class FileService {
           .replace(/'/g, '&#039;');
     }
 
-    // Get the download path of a descriptor
-    getDescriptorPath(entrypath, currentVersion, currentFile, descriptor, entrytype): string {
-      if (currentFile != null) {
-        const basepath = Dockstore.API_URI + ga4ghPath + '/tools/';
-        let descriptorType = 'plain-CWL';
-        if (descriptor === 'wdl') {
-          descriptorType = 'plain-WDL';
-        }
-
-        let entry = '';
-        if (entrytype === 'workflow') {
-          entry = encodeURIComponent('#workflow/' + entrypath);
-        } else {
-          entry = encodeURIComponent(entrypath);
-        }
-
-        const customPath =  entry + '/versions/' + encodeURIComponent(currentVersion.name) + '/'
-          + descriptorType + '/descriptor/' + encodeURIComponent(currentFile.path);
-        return basepath + customPath;
-      } else {
+    /**
+     * Get the download path of a descriptor
+     * TODO: Convert to pipe
+     * @param {string} entryPath         the entry's path (e.g. "quay.io/pancancer/pcawg-dkfz-workflow")
+     * @param {string} entryVersion      the version object of the entry
+     * @param {string} sourceFile        path of the file (e.g. "/Dockstore.cwl")
+     * @param {string} descriptorType    the descriptor type (e.g. "cwl")
+     * @param {string} entryType         the entry type, either "tool" or "workflow"
+     * @returns {string}                 the url to download the test parameter file
+     * @memberof FileService
+     */
+    getDescriptorPath(entryPath: string, entryVersion: (Tag | WorkflowVersion), sourceFile: SourceFile,
+      descriptorType: string, entryType: string): string {
+      if (!entryPath || !entryVersion || !sourceFile || !descriptorType || !entryType) {
         return null;
+      } else {
+        let type = '';
+        switch (descriptorType) {
+          case 'wdl':
+            type = 'PLAIN-WDL';
+            break;
+          case 'cwl':
+            type = 'PLAIN-CWL';
+            break;
+          default:
+            console.log('Unhandled type: ' + descriptorType);
+            return null;
+        }
+        return this.getDownloadFilePath(entryPath, entryVersion.name, sourceFile.path, type, entryType);
       }
     }
 
-    // Downloads a file
-    // TODO: Temporary, need to update test param endpoint to return raw file based on path
-    downloadFile(file, id): void {
-      let filename = 'dockstore.txt';
-      if (file != null) {
-        const splitFileName = (file.path).split('/');
-        filename = splitFileName[splitFileName.length - 1];
+    /**
+     * Get the download path of a test parameter file
+     * TODO: Convert to pipe
+     * @private
+     * @param {string} entryPath         the entry's path (e.g. "quay.io/pancancer/pcawg-dkfz-workflow")
+     * @param {string} version           the version of the entry (e.g. "2.0.1_cwl1.0")
+     * @param {string} filePath          path of the file (e.g. "/Dockstore.json")
+     * @param {string} type              the string used for the GA4GH type (e.g. "PLAIN_CWL", "PLAIN_TEST_WDL_FILE")
+     * @param {string} entryType         the entry type, either "tool" or "workflow"
+     * @returns {string}
+     * @memberof FileService
+     */
+    private getDownloadFilePath(entryPath: string, version: string, filePath: string, type: string, entryType: string): string {
+      const basepath = Dockstore.API_URI + ga4ghPath + '/tools/';
+      let entry = '';
+      if (entryType === 'workflow') {
+        entry = encodeURIComponent('#workflow/' + entryPath);
+      } else {
+        entry = encodeURIComponent(entryPath);
       }
-      const data = 'data:text/plain,' + encodeURIComponent(file.content);
-
-      $('#' + id).attr('href', data).attr('download', filename);
+      // Do not encode the filePath because webservice can handle an unencoded file path.  Also the default file name is prettier this way
+      const customPath =  entry + '/versions/' + encodeURIComponent(version) + '/'
+        + type + '/descriptor/' + filePath;
+      return basepath + customPath;
     }
 
     // Get the path of the file

--- a/src/app/starring/starring.component.ts
+++ b/src/app/starring/starring.component.ts
@@ -85,7 +85,7 @@ export class StarringComponent implements OnInit {
   }
 
   calculateRate(starredUsers: User[]): boolean {
-    if (!this.user) {
+    if (!this.user || !starredUsers) {
       return false;
     } else {
       let matchingUser: User;

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -173,3 +173,10 @@ export const wdlSourceFile: SourceFile = {
   path: '',
   type: undefined
 };
+
+export const sampleSourceFile: SourceFile = {
+  content: 'potato',
+  id: 1,
+  path: '/cwl.json',
+  type: SourceFile.TypeEnum.CWLTESTJSON
+};

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -25,7 +25,7 @@
   </span>
   <div *ngIf="content && _selectedVersion?.valid" class="row no-margin">
     <div class="btn-group">
-      <a href id="downloadLinkParams" (click)="downloadFile(currentFile, 'downloadLinkParams')" class="btn btn-default" type="button" title="{{filePath}}">
+      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content">

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -36,11 +36,14 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
     this.onVersionChange(value);
   }
   public filePath: string;
+  public entryType = 'workflow';
+  public downloadFilePath: string;
 
   constructor(private paramfilesService: ParamfilesService,
               public fileService: FileService,
               private workflowService: WorkflowService) {
     super();
+    this.published$ = this.workflowService.workflowIsPublished$;
   }
   getDescriptors(version): Array<any> {
     return this.paramfilesService.getDescriptors(this._selectedVersion);
@@ -53,11 +56,8 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
   reactToFile(): void {
     this.content = this.currentFile.content;
     this.filePath = this.getFilePath(this.currentFile);
-  }
-
-  // Downloads a file
-  downloadFile(file, id): void {
-    this.fileService.downloadFile(file, id);
+    this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion,
+      this.currentFile, this.currentDescriptor, this.entryType);
   }
 
   // Get the path of the file


### PR DESCRIPTION
For ga4gh/dockstore#1422

Changes the download test parameter file button to use the new ga4gh endpoint.  When using the relative-path endpoints, opt to not encode the last part since the webservice is able to handle it and downloading the file ends up with a better file name. 

Downloading the file, as opposed to going to the url only works with Chrome.  Firefox only allows download when it's the same origin (workaround requires using content disposition or changing content type)