### PR TITLE
Convert to relative paths for all

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { ClipboardModule } from 'ngx-clipboard';
 import { AppComponent } from './app.component';
 import { CLIENT_ROUTER_PROVIDERS, routing } from './app.routing';
 import { FooterComponent } from './footer/footer.component';
+import { FundingComponent } from './funding/funding.component';
 import { HomeFootNoteComponent } from './home-foot-note/home-foot-note.component';
 import { HomeComponent } from './home/home.component';
 import { ListentryModule } from './listentry/listentry.module';
@@ -48,7 +49,6 @@ import { TokenService } from './loginComponents/token.service';
 import { TokensComponent } from './loginComponents/tokens/tokens.component';
 import { UserService } from './loginComponents/user.service';
 import { MaintenanceComponent } from './maintenance/maintenance.component';
-import { FundingComponent } from './funding/funding.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { SearchModule } from './search/search.module';
 import { SearchService } from './search/search.service';
@@ -70,6 +70,7 @@ import { ListContainersModule } from './shared/modules/list-containers.module';
 import { ListWorkflowsModule } from './shared/modules/list-workflows.module';
 import { OrderByModule } from './shared/modules/orderby.module';
 import { PagenumberService } from './shared/pagenumber.service';
+import { PathService } from './shared/path.service';
 import { ProviderService } from './shared/provider.service';
 import { RefreshService } from './shared/refresh.service';
 import { StateService } from './shared/state.service';
@@ -149,6 +150,7 @@ import { ToolDetailsComponent } from './tool-details/tool-details.component';
     UserService,
     ListService,
     CommunicatorService,
+    PathService,
     ProviderService,
     ContainerService,
     WorkflowService,

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -15,18 +15,18 @@
  */
 import { Location } from '@angular/common';
 import { Component } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
 import { ListContainersService } from '../containers/list/list.service';
 import { CommunicatorService } from '../shared/communicator.service';
 import { ContainerService } from '../shared/container.service';
 import { DateService } from '../shared/date.service';
-import { Dockstore } from '../shared/dockstore.model';
 import { DockstoreService } from '../shared/dockstore.service';
 import { Entry } from '../shared/entry';
 import { ImageProviderService } from '../shared/image-provider.service';
 import { ProviderService } from '../shared/provider.service';
+import { DockstoreTool } from '../shared/swagger';
 import { Tag } from '../shared/swagger/model/tag';
 import { WorkflowVersion } from '../shared/swagger/model/workflowVersion';
 import { TrackLoginService } from '../shared/track-login.service';
@@ -191,7 +191,10 @@ export class ContainerComponent extends Entry {
         publish: this.published
       };
       this.containersService.publish(this.tool.id, request).subscribe(
-        response => this.tool.is_published = response.is_published, err => {
+        (response: DockstoreTool) => {
+          this.containerService.upsertToolToTools(response);
+          this.containerService.setTool(response);
+        }, err => {
           this.published = !this.published;
           this.refreshService.handleError('publish error', err);
         });

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -35,7 +35,7 @@
 
   <div *ngIf="!nullDescriptors && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a download [href]="getDescriptorPath(currentDescriptor)" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+      <a download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'descriptors_file'}"

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -13,36 +13,35 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
 <div>
-  <span *ngIf="_selectedVersion?.valid && !nullDescriptors" class="row no-margin">
-    <span class="form-group col-sm-4">
-      <strong>Descriptor Type:</strong>
-      <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
-    </span>
-    <span class="form-group col-sm-4">
-      <strong>File:</strong>
-      <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-    </span>
-  </span>
-
-  <div *ngIf="nullDescriptors || !_selectedVersion?.valid">
+  <div *ngIf="(nullDescriptors || !content || !_selectedVersion?.valid); else displayContent">
     <alert type="warning">
       <span class="glyphicon glyphicon-warning-sign"></span>
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </alert>
   </div>
-
-  <div *ngIf="!nullDescriptors && _selectedVersion?.valid" class="code-copy">
-    <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
-        <span class="glyphicon glyphicon-download"></span>
-      </a>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'descriptors_file'}"
-              (cbOnSuccess)="toolCopyBtnClick('descriptors_file')" title="Copy to clipboard">
-        <span class="glyphicon glyphicon-copy"></span>
-      </button>
+  <ng-template #displayContent>
+    <span class="row no-margin">
+      <span class="form-group col-sm-4">
+        <strong>Descriptor Type:</strong>
+        <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
+      </span>
+      <span class="form-group col-sm-4">
+        <strong>File:</strong>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+      </span>
+    </span>
+    <div class="code-copy">
+      <div class="code-copy-button btn-group">
+        <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+          <span class="glyphicon glyphicon-download"></span>
+        </a>
+        <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'descriptors_file'}"
+          (cbOnSuccess)="toolCopyBtnClick('descriptors_file')" title="Copy to clipboard">
+          <span class="glyphicon glyphicon-copy"></span>
+        </button>
+      </div>
+      <section [innerHTML]="fileService.highlightCode(content)"></section>
     </div>
