### PR TITLE
Feature/1435/commit

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        threshold: 1

--- a/cypress/integration/hostedTools.js
+++ b/cypress/integration/hostedTools.js
@@ -86,8 +86,7 @@ describe('Dockstore my tools', function() {
           .parent()
           .click()
           .get('table')
-          .find('a')
-          .contains('1')
+          .contains('span', /\b1\b/)
 
           // Add a new version with a second descriptor and a test json
           cy
@@ -141,8 +140,7 @@ describe('Dockstore my tools', function() {
             .parent()
             .click()
             .get('table')
-            .find('a')
-            .contains('2')
+            .contains('span', /\b2\b/)
 
           // Should be able to publish
           cy
@@ -183,8 +181,7 @@ describe('Dockstore my tools', function() {
             .parent()
             .click()
             .get('table')
-            .find('a')
-            .contains('3')
+            .contains('span', /\b3\b/)
 
           // Delete a version
           cy

--- a/cypress/integration/hostedWorkflows.js
+++ b/cypress/integration/hostedWorkflows.js
@@ -72,8 +72,7 @@ describe('Dockstore my workflows', function() {
           .parent()
           .click()
           .get('table')
-          .find('a')
-          .contains('1')
+          .contains('span', /\b1\b/)
 
           // Add a new version with a second descriptor and a test json
           cy
@@ -122,8 +121,7 @@ describe('Dockstore my workflows', function() {
             .parent()
             .click()
             .get('table')
-            .find('a')
-            .contains('2')
+          .contains('span', /\b2\b/)
 
           // Should be able to publish
           cy
@@ -159,8 +157,7 @@ describe('Dockstore my workflows', function() {
             .parent()
             .click()
             .get('table')
-            .find('a')
-            .contains('3')
+          .contains('span', /\b3\b/)
 
           // Delete a version
           cy

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -85,18 +85,22 @@
           <div class="text-center">No Records Found</div>
         </td>
       </tr>
-      <tr *ngFor="let version of versions | orderBy : convertSorting()" [ngClass]="{'info': versionTag != null && version != null && versionTag.id == version.id}">
+      <tr (click)="setVersion(version)" *ngFor="let version of versions | orderBy : convertSorting()" [ngClass]="{'info': versionTag != null && version != null && versionTag.id == version.id}">
         <td class="break">
           <span *ngIf="publicPage && defaultVersion ===version.name" class="label label-primary">Default</span>
           <input class="radio-button-reference" *ngIf="version.name !== 'latest' && !publicPage " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
             [value]="version.name" (click)="updateDefaultVersion(version.name)" [tooltip]="getDefaultTooltip(publicPage)"/>
-          <a (click)="setVersion(version)">{{version?.name}}</a>
+          <span>{{version?.name}}</span>
         </td>
         <td *ngIf="tool?.mode === DockstoreToolType.ModeEnum.HOSTED">{{ version?.versionEditor?.name }}</td>
         <td *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
           <i *ngIf="version.referenceType === 'BRANCH'" class="fa fa-code-fork" aria-hidden="true" title="Branch"></i>
           <i *ngIf="version.referenceType === 'TAG'" class="fa fa-tag" aria-hidden="true" title="Tag"></i>
-          {{ version.reference || 'n/a' }}</td>
+          <span *ngIf="(version.commitID && (version.commitID | commitUrl: tool?.providerUrl)); else noCommitID" [tooltip]="version.commitID? 'Commit ID: ' + version.commitID : ''">
+            <a [href]="version.commitID | commitUrl: tool?.providerUrl">{{ version.reference || 'n/a' }}</a>
+          </span>
+          <ng-template #noCommitID>{{ version.reference || 'n/a' }}</ng-template>
+        </td>
         <td *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
           <div>
             {{ version.cwl_path }}

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -99,7 +99,7 @@
           <span *ngIf="(version.commitID && (version.commitID | commitUrl: tool?.providerUrl)); else noCommitID" [tooltip]="version.commitID? 'Commit ID: ' + version.commitID : ''">
             <a [href]="version.commitID | commitUrl: tool?.providerUrl">{{ version.reference || 'n/a' }}</a>
           </span>
-          <ng-template #noCommitID>{{ version.reference || 'n/a' }}</ng-template>
+          <ng-template #noCommitID><span>{{ version.reference || 'n/a' }}</span></ng-template>
         </td>
         <td *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
           <div>

--- a/src/app/shared/entry/commit-url.pipe.spec.ts
+++ b/src/app/shared/entry/commit-url.pipe.spec.ts
@@ -1,0 +1,13 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async } from '@angular/core/testing';
+import { CommitUrlPipe } from './commit-url.pipe';
+
+describe('Pipe: CommitUrle', () => {
+  it('create an instance', () => {
+    const pipe = new CommitUrlPipe();
+    expect(pipe).toBeTruthy();
+    expect(pipe.transform('868a1c6b02344dd679eb0548889de03e6affef99', 'https://github.com/garyluu/example_cwl_workflow'))
+      .toBe('https://github.com/garyluu/example_cwl_workflow/tree/868a1c6b02344dd679eb0548889de03e6affef99');
+  });
+});

--- a/src/app/shared/entry/commit-url.pipe.ts
+++ b/src/app/shared/entry/commit-url.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'commitUrl'
+})
+export class CommitUrlPipe implements PipeTransform {
+
+  transform(commitId: string, providerUrl: string): string {
+    if (providerUrl.startsWith('https://github.com/')) {
+      return providerUrl + '/tree/' + commitId;
+    } else {
+      if (providerUrl.startsWith('http://bitbucket.org/')) {
+        return providerUrl + 'src/' + commitId;
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -27,6 +27,7 @@ import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch
 import { RegisterCheckerWorkflowComponent } from './register-checker-workflow/register-checker-workflow.component';
 import { CodeEditorComponent } from './../code-editor/code-editor.component';
 import { CodeEditorListComponent } from './../code-editor-list/code-editor-list.component';
+import { CommitUrlPipe } from './commit-url.pipe';
 
 @NgModule({
   imports: [
@@ -41,14 +42,16 @@ import { CodeEditorListComponent } from './../code-editor-list/code-editor-list.
     RegisterCheckerWorkflowComponent,
     LaunchCheckerWorkflowComponent,
     CodeEditorComponent,
-    CodeEditorListComponent
-  ],
+    CodeEditorListComponent,
+    CommitUrlPipe
+],
   exports: [
     InfoTabCheckerWorkflowPathComponent,
     LaunchCheckerWorkflowComponent,
     CodeEditorComponent,
     CodeEditorListComponent,
-    CustomMaterialModule
+    CustomMaterialModule,
+    CommitUrlPipe
   ]
 })
 export class EntryModule { }

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -113,7 +113,7 @@
       <span *ngIf="(version.commitID && (version.commitID | commitUrl: workflow?.providerUrl)); else noCommitID" [tooltip]="version.commitID? 'Commit ID: ' + version.commitID : ''">
         <a [href]="version.commitID | commitUrl: workflow?.providerUrl">{{version?.name}}</a>
       </span>
-      <ng-template #noCommitID>{{version?.name}}</ng-template>
+      <ng-template #noCommitID><span>{{version?.name}}</span></ng-template>
     </td>
       <td *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED">{{ version?.versionEditor?.name }}</td>
       <td>{{ version.workflow_path }}</td>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -103,17 +103,18 @@
         <div class="text-center">No Records Found</div>
       </td>
     </tr>
-    <tr *ngFor="let version of versions | orderBy : convertSorting()" [ngClass]="{'info': _selectedVersion != null && version != null && _selectedVersion.id == version.id}">
-      <td>
-        <span *ngIf="publicPage && defaultVersion === version.name" class="label label-primary">Default</span>
-        <input class="radio-button-reference" *ngIf="version.name !== 'latest' && !publicPage " type="radio" name="defaultVersion"
-                     [(ngModel)]="defaultVersion" [value]="version.reference" (click)="updateDefaultVersion(version.reference)"
-                     [tooltip]="getDefaultTooltip(publicPage)"/>
-
-       <i *ngIf="version.referenceType === 'BRANCH'" class="fa fa-code-fork" aria-hidden="true" title="Branch"></i>
-       <i *ngIf="version.referenceType === 'TAG'" class="fa fa-tag" aria-hidden="true" title="Tag"></i>
-       <a (click)="setVersion(version)">{{version?.name}}</a>
-      </td>
+    <tr (click)="setVersion(version)" *ngFor="let version of versions | orderBy : convertSorting()" [ngClass]="{'info': _selectedVersion != null && version != null && _selectedVersion.id == version.id}">
+    <td>
+      <span *ngIf="publicPage && defaultVersion === version.name" class="label label-primary">Default</span>
+      <input class="radio-button-reference" *ngIf="version.name !== 'latest' && !publicPage " type="radio" name="defaultVersion" [(ngModel)]="defaultVersion"
+        [value]="version.reference" (click)="updateDefaultVersion(version.reference)" [tooltip]="getDefaultTooltip(publicPage)" />&nbsp;
+      <i *ngIf="version.referenceType === 'BRANCH'" class="fa fa-code-fork" aria-hidden="true" title="Branch"></i>
+      <i *ngIf="version.referenceType === 'TAG'" class="fa fa-tag" aria-hidden="true" title="Tag"></i>
+      <span *ngIf="(version.commitID && (version.commitID | commitUrl: workflow?.providerUrl)); else noCommitID" [tooltip]="version.commitID? 'Commit ID: ' + version.commitID : ''">
+        <a [href]="version.commitID | commitUrl: workflow?.providerUrl">{{version?.name}}</a>
+      </span>
+      <ng-template #noCommitID>{{version?.name}}</ng-template>
+    </td>
       <td *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED">{{ version?.versionEditor?.name }}</td>
       <td>{{ version.workflow_path }}</td>
       <td>{{ getDateTimeString(version.last_modified) }}</td>

--- a/src/app/workflow/versions/versions.component.spec.ts
+++ b/src/app/workflow/versions/versions.component.spec.ts
@@ -29,6 +29,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OrderBy } from '../../shared/orderBy';
 
 import { VersionsWorkflowComponent } from './versions.component';
+import { CommitUrlPipe } from '../../shared/entry/commit-url.pipe';
 
 describe('VersionsWorkflowComponent', () => {
   let component: VersionsWorkflowComponent;
@@ -36,7 +37,7 @@ describe('VersionsWorkflowComponent', () => {
   let workflowService: WorkflowService;
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ VersionsWorkflowComponent, OrderBy ],
+      declarations: [ VersionsWorkflowComponent, OrderBy, CommitUrlPipe ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [DockstoreService,
         { provide: DateService, useClass: DateStubService},


### PR DESCRIPTION
For ga4gh/dockstore#1435

Add commit id tooltip to every git reference in both tool versions and workflow versions.  

Clicking the git reference in the workflow version no longer changes the selected version.  Clicking the git reference hyperlink will take the user to the github repo page with that commit ID.  Clicking anywhere except the git reference in both tools/workflows page will change the selected version.