### PR TITLE
Improve CWL Viewer Error Handling

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -57,7 +57,7 @@ export class Dockstore {
   static readonly CWL_VISUALIZER_URI = 'https://view.commonwl.org';
 
   static readonly FEATURES = {
-    enableCwlViewer: false,
+    enableCwlViewer: true,
     enableLaunchWithFireCloud: true
   };
 }

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.component.ts
@@ -14,10 +14,11 @@
  *    limitations under the License.
  */
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { CwlViewerDescriptor, CwlViewerService } from './cwl-viewer.service';
 import { WorkflowVersion } from '../../../shared/swagger/model/workflowVersion';
 import { ExtendedWorkflow } from '../../../shared/models/ExtendedWorkflow';
+import { Subject } from 'rxjs/Subject';
 
 @Component({
   selector: 'app-cwl-viewer',
@@ -26,7 +27,7 @@ import { ExtendedWorkflow } from '../../../shared/models/ExtendedWorkflow';
   styleUrls: ['./cwl-viewer.scss']
 })
 
-export class CwlViewerComponent implements OnInit {
+export class CwlViewerComponent implements OnInit, OnDestroy {
 
   @Input() workflow: ExtendedWorkflow;
   @Input() set selectedVersion(value: WorkflowVersion) {
@@ -43,15 +44,21 @@ export class CwlViewerComponent implements OnInit {
   public cwlViewerError = false;
   public cwlViewerPercentageZoom = 100;
   public cwlViewerDescriptor: CwlViewerDescriptor;
+  public errorMessage;
   public loading = false;
 
   private version;
+  private onDestroy$ = new Subject<void>();
 
   constructor(private cwlViewerService: CwlViewerService) {
   }
 
   ngOnInit(): void {
     this.cwlViewerDescriptor = null;
+  }
+
+  ngOnDestroy(): void {
+    this.onDestroy$.next();
   }
 
   resetZoom() {
@@ -62,8 +69,9 @@ export class CwlViewerComponent implements OnInit {
     if (this.version) {
       this.loading = true;
       this.cwlViewerDescriptor = null;
+      this.errorMessage = null;
       this.cwlViewerService.getVisualizationUrls(this.workflow.providerUrl, this.version.reference,
-        this.version.workflow_path)
+        this.version.workflow_path, this.onDestroy$)
         .subscribe(
           cwlViewerDescriptor => {
             this.cwlViewerDescriptor = cwlViewerDescriptor;
@@ -71,7 +79,8 @@ export class CwlViewerComponent implements OnInit {
             this.loading = false;
             this.resetZoom();
           },
-          () => {
+          (error) => {
+            this.errorMessage = error;
             this.cwlViewerDescriptor = null;
             this.cwlViewerError = true;
             this.loading = false;

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
@@ -1,8 +1,8 @@
 <div [ngClass]="{'fullscreen-element large-dag': expanded}" class="cwl-viewer" >
   <div *ngIf="cwlViewerError" class="alert alert-warning">
     <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
-    <span>The Common Workflow Language Viewer was unable to process the CWL. Note that the viewer only supports
-      branches and does not support tags.</span>
+    <div>The Common Workflow Language Viewer was unable to process the CWL. <span *ngIf="errorMessage">It returned the following error:</span></div>
+    <div>{{errorMessage}}</div>
   </div>
   <div>
     <span *ngIf="!cwlViewerError">See on <a [href]="cwlViewerDescriptor?.webPageUrl" target="_blank">Common Workflow Language Viewer <span class="glyphicon glyphicon-new-window"></span></a></span>

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts
@@ -35,9 +35,13 @@ describe('Service: CWLViewer', () => {
     'roBundle': '/robundle/github.com/dockstore-testing/Metaphlan-ISBCGC/blob/master/metaphlan_wfl.cwl'
   };
 
+  const message = 'Tool definition failed initialization:\nTool definition file:///data/git/e9cccbaa54f2e73180'
+    + 'bf13e2ae02cf2af4df51f7/tools/picard-CreateSequenceDictionary.cwl failed validation:\n  The CWL reference runner'
+    + ' no longer supports pre CWL v1.0 documents. Supported versions are: \n  v1.0\n  v1.1.0-dev1 '
+    + '(with --enable-dev flag only)\n';
   const cwlViewerError = {
     'cwltoolStatus': 'ERROR',
-    'message': 'Tool definition failed initialization:\nTool definition file:///data/git/e9cccbaa54f2e73180bf13e2ae02cf2af4df51f7/tools/picard-CreateSequenceDictionary.cwl failed validation:\n  The CWL reference runner no longer supports pre CWL v1.0 documents. Supported versions are: \n  v1.0\n  v1.1.0-dev1 (with --enable-dev flag only)\n'
+    'message': message
   };
 
 


### PR DESCRIPTION
Fixes ga4gh/dockstore#1518.

* Look for a 200 response when polling the queue that might have a
cwltoolStatus of ERROR.
* Reduce polling frequency to every 500ms instead of 250ms.
* Stop polling when leaving the page.
* Display the error message that comes back from CWL Viewer instead
of a generic message.