### PR TITLE
Add version to checker entry2json convert command

### DIFF
--- a/src/app/container/launch/launch.component.html
+++ b/src/app/container/launch/launch.component.html
@@ -62,7 +62,7 @@
           <pre>{{ consonance }}</pre>
         </div>
       </div>
-      <app-launch-checker-workflow [command]="checkEntryCommand"></app-launch-checker-workflow>
+      <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
     </div>
   </div>
 </div>

--- a/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.html
+++ b/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.html
@@ -1,6 +1,21 @@
+<!--
+    Copyright 2018 OICR
+
+    Licensed under the Apache License, Version 2.0 (the "License")
+    you may not use this file except in compliance with the License
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <div id="launchCheckerWorkflow" *ngIf="checkerWorkflowPath$ | async" class="well well-sm" tooltip="Commands for running the checker workflow of this tool/workflow through Dockstore CLI">
   Run a checker workflow with:
   <pre>{{ command }}</pre>
   Make a runtime JSON template and fill in desired inputs, outputs, and other parameters from the checker workflow with:
-  <pre>dockstore workflow convert entry2json --entry {{checkerWorkflowPath$ | async}} > Dockstore.json</pre>
+  <pre>dockstore workflow convert entry2json --entry {{checkerWorkflowPath$ | async}}{{versionName ? ':' + versionName : ''}} > Dockstore.json</pre>
 </div>

--- a/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.ts
+++ b/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.ts
@@ -25,6 +25,7 @@ import { CheckerWorkflowService } from './../../checker-workflow.service';
 })
 export class LaunchCheckerWorkflowComponent implements OnInit {
   @Input() command: string;
+  @Input() versionName: string;
   command$: Observable<string>;
   checkerWorkflowPath$: Observable<string>;
   constructor(private checkerWorkflowService: CheckerWorkflowService) {

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -52,7 +52,7 @@
           <pre>{{ dockstoreSupportedCwlMakeTemplate }}</pre>
         </div>
       </div>
-      <app-launch-checker-workflow [command]="checkEntryCommand"></app-launch-checker-workflow>
+      <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The checker entry2json convert command was missing the version name.  This fixes it.