-    <section [innerHTML]="fileService.highlightCode(content)"></section>
-  </div>
+  </ng-template>
 </div>

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -35,7 +35,7 @@
 
   <div *ngIf="!nullDescriptors && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'descriptors_file'}"

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -49,6 +49,7 @@ export class DescriptorsComponent extends EntryFileSelector implements AfterView
               public fileService: FileService,
               private elementRef: ElementRef) {
     super();
+    this.published$ = this.containerService.toolIsPublished$;
   }
 
   getDescriptors(version): Array<any> {

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -42,6 +42,7 @@ export class DescriptorsComponent extends EntryFileSelector implements AfterView
     this.onVersionChange(value);
   }
 
+  public downloadFilePath: string;
   constructor(private containerService: ContainerService,
               private highlightJsService: HighlightJsService,
               private descriptorsService: ToolDescriptorService,
@@ -61,6 +62,8 @@ export class DescriptorsComponent extends EntryFileSelector implements AfterView
   reactToFile(): void {
     this.content = this.currentFile.content;
     this.contentHighlighted = true;
+    this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, this.currentFile,
+      this.currentDescriptor, 'tool');
   }
 
   ngAfterViewChecked() {
@@ -68,10 +71,6 @@ export class DescriptorsComponent extends EntryFileSelector implements AfterView
       this.contentHighlighted = false;
       this.highlightJsService.highlight(this.elementRef.nativeElement.querySelector('.highlight'));
     }
-  }
-
-  getDescriptorPath(descType): string {
-    return this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, this.currentFile, this.currentDescriptor, 'tool');
   }
 
   // Get the path of the file

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -13,35 +13,35 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
 <div>
-  <span *ngIf="content != null && _selectedVersion?.valid" class="row no-margin">
-    <span class="form-group col-sm-4">
-      <strong>Descriptor Type:</strong>
-      <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
-    </span>
-    <span class="form-group col-sm-4">
-      <strong>File:</strong>
-      <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-    </span>
-  </span>
-
-  <div *ngIf="!content ||  !_selectedVersion?.valid">
+  <div *ngIf="(!content ||  !_selectedVersion?.valid); else displayContent">
     <alert type="warning">
       <span class="glyphicon glyphicon-warning-sign"></span>
       &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
     </alert>
   </div>
-  <div *ngIf="content && _selectedVersion?.valid" class="code-copy">
-    <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
-      </a>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'test_param_file'}"
-              (cbOnSuccess)="toolCopyBtnClick('test_param_file')" title="Copy to clipboard">
-        <span class="glyphicon glyphicon-copy"></span>
-      </button>
+  <ng-template #displayContent>
+    <span class="row no-margin">
+      <span class="form-group col-sm-4">
+        <strong>Descriptor Type:</strong>
+        <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
+      </span>
+      <span class="form-group col-sm-4">
+        <strong>File:</strong>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+      </span>
+    </span>
+    <div class="code-copy">
+      <div class="code-copy-button btn-group">
+        <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
+          <span class="glyphicon glyphicon-download"></span>
+        </a>
+        <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'test_param_file'}" (cbOnSuccess)="toolCopyBtnClick('test_param_file')"
+          title="Copy to clipboard">
+          <span class="glyphicon glyphicon-copy"></span>
+        </button>
+      </div>
+      <section [innerHTML]="fileService.highlightCode(content)"></section>
     </div>
-    <section [innerHTML]="fileService.highlightCode(content)"></section>
-  </div>
+  </ng-template>
 </div>

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -13,19 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import { ContainersService } from '../../shared/swagger';
-import { Component, Input, ElementRef, OnInit, AfterViewChecked} from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { HighlightJsService } from '../../shared/angular2-highlight-js/lib/highlight-js.module';
-
 import { ContainerService } from '../../shared/container.service';
