### PR TITLE
Revert test parameter file download link change 

### DIFF
--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -34,7 +34,7 @@
   </div>
   <div *ngIf="content && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
+      <a *ngIf="(published$ | async)" href id="downloadLinkParams" (click)="downloadFile(currentFile, 'downloadLinkParams')" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" [ngClass]="{'btn-copy':toolCopyBtn === 'test_param_file'}"

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -13,19 +13,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import { ContainersService } from '../../shared/swagger';
-import { Component, Input, ElementRef, OnInit, AfterViewChecked} from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { HighlightJsService } from '../../shared/angular2-highlight-js/lib/highlight-js.module';
-
 import { ContainerService } from '../../shared/container.service';
-import { ParamfilesService } from './paramfiles.service';
-import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-
 import { FileService } from '../../shared/file.service';
+import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
+import { ContainersService } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
+import { ParamfilesService } from './paramfiles.service';
 
 @Component({
   selector: 'app-paramfiles-container',
@@ -45,12 +42,12 @@ export class ParamfilesComponent extends EntryFileSelector implements AfterViewC
   public downloadFilePath: string;
 
   constructor(private containerService: ContainerService, private containersService: ContainersService,
-              private highlightJsService: HighlightJsService,
-              private paramfilesService: ParamfilesService,
-              public fileService: FileService,
-              private elementRef: ElementRef) {
+    private highlightJsService: HighlightJsService,
+    private paramfilesService: ParamfilesService,
+    public fileService: FileService,
+    private elementRef: ElementRef) {
     super();
-      this.published$ = this.containerService.toolIsPublished$;
+    this.published$ = this.containerService.toolIsPublished$;
   }
   getDescriptors(version): Array<any> {
     return this.paramfilesService.getDescriptors(this._selectedVersion);
@@ -78,5 +75,9 @@ export class ParamfilesComponent extends EntryFileSelector implements AfterViewC
   // Get the path of the file
   getFilePath(file): string {
     return this.fileService.getFilePath(file);
+  }
+
+  downloadFile(file, id): void {
+    this.fileService.downloadFile(file, id);
   }
 }

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -89,4 +89,16 @@ export class FileService {
       }
       return null;
     }
+
+  // Downloads a file
+  // TODO: Temporary, need to update test param endpoint to return raw file based on path
+  downloadFile(file, id): void {
+    let filename = 'dockstore.txt';
+    if (file != null) {
+      const splitFileName = (file.path).split('/');
+      filename = splitFileName[splitFileName.length - 1];
+      const data = 'data:text/plain,' + encodeURIComponent(file.content);
+      $('#' + id).attr('href', data).attr('download', filename);
+    }
+  }
 }

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -25,7 +25,7 @@
   </span>
   <div *ngIf="content && _selectedVersion?.valid" class="code-copy">
     <div class="code-copy-button btn-group">
-      <a *ngIf="(published$ | async)" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
+      <a *ngIf="(published$ | async)" href id="downloadLinkParams" (click)="downloadFile(currentFile, 'downloadLinkParams')" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>
       </a>
       <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content"

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -13,14 +13,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-import {Component, Input, OnInit, ElementRef, AfterViewChecked} from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { HighlightJsService } from '../../shared/angular2-highlight-js/lib/highlight-js.module';
-import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-
 import { FileService } from '../../shared/file.service';
+import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowService } from '../../shared/workflow.service';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
 
@@ -41,10 +40,10 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector implements Af
   public downloadFilePath: string;
 
   constructor(private paramfilesService: ParamfilesService,
-              private highlightJsService: HighlightJsService,
-              public fileService: FileService,
-              private elementRef: ElementRef,
-              private workflowService: WorkflowService) {
+    private highlightJsService: HighlightJsService,
+    public fileService: FileService,
+    private elementRef: ElementRef,
+    private workflowService: WorkflowService) {
     super();
     this.published$ = this.workflowService.workflowIsPublished$;
   }
@@ -74,5 +73,9 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector implements Af
   // Get the path of the file
   getFilePath(file): string {
     return this.fileService.getFilePath(file);
+  }
+
+  downloadFile(file, id): void {
+    this.fileService.downloadFile(file, id);
   }
 }


### PR DESCRIPTION
This is to be reverted later when GA4GH endpoint is used to get the download file path.

Meant to revert https://github.com/dockstore/dockstore-ui2/pull/298
