### PR TITLE
Change version selection

### DIFF
--- a/cypress/integration/checkerWorkflowFromWorkflows.js
+++ b/cypress/integration/checkerWorkflowFromWorkflows.js
@@ -33,7 +33,7 @@ describe('Checker workflow test from workflows', function() {
             cy.get('#viewCheckerWorkflowButton').should('visible').click()
 
             // In the checker workflow right now
-            cy.url().should('eq', String(global.baseUrl) + '/workflows/github.com/A/l/_cwl_checker:master?tab=info')
+            cy.url().should('eq', String(global.baseUrl) + '/workflows/github.com/A/l/_cwl_checker?tab=info')
             cy.get('#viewCheckerWorkflowButton').should('not.be.visible')
             cy.get('#addCheckerWorkflowButton').should('not.be.visible')
             cy.get('#launchCheckerWorkflow').should('not.be.visible')

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -128,7 +128,7 @@ export class ContainerComponent extends Entry {
           if (this.tool.tags.length === 0) {
             this.selectedVersion = null;
           } else {
-            this.selectedVersion = this.selectVersion(this.tool.tags, this.urlVersion, this.tool.defaultVersion, this.selectedVersion);
+            this.selectedVersion = this.selectVersion(this.tool.tags, this.urlVersion, this.tool.defaultVersion);
           }
         }
         // Select version
@@ -171,7 +171,7 @@ export class ContainerComponent extends Entry {
       this.containersService.getPublishedContainerByToolPath(this.title)
         .subscribe(tool => {
           this.containerService.setTool(tool);
-          this.selectedVersion = this.selectVersion(this.tool.tags, this.urlVersion, this.tool.defaultVersion, this.selectedVersion);
+          this.selectedVersion = this.selectVersion(this.tool.tags, this.urlVersion, this.tool.defaultVersion);
 
           this.selectTab(this.validTabs.indexOf(this.currentTab));
           if (this.tool != null) {

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -175,34 +175,37 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
-  public selectVersion(versions, urlVersion, defaultVersion, selectedVersion): any {
-    let useFirstTag = true;
-    let urlTagExists = false;
-    // Determine which tag to select
-    for (const item of versions) {
-      // If a tag is specified in the URL then use it
-      if (urlVersion !== null) {
-        if (item.name === urlVersion) {
-          selectedVersion = item;
-          useFirstTag = false;
-          urlTagExists = true;
-          break;
-        }
-      } else if (defaultVersion !== null && !urlTagExists) {
-        // If the tool has a default version then use it
-        if (item.name === defaultVersion) {
-          selectedVersion = item;
-          useFirstTag = false;
-          break;
-        }
+  /**
+   * Given an array of WorkflowVersions or Tag, decide which one to return (displayed to the user)
+   * 1. If the URL specifies a specific Tag or WorkflowVersion, choose to display that one.  Otherwise,
+   * 2. If the default version is specified, choose to display the default version.  Otherwise,
+   * 3. Choose the last version in the array (the last updated version?)
+   * @param {((Array<WorkflowVersion | Tag>))} versions
+   * @param {string} urlVersion
+   * @param {string} defaultVersion
+   * @param {((WorkflowVersion | Tag))} selectedVersion
+   * @returns {((WorkflowVersion | Tag))}
+   * @memberof Entry
+   */
+  public selectVersion(versions: (Array<WorkflowVersion | Tag>), urlVersion: string, defaultVersion: string,
+    selectedVersion: (WorkflowVersion | Tag)): (WorkflowVersion | Tag) {
+    if (!versions || versions.length === 0) {
+      return null;
+    }
+    let foundVersion: (WorkflowVersion | Tag);
+    if (urlVersion) {
+      foundVersion = versions.find((version: (WorkflowVersion | Tag)) => version.name === urlVersion);
+      if (foundVersion) {
+        return foundVersion;
       }
     }
-
-    // If no url tag or default version, select first element in the dropdown
-    if (useFirstTag && versions.length > 0) {
-      selectedVersion = versions[0];
+    if (defaultVersion) {
+      foundVersion = versions.find((version: (WorkflowVersion | Tag)) => version.name === defaultVersion);
+      if (foundVersion) {
+        return foundVersion;
+      }
     }
-    return selectedVersion;
+    return versions[0];
   }
 
   public getEntryPathFromURL(): string {

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -179,16 +179,16 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
    * Given an array of WorkflowVersions or Tag, decide which one to return (displayed to the user)
    * 1. If the URL specifies a specific Tag or WorkflowVersion, choose to display that one.  Otherwise,
    * 2. If the default version is specified, choose to display the default version.  Otherwise,
-   * 3. Choose the last version in the array (the last updated version?)
-   * @param {((Array<WorkflowVersion | Tag>))} versions
-   * @param {string} urlVersion
-   * @param {string} defaultVersion
-   * @param {((WorkflowVersion | Tag))} selectedVersion
-   * @returns {((WorkflowVersion | Tag))}
+   * 3. Choose the first version in the array (the last updated version?)
+   * @param {((Array<WorkflowVersion | Tag>))} versions    All versions of an entry.
+   * This is supposed to be (Array<WorkflowVersion> | Array<Tag>).
+   * No idea why errors appear when attempted to do so.
+   * @param {string} urlVersion  The version of the entry specified in the URL (possibly null or undefined)
+   * @param {string} defaultVersion  The default version of an entry (possibly null or undefined)
+   * @returns {((WorkflowVersion | Tag))}  The version to display to the user
    * @memberof Entry
    */
-  public selectVersion(versions: (Array<WorkflowVersion | Tag>), urlVersion: string, defaultVersion: string,
-    selectedVersion: (WorkflowVersion | Tag)): (WorkflowVersion | Tag) {
+  public selectVersion(versions: (Array<WorkflowVersion | Tag>), urlVersion: string, defaultVersion: string): (WorkflowVersion | Tag) {
     if (!versions || versions.length === 0) {
       return null;
     }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -153,7 +153,7 @@ export class WorkflowComponent extends Entry {
         if (workflow) {
           this.published = this.workflow.is_published;
           this.selectedVersion = this.selectVersion(this.workflow.workflowVersions, this.urlVersion,
-            this.workflow.defaultVersion, this.selectedVersion);
+            this.workflow.defaultVersion);
         }
         this.setUpWorkflow(workflow);
       }
@@ -173,7 +173,7 @@ export class WorkflowComponent extends Entry {
         .subscribe(workflow => {
           this.workflowService.setWorkflow(workflow);
           this.selectedVersion = this.selectVersion(this.workflow.workflowVersions, this.urlVersion,
-            this.workflow.defaultVersion, this.selectedVersion);
+            this.workflow.defaultVersion);
 
           this.selectTab(this.validTabs.indexOf(this.currentTab));
           if (this.workflow != null) {


### PR DESCRIPTION
For ga4gh/dockstore#1553

Changing the previous selection algorithm to be easier to read.

1. If the URL specifies a specific Tag or WorkflowVersion, choose to display that one.  Otherwise,
2. If the default version is specified, choose to display the default version.  Otherwise,
3. Choose the first version in the array (the last updated version?)

Also change the test because the checker is a stub since it can't be refreshed (no such Git repo).  Therefore, it cannot have a master branch to go to (not sure why it went there in the first place).