### PR TITLE
Update Launch With Buttons

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
-import { MatButtonModule, MatSnackBarModule } from '@angular/material';
+import { MatButtonModule, MatIconModule, MatSnackBarModule } from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthService, Ng2UiAuthModule } from 'ng2-ui-auth';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
@@ -120,6 +120,7 @@ import { StarringModule } from './starring/starring.module';
     Ng2UiAuthModule.forRoot(AuthConfig),
     HeaderModule,
     MatButtonModule,
+    MatIconModule,
     ListContainersModule,
     ListWorkflowsModule,
     BsDropdownModule.forRoot(),

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -18,6 +18,7 @@ import { DockstoreTool } from './../shared/swagger/model/dockstoreTool';
 import { SourceFile } from './../shared/swagger/model/sourceFile';
 import { Token } from './../shared/swagger/model/token';
 import { Workflow } from './../shared/swagger/model/workflow';
+import { WorkflowVersion } from '../shared/swagger';
 
 export const updatedWorkflow: Workflow = {
     'descriptorType': 'cwl',
@@ -71,7 +72,29 @@ export const sampleWorkflow3: Workflow = {
     'workflowVersions': [],
     'defaultTestParameterFilePath': 'updatedTestParameterPath',
     'sourceControl': 'github.com',
-    'source_control_provider': 'GITHUB'
+    'source_control_provider': 'GITHUB',
+    'full_workflow_path': 'github.com/sampleWorkflowPath'
+};
+
+export const sampleWdlWorkflow1: Workflow = {
+  id: 4,
+  'descriptorType': 'wdl',
+  'gitUrl': 'sampleGitUrl',
+  'mode': Workflow.ModeEnum.FULL,
+  'organization': 'sampleOrganization',
+  'repository': 'sampleRepository',
+  'workflow_path': 'sampleWorkflowPath',
+  'workflowVersions': [],
+  'defaultTestParameterFilePath': 'updatedTestParameterPath',
+  'sourceControl': 'github.com',
+  'source_control_provider': 'GITHUB',
+  'full_workflow_path': 'github.com/DataBiosphere/topmed-workflows/Functional_Equivalence'
+};
+
+export const sampleWorkflowVersion: WorkflowVersion = {
+  'id': 1,
+  'reference': '',
+  'name': 'master'
 };
 
 export const sampleTool1: DockstoreTool = {
@@ -171,8 +194,22 @@ export const wdlSourceFile: SourceFile = {
   content: 'task foo {}',
   id: 0,
   path: '',
-  type: undefined
+  type: 'DOCKSTORE_WDL'
 };
+
+export const emptyWdlSourceFile: SourceFile = {
+  content: '',
+  id: 1,
+  path: '/foo.wdl',
+  type: 'DOCKSTORE_WDL'
+};
+
+export const wdlSourceFileWithHttpImport: SourceFile = {
+  content: 'import http://example.com/foo',
+  id: 2,
+  path: '/goo.wdl',
+  type: 'DOCKSTORE_WDL'
+}
 
 export const sampleSourceFile: SourceFile = {
   content: 'potato',

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -209,7 +209,7 @@ export const wdlSourceFileWithHttpImport: SourceFile = {
   id: 2,
   path: '/goo.wdl',
   type: 'DOCKSTORE_WDL'
-}
+};
 
 export const sampleSourceFile: SourceFile = {
   content: 'potato',

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -288,8 +288,6 @@ export class WorkflowStubService {
     getTestJson() {
         return observableOf({});
     }
-    get full_workflow_path() { return ''; }
-    get descriptorType() { return ''; }
 }
 
 export class HostedStubService {
@@ -725,9 +723,6 @@ export class VersionModalStubService {
 
 }
 
-export class WorkflowVersionStubService {
-  get name() {return ''; }
-}
 
 export class StateStubService {
     publicPage$ = observableOf(false);

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="isWdl()" class="panel panel-default">
+<div *ngIf="isWdl" class="panel panel-default">
   <div class="panel-heading">
     <h3>Launch with</h3>
   </div>
@@ -10,25 +10,28 @@
             <div *ngIf="wdlHasFileImports || wdlHasHttpImports" class="import-warning">
               Warning: this version of the WDL has imports, which are not supported by DNAstack. Make sure to select a version without imports in DNAstack.
             </div>
-            <button mat-raised-button
+            <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
-               (click)="goto(dnastackURL)"
+               target="_blank"
+               [attr.href]="dnastackURL"
                [disabled]="!dnastackURL"
-               color="primary"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</button>
+               color="primary"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a>
           </div>
           <div fxFlex="100%">
-            <button mat-raised-button
+            <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : (wdlHasFileImports ? 'FireCloud does not support file-path imports in WDL. It only supports http(s) imports.' : '')}}"
-               (click)="goto(fireCloudURL)"
+               target="_blank"
+               [attr.href]="fireCloudURL"
                [disabled]="!fireCloudURL"
-               color="primary"><mat-icon svgIcon="firecloud"></mat-icon> FireCloud &raquo;</button>
+               color="primary"><mat-icon svgIcon="firecloud"></mat-icon> FireCloud &raquo;</a>
           </div>
           <div fxFlex="100%">
-            <button mat-raised-button
+            <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
-               (click)="goto(dnanexusURL)"
+               target="_blank"
+               [attr.href]="dnanexusURL"
                [disabled]="!dnanexusURL"
-               color="primary"><mat-icon svgIcon="dnanexus"></mat-icon> DNAnexus &raquo;</button>
+               color="primary"><mat-icon svgIcon="dnanexus"></mat-icon> DNAnexus &raquo;</a>
           </div>
         </div>
       </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -13,6 +13,7 @@
             <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
                target="_blank"
+               rel="noopener"
                [attr.href]="dnastackURL"
                [disabled]="!dnastackURL"
                color="primary"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a>
@@ -21,6 +22,7 @@
             <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : (wdlHasFileImports ? 'FireCloud does not support file-path imports in WDL. It only supports http(s) imports.' : '')}}"
                target="_blank"
+               rel="noopener"
                [attr.href]="fireCloudURL"
                [disabled]="!fireCloudURL"
                color="primary"><mat-icon svgIcon="firecloud"></mat-icon> FireCloud &raquo;</a>
@@ -29,6 +31,7 @@
             <a mat-raised-button
                title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
                target="_blank"
+               rel="noopener"
                [attr.href]="dnanexusURL"
                [disabled]="!dnanexusURL"
                color="primary"><mat-icon svgIcon="dnanexus"></mat-icon> DNAnexus &raquo;</a>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -1,22 +1,34 @@
-<div *ngIf="dnastackURL || fireCloudURL" class="panel panel-default">
+<div *ngIf="isWdl()" class="panel panel-default">
   <div class="panel-heading">
     <h3>Launch with</h3>
   </div>
   <div class="panel-body">
     <div class="container-source-repos">
       <div class="container-launch-with">
-        <div class="button-wrap">
-          <div *ngIf="dnastackURL" class="button">
-            <p><a href="{{dnastackURL}}"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</a>
-            </p>
+        <div fxLayout="row wrap">
+          <div fxFlex="100%">
+            <div *ngIf="wdlHasFileImports || wdlHasHttpImports" class="import-warning">
+              Warning: this version of the WDL has imports, which are not supported by DNAstack. Make sure to select a version without imports in DNAstack.
+            </div>
+            <button mat-raised-button
+               title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
+               (click)="goto(dnastackURL)"
+               [disabled]="!dnastackURL"
+               color="primary"><img src="../../assets/images/thirdparty/dnastack.png"> DNAstack &raquo;</button>
           </div>
-          <div *ngIf="fireCloudURL" class="button">
-            <p><a href="{{fireCloudURL}}"><img src="../../assets/images/thirdparty/FireCloud-white-icon.svg"> FireCloud
-              &raquo;</a></p>
+          <div fxFlex="100%">
+            <button mat-raised-button
+               title="{{!wdlHasContent ? 'The WDL has no content.' : (wdlHasFileImports ? 'FireCloud does not support file-path imports in WDL. It only supports http(s) imports.' : '')}}"
+               (click)="goto(fireCloudURL)"
+               [disabled]="!fireCloudURL"
+               color="primary"><mat-icon svgIcon="firecloud"></mat-icon> FireCloud &raquo;</button>
           </div>
-          <div *ngIf="dnanexusURL" class="button">
-            <p><a href="{{dnanexusURL}}"><img src="../../assets/images/thirdparty/DX_Logo_white_alpha.svg"> DNAnexus
-              &raquo;</a></p>
+          <div fxFlex="100%">
+            <button mat-raised-button
+               title="{{!wdlHasContent ? 'The WDL has no content.' : ''}}"
+               (click)="goto(dnanexusURL)"
+               [disabled]="!dnanexusURL"
+               color="primary"><mat-icon svgIcon="dnanexus"></mat-icon> DNAnexus &raquo;</button>
           </div>
         </div>
       </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -1,11 +1,16 @@
-.button-wrap {
-  display: inline-block;
-}
-
-.button-wrap > .button {
-  display: block;
-}
-
-.button-wrap > .button:not(:last-child) {
+button {
   margin-bottom: 10px;
+  width: 150px;
+  max-width: 98%;
+  img {
+    width: 24px;
+    height: 24px;
+  }
+}
+.import-warning {
+  font-size: 11px;
+  font-style: italic;
+  text-align: left;
+  line-height: 1em;
+  margin-bottom: 4px;
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -1,4 +1,4 @@
-button {
+a {
   margin-bottom: 10px;
   width: 150px;
   max-width: 98%;

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -4,16 +4,17 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LaunchThirdPartyComponent } from './launch-third-party.component';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import {
-  sampleWorkflow3,
+  emptyWdlSourceFile,
   sampleWdlWorkflow1,
+  sampleWorkflow3,
   sampleWorkflowVersion,
   wdlSourceFile,
-  emptyWdlSourceFile, wdlSourceFileWithHttpImport
+  wdlSourceFileWithHttpImport
 } from '../../test/mocked-objects';
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { WorkflowsStubService } from '../../test/service-stubs';
-import { SourceFile } from 'typescript';
-import { from } from 'rxjs/internal/observable/from';
+import { CustomMaterialModule } from '../../shared/modules/material.module';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('LaunchThirdPartyComponent', () => {
   let component: LaunchThirdPartyComponent;
@@ -23,6 +24,7 @@ describe('LaunchThirdPartyComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ LaunchThirdPartyComponent ],
+      imports: [CustomMaterialModule, HttpClientModule],
       providers: [
         { provide: WorkflowsService, useClass: WorkflowsStubService}
       ],

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -28,6 +28,7 @@ export class LaunchThirdPartyComponent implements OnChanges {
   wdlHasHttpImports: boolean;
   wdlHasFileImports: boolean;
   wdlHasContent: boolean;
+  isWdl: boolean;
 
   constructor(private workflowsService: WorkflowsService,
               private launchThirdPartyService: LaunchThirdPartyService,
@@ -42,7 +43,8 @@ export class LaunchThirdPartyComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     this.fireCloudURL = this.dnastackURL = this.dnanexusURL = null;
     this.wdlHasContent = this.wdlHasFileImports = this.wdlHasHttpImports = false;
-    if (this.isWdl() && this.selectedVersion) {
+    this.isWdl = this.workflow && this.workflow && this.workflow.full_workflow_path && this.workflow.descriptorType === 'wdl';
+    if (this.isWdl && this.selectedVersion) {
       this.workflowsService.wdl(this.workflow.id, this.selectedVersion.name).subscribe((sourceFile: SourceFile) => {
         if (sourceFile && sourceFile.content && sourceFile.content.length) {
           this.wdlHasContent = true;
@@ -61,14 +63,6 @@ export class LaunchThirdPartyComponent implements OnChanges {
         }
       });
     }
-  }
-
-  public isWdl() {
-    return this.workflow && this.workflow && this.workflow.full_workflow_path && this.workflow.descriptorType === 'wdl';
-  }
-
-  public goto(url: string) {
-    open(url, '_blank');
   }
 
 }


### PR DESCRIPTION
gahgh/dockstore#1575

* Changed to Material
* Use/implement OnChanges in LaunchThirdPartyComponent; simplified
things, including getting rid of _workflow and _selectedVersion
properties.
* Changed links to buttons, as disable doesn't work on links (sort of
had it working with links, but then tests would complain about <a> not
having the disabled attribute).
* Disabling logic:
    * Disable all if there is no content for the current version. For
    DNAstack, could arguably not disable in this case, since you can
    select any version in their UI, but then it would have been a
    confusing message.
    * Disable FireCloud if there are file-path imports.
    * Display warning message if there are any imports for DNAstack, but
    don't disable button.
    * DNAnexus supports all imports, so never disable based on imports.
* Had somehow embarassingly put mock object logic into service-stubs;
moved that into mocked-objects.

Screenshots with no warnings/disablement:

![screen shot 2018-07-18 at 5 39 23 pm](https://user-images.githubusercontent.com/1049340/42960771-ab119506-8b41-11e8-9863-d4527ff327a2.png)

Screenshot with warnings/disablement:

![screen shot 2018-07-18 at 5 43 32 pm 2](https://user-images.githubusercontent.com/1049340/42960793-c075c39a-8b41-11e8-8167-469dfd854f92.png)