-import { ParamfilesService } from './paramfiles.service';
-import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-
 import { FileService } from '../../shared/file.service';
+import { PathService } from '../../shared/path.service';
+import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
+import { ContainersService } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
+import { ParamfilesService } from './paramfiles.service';
 
 @Component({
   selector: 'app-paramfiles-container',
@@ -47,7 +45,7 @@ export class ParamfilesComponent extends EntryFileSelector implements AfterViewC
   constructor(private containerService: ContainerService, private containersService: ContainersService,
               private highlightJsService: HighlightJsService,
               private paramfilesService: ParamfilesService,
-              public fileService: FileService,
+              public fileService: FileService, private pathService: PathService,
               private elementRef: ElementRef) {
     super();
       this.published$ = this.containerService.toolIsPublished$;
@@ -64,6 +62,22 @@ export class ParamfilesComponent extends EntryFileSelector implements AfterViewC
     this.content = this.currentFile.content;
     this.contentHighlighted = true;
     this.filePath = this.getFilePath(this.currentFile);
+    let basePath: string;
+    switch (this.currentDescriptor) {
+      case 'wdl': {
+        basePath = this._selectedVersion.wdl_path;
+        break;
+      }
+      case 'cwl': {
+        basePath = this._selectedVersion.cwl_path;
+        break;
+      }
+      default: {
+        console.log('Unrecognized descriptor type.  Could not get base path');
+      }
+    }
+    const relativePath = this.pathService.relative(basePath, this.currentFile.path);
+    this.currentFile.path = relativePath;
     this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion,
       this.currentFile, this.currentDescriptor, this.entryType);
   }

--- a/src/app/container/paramfiles/paramfiles.service.spec.ts
+++ b/src/app/container/paramfiles/paramfiles.service.spec.ts
@@ -1,4 +1,3 @@
-import { RefreshService } from './../../shared/refresh.service';
 /*
  *    Copyright 2017 OICR
  *
@@ -14,14 +13,16 @@ import { RefreshService } from './../../shared/refresh.service';
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { inject, TestBed } from '@angular/core/testing';
 
-import { Tag } from './../../shared/swagger/model/tag';
-import { SourceFile } from './../../shared/swagger/model/sourceFile';
+import { PathService } from '../../shared/path.service';
+import { RefreshService } from './../../shared/refresh.service';
 import { ContainersService } from './../../shared/swagger/api/containers.service';
-import { WorkflowsStubService, ContainersStubService, RefreshStubService } from './../../test/service-stubs';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
+import { SourceFile } from './../../shared/swagger/model/sourceFile';
+import { Tag } from './../../shared/swagger/model/tag';
+import { ContainersStubService, RefreshStubService, WorkflowsStubService } from './../../test/service-stubs';
 import { ParamfilesService } from './paramfiles.service';
-import { TestBed, async, inject } from '@angular/core/testing';
 
 describe('Service: paramFiles.service.ts', () => {
   beforeEach(() => {
@@ -29,7 +30,8 @@ describe('Service: paramFiles.service.ts', () => {
       providers: [ParamfilesService,
         { provide: WorkflowsService, useClass: WorkflowsStubService },
         { provide: ContainersService, useClass: ContainersStubService },
-        { provide: RefreshService, useClass: RefreshStubService }
+        { provide: RefreshService, useClass: RefreshStubService },
+        PathService
       ]
     });
   });

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -24,7 +24,7 @@ import {
 } from './info-tab-checker-workflow-path/info-tab-checker-workflow-path.component';
 import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch-checker-workflow.component';
 import { RegisterCheckerWorkflowComponent } from './register-checker-workflow/register-checker-workflow.component';
-
+import { Ga4ghFilesStateService } from './ga4gh-files-state.service';
 @NgModule({
   imports: [
     CommonModule,
@@ -32,6 +32,7 @@ import { RegisterCheckerWorkflowComponent } from './register-checker-workflow/re
     FormsModule,
     ModalModule
   ],
+  providers: [Ga4ghFilesStateService],
   declarations: [InfoTabCheckerWorkflowPathComponent, RegisterCheckerWorkflowComponent,
     LaunchCheckerWorkflowComponent
   ],

--- a/src/app/shared/entry/ga4gh-files-state.service.spec.ts
+++ b/src/app/shared/entry/ga4gh-files-state.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { Ga4ghFilesStateService } from './ga4gh-files-state.service';
+
+describe('Service: Ga4ghFilesState', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [Ga4ghFilesStateService]
+    });
+  });
+
+  it('should ...', inject([Ga4ghFilesStateService], (service: Ga4ghFilesStateService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/shared/entry/ga4gh-files-state.service.ts
+++ b/src/app/shared/entry/ga4gh-files-state.service.ts
@@ -1,0 +1,64 @@
+/*
+ *     Copyright 2018 OICR
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ToolFile, GA4GHService } from '../swagger';
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * This file services as the state for the GA4GH files endpoint
+ * Contains both actions and store
+ * @export
+ * @class Ga4ghFilesStateService
+ */
+@Injectable()
+export class Ga4ghFilesStateService {
+  public toolFiles$: Observable<Array<ToolFile>> = Observable.of([]);
+  public containerToolFiles$: Observable<Array<ToolFile>>;
+  public descriptorToolFiles$: Observable<Array<ToolFile>>;
+  public testToolFiles$: Observable<Array<ToolFile>>;
+  constructor(private ga4ghService: GA4GHService) {
+  }
+  update(type: string, id: string, version: string) {
+    // TODO: Grab from all descriptor types (CWL, WDL, NFL) to get all test parameter files
+    this.toolFiles$ = this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(
+      type.toUpperCase(), encodeURIComponent(id), encodeURIComponent(version));
+        this.containerToolFiles$ = this.toolFiles$.map((toolFiles: Array<ToolFile>) => {
+          if (!toolFiles) {
+            toolFiles = [];
+          }
+          return toolFiles.filter((toolFile: ToolFile) => {
+            return toolFile.file_type === ToolFile.FileTypeEnum.CONTAINERFILE;
+          });
+        });
+        this.descriptorToolFiles$ = this.toolFiles$.map((toolFiles: Array<ToolFile>) => {
+          if (!toolFiles) {
+            toolFiles = [];
+          }
+          return toolFiles.filter((toolFile: ToolFile) => {
+            return (toolFile.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR ||
+              toolFile.file_type === ToolFile.FileTypeEnum.SECONDARYDESCRIPTOR);
+          });
+        });
+        this.testToolFiles$ = this.toolFiles$.map((toolFiles: Array<ToolFile>) => {
+          if (!toolFiles) {
+            toolFiles = [];
+          }
+          return toolFiles.filter((toolFile: ToolFile) => {
+            return toolFile.file_type === ToolFile.FileTypeEnum.TESTFILE;
+          });
+        });
+  }
+}

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -34,7 +34,7 @@ describe('FileService', () => {
     const descriptorType = 'cwl';
     const entryType = 'tool';
     const url = fileService.getDescriptorPath('quay.io/org/repo', tag, sourceFile, descriptorType, entryType);
-    expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN-CWL/descriptor//cwl.json');
+    expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN-CWL/descriptor/%2Fcwl.json');
   }));
 });
 

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -33,7 +33,7 @@ describe('FileService', () => {
     const sourceFile = sampleSourceFile;
     const descriptorType = 'cwl';
     const entryType = 'tool';
-    const url = fileService.getDescriptorPath('quay.io/org/repo', tag, sourceFile, descriptorType, entryType);
+    const url = fileService.getDescriptorPath('quay.io/org/repo', tag, '/cwl.json', descriptorType, entryType);
     expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN-CWL/descriptor/%2Fcwl.json');
   }));
 });

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -35,9 +35,9 @@ export class FileService {
      * @returns {string}                 the url to download the test parameter file
      * @memberof FileService
      */
-    getDescriptorPath(entryPath: string, entryVersion: (Tag | WorkflowVersion), sourceFile: SourceFile,
+    getDescriptorPath(entryPath: string, entryVersion: (Tag | WorkflowVersion), relativePath: string,
       descriptorType: string, entryType: string): string {
-      if (!entryPath || !entryVersion || !sourceFile || !descriptorType || !entryType) {
+      if (!entryPath || !entryVersion || !relativePath || !descriptorType || !entryType) {
         return null;
       } else {
         let type = '';
@@ -52,7 +52,7 @@ export class FileService {
             console.log('Unhandled type: ' + descriptorType);
             return null;
         }
-        return this.getDownloadFilePath(entryPath, entryVersion.name, sourceFile.path, type, entryType);
+        return this.getDownloadFilePath(entryPath, entryVersion.name, relativePath, type, entryType);
       }
     }
 
@@ -86,7 +86,7 @@ export class FileService {
     // Get the path of the file
     getFilePath(file): string {
       if (file != null) {
-        return file.path;
+        return file.url;
       }
       return null;
     }

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -78,7 +78,8 @@ export class FileService {
       }
       // Do not encode the filePath because webservice can handle an unencoded file path.  Also the default file name is prettier this way
       const customPath =  entry + '/versions/' + encodeURIComponent(version) + '/'
-        + type + '/descriptor/' + filePath;
+
+        + type + '/descriptor/' + encodeURIComponent(filePath);
       return basepath + customPath;
     }
 

--- a/src/app/shared/path.service.spec.ts
+++ b/src/app/shared/path.service.spec.ts
@@ -1,0 +1,20 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { PathService } from './path.service';
+
+describe('Service: Path', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PathService]
+    });
+  });
+
+  it('should be able to calculate relative paths', inject([PathService], (service: PathService) => {
+    expect(service).toBeTruthy();
+    expect(service.relative('/a/b/file1', '/a/b/d/file2')).toBe('d/file2');
+    expect(service.relative('/a/b/file1', '/a/file2')).toBe('../file2');
+    expect(service.relative('/a/b/file1', '/a/b/file2')).toBe('file2');
+    expect(service.relative('/file2', '/a/b/file2')).toBe('a/b/file2');
+  }));
+});

