### PR TITLE
Use bootstrap 4 classes, fix workflow version editor form style

### DIFF
--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -94,7 +94,7 @@
               </div>
             </div>
             <div class="col-sm-9 col-md-9 col-lg-9" [ngClass]="{'col-sm-offset-3' : unsavedCWLTestParameterFilePaths.length > 0}" *ngIf="editMode">
-              <div class="input-group full-width">
+              <div class="input-group">
                 <input [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="cwlTestParameterFilePath" [(ngModel)]="unsavedTestCWLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a CWL Test Parameter File in the Git repository." placeholder="e.g. /test.cwl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''"/>
                 <span class="input-group-btn">
                   <button title="Add CWL test parameter file" type="button" class="btn btn-default form-sm-button" [disabled]="hasDuplicateTestJson('cwl')" (click)="addTestParameterFile(DescriptorType.CWL)" *ngIf="editMode && !(model1.invalid || unsavedTestCWLFile.length == 0)">
@@ -121,7 +121,7 @@
             <label class="col-sm-3 col-md-3 col-lg-3 control-label">
               WDL Test Parameter File(s):
             </label>
-            <div class="col-sm-9 col-md-9 col-lg-9 form-margin" *ngFor="let item of unsavedWDLTestParameterFilePaths; let i = index;trackBy:trackByIndex;">
+            <div class="col-sm-9 col-md-9 col-lg-9 form-margin" [ngClass]="{ 'col-sm-offset-3' : i > 0 }" *ngFor="let item of unsavedWDLTestParameterFilePaths; let i = index;trackBy:trackByIndex;">
               <div class="input-group">
                 <input [ngClass]="{ 'input-right-button' : editMode, 'input-no-button' : !editMode }" type="text" class="form-control" name="unsavedWDLTestParameterFilePaths[{{i}}]" [(ngModel)]="unsavedWDLTestParameterFilePaths[i]" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" disabled ng-class="editMode ? 'test_parameter_input' : ''" />
                 <span class="input-group-btn">
@@ -132,7 +132,7 @@
               </div>
             </div>
             <div class="col-sm-9 col-md-9 col-lg-9" [ngClass]="{'col-sm-offset-3' : unsavedWDLTestParameterFilePaths.length > 0}" *ngIf="editMode">
-              <div class="input-group full-width">
+              <div class="input-group">
                 <input [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="wdlTestParameterFilePath" [(ngModel)]="unsavedTestWDLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''"/>
                 <span class="input-group-btn">
                   <button title="Add WDL test parameter file" type="button" class="btn btn-default form-sm-button" [disabled]="hasDuplicateTestJson('wdl')" (click)="addTestParameterFile(DescriptorType.WDL)" *ngIf="editMode && !(model1.invalid || unsavedTestWDLFile.length == 0)">

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -170,7 +170,7 @@
       <div class="panel-body">
         <div>
           <span *ngFor="let sortedVersion of sortedVersions">
-            <p class="top-down-padding no-margin">
+            <p class="top-down-padding m-0">
               <span id="verifiedIcon" *ngIf="sortedVersion?.verified">
                 <a href= {{getVerifiedLink()}} class="verified-check">
                   <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
@@ -179,7 +179,7 @@
               <a (click)="onSelectedVersionChange(sortedVersion)">{{sortedVersion?.name}} </a>
               <small>{{sortedVersion.last_modified | date}}</small>
             </p>
-            <hr class="no-margin">
+            <hr class="m-0">
           </span>
           <a (click)="selectTab(2)">See all tags</a>
         </div>

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -15,7 +15,7 @@
   -->
 
 <div>
-  <span *ngIf="_selectedVersion?.valid && !nullDescriptors" class="row no-margin">
+  <span *ngIf="_selectedVersion?.valid && !nullDescriptors" class="row m-0">
     <span class="form-group col-sm-4">
       <strong>Descriptor Type:</strong>
       <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
@@ -33,7 +33,7 @@
     </alert>
   </div>
 
-  <div *ngIf="content && _selectedVersion?.valid" class="row no-margin">
+  <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
       <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/container/dockerfile/dockerfile.component.html
+++ b/src/app/container/dockerfile/dockerfile.component.html
@@ -21,7 +21,7 @@
       &nbsp;A Dockerfile associated with this Docker container could not be found.
     </alert>
   </div>
-  <div *ngIf="!nullContent && _selectedVersion?.valid" class="row no-margin">
+  <div *ngIf="!nullContent && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group" role="group">
       <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 <div>
-  <span *ngIf="content != null && _selectedVersion?.valid" class="row no-margin">
+  <span *ngIf="content != null && _selectedVersion?.valid" class="row m-0">
     <span class="form-group col-sm-4">
       <strong>Descriptor Type:</strong>
       <app-select [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
@@ -30,7 +30,7 @@
       &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
     </alert>
   </div>
-  <div *ngIf="content && _selectedVersion?.valid" class="row no-margin">
+  <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
       <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -101,7 +101,7 @@
               </div>
             </div>
             <div class="col-sm-9 col-md-9 col-lg-9" [ngClass]="{'col-sm-offset-3' : unsavedCWLTestParameterFilePaths.length > 0}" *ngIf="editMode">
-              <div class="input-group full-width">
+              <div class="input-group">
                 <input id="addCWLField" [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="cwlTestParameterFilePath" [(ngModel)]="unsavedTestCWLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a CWL Test Parameter File in the Git repository." placeholder="e.g. /test.cwl.json" [disabled]="!editMode || tool?.mode === DockstoreToolType.ModeEnum.HOSTED" ng-class="editMode ? 'test_parameter_input' : ''"/>
                 <span class="input-group-btn">
                   <button title="Add CWL test parameter file" type="button" class="btn btn-default form-sm-button" [disabled]="hasDuplicateTestJson(DescriptorType.CWL) || tool?.mode === DockstoreToolType.ModeEnum.HOSTED" (click)="addTestParameterFile(DescriptorType.CWL)" *ngIf="editMode && !(model1.invalid || unsavedTestCWLFile.length == 0)">
@@ -139,7 +139,7 @@
               </div>
             </div>
             <div class="col-sm-9 col-md-9 col-lg-9" [ngClass]="{'col-sm-offset-3' : unsavedWDLTestParameterFilePaths.length > 0}" *ngIf="editMode">
-              <div class="input-group full-width">
+              <div class="input-group">
                 <input id="addWDLField" [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="wdlTestParameterFilePath" [(ngModel)]="unsavedTestWDLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository." placeholder="e.g. /test.wdl.json" [disabled]="!editMode || tool?.mode === DockstoreToolType.ModeEnum.HOSTED" ng-class="editMode ? 'test_parameter_input' : ''"/>
                 <span class="input-group-btn">
                   <button title="Add WDL test parameter file" type="button" class="btn btn-default form-sm-button"[disabled]="hasDuplicateTestJson(DescriptorType.WDL) || tool?.mode === DockstoreToolType.ModeEnum.HOSTED" (click)="addTestParameterFile(DescriptorType.WDL)" *ngIf="editMode && !(model1.invalid || unsavedTestWDLFile.length == 0)">

--- a/src/app/containers/list/list.component.html
+++ b/src/app/containers/list/list.component.html
@@ -17,8 +17,8 @@
   <div *ngIf="(dataSource.loading$ | async); else placeholder">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
-  <ng-template #placeholder class="pt-1">
-    <div class="pt-1"></div>
+  <ng-template #placeholder>
+    <div class="pt-2"></div>
   </ng-template>
   <div [hidden]="previewMode">
     <mat-form-field>

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -21,7 +21,7 @@
       </button>
     </div>
   </app-header>
-  <div class="container padding-top">
+  <div class="container pt-3">
     <app-alert></app-alert>
     <!--Msg/Warning Page, this should be a Component-->
     <div class="row" *ngIf="groupEntriesObject?.length == 0 || !groupEntriesObject">

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -17,7 +17,7 @@
   <button mat-icon-button (click)="toggleSidebar()"><mat-icon>menu</mat-icon></button>
   <img src="../assets/images/dockstore/dockstore-workflows-green.png"> My Workflows
 </app-header>
-<div class="container-fluid padding-top sidebar-set-height">
+<div class="container-fluid pt-3 sidebar-set-height">
   <!--Tool Content Page-->
   <div class="row containers-rsb" style="height:100%;">
     <mat-sidenav-container autosize class="sidebar-set-height">

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -66,7 +66,7 @@
                   </p>
               </div>
           </li>
-          <li *ngIf=isLoggedIn class="btn-group no-margin" dropdown>
+          <li *ngIf=isLoggedIn class="btn-group m-0" dropdown>
               <div class="button login">
                   <a href dropdownToggle (click)="false" id="dropdown-main" class="account-dropdown dropdown-toggle">
                       <span class="glyphicon glyphicon-user"></span>

--- a/src/app/shared/refresh-organization/refresh-organization.component.html
+++ b/src/app/shared/refresh-organization/refresh-organization.component.html
@@ -14,6 +14,6 @@
   ~    limitations under the License.
   -->
 
-<button mat-mini-fab color="accent" matTooltip="Refresh organization" [matTooltipShowDelay]="1000" [matTooltipPosition]="'after'" type="button" class=" mr-1" (click)="refreshOrganization()" [disabled]="toDisable()">
+<button mat-mini-fab color="accent" matTooltip="Refresh organization" [matTooltipShowDelay]="1000" [matTooltipPosition]="'after'" type="button" class="mr-1" (click)="refreshOrganization()" [disabled]="toDisable()">
     <mat-icon>refresh</mat-icon>
 </button>

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 <div>
-  <span *ngIf="_selectedVersion?.valid" class="row no-margin">
+  <span *ngIf="_selectedVersion?.valid" class="row m-0">
     <span class="form-group col-sm-4">
       <strong>File:</strong>
       <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
@@ -26,7 +26,7 @@
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </alert>
   </div>
-  <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="row no-margin">
+  <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group" role="group">
       <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -15,7 +15,7 @@
   -->
 
 <div>
-  <span *ngIf="_selectedVersion?.valid && content" class="row no-margin">
+  <span *ngIf="_selectedVersion?.valid && content" class="row m-0">
     <span class="form-group col-sm-4">
       <strong>File:</strong>
       <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
@@ -23,7 +23,7 @@
   </span>
   <span *ngIf="content" class="input-group-btn code-copy">
   </span>
-  <div *ngIf="content && _selectedVersion?.valid" class="row no-margin">
+  <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
       <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
         <span class="glyphicon glyphicon-download"></span>

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -75,7 +75,7 @@
                 </div>
               </div>
               <div class="col-sm-9 col-md-9 col-lg-9" [ngClass]="{'col-sm-offset-3' : testParameterFilePaths.length > 0}" *ngIf="!isPublic">
-                <div class="input-group full-width">
+                <div class="input-group">
                   <input [ngClass]="{ 'input-right-button' : !isPublic }" type="text" #model1="ngModel" class="form-control" name="cwlTestParameterFilePath" [(ngModel)]="testParameterFilePath"
                     minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" placeholder="e.g. /test.cwl.json" [disabled]="isPublic || !canWrite || workflow?.mode === WorkflowType.ModeEnum.HOSTED"
                     ng-class="!isPublic ? 'test_parameter_input' : ''" />

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -178,7 +178,7 @@
       <div class="panel-body">
         <div>
           <span *ngFor="let sortedVersion of sortedVersions">
-            <p class="top-down-padding no-margin">
+            <p class="top-down-padding m-0">
               <span id="verifiedIcon" *ngIf="sortedVersion?.verified">
                 <a href= {{getVerifiedLink()}} class="verified-check">
                   <span class="glyphicon glyphicon-ok" tooltip="Verified"></span>
@@ -187,7 +187,7 @@
               <a (click)="onSelectedVersionChange(sortedVersion)">{{sortedVersion.name}} </a>
               <small>{{sortedVersion.last_modified | date}}</small>
             </p>
-            <hr class="no-margin">
+            <hr class="m-0">
           </span>
           <a (click)="selectTab(2)">See all versions</a>
         </div>

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -17,8 +17,8 @@
   <div *ngIf="(dataSource.loading$ | async); else placeholder">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
-  <ng-template #placeholder class="pt-1">
-    <div class="pt-1"></div>
+  <ng-template #placeholder>
+    <div class="pt-2"></div>
   </ng-template>
   <div [hidden]="previewMode">
     <mat-form-field>

--- a/src/bootstrap4.scss
+++ b/src/bootstrap4.scss
@@ -1,0 +1,379 @@
+/*
+ *     Copyright 2018 OICR
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+ /* These classes are from bootstrap v4.1.3.
+  * If we never migrate to bootstrap 4+, keep these because they're generally useful.
+  * If we do migrate, remove this file.
+  */
+.w-25 {
+  width: 25% !important;
+}
+
+.w-50 {
+  width: 50% !important;
+}
+
+.w-75 {
+  width: 75% !important;
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.w-auto {
+  width: auto !important;
+}
+
+.h-25 {
+  height: 25% !important;
+}
+
+.h-50 {
+  height: 50% !important;
+}
+
+.h-75 {
+  height: 75% !important;
+}
+
+.h-100 {
+  height: 100% !important;
+}
+
+.h-auto {
+  height: auto !important;
+}
+
+.mw-100 {
+  max-width: 100% !important;
+}
+
+.mh-100 {
+  max-height: 100% !important;
+}
+
+.m-0 {
+  margin: 0 !important;
+}
+
+.mt-0,
+.my-0 {
+  margin-top: 0 !important;
+}
+
+.mr-0,
+.mx-0 {
+  margin-right: 0 !important;
+}
+
+.mb-0,
+.my-0 {
+  margin-bottom: 0 !important;
+}
+
+.ml-0,
+.mx-0 {
+  margin-left: 0 !important;
+}
+
+.m-1 {
+  margin: 0.25rem !important;
+}
+
+.mt-1,
+.my-1 {
+  margin-top: 0.25rem !important;
+}
+
+.mr-1,
+.mx-1 {
+  margin-right: 0.25rem !important;
+}
+
+.mb-1,
+.my-1 {
+  margin-bottom: 0.25rem !important;
+}
+
+.ml-1,
+.mx-1 {
+  margin-left: 0.25rem !important;
+}
+
+.m-2 {
+  margin: 0.5rem !important;
+}
+
+.mt-2,
+.my-2 {
+  margin-top: 0.5rem !important;
+}
+
+.mr-2,
+.mx-2 {
+  margin-right: 0.5rem !important;
+}
+
+.mb-2,
+.my-2 {
+  margin-bottom: 0.5rem !important;
+}
+
+.ml-2,
+.mx-2 {
+  margin-left: 0.5rem !important;
+}
+
+.m-3 {
+  margin: 1rem !important;
+}
+
+.mt-3,
+.my-3 {
+  margin-top: 1rem !important;
+}
+
+.mr-3,
+.mx-3 {
+  margin-right: 1rem !important;
+}
+
+.mb-3,
+.my-3 {
+  margin-bottom: 1rem !important;
+}
+
+.ml-3,
+.mx-3 {
+  margin-left: 1rem !important;
+}
+
+.m-4 {
+  margin: 1.5rem !important;
+}
+
+.mt-4,
+.my-4 {
+  margin-top: 1.5rem !important;
+}
+
+.mr-4,
+.mx-4 {
+  margin-right: 1.5rem !important;
+}
+
+.mb-4,
+.my-4 {
+  margin-bottom: 1.5rem !important;
+}
+
+.ml-4,
+.mx-4 {
+  margin-left: 1.5rem !important;
+}
+
+.m-5 {
+  margin: 3rem !important;
+}
+
+.mt-5,
+.my-5 {
+  margin-top: 3rem !important;
+}
+
+.mr-5,
+.mx-5 {
+  margin-right: 3rem !important;
+}
+
+.mb-5,
+.my-5 {
+  margin-bottom: 3rem !important;
+}
+
+.ml-5,
+.mx-5 {
+  margin-left: 3rem !important;
+}
+
+.p-0 {
+  padding: 0 !important;
+}
+
+.pt-0,
+.py-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0,
+.px-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0,
+.py-0 {
+  padding-bottom: 0 !important;
+}
+
+.pl-0,
+.px-0 {
+  padding-left: 0 !important;
+}
+
+.p-1 {
+  padding: 0.25rem !important;
+}
+
+.pt-1,
+.py-1 {
+  padding-top: 0.25rem !important;
+}
+
+.pr-1,
+.px-1 {
+  padding-right: 0.25rem !important;
+}
+
+.pb-1,
+.py-1 {
+  padding-bottom: 0.25rem !important;
+}
+
+.pl-1,
+.px-1 {
+  padding-left: 0.25rem !important;
+}
+
+.p-2 {
+  padding: 0.5rem !important;
+}
+
+.pt-2,
+.py-2 {
+  padding-top: 0.5rem !important;
+}
+
+.pr-2,
+.px-2 {
+  padding-right: 0.5rem !important;
+}
+
+.pb-2,
+.py-2 {
+  padding-bottom: 0.5rem !important;
+}
+
+.pl-2,
+.px-2 {
+  padding-left: 0.5rem !important;
+}
+
+.p-3 {
+  padding: 1rem !important;
+}
+
+.pt-3,
+.py-3 {
+  padding-top: 1rem !important;
+}
+
+.pr-3,
+.px-3 {
+  padding-right: 1rem !important;
+}
+
+.pb-3,
+.py-3 {
+  padding-bottom: 1rem !important;
+}
+
+.pl-3,
+.px-3 {
+  padding-left: 1rem !important;
+}
+
+.p-4 {
+  padding: 1.5rem !important;
+}
+
+.pt-4,
+.py-4 {
+  padding-top: 1.5rem !important;
+}
+
+.pr-4,
+.px-4 {
+  padding-right: 1.5rem !important;
+}
+
+.pb-4,
+.py-4 {
+  padding-bottom: 1.5rem !important;
+}
+
+.pl-4,
+.px-4 {
+  padding-left: 1.5rem !important;
+}
+
+.p-5 {
+  padding: 3rem !important;
+}
+
+.pt-5,
+.py-5 {
+  padding-top: 3rem !important;
+}
+
+.pr-5,
+.px-5 {
+  padding-right: 3rem !important;
+}
+
+.pb-5,
+.py-5 {
+  padding-bottom: 3rem !important;
+}
+
+.pl-5,
+.px-5 {
+  padding-left: 3rem !important;
+}
+
+.m-auto {
+  margin: auto !important;
+}
+
+.mt-auto,
+.my-auto {
+  margin-top: auto !important;
+}
+
+.mr-auto,
+.mx-auto {
+  margin-right: auto !important;
+}
+
+.mb-auto,
+.my-auto {
+  margin-bottom: auto !important;
+}
+
+.ml-auto,
+.mx-auto {
+  margin-left: auto !important;
+}

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -665,10 +665,6 @@ div.contact-button {
   }
 }
 
-.padding-top {
-  padding-top: 12px;
-}
-
 .center-image {
   display: block;
   margin-left: auto;
@@ -682,10 +678,6 @@ div.contact-button {
 .accordion-hr {
   margin-top:5px;
   margin-bottom:5px;
-}
-
-.mr-1 {
-  margin-right:5px;
 }
 
 .verified-check:hover, .verified-check:visited {
@@ -725,10 +717,6 @@ div.contact-button {
 
 .small-bottom-margin {
   margin-bottom: 5px;
-}
-
-.full-width {
-  width: 100%;
 }
 
 .right-button {

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -724,10 +724,6 @@ div.contact-button {
   border-bottom-left-radius: 0;
 }
 
-.no-margin {
-  margin:0px;
-}
-
 .ds-green {
   color: #487980 !important;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -211,10 +211,6 @@ nav > .container {
   box-shadow: none;
 }
 
-.no-margin {
-  margin: 0px !important;
-}
-
 p {
   font-size: 14px;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,7 +15,7 @@
  */
 
 @import "ds-style-fix.scss";
-
+@import "bootstrap4.scss";
 /*@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,600);*/
 
 
@@ -395,10 +395,6 @@ img.site-icons-tab {
 
 .button.login p {
   line-height: 2.2em;
-}
-
-.pt-1 {
-  padding-top: 5px;
 }
 
 .search {
@@ -1051,11 +1047,6 @@ div.tabs>div:target>div,
 
 .search-date {
   color: #808080;
-}
-
-.my-1 {
-  margin-top: 5px;
-  margin-bottom: 5px;
 }
 
 .ellipsis-lines {


### PR DESCRIPTION
- Fixes the WDL test parameter files style in the version modal.
- Added partial bootstrap 4 utility style classes because they've been useful and will be useful
- Remove several generic style (there should be many more to remove at some later point in time)

If we never migrate to bootstrap 4+, keep these because they're generally useful.
If we do migrate, remove this file.