### PR TITLE
Change validation pattern when descriptor type changes

### DIFF
--- a/cypress/integration/myworkflows.js
+++ b/cypress/integration/myworkflows.js
@@ -45,6 +45,87 @@ describe('Dockstore my workflows', function() {
         });
     });
 
+    function haveAlert() {
+        cy
+            .get('.alert')
+            .should('be.visible')
+    }
+
+
+    function notHaveAlert() {
+        cy
+            .get('.alert')
+            .should('not.be.visible')
+    }
+
+    describe('test register workflow form validation', function() {
+        it('It should have 3 seperate descriptor path validation patterns', function() {
+            cy
+                .get('#registerWorkflowButton')
+                .should('be.visible')
+                .should('be.enabled')
+                .click()
+            cy
+                .contains('button', 'Next')
+                .click()
+            cy
+                .get('#sourceCodeRepositoryInput')
+                .clear()
+                .type('beef/stew')
+            haveAlert()
+            cy
+                .get('#sourceCodeRepositoryWorkflowPathInput')
+                .clear()
+                .type('/Dockstore.cwl')
+            notHaveAlert()
+            cy
+                .get('.dropdown-toggle')
+                .contains('button', 'cwl')
+                .click()
+            cy
+                .contains('li', 'wdl')
+                .click()
+            haveAlert()
+            cy
+                .get('#sourceCodeRepositoryWorkflowPathInput')
+                .clear()
+                .type('/Dockstore.wdl')
+            notHaveAlert()
+            cy
+                .get('.dropdown-toggle')
+                .contains('button', 'wdl')
+                .click()
+            cy
+                .contains('li', 'nextflow')
+                .click()
+            haveAlert()
+            cy
+                .get('#sourceCodeRepositoryWorkflowPathInput')
+                .clear()
+                .type('/Dockstore.config')
+            notHaveAlert()
+            cy
+                .get('.dropdown-toggle')
+                .contains('button', 'nextflow')
+                .click()
+            cy
+                .contains('li', 'cwl')
+                .click()
+            haveAlert()
+            cy
+                .get('#sourceCodeRepositoryWorkflowPathInput')
+                .clear()
+                .type('/Dockstore.cwl')
+            notHaveAlert()
+            cy
+                .get('#closeRegisterWorkflowModalButton')
+                .contains('button', 'Close')
+                .should('be.visible')
+                .should('be.enabled')
+                .click()
+        });
+    });
+
     describe('Look at a published workflow', function() {
         it('Look at each tab', function() {
             cy.visit(String(global.baseUrl) + "/my-workflows/github.com/A/l")

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -93,7 +93,7 @@
         </accordion-group>
       </accordion>
       <div *ngIf="groupEntriesObject?.length > 0 && groupEntriesObject">
-        <button type="button" class="btn btn-primary btn-sm pull-right" (click)="showRegisterEntryModal()" [disabled]="refreshMessage !== null">Register Workflow</button>
+        <button id="registerWorkflowButton" type="button" class="btn btn-primary btn-sm pull-right" (click)="showRegisterEntryModal()" [disabled]="refreshMessage !== null">Register Workflow</button>
       </div>
       <app-register-workflow-modal></app-register-workflow-modal>
     </div>

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -44,6 +44,7 @@ export const validationDescriptorPatterns = {
   'gitPath': '^([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$',
   'cwlPath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+\.(cwl|yaml|yml)',
   'wdlPath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.wdl$',
+  'nflPath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+\.(config)',
   'dockerfilePath': '^/([^\/?:*|<>]+/)*(([a-zA-Z]+[.])?Dockerfile|Dockerfile([.][a-zA-Z]+)?)$',
   'testFilePath': '^/([^\/?:*|<>]+/)*[^\/?:*|<>]+.(json|yml|yaml)$',
   'imagePath': '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$',
@@ -144,7 +145,8 @@ export const validationMessages = {
     'minlength': 'Workflow Path is too short. (Min. 3 characters.)',
     'maxlength': 'Workflow Path is too long. (Max 256 characters.)',
     'pattern': 'Invalid Workflow Path format. ' +
-    'Workflow Path must begin with \'/\' and end with \'*.cwl\', \'*.yml\', \'*.yaml\', or\'*.wdl\'.'
+    'Workflow Path must begin with \'/\' and end with \'*.cwl\', \'*.yml\', \'*.yaml\', \'*.config\', or\'*.wdl\' ' +
+    'depending on the descriptor type.'
   },
   'workflowName': {
     'maxlength': 'Workflow Name is too long. (Max 256 characters.)',

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -137,7 +137,7 @@
               </div>
             </div>
             <div class="modal-footer">
-              <button mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
+              <button id="closeRegisterWorkflowModalButton" mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
                 Close
               </button>
               <button id="submitButton" type="submit" mat-raised-button color="primary" disabled="{{!registerWorkflowForm.form.valid || refreshMessage !== null}}">

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -104,16 +104,17 @@
                         <span class="caret"></span>
                       </button>
                       <ul class="dropdown-menu">
-                        <li *ngFor="let descriptorType of getDescriptorTypes()">
-                          <a class="dropdown-item" (click)="workflow.descriptorType = descriptorType.toLowerCase()">
+                        <li *ngFor="let descriptorType of (descriptorLanguages$ | async)">
+                          <a class="dropdown-item" (click)="changeDescriptorType(descriptorType.toLowerCase())">
                             {{descriptorType | lowercase}}
                           </a>
                         </li>
                       </ul>
                     </div>
-                    <input id="sourceCodeRepositoryWorkflowPathInput" type="text" class="form-control" name="workflow_path" [(ngModel)]="workflow.workflow_path" minlength="3" maxlength="128" [pattern]="validationPatterns.workflowDescriptorPath" required tooltip="Git Repository path." placeholder='{{ examplePatterns[workflow.descriptorType] }}' />
+                    <input id="sourceCodeRepositoryWorkflowPathInput" type="text" class="form-control" name="workflow_path" [(ngModel)]="workflow.workflow_path" minlength="3" maxlength="128" [pattern]="descriptorValidationPattern" required tooltip="Git Repository path." placeholder='{{ examplePatterns[workflow.descriptorType] }}' />
                   </div>
-                  <div *ngIf="formErrors.workflow_path" class="alert alert-danger"> {{ formErrors.workflow_path }} </div>
+                  <!-- TODO: Actually return 3 seperate sets of form error messages depending on the descriptor type selected -->
+                  <div *ngIf="formErrors.workflow_path" class="alert alert-danger"> {{ formErrors.workflow_path }}</div>
                 </div>
               </div>
               <div class="form-group form-group-sm">
@@ -158,7 +159,7 @@
                         <span class="caret"></span>
                       </button>
                       <ul class="dropdown-menu">
-                        <li *ngFor="let descriptorType of getDescriptorTypes()">
+                        <li *ngFor="let descriptorType of (descriptorLanguages$ | async)">
                           <a class="dropdown-item" (click)="hostedWorkflow.descriptorType = descriptorType.toLowerCase()">
                             {{descriptorType | lowercase}}
                           </a>

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
@@ -15,6 +15,8 @@
  */
 import { AfterViewChecked, Component, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
+import { Observable } from 'rxjs';
+
 import { StateService } from '../../shared/state.service';
 import { Workflow } from '../../shared/swagger';
 import {
@@ -38,6 +40,8 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked 
   public workflowRegisterError;
   public isModalShown: boolean;
   public refreshMessage: string;
+  public descriptorValidationPattern;
+  public descriptorLanguages$: Observable<Array<string>>;
   public hostedWorkflow = {
     name: '',
     descriptorType: 'cwl'
@@ -68,11 +72,6 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked 
     // return this.registerWorkflowModalService.friendlyRepositoryKeys();
   }
 
-  // TODO: This is called many times, needs to be optimized
-  getDescriptorTypes(): Array<string> {
-    return this.registerWorkflowModalService.getDescriptorLanguageKeys();
-  }
-
   clearWorkflowRegisterError(): void {
     this.registerWorkflowModalService.clearWorkflowRegisterError();
   }
@@ -83,11 +82,13 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked 
       workflowRegisterError => this.workflowRegisterError = workflowRegisterError);
     this.registerWorkflowModalService.isModalShown$.subscribe(isModalShown => this.isModalShown = isModalShown);
     this.stateService.refreshMessage$.subscribe(refreshMessage => this.refreshMessage = refreshMessage);
-  }
-
-  // Validation starts here, should move most of these to a service somehow
-  ngAfterViewChecked() {
-    this.formChanged();
+    this.descriptorLanguages$ = this.registerWorkflowModalService.descriptorLanguages$;
+    // Using this to set the initial validation pattern.  TODO: find a better way
+    this.descriptorLanguages$.subscribe((languages: Array<string>) => {
+      if (languages && languages.length > 0) {
+        this.changeDescriptorType(languages[0].toLowerCase());
+      }
+    });
   }
 
   registerWorkflow() {
@@ -104,6 +105,12 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked 
 
   hideModal() {
     this.registerWorkflowModalService.setIsModalShown(false);
+  }
+
+
+  // Validation starts here, should move most of these to a service somehow
+  ngAfterViewChecked() {
+    this.formChanged();
   }
 
   formChanged() {
@@ -135,4 +142,33 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked 
   }
   // Validation ends here
 
+  /**
+   * This is triggered when the descriptor type changes in the dropdown menu.
+   * Change the descriptor pattern required for validation when this happens.
+   * TODO: Also change the form error message and reset the others
+   *
+   * @param {string} descriptorType  The current selected descriptor type
+   * @memberof RegisterWorkflowModalComponent
+   */
+  changeDescriptorType(descriptorType: string): void {
+    this.workflow.descriptorType = descriptorType;
+    switch (descriptorType) {
+      case 'cwl': {
+        this.descriptorValidationPattern = validationDescriptorPatterns.cwlPath;
+        break;
+      }
+      case 'wdl': {
+        this.descriptorValidationPattern = validationDescriptorPatterns.wdlPath;
+        break;
+      }
+      case 'nextflow': {
+        this.descriptorValidationPattern = validationDescriptorPatterns.nflPath;
+        break;
+      }
+      default: {
+        console.log('Unrecognized descriptor type: ' + descriptorType);
+        this.descriptorValidationPattern = '.*';
+      }
+    }
+  }
 }

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -14,16 +14,16 @@
  *    limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { DescriptorLanguageService } from './../../shared/entry/descriptor-language.service';
 import { StateService } from './../../shared/state.service';
+import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { MetadataService } from './../../shared/swagger/api/metadata.service';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { Workflow } from './../../shared/swagger/model/workflow';
 import { WorkflowService } from './../../shared/workflow.service';
-import { HostedService } from './../../shared/swagger/api/hosted.service';
 
 @Injectable()
 export class RegisterWorkflowModalService {
@@ -34,6 +34,7 @@ export class RegisterWorkflowModalService {
     private sourceControlMap = [];
     workflows: any;
     isModalShown$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+    public descriptorLanguages$: Observable<Array<string>>;
     workflow: BehaviorSubject<Workflow> = new BehaviorSubject<Workflow>(
         this.sampleWorkflow);
     constructor(private workflowsService: WorkflowsService,
@@ -45,6 +46,7 @@ export class RegisterWorkflowModalService {
         this.sampleWorkflow.workflowName = '';
         this.metadataService.getSourceControlList().subscribe(map => this.sourceControlMap = map);
         this.descriptorLanguageService.descriptorLanguages$.subscribe(map => this.descriptorLanguageMap = map);
+        this.descriptorLanguages$ = this.descriptorLanguageService.descriptorLanguages$;
         this.workflow.subscribe(workflow => this.actualWorkflow = workflow);
         this.workflowService.workflows$.subscribe(workflows => this.workflows = workflows);
     }


### PR DESCRIPTION
For issue ga4gh/dockstore#1391

Reduced the getDescriptorType() calls by a bajillion

Have a different descriptor path validation patterns for the 3 descriptor types

TODO: 
- Set the initial validation pattern in a better way
- Have 3 different form errors for pattern


