### PR TITLE
Better error handling for permissions

### DIFF
--- a/src/app/workflow/permissions/permissions.component.ts
+++ b/src/app/workflow/permissions/permissions.component.ts
@@ -56,7 +56,12 @@ export class PermissionsComponent implements OnInit {
         this.updating--;
         this.processResponse(userPermissions);
       },
-      () => this.updating--
+      (e) => {
+        this.updating--;
+        const message = e.error || `Error removing user ${entity}.`;
+        this.snackBar.open(message,
+          'Dismiss', {duration: 5000});
+      }
     );
   }
 
@@ -73,7 +78,8 @@ export class PermissionsComponent implements OnInit {
         },
         (e) => {
           this.updating--;
-          this.snackBar.open(`Error adding user ${value}. Please make sure ${value} is registered with FireCloud`,
+          const message = e.error || `Error adding user ${value}. Please make sure ${value} is registered with FireCloud`;
+          this.snackBar.open(message,
             'Dismiss', {duration: 5000});
         }
       );


### PR DESCRIPTION
Related to ga4gh/dockstore#1657, now that the PR there returns
an error message when trying to change the permissions of an
original owner.

1. When removing a user failed, wasn't displaying an feedback at all.
2. Now by default display the message that comes back from the
API; have a default message if it is not present.