### PR TITLE
Fix for TRS link, only show if public

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -46,18 +46,20 @@
         {{ tool?.imgProviderUrl }}
       </span>
     </li>
-    <li *ngIf="trsLinkCWL">
-      <strong tooltip="TRS link to the main CWL descriptor for the selected tool version">TRS CWL</strong>:
-      <a [href]="trsLinkCWL">
-        {{tool?.tool_path}}
-      </a>
-    </li>
-    <li *ngIf="trsLinkWDL">
-      <strong tooltip="TRS link to the main WDL descriptor for the selected tool version">TRS WDL</strong>:
-      <a [href]="trsLinkWDL">
-        {{tool?.tool_path}}
-      </a>
-    </li>
+    <span *ngIf="isPublic">
+      <li *ngIf="trsLinkCWL">
+        <strong tooltip="TRS link to the main CWL descriptor for the selected tool version">TRS CWL</strong>:
+        <a [href]="trsLinkCWL">
+          {{tool?.tool_path}}
+        </a>
+      </li>
+      <li *ngIf="trsLinkWDL">
+        <strong tooltip="TRS link to the main WDL descriptor for the selected tool version">TRS WDL</strong>:
+        <a [href]="trsLinkWDL">
+          {{tool?.tool_path}}
+        </a>
+      </li>
+    </span>
     <li *ngIf="(tool?.default_dockerfile_path || !isPublic)">
       <form #editDockerfileForm="ngForm" class="form-inline">
         <div class="form-group">

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -46,7 +46,7 @@
         {{ tool?.imgProviderUrl }}
       </span>
     </li>
-    <span *ngIf="isPublic">
+    <span *ngIf="isPublic && isValidVersion">
       <li *ngIf="trsLinkCWL">
         <strong tooltip="TRS link to the main CWL descriptor for the selected tool version">TRS CWL</strong>:
         <a [href]="trsLinkCWL">

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -69,6 +69,8 @@ export class InfoTabComponent implements OnInit, OnChanges {
       }
     } else {
       this.isValidVersion = false;
+      this.trsLinkCWL = null;
+      this.trsLinkWDL = null;
     }
   }
 

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -62,10 +62,10 @@ export class InfoTabComponent implements OnInit, OnChanges {
       this.isValidVersion = found ? true : false;
       this.downloadZipLink = Dockstore.API_URI + '/containers/' + this.tool.id + '/zip/' + this.currentVersion.id;
       if (this.tool.descriptorType.includes('cwl')) {
-        this.trsLinkCWL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'cwl');
+        this.trsLinkCWL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'cwl', this.currentVersion.cwl_path);
       }
       if (this.tool.descriptorType.includes('wdl')) {
-        this.trsLinkWDL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'wdl');
+        this.trsLinkWDL = this.getTRSLink(this.tool.tool_path, this.currentVersion.name, 'wdl', this.currentVersion.wdl_path);
       }
     } else {
       this.isValidVersion = false;
@@ -144,10 +144,12 @@ export class InfoTabComponent implements OnInit, OnChanges {
    * @param path tool path
    * @param versionName name of version
    * @param descriptorType descriptor type (CWL or WDL)
+   * @param descriptorPath primary descriptor path
    */
-  getTRSLink(path: string, versionName: string, descriptorType: string): string {
+  getTRSLink(path: string, versionName: string, descriptorType: string,
+    relativePath: string): string {
     return `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(path)}` +
       `/versions/${encodeURIComponent(versionName)}/plain-` + descriptorType.toUpperCase() +
-      `/descriptor`;
+      `/descriptor/` + relativePath;
   }
 }

--- a/src/app/shared/entry/versionProviderUrl.pipe.ts
+++ b/src/app/shared/entry/versionProviderUrl.pipe.ts
@@ -6,8 +6,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class VersionProviderUrlPipe implements PipeTransform {
 
   transform(providerUrl: string, versionName: string): any {
-    console.log(providerUrl);
-    console.log(versionName);
     if (providerUrl.includes('github.com') && versionName) {
       return providerUrl + '/tree/' + versionName;
     } else {

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -38,7 +38,7 @@
           <strong tooltip="The source code for this workflow is stored on Dockstore.org">Dockstore.org</strong>:
           <i>The source code for this workflow is stored on Dockstore.org</i>
       </li>
-      <li>
+      <li *ngIf="isPublic && isValidVersion">
         <strong tooltip="TRS link to the main descriptor for the selected workflow version">TRS</strong>:
         <a [href]="trsLink">
           #workflow/{{workflow?.full_workflow_path}}

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -61,7 +61,8 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   ngOnChanges() {
     if (this.selectedVersion && this.workflow) {
       this.currentVersion = this.selectedVersion;
-      this.trsLink = this.getTRSLink(this.workflow.full_workflow_path, this.selectedVersion.name, this.workflow.descriptorType);
+      this.trsLink = this.getTRSLink(this.workflow.full_workflow_path, this.selectedVersion.name, this.workflow.descriptorType,
+        this.selectedVersion.workflow_path);
       const found = this.validVersions.find((version: WorkflowVersion) => version.id === this.selectedVersion.id);
       this.isValidVersion = found ? true : false;
       this.downloadZipLink = Dockstore.API_URI + '/workflows/' + this.workflow.id + '/zip/' + this.currentVersion.id;
@@ -139,10 +140,12 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
    * @param path full workflow path
    * @param versionName name of version
    * @param descriptorType descriptor type (CWL or WDL)
+   * @param descriptorPath primary descriptor path
    */
-  getTRSLink(path: string, versionName: string, descriptorType: string): string {
+  getTRSLink(path: string, versionName: string, descriptorType: string,
+    descriptorPath: string): string {
     return `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent('#workflow/' + path)}` +
       `/versions/${encodeURIComponent(versionName)}/plain-` + descriptorType.toUpperCase() +
-      `/descriptor`;
+      `/descriptor/` + descriptorPath;
   }
 }

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -67,6 +67,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       this.downloadZipLink = Dockstore.API_URI + '/workflows/' + this.workflow.id + '/zip/' + this.currentVersion.id;
     } else {
       this.isValidVersion = false;
+      this.trsLink = null;
     }
   }
 


### PR DESCRIPTION
TRS link is now only shown when public and looking at a valid version. Also using relative path endpoint.
https://github.com/ga4gh/dockstore/issues/1631