### PR TITLE
Add syntax highlighting for .config and .nf files

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,6 +35,7 @@
               "node_modules/jquery/dist/jquery.js",
               "node_modules/ace-builds/src-min-noconflict/ace.js",
               "node_modules/ace-builds/src-min-noconflict/mode-yaml.js",
+              "node_modules/ace-builds/src-min-noconflict/mode-groovy.js",
               "node_modules/ace-builds/src-min-noconflict/mode-json.js",
               "node_modules/ace-builds/src-min-noconflict/mode-dockerfile.js",
               "node_modules/ace-builds/src-min-noconflict/mode-text.js",

--- a/angular.json
+++ b/angular.json
@@ -111,6 +111,7 @@
               "node_modules/jquery/dist/jquery.js",
               "node_modules/ace-builds/src-min-noconflict/ace.js",
               "node_modules/ace-builds/src-min-noconflict/mode-yaml.js",
+              "node_modules/ace-builds/src-min-noconflict/mode-groovy.js",
               "node_modules/ace-builds/src-min-noconflict/mode-json.js",
               "node_modules/ace-builds/src-min-noconflict/mode-dockerfile.js",
               "node_modules/ace-builds/src-min-noconflict/mode-text.js",

--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -68,6 +68,10 @@ export class CodeEditorComponent implements AfterViewInit {
         this.mode = 'json';
       } else if (filepath.endsWith('yml') || filepath.endsWith('yaml')) {
         this.mode = 'yaml';
+      } else if (filepath.endsWith('config')) {
+        this.mode = 'groovy';
+      } else if (filepath.endsWith('nf')) {
+        this.mode = 'nfl';
       } else {
         this.mode = 'text';
       }

--- a/src/app/shared/grammars/custom-grammars.js
+++ b/src/app/shared/grammars/custom-grammars.js
@@ -307,8 +307,96 @@ oop.inherits(Mode, TextMode);
 exports.Mode = Mode;
 });
 
+// NFL Grammar
+ace.define("ace/mode/nfl_highlight_rules",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules","ace/mode/groovy_highlight_rules"], function(require, exports, module) {
+  "use strict";
+
+  var oop = require("../lib/oop");
+  var GroovyHighlightRules = require("./groovy_highlight_rules").GroovyHighlightRules;
+
+  var NextflowHighlightRules = function(options) {
+      var ruless =[{
+              token: [
+                  "process.nextflow",
+                  "keyword.nextflow",
+                  "process.nextflow",
+                  "function.nextflow",
+                  "process.nextflow"
+              ],
+              regex: /^(\s*)(process)(\s+)(\w+|"[^"]+"|'[^']+')(\s*)/,
+              push: [{
+                  token: "process.nextflow",
+                  regex: /}/,
+                  next: "pop"
+              }, {
+                  include: "#process-body"
+              }, {
+                  defaultToken: "process.nextflow"
+              }]
+          },
+          {
+              token: "process.body.nextflow",
+              regex: /{/,
+              push: [{
+                  token: "process.body.nextflow",
+                  regex: /(?=})/,
+                  next: "pop"
+              }, {
+                  token: "process.directive.type.nextflow",
+                  regex: /(?:afterScript|beforeScript|cache|container|cpus|clusterOptions|disk|echo|errorStrategy|executor|ext|maxErrors|maxForks|maxRetries|memory|module|penv|publishDir|queue|scratch|storeDir|stageInMode|stageOutMode|tag|time|validExitStatus)\b/
+              }, {
+                  token: "constant.block.nextflow",
+                  regex: /(?:input|output|script|shell|exec):/
+              }, {
+                  defaultToken: "process.body.nextflow"
+              }]
+          },{
+              token: "code.block.nextflow",
+              regex: /{/,
+              push: [{
+                  token: "code.block.nextflow",
+                  regex: /}/,
+                  next: "pop"
+              }, {
+                  include: "#nfl-rules"
+              }, {
+                  defaultToken: "code.block.nextflow"
+              }]
+          }]
+
+      var GroovyRules = new GroovyHighlightRules().getRules();
+
+      GroovyRules.start = ruless.concat(GroovyRules.start);
+      this.$rules = GroovyRules;
+  };
+
+  oop.inherits(NextflowHighlightRules, GroovyHighlightRules);
+
+  exports.NextflowHighlightRules = NextflowHighlightRules;
+  });
+  ace.define('ace/mode/nfl',["require","exports","module","ace/lib/oop","ace/mode/nfl_highlight_rules","ace/mode/groovy_highlight_rules"], function(require, exports, module) {
+
+    var oop = require("../lib/oop");
+    // var TextHighlightRules = require("./nfl_highlight_rules").TextHighlightRules;
+    var GroovyHighlightRules = require("./groovy_highlight_rules").GroovyHighlightRules;
+    var TextMode = require("./text").Mode;
+
+  var NextflowHighlightRules = require("ace/mode/nfl_highlight_rules").NextflowHighlightRules;
+
+  var Mode = function() {
+      this.HighlightRules = NextflowHighlightRules;
+  };
+  oop.inherits(Mode, TextMode);
+
+  (function() {
+      // Extra logic goes here. (see below)
+  }).call(Mode.prototype);
+
+  exports.Mode = Mode;
+  });
+
 (function() {
-    ace.require(["ace/mode/wdl","ace/mode/cwl"], function(m) {
+    ace.require(["ace/mode/wdl","ace/mode/cwl","ace/mode/nfl"], function(m) {
         if (typeof module == "object" && typeof exports == "object" && module) {
             module.exports = m;
         }


### PR DESCRIPTION
Adds syntax highlighting for .config files and .nf files

.config uses groovy, .nf uses custom nextflow language that is then based upon the groovy language.

Partial implementation for ga4gh/dockstore#1396

Currently only uses https://github.com/nextflow-io/vscode-language-nextflow/blob/master/syntaxes/nextflow.tmLanguage.json and inherits groovy in order to highlight.  Ideally it should use https://github.com/nextflow-io/vscode-language-nextflow/blob/master/syntaxes/groovy.tmLanguage.json also.