### PR TITLE
WIP: Better Handling for Permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - oraclejdk8
 env:
   global:
-    - WEBSERVICE_VERSION="1.5.0-alpha.7"
+    - WEBSERVICE_VERSION="1.5.0-alpha.8"
   matrix:
     - RUN_PROD=false
     - RUN_PROD=true

--- a/cypress/integration/sharedWorkflows.js
+++ b/cypress/integration/sharedWorkflows.js
@@ -10,23 +10,23 @@ describe('Shared with me workflow test from my-workflows', function() {
       cy
       .route({
         method: "GET",
-        url: /readertest\/permissions/,
-        response: [{"email":"user_A","role":"READER"}]
-      }).as('readerPermissions')
+        url: /readertest\/actions/,
+        response: ["READ"]
+      }).as('readerActions')
 
       cy
       .route({
         method: "GET",
-        url: /writertest\/permissions/,
-        response: [{"email":"user_A","role":"WRITER"}]
-      }).as('writerPermissions')
+        url: /writertest\/actions/,
+        response: ["READ", "WRITE"]
+      }).as('writerActions')
 
       cy
       .route({
         method: "GET",
-        url: /ownertest\/permissions/,
-        response: [{"email":"user_A","role":"OWNER"}]
-      }).as('ownerPermissions')
+        url: /ownertest\/actions/,
+        response: ["READ", "WRITE", "SHARE", "DELETE"]
+      }).as('ownerActions')
 
       let readerWorkflow = createHostedWorkflow('readertest', 200)
       let writerWorkflow = createHostedWorkflow('writertest', 201);

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -164,7 +164,7 @@
           <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> To see the DAG, please refresh the workflow.
         </div>
       </tab>
-      <tab *ngIf="!isPublic() && isHosted() && isUserOwner()" id="permissionsTab" heading="Permissions" (select)="setEntryTab('permissions')">
+      <tab *ngIf="!isPublic() && isHosted() && isOwner" id="permissionsTab" heading="Permissions" (select)="setEntryTab('permissions')">
         <app-permissions [workflow]="workflow"></app-permissions>
       </tab>
     </tabset>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -79,14 +79,10 @@ export class WorkflowComponent extends Entry {
     this.resourcePath = this.location.prepareExternalUrl(this.location.path());
   }
 
-  private processResponse(userPermissions: Permission[]): void {
+  private processPermissions(userPermissions: Permission[]): void {
     this.owners = this.specificPermissionEmails(userPermissions, RoleEnum.OWNER);
     this.writers = this.specificPermissionEmails(userPermissions, RoleEnum.WRITER);
     this.readers = this.specificPermissionEmails(userPermissions, RoleEnum.READER);
-
-    this.canRead = this.canUserRead();
-    this.canWrite = this.canUserWrite();
-    this.isOwner = this.isUserOwner();
   }
 
   private specificPermissionEmails(permissions: Permission[], role: RoleEnum): string[] {
@@ -149,13 +145,22 @@ export class WorkflowComponent extends Entry {
       if (this.publicPage) {
         this.sortedVersions = this.dockstoreService.getValidVersions(this.sortedVersions);
       }
-      this.workflowsService.getWorkflowPermissions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe)).subscribe(
-        (userPermissions: Permission[]) => {
-          this.processResponse(userPermissions);
-        },
-        () => {
-        }
-      );
+      this.canRead = this.canWrite = this.isOwner = false;
+      this.readers = this.writers = this.owners = [];
+      this.workflowsService.getWorkflowActions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe((actions: Array<string>) => {
+          // Alas, Swagger codegen does not generate a type for the actions
+          this.canRead = actions.indexOf('READ') !== -1;
+          this.canWrite = actions.indexOf('WRITE') !== -1;
+          this.isOwner = actions.indexOf('SHARE') !== -1;
+          if (this.isOwner) {
+            this.workflowsService.getWorkflowPermissions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe))
+              .subscribe((userPermissions: Permission[]) => {
+                this.processPermissions(userPermissions);
+              }
+            );
+          }
+        });
     }
   }
 
@@ -353,50 +358,4 @@ export class WorkflowComponent extends Entry {
     }
   }
 
-  /**
-   * True if user is in users list, or username is in read,write,owner permissions, false otherwise
-   */
-  canUserRead(): boolean {
-    const username = this.user && this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.readers.includes(username) || this.writers.includes(username) || this.owners.includes(username) ;
-  }
-
-  /**
-   * True if user is in users list, or username is in write or owner permissions, false otherwise
-   */
-  canUserWrite(): boolean {
-    const username = this.user && this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.writers.includes(username) || this.owners.includes(username);
-  }
-
-  /**
-   * True if user is in users list, or username is in owner permissions, false otherwise
-   */
-  isUserOwner(): boolean {
-    const username = this.user && this.user.username;
-    if (this.isInUserArray(username)) {
-      return true;
-    }
-    return this.owners.includes(username);
-  }
-
-  /**
-   * True if username is in the workflow user array, false otherwise
-   * @param username
-   */
-  isInUserArray(username: string): boolean {
-    if (this.workflow.users) {
-      const match = this.workflow.users.find((user) => user.username === username);
-      if (match !== undefined) {
-        return true;
-      }
-    }
-    return false;
-  }
 }

--- a/travisci/web.yml
+++ b/travisci/web.yml
@@ -12,9 +12,12 @@ bitbucketClientSecret: <bitbucket secret here>
 googleClientID: <fill me in>
 googleClientSecret: <fill me in>
 googleRedirectURI: http://localhost:8080/auth/tokens/google.com
-hostname: localhost
-scheme: http
-port: 8080
+
+externalConfig:
+  basePath: /
+  hostname: localhost
+  scheme: http
+  port: 8080
 
 authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
 

--- a/travisci/web.yml
+++ b/travisci/web.yml
@@ -13,6 +13,8 @@ googleClientID: <fill me in>
 googleClientSecret: <fill me in>
 googleRedirectURI: http://localhost:8080/auth/tokens/google.com
 
+authorizerType: inmemory
+
 externalConfig:
   basePath: /
   hostname: localhost


### PR DESCRIPTION
UI portion of ga4gh/dockstore#1589

This has a dependency on PR ga4gh/dockstore#1638, which has a new
endpoint.

Call new endpoint to get allowable actions. If SHARE action is one
of the actions, then user is an owner, and go ahead and fetch all
permissions for the workflow.

Unfortunately, generated TS code doesn't generate a type for the enum
returned by Actions.