### PR TITLE
Feature/1489/fixes

### DIFF
--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -150,7 +150,7 @@ export class ContainerComponent extends Entry {
     if (tool) {
       this.tool = tool;
       if (!tool.providerUrl) {
-        this.providerService.setUpProvider(tool, this.selectedVersion);
+        this.providerService.setUpProvider(tool);
       }
       this.tool = Object.assign(tool, this.tool);
       const toolRef: ExtendedDockstoreTool = this.tool;
@@ -176,7 +176,7 @@ export class ContainerComponent extends Entry {
           if (this.tool != null) {
             this.updateUrl(this.tool.tool_path, 'my-tools', 'containers');
           }
-          this.providerService.setUpProvider(this.tool, this.selectedVersion);
+          this.providerService.setUpProvider(this.tool);
         }, error => {
           this.router.navigate(['../']);
         });
@@ -285,7 +285,7 @@ export class ContainerComponent extends Entry {
     this.selectedVersion = tag;
     if (this.tool != null) {
       this.updateUrl(this.tool.tool_path, 'my-tools', 'containers');
-      this.providerService.setUpProvider(this.tool, tag);
+      this.providerService.setUpProvider(this.tool);
     }
     this.onTagChange(tag);
   }

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -30,7 +30,7 @@
         {{ tool?.provider}}
       </strong>:
       <a [href]="tool?.providerUrl">
-        {{ tool?.providerUrl }}
+        {{ tool?.providerUrl | versionProviderUrl : (isPublic ? selectedVersion?.name : '') }}
       </a>
     </li>
     <li *ngIf="tool?.mode === DockstoreToolType.ModeEnum.HOSTED">

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -13,39 +13,29 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
+import { Dockstore } from '../../shared/dockstore.model';
+import { ga4ghPath } from './../../shared/constants';
 import { ContainerService } from './../../shared/container.service';
 import { ExtendedDockstoreTool } from './../../shared/models/ExtendedDockstoreTool';
 import { StateService } from './../../shared/state.service';
 import { ContainersService } from './../../shared/swagger/api/containers.service';
+import { DockstoreTool } from './../../shared/swagger/model/dockstoreTool';
+import { Tag } from './../../shared/swagger/model/tag';
 import { exampleDescriptorPatterns, validationDescriptorPatterns } from './../../shared/validationMessages.model';
 import { InfoTabService } from './info-tab.service';
-import { DockstoreTool } from './../../shared/swagger/model/dockstoreTool';
-import { Dockstore } from '../../shared/dockstore.model';
-import { ga4ghPath } from './../../shared/constants';
-import { Tag } from './../../shared/swagger/model/tag';
 
 @Component({
   selector: 'app-info-tab',
   templateUrl: './info-tab.component.html',
   styleUrls: ['./info-tab.component.css']
 })
-export class InfoTabComponent implements OnInit {
+export class InfoTabComponent implements OnInit, OnChanges {
   currentVersion: Tag;
-  @Input() set selectedVersion(value: Tag) {
-    if (value != null && this.tool != null) {
-      this.currentVersion = value;
-      if (this.tool.descriptorType.includes('cwl')) {
-        this.trsLinkCWL = this.getTRSLink(this.tool.tool_path, value.name, 'cwl');
-      }
-      if (this.tool.descriptorType.includes('wdl')) {
-        this.trsLinkWDL = this.getTRSLink(this.tool.tool_path, value.name, 'wdl');
-      }
-    }
-  }
+  @Input() selectedVersion: Tag;
   @Input() privateOnlyRegistry;
-  @Input() tool;
+  @Input() tool: ExtendedDockstoreTool;
   public validationPatterns = validationDescriptorPatterns;
   public exampleDescriptorPatterns = exampleDescriptorPatterns;
   public DockstoreToolType = DockstoreTool;
@@ -59,7 +49,19 @@ export class InfoTabComponent implements OnInit {
   trsLinkWDL: string;
   constructor(private containerService: ContainerService, private infoTabService: InfoTabService, private stateService: StateService,
     private containersService: ContainersService) {
+  }
+
+  ngOnChanges() {
+    if (this.selectedVersion && this.tool) {
+      this.currentVersion = this.selectedVersion;
+      if (this.tool.descriptorType.includes('cwl')) {
+        this.trsLinkCWL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'cwl');
+      }
+      if (this.tool.descriptorType.includes('wdl')) {
+        this.trsLinkWDL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'wdl');
+      }
     }
+  }
 
   ngOnInit() {
     this.infoTabService.dockerFileEditing$.subscribe(editing => this.dockerFileEditing = editing);

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -18,16 +18,17 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { CustomMaterialModule } from './../modules/material.module';
 
+import { CodeEditorListComponent } from './../code-editor-list/code-editor-list.component';
+import { CodeEditorComponent } from './../code-editor/code-editor.component';
+import { CustomMaterialModule } from './../modules/material.module';
+import { CommitUrlPipe } from './commit-url.pipe';
 import {
   InfoTabCheckerWorkflowPathComponent,
 } from './info-tab-checker-workflow-path/info-tab-checker-workflow-path.component';
 import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch-checker-workflow.component';
 import { RegisterCheckerWorkflowComponent } from './register-checker-workflow/register-checker-workflow.component';
-import { CodeEditorComponent } from './../code-editor/code-editor.component';
-import { CodeEditorListComponent } from './../code-editor-list/code-editor-list.component';
-import { CommitUrlPipe } from './commit-url.pipe';
+import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
 
 @NgModule({
   imports: [
@@ -43,7 +44,8 @@ import { CommitUrlPipe } from './commit-url.pipe';
     LaunchCheckerWorkflowComponent,
     CodeEditorComponent,
     CodeEditorListComponent,
-    CommitUrlPipe
+    CommitUrlPipe,
+    VersionProviderUrlPipe
 ],
   exports: [
     InfoTabCheckerWorkflowPathComponent,
@@ -51,7 +53,8 @@ import { CommitUrlPipe } from './commit-url.pipe';
     CodeEditorComponent,
     CodeEditorListComponent,
     CustomMaterialModule,
-    CommitUrlPipe
+    CommitUrlPipe,
+    VersionProviderUrlPipe
   ]
 })
 export class EntryModule { }

--- a/src/app/shared/entry/versionProviderUrl.pipe.spec.ts
+++ b/src/app/shared/entry/versionProviderUrl.pipe.spec.ts
@@ -1,0 +1,17 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async } from '@angular/core/testing';
+import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
+
+describe('Pipe: VersionProviderUrle', () => {
+  it('create an instance', () => {
+    const pipe = new VersionProviderUrlPipe();
+    expect(pipe).toBeTruthy();
+    expect(pipe.transform('https://github.com/garyluu/example_cwl_workflow', ''))
+      .toBe('https://github.com/garyluu/example_cwl_workflow');
+    expect(pipe.transform('https://github.com/garyluu/example_cwl_workflow', 'potato'))
+      .toBe('https://github.com/garyluu/example_cwl_workflow/tree/potato');
+      expect(pipe.transform('beef', 'stew'))
+      .toBe('beef');
+  });
+});

--- a/src/app/shared/entry/versionProviderUrl.pipe.ts
+++ b/src/app/shared/entry/versionProviderUrl.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'versionProviderUrl'
+})
+export class VersionProviderUrlPipe implements PipeTransform {
+
+  transform(providerUrl: string, versionName: string): any {
+    console.log(providerUrl);
+    console.log(versionName);
+    if (providerUrl.includes('github.com') && versionName) {
+      return providerUrl + '/tree/' + versionName;
+    } else {
+      return providerUrl;
+    }
+  }
+}