--- a/src/app/shared/path.service.spec.ts
+++ b/src/app/shared/path.service.spec.ts
@@ -16,5 +16,6 @@ describe('Service: Path', () => {
     expect(service.relative('/a/b/file1', '/a/file2')).toBe('../file2');
     expect(service.relative('/a/b/file1', '/a/b/file2')).toBe('file2');
     expect(service.relative('/file2', '/a/b/file2')).toBe('a/b/file2');
+    expect(service.relative('/c/d/file2', '/a/b/file2')).toBe('../../a/b/file2');
   }));
 });

--- a/src/app/shared/path.service.ts
+++ b/src/app/shared/path.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class PathService {
+
+  constructor() { }
+
+  /**
+   * This function is taken from the native node path module https://github.com/jinder/path/blob/master/path.js#L270
+   * Style changes and types added as well as popping the base path in order to get the base directory instead
+   * @param {string} from The absolute base path (which is a file path)
+   * @param {string} to The absolute path that will be converted to relative path
+   * @returns {string} A relative path based on the DIRECTORY of the 'from' parameter (not the 'from' file path)
+   * @memberof PathService
+   */
+  public relative(from: string, to: string): string {
+    const toParts = this.trimArray(to.split('/'));
+    const lowerFromParts = this.trimArray(from.split('/'));
+
+    // Calculating relative to the directory of the 'from' file, not from the actual file
+    lowerFromParts.pop();
+    const lowerToParts = this.trimArray(to.split('/'));
+
+    const length = Math.min(lowerFromParts.length, lowerToParts.length);
+    let samePartsLength = length;
+    for (let i = 0; i < length; i++) {
+      if (lowerFromParts[i] !== lowerToParts[i]) {
+        samePartsLength = i;
+        break;
+      }
+    }
+
+    if (samePartsLength === 0) {
+      // Don't return absolute path, change to relative even if the base is root
+      return toParts.join('/');
+    }
+
+    let outputParts = [];
+    for (let i = samePartsLength; i < lowerFromParts.length; i++) {
+      outputParts.push('..');
+    }
+
+    outputParts = outputParts.concat(toParts.slice(samePartsLength));
+    return outputParts.join('/');
+  }
+
+  /**
+   * returns an array with empty elements removed from either end of the input
+   * array or the original array if no elements need to be removed
+   * https://github.com/jinder/path/blob/master/path.js#L58
+   * @private
+   * @param {Array<string>} arr Path segments
+   * @returns {Array<string>} Path segments without empty elements
+   * @memberof PathService
+   */
+  private trimArray(arr: Array<string>): Array<string> {
+    const lastIndex = arr.length - 1;
+    let start = 0;
+    for (; start <= lastIndex; start++) {
+      if (arr[start]) {
+        break;
+      }
+    }
+
+    let end = lastIndex;
+    for (; end >= 0; end--) {
+      if (arr[end]) {
+        break;
+      }
+    }
+
+    if (start === 0 && end === lastIndex) {
+      return arr;
+    }
+    if (start > end) {
+      return [];
+    }
+    return arr.slice(start, end + 1);
+  }
+
+}

