### PR TITLE
WIP: Properly Check Permissions for Shared Workflow

### DIFF
--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -164,7 +164,7 @@
           <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> To see the DAG, please refresh the workflow.
         </div>
       </tab>
-      <tab *ngIf="!isPublic() && isHosted() && isUserOwner()" id="permissionsTab" heading="Permissions" (select)="setEntryTab('permissions')">
+      <tab *ngIf="!isPublic() && isHosted() && isOwner" id="permissionsTab" heading="Permissions" (select)="setEntryTab('permissions')">
         <app-permissions [workflow]="workflow"></app-permissions>
       </tab>
     </tabset>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -25,7 +25,7 @@ import { DockstoreService } from '../shared/dockstore.service';
 import { Entry } from '../shared/entry';
 import { ProviderService } from '../shared/provider.service';
 import { Tag } from '../shared/swagger/model/tag';
-import {WorkflowVersion } from '../shared/swagger/model/workflowVersion';
+import { WorkflowVersion } from '../shared/swagger/model/workflowVersion';
 import { TrackLoginService } from '../shared/track-login.service';
 import { WorkflowService } from '../shared/workflow.service';
 import { ErrorService } from './../shared/error.service';
@@ -36,8 +36,7 @@ import { WorkflowsService } from './../shared/swagger/api/workflows.service';
 import { PublishRequest } from './../shared/swagger/model/publishRequest';
 import { Workflow } from './../shared/swagger/model/workflow';
 import { UrlResolverService } from './../shared/url-resolver.service';
-import { Permission } from './../shared/swagger';
-import RoleEnum = Permission.RoleEnum;
+import { HostedService } from './../shared/swagger';
 
 @Component({
   selector: 'app-workflow',
@@ -61,14 +60,11 @@ export class WorkflowComponent extends Entry {
   protected canRead = false;
   protected canWrite = false;
   protected isOwner = false;
-  protected readers = [];
-  protected writers = [];
-  protected owners = [];
   @Input() user;
 
   constructor(private dockstoreService: DockstoreService, dateService: DateService, private refreshService: RefreshService,
-    private workflowsService: WorkflowsService, trackLoginService: TrackLoginService, providerService: ProviderService,
-    router: Router, private workflowService: WorkflowService,
+    private workflowsService: WorkflowsService, private hostedService: HostedService, trackLoginService: TrackLoginService,
+    providerService: ProviderService,  router: Router, private workflowService: WorkflowService,
     stateService: StateService, errorService: ErrorService, urlResolverService: UrlResolverService,
     location: Location, activatedRoute: ActivatedRoute) {
     super(trackLoginService, providerService, router,
@@ -77,22 +73,6 @@ export class WorkflowComponent extends Entry {
     this.location = location;
     this.redirectAndCallDiscourse('/my-workflows');
     this.resourcePath = this.location.prepareExternalUrl(this.location.path());
-  }
-
-  private processResponse(userPermissions: Permission[]): void {
-    this.owners = this.specificPermissionEmails(userPermissions, RoleEnum.OWNER);
-    this.writers = this.specificPermissionEmails(userPermissions, RoleEnum.WRITER);
-    this.readers = this.specificPermissionEmails(userPermissions, RoleEnum.READER);
-
-    this.canRead = this.canUserRead();
-    this.canWrite = this.canUserWrite();
-    this.isOwner = this.isUserOwner();
-  }
-
-  private specificPermissionEmails(permissions: Permission[], role: RoleEnum): string[] {
-    return permissions
-      .filter(u => u.role === role)
-      .map(c => c.email);
   }
 
   isPublic(): boolean {
@@ -150,13 +130,36 @@ export class WorkflowComponent extends Entry {
         this.sortedVersions = this.dockstoreService.getValidVersions(this.sortedVersions);
       }
       this.workflowsService.getWorkflowPermissions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe)).subscribe(
-        (userPermissions: Permission[]) => {
-          this.processResponse(userPermissions);
+        () => {
+          // If we can fetch permissions, we are the owner.
+          this.isOwner = true;
+          this.canWrite = true;
+          this.canRead = true;
         },
         () => {
+          // If we can't fetch permissions, we're not the owner. Check the corresponding endpoints to see what we can do.
+          if (this.isHosted()) {
+            this.hostedService.hostedWorkflowOptions(this.workflow.id, 'response')
+              .pipe(takeUntil(this.ngUnsubscribe)).subscribe(response => {
+              this.configurePermissions(response.headers.get('Allow') || '');
+            });
+          } else {
+            this.workflowsService.getWorkflowByPathOptions(this.workflow.full_workflow_path, 'response')
+              .pipe(takeUntil(this.ngUnsubscribe)).subscribe(
+              (response => {
+                this.configurePermissions(response.headers.get('Allow') || '');
+              })
+            );
+          }
         }
       );
     }
+  }
+
+  private configurePermissions(allowHeader: string) {
+    const allowMethods = allowHeader.split(',').map(method => method.trim());
+    this.canRead = allowMethods.indexOf('GET') !== -1;
+    this.canWrite = allowMethods.indexOf('PATCH') !== -1;
   }
 
   public subscriptions(): void {
@@ -353,50 +356,4 @@ export class WorkflowComponent extends Entry {
     }
   }
 
-  /**
-   * True if user is in users list, or username is in read,write,owner permissions, false otherwise
-   */
-  canUserRead(): boolean {
-    const username = this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.readers.includes(username) || this.writers.includes(username) || this.owners.includes(username) ;
-  }
-
-  /**
-   * True if user is in users list, or username is in write or owner permissions, false otherwise
-   */
-  canUserWrite(): boolean {
-    const username = this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.writers.includes(username) || this.owners.includes(username);
-  }
-
-  /**
-   * True if user is in users list, or username is in owner permissions, false otherwise
-   */
-  isUserOwner(): boolean {
-    const username = this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.owners.includes(username);
-  }
-
-  /**
-   * True if username is in the workflow user array, false otherwise
-   * @param username
-   */
-  isInUserArray(username: string): boolean {
-    if (this.workflow.users) {
-      const match = this.workflow.users.find((user) => user.username === username);
-      if (match !== undefined) {
-        return true;
-      }
-    }
-    return false;
-  }
 }


### PR DESCRIPTION
A fix for ga4gh/dockstore#1589

Not sure if we should take this; see my following comments.

We have to go with this approach with the current webservice API,
which makes me the question the current permissions API.

The logic is, if you can fetch permissions, you are an owner. If you
are not, then make OPTIONS calls to see what APIs you can invoke,
and the `Allow` header in the response will indicate what HTTP method
you have permissions to invoke.

My thinking was:

/path/workflow/{repository}/permissions should be an unauthorized call
if you are not an owner of {repository} -- e.g., if you only have read
permissions on the workflow, you should be able to see the workflow
but not who it's been shared with (in fact, that is how the policies
are currently defined in SAM, although we could change them).

Given that, I thought that the API could support OPTIONS calls to
indicate which endpoints are invocable with which methods. I liked
that, because if I have an endpoint that simply says for example that
you have READ permissions on a workflow, then the UI has to figure out
which API calls are allowed with that permission and which are not.
Whereas with OPTIONS you can query the API call you are going to make
and let the backend tell you whether you have permissions or not.

However:

1. I've only added a couple of OPTIONS endpoints, for the endpoints that
currently can be affected by permissions, so it's incomplete.
2. This UI code is convoluted.

So maybe we should just enable the permissions endpoint for all users,
but if you are not an owner, it only returns the current user's
permissions. That means the UI would have to figure out what API calls
it can and can't make, but it looks like it was essentially doing
that anyway.