### PR TITLE
Feature/update user after tokens

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -99,15 +99,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     }
   }
 
-  // Unlink account in accountsInfo
-  private unlinkToken(source) {
-    for (const account of this.accountsInfo) {
-      if (account.source === source) {
-        account.isLinked = false;
-      }
-    }
-  }
-
   link(source: string): void {
     this.accountsService.link(source);
   }
@@ -116,8 +107,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   unlink(source: string) {
     this.deleteToken(source).pipe(
       first()).subscribe(() => {
-        this.tokenService.updateTokens();
-        this.unlinkToken(source);
+        this.userService.updateUser();
       });
   }
 

--- a/src/app/loginComponents/accounts/external/accounts.service.spec.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.spec.ts
@@ -1,17 +1,18 @@
-/* tslint:disable:no-unused-variable */
+import { inject, TestBed } from '@angular/core/testing';
 
-import { TestBed, async, inject } from '@angular/core/testing';
-import { AccountsService } from './accounts.service';
 import { LoginService } from '../../../login/login.service';
-import { LoginStubService, TokenStubService } from '../../../test/service-stubs';
+import { LoginStubService, TokenStubService, UserStubService } from '../../../test/service-stubs';
 import { TokenService } from '../../token.service';
+import { UserService } from '../../user.service';
+import { AccountsService } from './accounts.service';
 
 describe('Service: Accounts', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [AccountsService,
-        { provide: LoginService, useClass: LoginStubService},
-        {provide: TokenService, useClass: TokenStubService}
+        { provide: LoginService, useClass: LoginStubService },
+        { provide: TokenService, useClass: TokenStubService },
+        { provide: UserService, useClass: UserStubService }
       ]
     });
   });

--- a/src/app/loginComponents/accounts/external/accounts.service.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.ts
@@ -1,14 +1,16 @@
-import {first} from 'rxjs/operators';
-import {Links} from './links.model';
-import {TokenSource} from './../../../shared/enum/token-source.enum';
-import {Injectable} from '@angular/core';
-import {LoginService} from '../../../login/login.service';
-import {TokenService} from '../../token.service';
+import { Injectable } from '@angular/core';
+import { first } from 'rxjs/operators';
+
+import { LoginService } from '../../../login/login.service';
+import { TokenService } from '../../token.service';
+import { UserService } from '../../user.service';
+import { TokenSource } from './../../../shared/enum/token-source.enum';
+import { Links } from './links.model';
 
 @Injectable()
 export class AccountsService {
 
-    constructor(private loginService: LoginService, private tokenService: TokenService) { }
+    constructor(private loginService: LoginService, private tokenService: TokenService, private userService: UserService) { }
 
     private stripSpace(url: string): string {
         return url.replace(/\s/g, '');
@@ -43,8 +45,8 @@ export class AccountsService {
                 }, error => {
                   // TODO: Hook up to snackbar
                 }, () => {
-                  // Always refresh tokens
-                  this.tokenService.updateTokens();
+                  // Also update user to get the new profile, which causes the token service to trigger and update the tokens too
+                  this.userService.updateUser();
                 });
                 break;
         }

--- a/src/app/loginComponents/auth/auth.component.spec.ts
+++ b/src/app/loginComponents/auth/auth.component.spec.ts
@@ -1,9 +1,10 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TokensStubService, TokenStubService } from './../../test/service-stubs';
-import { TokenService } from '../token.service';
-import { AuthComponent } from './auth.component';
-import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 
+import { TokenService } from '../token.service';
+import { UserService } from '../user.service';
+import { TokenStubService, UserStubService } from './../../test/service-stubs';
+import { AuthComponent } from './auth.component';
 
 describe('AuthComponent', () => {
   let component: AuthComponent;
@@ -11,11 +12,14 @@ describe('AuthComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AuthComponent],
-      imports: [ RouterTestingModule.withRoutes([{path: '**', component: AuthComponent}]) ],
-      providers: [{provide: TokenService, useClass: TokenStubService}]
+      declarations: [AuthComponent],
+      imports: [RouterTestingModule.withRoutes([{ path: '**', component: AuthComponent }])],
+      providers: [
+        { provide: TokenService, useClass: TokenStubService },
+        { provide: UserService, useClass: UserStubService }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/loginComponents/auth/auth.component.ts
+++ b/src/app/loginComponents/auth/auth.component.ts
@@ -6,6 +6,7 @@ import { Provider } from '../../shared/enum/provider.enum';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TokenService } from '../token.service';
+import { UserService } from '../user.service';
 
 @Component({
   selector: 'app-auth',
@@ -15,7 +16,7 @@ export class AuthComponent implements OnInit, OnDestroy {
 
   tokenSubscription: ISubscription;
 
-  constructor(private tokenService: TokenService,
+  constructor(private tokenService: TokenService, private userService: UserService,
               private activatedRoute: ActivatedRoute,
               private router: Router) { }
 
@@ -69,9 +70,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const prevPage = localStorage.getItem('page');
 
     this.tokenSubscription = this.addToken().subscribe(token => {
-      if (token) {
-        this.tokenService.updateTokens();
-      }
+      this.userService.updateUser();
       this.router.navigate([`${ prevPage }`]);
     }, error => {
       this.router.navigate([`${ prevPage }`]);

--- a/src/app/loginComponents/token.service.ts
+++ b/src/app/loginComponents/token.service.ts
@@ -66,7 +66,7 @@ export class TokenService {
     this.tokens$.next(tokens);
   }
 
-  updateTokens() {
+  private updateTokens() {
     this.usersService.getUserTokens(this.user.id).subscribe(token => this.setTokens(token));
   }
 

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -413,6 +413,8 @@ export class LogoutStubService {
 export class UserStubService {
     userId$ = observableOf(5);
     user$ = observableOf({});
+    updateUser() {
+    }
 }
 
 export class TokenStubService {


### PR DESCRIPTION
For ga4gh/dockstore#1370

Primarily to fix the user profile not being shown after token link.  

Does so in the following way:

The token service subscribes to the user object.  Every time the user object changes, it grabs a fresh set of tokens.  Therefore, in order to grab the tokens, just update the user object.  Take care in not grabbing the user after the tokens, otherwise leads to infinite loop.

Also removed the unlinkToken function because that artificially unlinks the account in the UI instead of looking at the tokens and determining whether it's linked or not.