--- a/src/app/shared/path.service.ts
+++ b/src/app/shared/path.service.ts
@@ -30,11 +30,6 @@ export class PathService {
       }
     }
 
-    if (samePartsLength === 0) {
-      // Don't return absolute path, change to relative even if the base is root
-      return toParts.join('/');
-    }
-
     let outputParts = [];
     for (let i = samePartsLength; i < lowerFromParts.length; i++) {
       outputParts.push('..');

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -15,6 +15,7 @@
  */
 import { Input } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { ToolFile } from '../swagger';
 
 /**
 * Abstract class to be implemented by components that have select boxes for a given entry and version
@@ -34,8 +35,10 @@ export abstract class EntryFileSelector {
   contentHighlighted: boolean;
 
   abstract getDescriptors(version): Array<any>;
-  abstract getFiles(descriptor): Observable<any>;
+  abstract getFiles(descriptor): Observable<Array<ToolFile>>;
   abstract reactToFile(): void;
+  abstract updateToolFiles(): void;
+  abstract getFileContent(toolFile: ToolFile): void;
 
   reactToVersion(): void {
     this.descriptors = this.getDescriptors(this._selectedVersion);
@@ -55,17 +58,20 @@ export abstract class EntryFileSelector {
   }
 
   reactToDescriptor() {
+    this.updateToolFiles();
     this.getFiles(this.currentDescriptor)
       .subscribe(files => {
         this.files = files;
         if (this.files.length) {
           this.onFileChange(this.files[0]);
-        }}
+        } else {
+          this.content = null;
+        }}, error => this.content = null
       );
   }
 
-  onFileChange(file) {
-    this.currentFile = file;
+  onFileChange(file: ToolFile) {
+    this.getFileContent(file);
     this.reactToFile();
   }
 

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -13,31 +13,31 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
-  <div>
-    <span *ngIf="_selectedVersion?.valid" class="row no-margin">
-      <span class="form-group col-sm-4">
-        <strong>File:</strong>
-        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-      </span>
-    </span>
-  <div *ngIf="this.nullDescriptors || !_selectedVersion?.valid">
+<div>
+  <div *ngIf="(nullDescriptors || !content || !_selectedVersion?.valid); else displayContent">
     <alert type="warning">
       <span class="glyphicon glyphicon-warning-sign"></span>
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </alert>
   </div>
-  <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="code-copy">
-    <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
-        <span class="glyphicon glyphicon-download"></span>
-      </a>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content"
-        [ngClass]="{'btn-copy':workflowCopyBtn === 'workflow_descriptors_file'}"
-        (cbOnSuccess)="workflowCopyBtnClick('workflow_descriptors_file')">
-        <span class="glyphicon glyphicon-copy"></span>
-      </button>
+  <ng-template #displayContent>
+    <span class="row no-margin">
+      <span class="form-group col-sm-4">
+        <strong>File:</strong>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+      </span>
+    </span>
+    <div class="code-copy">
+      <div class="code-copy-button btn-group">
+        <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+          <span class="glyphicon glyphicon-download"></span>
+        </a>
+        <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':workflowCopyBtn === 'workflow_descriptors_file'}"
+          (cbOnSuccess)="workflowCopyBtnClick('workflow_descriptors_file')">
+          <span class="glyphicon glyphicon-copy"></span>
+        </button>
+      </div>
+      <section *ngIf="content && _selectedVersion?.valid" [innerHTML]="fileService.highlightCode(content)"></section>
     </div>
-    <section *ngIf="content && _selectedVersion?.valid" [innerHTML]="fileService.highlightCode(content)"></section>
-  </div>
+  </ng-template>
 </div>

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -29,7 +29,7 @@
   </div>
   <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a download [href]="getDescriptorPath(currentDescriptor)" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+      <a download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content"

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -29,7 +29,7 @@
   </div>
   <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
+      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{getFilePath(currentFile)}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content"

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -25,6 +25,8 @@ import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 
 import { FileService } from '../../shared/file.service';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
+import { Ga4ghFilesStateService } from '../../shared/entry/ga4gh-files-state.service';
+import { ToolFile, ToolDescriptor, GA4GHService } from '../../shared/swagger';
 
 @Component({
   selector: 'app-descriptors-workflow',
@@ -41,8 +43,8 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements A
   content: string;
   contentHighlighted: boolean;
   public downloadFilePath: string;
-  constructor(private highlightJsService: HighlightJsService,
-              private workflowDescriptorService: WorkflowDescriptorService,
+  constructor(private highlightJsService: HighlightJsService, private ga4ghFilesStateService: Ga4ghFilesStateService,
+              private workflowDescriptorService: WorkflowDescriptorService, private ga4ghService: GA4GHService,
               public fileService: FileService,
               private workflowService: WorkflowService,
               private elementRef: ElementRef) {
@@ -53,18 +55,38 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements A
     return this.workflowDescriptorService.getDescriptors(this._selectedVersion);
   }
 
-  getFiles(descriptor): Observable<any> {
-    return this.workflowDescriptorService.getFiles(this.id, this._selectedVersion.name, this.currentDescriptor);
+  getFiles(descriptor): Observable<Array<ToolFile>> {
+    return this.ga4ghFilesStateService.descriptorToolFiles$;
   }
 
   reactToFile(): void {
-    this.content = this.currentFile.content;
-    this.contentHighlighted = true;
-    this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, this.currentFile,
-      this.currentDescriptor, 'workflow');
+
   }
+
+  getFileContent(toolFile: ToolFile): void {
+    this.currentFile = toolFile;
+    const type = this.currentDescriptor;
+    const id = this.entrypath;
+    const versionId = this._selectedVersion.name;
+    const relativePath = toolFile.path;
+    // TODO: Use oneOf in OpenAPI 3.0 to avoid casting
+    this.ga4ghService.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(type, '#workflow/' + id, versionId, relativePath)
+      .subscribe((file: ToolDescriptor) => {
+        if (file) {
+          this.content = file.descriptor;
+          this.contentHighlighted = true;
+          this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, relativePath,
+            this.currentDescriptor, 'workflow');
+        }
+      });
+  }
+
+  updateToolFiles(): void {
+    this.ga4ghFilesStateService.update(this.currentDescriptor, '#workflow/' + this.entrypath, this._selectedVersion.name);
+  }
+
   ngAfterViewChecked() {
-    if (this.contentHighlighted) {
+    if (this.contentHighlighted  && this.elementRef.nativeElement.querySelector('.highlight')) {
       this.contentHighlighted = false;
       this.highlightJsService.highlight(this.elementRef.nativeElement.querySelector('.highlight'));
     }

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -40,6 +40,7 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements A
 
   content: string;
   contentHighlighted: boolean;
+  public downloadFilePath: string;
   constructor(private highlightJsService: HighlightJsService,
               private workflowDescriptorService: WorkflowDescriptorService,
               public fileService: FileService,
@@ -58,16 +59,14 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements A
   reactToFile(): void {
     this.content = this.currentFile.content;
     this.contentHighlighted = true;
+    this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, this.currentFile,
+      this.currentDescriptor, 'workflow');
   }
   ngAfterViewChecked() {
     if (this.contentHighlighted) {
       this.contentHighlighted = false;
       this.highlightJsService.highlight(this.elementRef.nativeElement.querySelector('.highlight'));
     }
-  }
-
-  getDescriptorPath(entrytype): string {
-    return this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion, this.currentFile, this.currentDescriptor, 'workflow');
   }
 
   // Get the path of the file

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -47,6 +47,7 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements A
               private workflowService: WorkflowService,
               private elementRef: ElementRef) {
     super();
+    this.published$ = this.workflowService.workflowIsPublished$;
   }
   getDescriptors(version): Array<any> {
     return this.workflowDescriptorService.getDescriptors(this._selectedVersion);

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -13,31 +13,31 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
 <div>
-  <span *ngIf="_selectedVersion?.valid && content" class="row no-margin">
-    <span class="form-group col-sm-4">
-      <strong>File:</strong>
-      <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-    </span>
-  </span>
-  <span *ngIf="content" class="input-group-btn code-copy">
-  </span>
-  <div *ngIf="content && _selectedVersion?.valid" class="code-copy">
-    <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
-      </a>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content"
-              [ngClass]="{'btn-copy':workflowCopyBtn === 'workflow_param_file'}"
-              (cbOnSuccess)="workflowCopyBtnClick('workflow_param_file')">
-        <span class="glyphicon glyphicon-copy"></span>
-      </button>
-    </div>
-    <section [innerHTML]="fileService.highlightCode(content)"></section>
-  </div>
-  <alert type="warning" *ngIf="!content || !_selectedVersion?.valid">
+  <alert type="warning" *ngIf="(!content || !_selectedVersion?.valid); else displayContent">
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp; A Test Parameter File associated with this workflow could not be found.
   </alert>
+  <ng-template #displayContent>
+    <span class="row no-margin">
+      <span class="form-group col-sm-4">
+        <strong>File:</strong>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+      </span>
+    </span>
+    <span class="input-group-btn code-copy">
+    </span>
+    <div *ngIf="content && _selectedVersion?.valid" class="code-copy">
+      <div class="code-copy-button btn-group">
+        <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
+          <span class="glyphicon glyphicon-download"></span>
+        </a>
+        <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':workflowCopyBtn === 'workflow_param_file'}"
+          (cbOnSuccess)="workflowCopyBtnClick('workflow_param_file')">
+          <span class="glyphicon glyphicon-copy"></span>
+        </button>
+      </div>
+      <section [innerHTML]="fileService.highlightCode(content)"></section>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/workflow/paramfiles/paramfiles.component.spec.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.spec.ts
@@ -13,11 +13,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HighlightJsService } from '../../shared/angular2-highlight-js/lib/highlight-js.module';
+import { PathService } from '../../shared/path.service';
 import { ParamfilesService } from './../../container/paramfiles/paramfiles.service';
 import { FileService } from './../../shared/file.service';
 import { WorkflowService } from './../../shared/workflow.service';
@@ -36,7 +36,7 @@ describe('ParamfilesWorkflowComponent', () => {
         { provide: ParamfilesService, useClass: ParamFilesStubService },
         HighlightJsService,
         { provide: FileService, useClass: FileStubService},
-        { provide: WorkflowService, useClass: WorkflowStubService}]
+        { provide: WorkflowService, useClass: WorkflowStubService}, PathService]
     })
       .compileComponents();
   }));

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -13,14 +13,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import {Component, Input, OnInit, ElementRef, AfterViewChecked} from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { HighlightJsService } from '../../shared/angular2-highlight-js/lib/highlight-js.module';
-import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-
 import { FileService } from '../../shared/file.service';
+import { PathService } from '../../shared/path.service';
+import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowService } from '../../shared/workflow.service';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
 
@@ -44,7 +44,7 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector implements Af
               private highlightJsService: HighlightJsService,
               public fileService: FileService,
               private elementRef: ElementRef,
-              private workflowService: WorkflowService) {
+              private workflowService: WorkflowService, private pathService: PathService) {
     super();
     this.published$ = this.workflowService.workflowIsPublished$;
   }
@@ -60,6 +60,8 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector implements Af
     this.content = this.currentFile.content;
     this.contentHighlighted = true;
     this.filePath = this.getFilePath(this.currentFile);
+    const relativePath = this.pathService.relative(this._selectedVersion.workflow_path, this.currentFile.path);
+    this.currentFile.path = relativePath;
     this.downloadFilePath = this.fileService.getDescriptorPath(this.entrypath, this._selectedVersion,
       this.currentFile, this.currentDescriptor, this.entryType);
   }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -217,6 +217,7 @@ export class WorkflowComponent extends Entry {
       this.workflowsService.publish(this.workflow.id, request).subscribe(
         (response: Workflow) => {
           this.workflowService.upsertWorkflowToWorkflow(response);
+          this.workflowService.setWorkflow(response);
         }, err => {
           this.published = !this.published;
           this.refreshService.handleError('publish error', err);


### PR DESCRIPTION
For ga4gh/dockstore#1422

Changing the absolute paths of the test parameter file download links to relative paths.

Conversion is mostly done using an altered nodejs path module relative function.

The relative path is based on the directory of the descriptor (not the descriptor itself).  See test for expected output.

Only works with hotfix/master webservice branch currently

