### PR TITLE
Add Launch with DNAnexus

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -32,6 +32,7 @@ export class Dockstore {
   static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
   static readonly DNASTACK_IMPORT_URL = 'https://app.dnastack.com/#/app/workflow/import/dockstore';
   static readonly FIRECLOUD_IMPORT_URL = 'https://portal.firecloud.org/#import/dockstore';
+  static readonly DNANEXUS_IMPORT_URL = 'https://platform.dnanexus.com/panx/tools/import-workflow';
 
   static readonly GITHUB_CLIENT_ID = 'fill_this_in';
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
@@ -60,7 +61,6 @@ export class Dockstore {
   static readonly CWL_VISUALIZER_URI = 'https://view.commonwl.org';
 
   static readonly FEATURES = {
-    enableCwlViewer: true,
-    enableLaunchWithFireCloud: true
+    enableCwlViewer: true
   };
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -6,6 +6,10 @@
     <div class="container-source-repos">
       <div class="container-launch-with">
         <div class="button-wrap">
+          <div *ngIf="dnanexusURL" class="button">
+            <p><a href="{{dnanexusURL}}"><img src="../../assets/images/thirdparty/DX_Logo_white_alpha.svg"> DNAnexus
+              &raquo;</a></p>
+          </div>
           <div *ngIf="dnastackURL" class="button">
             <p><a href="{{dnastackURL}}"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a>
             </p>

--- a/src/app/workflow/launch-third-party/launch-third-party.service.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { LaunchThirdPartyService } from './launch-third-party.service';
+import { Dockstore } from '../../shared/dockstore.model';
+
+describe('LaunchThirdPartyService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LaunchThirdPartyService]
+    });
+  });
+
+  const path = 'github.com/gatk-workflows/gatk4-germline-snps-indels';
+  const version = '1.0.1';
+
+  it('should be created', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should create encoded DNAnexus url', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    const dnanexusUrl = service.dnanexusUrl(path, version);
+    const expectedEncodedSourcePath =
+      'api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fgatk-workflows%2Fgatk4-germline-snps-indels/versions/1.0.1';
+    expect(dnanexusUrl).toBe(`${Dockstore.DNANEXUS_IMPORT_URL}?source=${Dockstore.API_URI}/${expectedEncodedSourcePath}`);
+  }));
+
+  it('should create encoded DNAstack url', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    const expected = 'https://app.dnastack.com/#/app/workflow/import/dockstore?path=github.com/gatk-workflows/'
+      + 'gatk4-germline-snps-indels&descriptorType=wdl';
+    expect(service.dnastackUrl(path, 'wdl'))
+      .toBe(expected);
+  }));
+
+  it('should create Firecloud url', inject([LaunchThirdPartyService], (service: LaunchThirdPartyService) => {
+    // The host is configurable, so just test from #import on
+    const importPart = '#import/dockstore/github.com/gatk-workflows/gatk4-germline-snps-indels:1.0.1';
+    expect(service.firecloudUrl(path, version).indexOf(importPart)).toBeGreaterThan(-1);
+  }));
+});

--- a/src/app/workflow/launch-third-party/launch-third-party.service.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { ga4ghPath } from '../../shared/constants';
+import { Dockstore } from '../../shared/dockstore.model';
+import { HttpParams } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LaunchThirdPartyService {
+
+  constructor() { }
+
+  public dnanexusUrl(path: string, version: string): string {
+      return Dockstore.DNANEXUS_IMPORT_URL + '?source=' + this.getTrsUrl(path, version);
+  }
+
+  public dnastackUrl(path: string, descriptorType: string): string {
+    const httpParams = new HttpParams()
+      .set('path', path)
+      .set('descriptorType', descriptorType);
+    return Dockstore.DNASTACK_IMPORT_URL + '?' + httpParams.toString();
+  }
+
+  public firecloudUrl(path: string, version: string): string {
+    return `${Dockstore.FIRECLOUD_IMPORT_URL}/${path}:${version}`;
+  }
+
+  private getTrsUrl(path: string, versionName: string): string {
+    return `${Dockstore.API_URI}${ga4ghPath}/tools/`
+      + encodeURIComponent(`#workflow/${path}`)
+      + '/versions/'
+      + encodeURIComponent(`${versionName}`);
+  }
+}

--- a/src/assets/images/thirdparty/DX_Logo_white_alpha.svg
+++ b/src/assets/images/thirdparty/DX_Logo_white_alpha.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="19px" height="23px" viewBox="0 0 19 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>DX_Logo_white_alpha</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <polygon id="path-1" points="3.8e-05 0.375918033 18.9069 0.375918033 18.9069 22.9984164 3.8e-05 22.9984164"></polygon>
+        <polygon id="path-3" points="7.6e-05 0.000268333333 18.9069 0.000268333333 18.9069 22.999885 7.6e-05 22.999885"></polygon>
+    </defs>
+    <g id="Details:-Login/Signup/ExternalAccess" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard-Copy-2" transform="translate(-25.000000, -18.000000)">
+            <g id="DX_Logo_white_alpha" transform="translate(25.000000, 18.000000)">
+                <g id="Group-6">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <g id="Clip-5"></g>
+                    <path d="M14.465498,0.375842623 C14.465498,5.79592459 11.074758,8.15021967 7.232578,10.3197607 C3.533658,12.4089902 3.8e-05,17.107023 3.8e-05,22.9984164 L4.441478,22.9984164 C4.441478,17.107023 7.853498,14.1102361 11.677818,12.0526787 C15.050318,10.237941 18.906938,5.79592459 18.906938,0.375842623 L14.465498,0.375842623 Z" id="Fill-4" fill-opacity="0.64" fill="#FFFFFF" mask="url(#mask-2)"></path>
+                </g>
+                <g id="Group-3">
+                    <mask id="mask-4" fill="white">
+                        <use xlink:href="#path-3"></use>
+                    </mask>
+                    <g id="Clip-2"></g>
+                    <path d="M4.441516,0.000268333333 C4.441516,5.510685 6.964336,8.37035167 10.806136,10.576435 C14.505436,12.6997183 18.906976,17.0103017 18.906976,22.999885 L14.465536,22.999885 C14.465536,17.0103017 11.839736,13.7703683 8.015796,11.6785183 C4.643296,9.833535 7.6e-05,5.510685 7.6e-05,0.000268333333 L4.441516,0.000268333333 Z" id="Fill-1" fill="#FFFFFF" mask="url(#mask-4)"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
ga4gh/dockstore#1537

Added launch with DNAnexus button. The order of the launch with
buttons in the UI is alphabetical.

Got rid of enableLaunchWithFireCloud feature flag. It was there
because at one point we were only able to test this feature on their
side in staging but not in prod, but now that it's been in prod
for a while, I think we can get rid of the flag and the tests for it.

Also introduced a service to generate the urls. Use HttpParams there
instead of the URLSearchParams being used previously in the
component because URLSearchParams is deprecated.

Note: I'm planning to tackle ga4gh/dockstore#1575 next in the UI, which
relates to disabling launch with buttons based on the file content.
Wanted to to do this on its own first.

Screenshot:

![screen shot 2018-07-17 at 2 43 00 pm](https://user-images.githubusercontent.com/1049340/42847431-cb5d3eae-89d0-11e8-8d2d-ec5c635d53f5.png)
