### PR TITLE
Enter on Register Modal Fix

### DIFF
--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -137,7 +137,7 @@
               </div>
             </div>
             <div class="modal-footer">
-              <button id="closeRegisterWorkflowModalButton" mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
+              <button type="button" id="closeRegisterWorkflowModalButton" mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
                 Close
               </button>
               <button id="submitButton" type="submit" mat-raised-button color="primary" disabled="{{!registerWorkflowForm.form.valid || refreshMessage !== null}}">
@@ -182,7 +182,7 @@
               </div>
             </div>
             <div class="modal-footer">
-              <button mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
+              <button type="button" mat-raised-button color="secondary" (click)="hideModal(); clearWorkflowRegisterError()">
                 Close
               </button>
               <button id="submitButton" type="submit" mat-raised-button color="primary" [disabled]="!registerHostedWorkflowForm.form.valid">


### PR DESCRIPTION
Enhancement for ga4gh/dockstore#1391

Previously, when enter is pressed, it is not entire clear what happens in the register modal with valid form and invalid form.

What actually happened is the close button gets pressed regardless of valid/invalid. 

This fix:
- correctly sets the close button to not be the focus and passes focus to the submit button.
- does nothing when enter pressed on invalid form
- submits on correct form when enter pressed