--- a/src/app/shared/provider.service.ts
+++ b/src/app/shared/provider.service.ts
@@ -21,12 +21,11 @@ import { ExtendedWorkflow } from './models/ExtendedWorkflow';
 export class ProviderService {
 
   /* set up project provider */
-  setUpProvider(tool: (ExtendedDockstoreTool | ExtendedWorkflow),
-    version: (Tag | WorkflowVersion) = null): (ExtendedDockstoreTool | ExtendedWorkflow) {
+  setUpProvider(tool: (ExtendedDockstoreTool | ExtendedWorkflow)): (ExtendedDockstoreTool | ExtendedWorkflow) {
     const gitUrl = tool.gitUrl;
 
     tool.provider = this.getProvider(gitUrl);
-    tool.providerUrl = this.getProviderUrl(gitUrl, tool.provider, version);
+    tool.providerUrl = this.getProviderUrl(gitUrl, tool.provider);
     return tool;
   }
 
@@ -47,7 +46,7 @@ export class ProviderService {
     return null;
   }
 
-  private getProviderUrl(gitUrl: string, provider: string, version: (Tag | WorkflowVersion)): string {
+  private getProviderUrl(gitUrl: string, provider: string): string {
       if (!gitUrl) {
         return null;
       }
@@ -76,11 +75,6 @@ export class ProviderService {
       }
 
       providerUrl += matchRes[1] + '/' + matchRes[2];
-      if (provider === 'GitHub') {
-        if (version) {
-          providerUrl += '/tree/' + version.name;
-        }
-      }
       return providerUrl;
   }
 

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -60,7 +60,7 @@ export class ContainerStubService {
     }
 }
 export class ProviderStubService {
-    setUpProvider(tool, version = null) {
+    setUpProvider(tool) {
         tool.provider = 'a provider';
         tool.providerUrl = 'a provider url';
         return tool;

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -30,7 +30,7 @@
             {{ workflow?.provider}}
           </strong>:
           <a [href]="workflow?.providerUrl">
-            {{ workflow?.providerUrl }}
+            {{ workflow?.providerUrl | versionProviderUrl : (isPublic ? selectedVersion?.name : '')}}
           </a>
         </li>
       </span>

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -1,4 +1,3 @@
-import { Tooltip } from '../../shared/tooltip';
 /*
  *    Copyright 2017 OICR
  *
@@ -14,35 +13,31 @@ import { Tooltip } from '../../shared/tooltip';
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
-import { validationDescriptorPatterns } from './../../shared/validationMessages.model';
-import { InfoTabService } from './info-tab.service';
+import { Dockstore } from '../../shared/dockstore.model';
+import { EntryTab } from '../../shared/entry/entry-tab';
+import { Tooltip } from '../../shared/tooltip';
+import { ga4ghPath } from './../../shared/constants';
 import { StateService } from './../../shared/state.service';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { Workflow } from './../../shared/swagger/model/workflow';
-import { WorkflowService } from './../../shared/workflow.service';
-import { Component, OnInit, Input } from '@angular/core';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
-import { EntryTab } from '../../shared/entry/entry-tab';
-import { Dockstore } from '../../shared/dockstore.model';
-import { ga4ghPath } from './../../shared/constants';
+import { validationDescriptorPatterns } from './../../shared/validationMessages.model';
+import { WorkflowService } from './../../shared/workflow.service';
+import { InfoTabService } from './info-tab.service';
 
 @Component({
   selector: 'app-info-tab',
   templateUrl: './info-tab.component.html',
   styleUrls: ['./info-tab.component.css']
 })
-export class InfoTabComponent extends EntryTab implements OnInit {
+export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   @Input() validVersions;
   @Input() defaultVersion;
   @Input() workflow;
   currentVersion: WorkflowVersion;
-  @Input() set selectedVersion(value: WorkflowVersion) {
-    if (value != null) {
-      this.currentVersion = value;
-      this.trsLink = this.getTRSLink(this.workflow.full_workflow_path, value.name, this.workflow.descriptorType);
-    }
-  }
+  @Input() selectedVersion: WorkflowVersion;
 
   public validationPatterns = validationDescriptorPatterns;
   public WorkflowType = Workflow;
@@ -53,8 +48,15 @@ export class InfoTabComponent extends EntryTab implements OnInit {
   trsLink: string;
   public refreshMessage: string;
   constructor(private workflowService: WorkflowService, private workflowsService: WorkflowsService, private stateService: StateService,
-  private infoTabService: InfoTabService) {
+    private infoTabService: InfoTabService) {
     super();
+  }
+
+  ngOnChanges() {
+    if (this.selectedVersion && this.workflow) {
+      this.currentVersion = this.selectedVersion;
+      this.trsLink = this.getTRSLink(this.workflow.full_workflow_path, this.selectedVersion.name, this.workflow.descriptorType);
+    }
   }
 
   ngOnInit() {
@@ -99,11 +101,11 @@ export class InfoTabComponent extends EntryTab implements OnInit {
     this.infoTabService.update(this.workflow);
   }
 
- /**
-   * Cancel button function
-   *
-   * @memberof InfoTabComponent
-   */
+  /**
+    * Cancel button function
+    *
+    * @memberof InfoTabComponent
+    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
   }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -140,7 +140,7 @@ export class WorkflowComponent extends Entry {
     if (workflow) {
       this.workflow = workflow;
       if (!workflow.providerUrl) {
-        this.providerService.setUpProvider(workflow, this.selectedVersion);
+        this.providerService.setUpProvider(workflow);
       }
       this.workflow = Object.assign(workflow, this.workflow);
       this.title = this.workflow.full_workflow_path;
@@ -192,7 +192,7 @@ export class WorkflowComponent extends Entry {
           if (this.workflow != null) {
             this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
           }
-          this.providerService.setUpProvider(this.workflow, this.selectedVersion);
+          this.providerService.setUpProvider(this.workflow);
         }, error => {
           const regex = /\/workflows\/(github.com)|(gitlab.com)|(bitbucket.org)\/.+/;
           if (regex.test(this.resourcePath)) {
@@ -317,7 +317,7 @@ export class WorkflowComponent extends Entry {
     this.selectedVersion = version;
     if (this.workflow != null) {
       this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
-      this.providerService.setUpProvider(this.workflow, version);
+      this.providerService.setUpProvider(this.workflow);
     }
   }
 


### PR DESCRIPTION
entry.providerUrl was modified so anything that previously depended on it as parameter is broken.
Reverting that change and using a pipe to generate the version-specific providerUrl on-the-fly

Fix for when tool not loaded before selected version update for some reason (occurs on initial page load)

Fix for ga4gh/dockstore#1489 and ga4gh/dockstore#1435

Not sure how it's intended to work but now:
- Public page will always display the version-specific providerUrl
- My-entry page will always display the workflow providerUrl