### PR TITLE
Expose web service messages for WebApplicationException

### DIFF
--- a/src/app/shared/error.service.spec.ts
+++ b/src/app/shared/error.service.spec.ts
@@ -13,10 +13,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { HttpErrorResponse } from '@angular/common/http';
-import { inject, TestBed } from '@angular/core/testing';
+import {HttpErrorResponse} from '@angular/common/http';
+import {inject, TestBed} from '@angular/core/testing';
 
-import { ErrorService } from './error.service';
+import {ErrorService} from './error.service';
 
 describe('ErrorService', () => {
     beforeEach(() => {
@@ -38,10 +38,10 @@ describe('ErrorService', () => {
           errorDetails: '[HTTP ' + '400' + '] ' + 'statusText' + ': ' +
           'error'
         };
-        console.log('actual message:'+ service.errorObj$.getValue().message);
-        console.log('expected message:' + errorObj.message);
-        console.log('actual errorDetails:'+ service.errorObj$.getValue().errorDetails);
-        console.log('expected errorDetails:' + errorObj.errorDetails);
+      console.log('actual message:' + service.errorObj$.getValue().message);
+      console.log('expected message:' + errorObj.message);
+      console.log('actual errorDetails:' + service.errorObj$.getValue().errorDetails);
+      console.log('expected errorDetails:' + errorObj.errorDetails);
         expect(service.errorObj$.getValue()).toEqual(errorObj);
     }));
 });

--- a/src/app/shared/error.service.spec.ts
+++ b/src/app/shared/error.service.spec.ts
@@ -38,8 +38,10 @@ describe('ErrorService', () => {
           errorDetails: '[HTTP ' + '400' + '] ' + 'statusText' + ': ' +
           'error'
         };
-        console.log(service.errorObj$.getValue());
-        console.log(errorObj);
+        console.log('actual message:'+ service.errorObj$.getValue().message);
+        console.log('expected message:' + errorObj.message);
+        console.log('actual errorDetails:'+ service.errorObj$.getValue().errorDetails);
+        console.log('expected errorDetails:' + errorObj.errorDetails);
         expect(service.errorObj$.getValue()).toEqual(errorObj);
     }));
 });

--- a/src/app/shared/error.service.ts
+++ b/src/app/shared/error.service.ts
@@ -33,7 +33,7 @@ export class ErrorService {
             errorObj = {
               message: 'The webservice encountered an error trying to create/modify.',
               errorDetails: '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
-              error.error
+              error.error && error.error.message ? error.error.message : error.error
             };
           }
         }

--- a/src/app/shared/error.service.ts
+++ b/src/app/shared/error.service.ts
@@ -33,7 +33,7 @@ export class ErrorService {
             errorObj = {
               message: 'The webservice encountered an error trying to create/modify.',
               errorDetails: '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
-              error.error && error.error.message ? error.error.message : error.error
+              (error.error && error.error.message ? error.error.message : error.error)
             };
           }
         }


### PR DESCRIPTION
Needed this to properly expose web service messages for WebApplicationException
otherwise we see "[HTTP 400] Bad Request: [object Object]" as opposed to "[HTTP 400] Bad Request: a message from the webservice"