### PR TITLE
Prepare for scoped tokens on gitlab

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.service.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.ts
@@ -1,10 +1,9 @@
-
 import {first} from 'rxjs/operators';
-import { Links } from './links.model';
-import { TokenSource } from './../../../shared/enum/token-source.enum';
-import { Injectable } from '@angular/core';
-import { LoginService } from '../../../login/login.service';
-import { TokenService } from '../../token.service';
+import {Links} from './links.model';
+import {TokenSource} from './../../../shared/enum/token-source.enum';
+import {Injectable} from '@angular/core';
+import {LoginService} from '../../../login/login.service';
+import {TokenService} from '../../token.service';
 
 @Injectable()
 export class AccountsService {
@@ -13,6 +12,10 @@ export class AccountsService {
 
     private stripSpace(url: string): string {
         return url.replace(/\s/g, '');
+    }
+
+    private openWindowPreserveSpaces(url: string): void {
+        window.location.href = url;
     }
 
     private openWindow(url: string): void {
@@ -29,7 +32,7 @@ export class AccountsService {
                 this.openWindow(Links.BITBUCKET);
                 break;
             case TokenSource.GITLAB:
-                this.openWindow(Links.GITLAB);
+                this.openWindowPreserveSpaces(Links.GITLAB);
                 break;
             case TokenSource.QUAY:
                 this.openWindow(Links.QUAY);

--- a/src/app/loginComponents/accounts/external/links.model.ts
+++ b/src/app/loginComponents/accounts/external/links.model.ts
@@ -18,9 +18,11 @@ export class Links {
                                ?client_id=${ Dockstore.BITBUCKET_CLIENT_ID }
                                &response_type=code`;
 
+  /** need this strange construction since gitlab scopes are space-separated */
   static readonly GITLAB = `${ Dockstore.GITLAB_AUTH_URL }
                             ?client_id=${ Dockstore.GITLAB_CLIENT_ID }
                             &redirect_uri=${ Dockstore.GITLAB_REDIRECT_URI }
-                            &response_type=code`;
+                            &response_type=code`.replace(/\s/g, '') +
+                            `&scope=${ Dockstore.GITLAB_SCOPE }`;
 
 }

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -50,6 +50,9 @@ export class Dockstore {
   static readonly GITLAB_AUTH_URL = 'https://gitlab.com/oauth/authorize';
   static readonly GITLAB_CLIENT_ID = 'fill_this_in';
   static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITLAB;
+  // getting ready for gitlab scopes, this seems to request a token with the correct scope but it doesn't work to retrieve membership
+  // static readonly GITLAB_SCOPE = 'read_user openid';
+  static readonly GITLAB_SCOPE = 'api';
 
   static readonly GOOGLE_CLIENT_ID = 'fill_this_in';
   static readonly GOOGLE_SCOPE = 'profile email';


### PR DESCRIPTION
* currently unable to determine membership or owned projects with a
token narrower than `api` which seems like a gitlab issue
https://github.com/timols/java-gitlab-api/blob/master/src/main/java/org/gitlab/api/GitlabAPI.java#L863
* tested with gitlab api 11.1.0-rc4-ee rev aedb3c9 (find at
https://gitlab.com/api/v4/version )

* note to self: follow with compose_setup PR when closing