### PR TITLE
Disable Launch w/FireCloud if WDL has file imports

### DIFF
--- a/src/app/workflow/workflow.component.css
+++ b/src/app/workflow/workflow.component.css
@@ -34,3 +34,10 @@ pre {
 .button-wrap > .button:not(:last-child) {
   margin-bottom: 10px;
 }
+a.disabled {
+  color: gray;
+  cursor: not-allowed;
+}
+a.disabled > img {
+    filter: brightness(90%);
+}

--- a/src/app/workflow/workflow.component.css
+++ b/src/app/workflow/workflow.component.css
@@ -41,3 +41,10 @@ a.disabled {
 a.disabled > img {
     filter: brightness(90%);
 }
+p.import-warning {
+  font-size: 11px;
+  font-style: italic;
+  text-align: left;
+  line-height: 1em;
+  margin-bottom: 4px;
+}

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -210,7 +210,7 @@
         </div>
       </div>
     </div>
-    <div class="panel panel-default" *ngIf="workflow && (dnastackURL || fireCloudURL)">
+    <div class="panel panel-default" *ngIf="isWdl(workflow)">
       <div class="panel-heading">
         <h3>Launch with</h3>
       </div>
@@ -221,8 +221,8 @@
               <div *ngIf="dnastackURL" class="button">
                 <p><a href="{{dnastackURL}}"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a></p>
               </div>
-              <div *ngIf="fireCloudURL" class="button">
-                <p><a href="{{fireCloudURL}}"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud &raquo;</a></p>
+              <div *ngIf="fireCloudURL || fireCloudDisabledMessage" class="button" [title]="fireCloudDisabledMessage">
+                <p><a [class.disabled]="!!fireCloudDisabledMessage" (click)="gotoFirecloud()"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud &raquo;</a></p>
               </div>
             </div>
           </div>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -218,11 +218,12 @@
         <div class="container-source-repos">
           <div class="container-launch-with">
             <div class="button-wrap">
+              <p *ngIf="dnastackURL && (wdlHasFileImports || wdlHasHttpImports)" class="import-warning" >Warning: this version of the WDL has imports, which are not supported by DNAstack. Make sure to select a version without imports in DNAstack.</p>
               <div *ngIf="dnastackURL" class="button">
                 <p><a href="{{dnastackURL}}"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a></p>
               </div>
-              <div *ngIf="fireCloudURL || fireCloudDisabledMessage" class="button" [title]="fireCloudDisabledMessage">
-                <p><a [class.disabled]="!!fireCloudDisabledMessage" (click)="gotoFirecloud()"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud &raquo;</a></p>
+              <div *ngIf="enableLaunchWithFireCloud" class="button" [title]="wdlHasFileImports ? 'FireCloud does not support file-path imports in WDL. It only supports http(s) imports.' : ''">
+                <p><a [class.disabled]="wdlHasFileImports" (click)="gotoFirecloud()"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud &raquo;</a></p>
               </div>
             </div>
           </div>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -47,6 +47,7 @@ export class WorkflowComponent extends Entry {
   workflowEditData: any;
   dnastackURL: string;
   fireCloudURL: string;
+  fireCloudDisabledMessage: string;
   public workflow;
   public missingWarning: boolean;
   public title: string;
@@ -110,18 +111,28 @@ export class WorkflowComponent extends Entry {
     }
   }
 
-  private isWdl(workflowRef: ExtendedWorkflow) {
-    return workflowRef.full_workflow_path && workflowRef.descriptorType === 'wdl';
+  public isWdl(workflowRef: ExtendedWorkflow) {
+    return workflowRef && workflowRef.full_workflow_path && workflowRef.descriptorType === 'wdl';
+  }
+
+  public gotoFirecloud() {
+    if (this.fireCloudURL) {
+      window.open(this.fireCloudURL);
+    }
   }
 
   private setupFireCloudUrl(workflowRef: ExtendedWorkflow) {
     if (Dockstore.FEATURES.enableLaunchWithFireCloud) {
       this.fireCloudURL = null;
+      this.fireCloudDisabledMessage = '';
       const version: WorkflowVersion = this.selectedVersion;
-      if (version && this.isWdl(workflowRef)) {
+      if (version) {
         this.workflowsService.secondaryWdl(workflowRef.id, version.name).subscribe((sourceFiles: Array<SourceFile>) => {
           if (!sourceFiles || sourceFiles.length === 0) {
             this.fireCloudURL =  `${Dockstore.FIRECLOUD_IMPORT_URL}/${workflowRef.full_workflow_path}:${version.name}`;
+          } else {
+            this.fireCloudDisabledMessage = 'FireCloud does not support file-path imports in WDL. '
+              + 'It only supports http(s) imports.';
           }
         });
       }


### PR DESCRIPTION
ga4gh/dockstore#330

Disable instead of hide the button so user knows what is going on, with
a tooltip explaining why.

Only did it for FireCloud, as for DNAstack the user selects the version, so it doesn't seem like we should disable the button based on the content of the current version.

Screenshot showing warning for DNAstack and disabled button with tooltip for FireCloud:

![screen shot 2018-07-05 at 3 57 26 pm 2](https://user-images.githubusercontent.com/1049340/42351924-573598ea-806c-11e8-9488-8526edede31e.png)




FYI, this will be a pain to merge into develop, as the develop branch has this code in a new component.