### PR TITLE
Disable instead of hide Launch with Buttons

### DIFF
--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -174,6 +174,13 @@ export const wdlSourceFile: SourceFile = {
   type: undefined
 };
 
+export const wdlSourceFileWithHttpImport: SourceFile = {
+  content: 'import "https://foo.com/some.wdl',
+  id: 1,
+  path: '',
+  type: undefined
+};
+
 export const sampleSourceFile: SourceFile = {
   content: 'potato',
   id: 1,

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="dnastackURL || fireCloudURL" class="panel panel-default">
+<div *ngIf="isWdl" class="panel panel-default">
   <div class="panel-heading">
     <h3>Launch with</h3>
   </div>
@@ -6,13 +6,14 @@
     <div class="container-source-repos">
       <div class="container-launch-with">
         <div class="button-wrap">
-          <div *ngIf="dnastackURL" class="button">
-            <p><a href="{{dnastackURL}}"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a>
+          <div class="button" [style.background-color]="dnastackErrorMessage ? '#d3d3d3' : '#487980'">
+            <p><button (click)="gotoDnastack()" [title]="dnastackErrorMessage" class="third-party dnastack"
+                       [disabled]="dnastackErrorMessage"> DNAstack &raquo;</button>
             </p>
           </div>
-          <div *ngIf="fireCloudURL" class="button">
-            <p><a href="{{fireCloudURL}}"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud
-              &raquo;</a></p>
+          <div class="button" [style.background-color]="fireCloudErrorMessage ? '#d3d3d3' : '#487980'">
+            <p><button (click)="gotoFirecloud()" class="third-party firecloud" [title]="fireCloudErrorMessage"
+                       [disabled]="fireCloudErrorMessage"> FireCloud &raquo;</button></p>
           </div>
         </div>
       </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -9,3 +9,21 @@
 .button-wrap > .button:not(:last-child) {
   margin-bottom: 10px;
 }
+
+button.third-party {
+  background-color:  transparent;
+  border-radius: 8px;
+  background-repeat: no-repeat;
+  background-size: auto 20px;
+  background-position: left;
+  vertical-align: middle;
+  font-weight: bold;
+  padding-left: 45px;
+  color: white;
+  &.firecloud {
+    background-image: url('../../../assets/images/thirdparty/FireCloud-white-icon.svg');
+  }
+  &.dnastack {
+    background-image: url('../../../assets/images/thirdparty/dnastack.png');
+  }
+}

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -6,7 +6,7 @@ import { LaunchThirdPartyComponent } from './launch-third-party.component';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { WorkflowsStubService, WorkflowStubService, WorkflowVersionStubService } from '../../test/service-stubs';
 import { Workflow, WorkflowVersion } from '../../shared/swagger';
-import { wdlSourceFile } from '../../test/mocked-objects';
+import { wdlSourceFile, wdlSourceFileWithHttpImport } from '../../test/mocked-objects';
 
 describe('LaunchThirdPartyComponent', () => {
   let component: LaunchThirdPartyComponent;
@@ -66,7 +66,7 @@ describe('LaunchThirdPartyComponent', () => {
       .toEqual('https://portal.firecloud.org/#import/dockstore/github.com/DataBiosphere/topmed-workflows/Functional_Equivalence:master');
   });
 
-  it('should set dnastack but not Firecloud if WDL with secondary files', () => {
+  it('should also not set dnastack if WDL with secondary files', () => {
     spyOnProperty(workflowVersion, 'name', 'get').and.returnValue('master');
     component.selectedVersion = workflowVersion;
     spyOnProperty(workflow, 'full_workflow_path', 'get').and
@@ -75,9 +75,20 @@ describe('LaunchThirdPartyComponent', () => {
     spyOn(workflowsService, 'wdl').and.returnValue(observableOf(wdlSourceFile));
     spyOn(workflowsService, 'secondaryWdl').and.returnValue(observableOf([wdlSourceFile]));
     component.workflow = workflow;
-    expect(component.dnastackURL)
-      // tslint:disable-next-line:max-line-length
-      .toEqual('https://app.dnastack.com/#/app/workflow/import/dockstore?path=github.com/DataBiosphere/topmed-workflows/Functional_Equivalence&descriptorType=wdl');
+    expect(component.dnastackURL).toBeFalsy();
     expect(component.fireCloudURL).toBeFalsy();
+  });
+
+  it('should set firecloud but not dnastack if http imports', () => {
+    spyOnProperty(workflowVersion, 'name', 'get').and.returnValue('master');
+    component.selectedVersion = workflowVersion;
+    spyOnProperty(workflow, 'full_workflow_path', 'get').and
+      .returnValue('github.com/DataBiosphere/topmed-workflows/Functional_Equivalence');
+    spyOnProperty(workflow, 'descriptorType', 'get').and.returnValue('wdl');
+    spyOn(workflowsService, 'wdl').and.returnValue(observableOf(wdlSourceFileWithHttpImport));
+    spyOn(workflowsService, 'secondaryWdl').and.returnValue(observableOf([]));
+    component.workflow = workflow;
+    expect(component.dnastackURL).toBeFalsy();
+    expect(component.fireCloudURL).toBeTruthy();
   });
 });

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -23,7 +23,7 @@ export class LaunchThirdPartyComponent {
 
   private _workflow: Workflow;
   private _selectedVersion: WorkflowVersion;
-  private isWdl: boolean;
+  public isWdl: boolean;
 
   @Input() set workflow(value: Workflow) {
     this._workflow = value;

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -1,13 +1,21 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Workflow, WorkflowVersion } from '../../shared/swagger';
 import { Dockstore } from '../../shared/dockstore.model';
 import { ExtendedWorkflow } from '../../shared/models/ExtendedWorkflow';
 import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { URLSearchParams } from '@angular/http';
+import { LaunchThirdPartyService } from './launch-third-party.service';
+
+const NO_CONTENT_ERROR = 'The WDL has no content.';
+const IMPORTS_NOT_SUPPORTED = 'DNAstack does not support the WDL import statement.';
+const FILE_IMPORTS_NOT_SUPPORTED = 'FireCloud does not support file-path imports in WDL. ' + '' +
+  'It only supports http(s) imports.';
+
 
 @Component({
   selector: 'app-launch-third-party',
+  providers: [LaunchThirdPartyService],
   templateUrl: './launch-third-party.component.html',
   styleUrls: ['./launch-third-party.component.scss']
 })
@@ -15,6 +23,7 @@ export class LaunchThirdPartyComponent {
 
   private _workflow: Workflow;
   private _selectedVersion: WorkflowVersion;
+  private isWdl: boolean;
 
   @Input() set workflow(value: Workflow) {
     this._workflow = value;
@@ -36,43 +45,69 @@ export class LaunchThirdPartyComponent {
 
   dnastackURL: string;
   fireCloudURL: string;
+  fireCloudErrorMessage: string;
+  dnastackErrorMessage: string;
 
-  constructor(private workflowsService: WorkflowsService) { }
+  constructor(private workflowsService: WorkflowsService, private launchThirdPartyService: LaunchThirdPartyService) { }
+
+  gotoFirecloud() {
+    window.open(this.fireCloudURL, '_blank');
+  }
+
+  gotoDnastack() {
+    window.open(this.dnastackURL, '_blank');
+  }
 
   private onChange() {
-    this.setupFireCloudUrl(this.workflow);
-    this.setupDnaStackUrl(this.workflow);
+    this.isWdl =  this.workflow && this.workflow.full_workflow_path && this.workflow.descriptorType === 'wdl';
+    this.setupFireCloudUrl(this.workflow, this.selectedVersion);
+    this.setupDnaStackUrl(this.workflow, this.selectedVersion);
   }
 
-  private isWdl(workflowRef: ExtendedWorkflow) {
-    return workflowRef && workflowRef.full_workflow_path && workflowRef.descriptorType === 'wdl';
-  }
-
-
-  private setupFireCloudUrl(workflowRef: ExtendedWorkflow) {
+  private setupFireCloudUrl(workflowRef: ExtendedWorkflow, version: WorkflowVersion) {
     if (Dockstore.FEATURES.enableLaunchWithFireCloud) {
       this.fireCloudURL = null;
-      const version: WorkflowVersion = this.selectedVersion;
-      if (version && this.isWdl(workflowRef)) {
+      this.fireCloudErrorMessage = '';
+      if (version && this.isWdl) {
         this.workflowsService.wdl(workflowRef.id, version.name).subscribe((sourceFile: SourceFile) => {
           if (sourceFile && sourceFile.content && sourceFile.content.length) {
             this.workflowsService.secondaryWdl(workflowRef.id, version.name).subscribe((sourceFiles: Array<SourceFile>) => {
               if (!sourceFiles || sourceFiles.length === 0) {
                 this.fireCloudURL =  `${Dockstore.FIRECLOUD_IMPORT_URL}/${workflowRef.full_workflow_path}:${version.name}`;
+              } else {
+                this.fireCloudErrorMessage = FILE_IMPORTS_NOT_SUPPORTED;
               }
             });
+          } else {
+            this.fireCloudErrorMessage = NO_CONTENT_ERROR;
           }
         });
       }
     }
   }
 
-  private setupDnaStackUrl(workflow: ExtendedWorkflow) {
-    if (this.isWdl(workflow)) {
-      const myParams = new URLSearchParams();
-      myParams.set('path', workflow.full_workflow_path);
-      myParams.set('descriptorType', workflow.descriptorType);
-      this.dnastackURL = Dockstore.DNASTACK_IMPORT_URL + '?' + myParams;
+  private setupDnaStackUrl(workflow: ExtendedWorkflow, version: WorkflowVersion) {
+    this.dnastackURL = null;
+    this.dnastackErrorMessage = '';
+    if (version && this.isWdl) {
+      this.workflowsService.wdl(workflow.id, version.name).subscribe((sourceFile: SourceFile) => {
+        if (sourceFile && sourceFile.content && sourceFile.content.length) {
+          this.workflowsService.secondaryWdl(workflow.id, version.name).subscribe((sourceFiles: Array<SourceFile>) => {
+            if (!sourceFiles || sourceFiles.length === 0 && !this.launchThirdPartyService.wdlHasHttpImports(sourceFile.content)) {
+              const myParams = new URLSearchParams();
+              myParams.set('path', workflow.full_workflow_path);
+              myParams.set('descriptorType', workflow.descriptorType);
+              this.dnastackURL = Dockstore.DNASTACK_IMPORT_URL + '?' + myParams;
+            } else {
+              this.dnastackErrorMessage = IMPORTS_NOT_SUPPORTED;
+            }
+          });
+        } else {
+          this.dnastackErrorMessage = NO_CONTENT_ERROR;
+        }
+      });
     }
   }
+
+
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.service.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { LaunchThirdPartyService } from './launch-third-party.service';
+
+describe('FireCloudService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LaunchThirdPartyService]
+    });
+  });
+
+  it('should not find http import', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    expect(service.wdlHasHttpImports('task foo')).toBeFalsy();
+    expect(service.wdlHasHttpImports('#import foo')).toBeFalsy();
+    expect(service.wdlHasHttpImports('importance')).toBeFalsy();
+    expect(service.wdlHasHttpImports('import "foo"')).toBeFalsy();
+  }));
+
+  it('should find http(s) import', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    const multiline1 = `
+      #line 1
+      import "http://something"
+    `;
+    const multiline2 = `
+      #line 1
+      import "https://something"
+    `;
+    expect(service.wdlHasHttpImports(multiline1)).toBeTruthy();
+  }));
+});

--- a/src/app/workflow/launch-third-party/launch-third-party.service.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class LaunchThirdPartyService {
+
+  private importRegEx: RegExp = new RegExp(/^\s*import\s+"https?/, 'm');
+
+  constructor() { }
+
+  /**
+   * Simple test to see if wdl has any Http(s) import statements.
+   *
+   * Look for any statement starting with the word `import` as the first non-blank characters at the beginning
+   * of any line.
+   *
+   * @param {string} wdl
+   * @returns {boolean}
+   */
+  wdlHasHttpImports(wdl: string): boolean {
+    if (wdl && wdl.length) {
+      return this.importRegEx.test(wdl);
+    }
+    return false;
+  }
+
+}


### PR DESCRIPTION
Instead of hiding Launch with FireCloud/DNAstack buttons when the WDL
is not supported, disable them so that the user knows what is going on.

For FireCloud, disable if there are file-based imports.

For DNAstack, disable if there are any imports.

Had to change to buttons from anchors, because you cannot disable
anchors (well, not with disabled attribute).

Test for http(s) imports is sort of crude; we should probably do it
server side using... wom?.

Also, there is some code duplication in checking if there are imports
for FC and DNAstack. But since this code is going into hotfix and
develop branch is on Angular 6, decided to do it that way rather than
using RxJs6 operators (which I don't know very well, plus wouldn't work
on hotfix).

Here is screenshot of buttons when disabled, with tooltip.

![screen shot 2018-07-03 at 5 31 23 pm 2](https://user-images.githubusercontent.com/1049340/42250838-9a9a70cc-7ee8-11e8-9e7b-38fd6b1d61a6.png)
