### PR TITLE
Fix url generated for DNAnexus

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -74,6 +74,18 @@ describe('LaunchThirdPartyComponent', () => {
     expect(component.fireCloudURL)
       // tslint:disable-next-line:max-line-length
       .toEqual('https://portal.firecloud.org/#import/dockstore/github.com/DataBiosphere/topmed-workflows/Functional_Equivalence:master');
+
+    // Expecting something like below; the problem is the dockstore host will not match when running UI locally
+    // or on Travis, so match beginning and end of the URL.
+    // tslint:disable-next-line:max-line-length
+    // https://platform.dnanexus.com/panx/tools/import-workflow?source=https://dockstore.org:8443/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FFunctional_Equivalence/versions/master
+    const dnanexusUrlStart = 'https://platform.dnanexus.com/panx/tools/import-workflow?source';
+    expect(component.dnanexusURL.indexOf(dnanexusUrlStart))
+      .toBe(0);
+    // tslint:disable-next-line:max-line-length
+    const dnanexusEnd = '/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FFunctional_Equivalence/versions/master';
+    expect(component.dnanexusURL.indexOf(dnanexusEnd))
+      .toBeGreaterThan(dnanexusUrlStart.length);
   });
 
   it('should set dnastack and dnanexus but not Firecloud if WDL with secondary files', () => {

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -49,7 +49,7 @@ export class LaunchThirdPartyComponent implements OnChanges {
         if (sourceFile && sourceFile.content && sourceFile.content.length) {
           this.wdlHasContent = true;
           // DNAnexus handles file and http(s) imports, no need to check
-          this.dnanexusURL = this.launchThirdPartyService.dnanexusUrl(this.selectedVersion.workflow_path, this.selectedVersion.name);
+          this.dnanexusURL = this.launchThirdPartyService.dnanexusUrl(this.workflow.full_workflow_path, this.selectedVersion.name);
           // DNAstack doesn't get passed a specific version
           this.dnastackURL = this.launchThirdPartyService.dnastackUrl(this.workflow.full_workflow_path, this.workflow.descriptorType);
           this.workflowsService.secondaryWdl(this.workflow.id, this.selectedVersion.name).subscribe((sourceFiles: Array<SourceFile>) => {


### PR DESCRIPTION
ga4gh/dockstore#1537

Was passing the wrong path to generate DNAnexus link.

Tested the link by replacing pasting it into the browser, replacing
local protocol/host/port with `https://dockstore.org:8443`, since
that is the only whitelisted by DNAnexus. Thought I had tried that
before, but apparently I hadn't.