### PR TITLE
Fix Launch With Disabling for Checker Workflows

### DIFF
--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -148,7 +148,7 @@ export class WorkflowComponent extends Entry {
       if (version) {
         if (version !== this.lastVersion || this.lastWorkflow !== workflowRef) {
           this.lastVersion = version;
-          this.lastWorkflow = this.lastWorkflow;
+          this.lastWorkflow = workflowRef;
           this.workflowsService.secondaryWdl(workflowRef.id, version.name).subscribe((sourceFiles: Array<SourceFile>) => {
             if (!sourceFiles || sourceFiles.length === 0) {
               this.workflowsService.wdl(workflowRef.id, version.name).subscribe((sourceFile) => {


### PR DESCRIPTION
ga4gh/dockstore#1548

Fix case when disabling of launch with FireCloud/DNAstack buttons did
not happen when it should have, when you select the checker workflow
by clicking View Checker when on the parent.

Events seem to fire in a different order when selecting a checker
workflow that way. Add a call to checkWdlForImportsAndSetFirecloudUrl in
setupPublicEntry().

To avoid too many calls to fetch secondary files, store the last time
workflow and version that was queried, and make sure we don't query
twice for the same workflow/version. Less than perfect, but will
will redo in ga4gh/dockstore#1575.