### PR TITLE
Feature/material buttons files

### DIFF
--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -35,20 +35,21 @@
 
   <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
-      <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
+      <a mat-mini-fab color="primary" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+        <mat-icon>save_alt</mat-icon>
       </a>
       <ng-template #unpublishedDownloadLink>
-        <a [href]="customDownloadHREF" [download]="customDownloadPath" class="btn btn-default" type="button" title="{{filePath}}">
-          <span class="glyphicon glyphicon-download"></span>
+        <a mat-mini-fab color="primary" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+          <mat-icon>save_alt</mat-icon>
         </a>
       </ng-template>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
-        <span class="glyphicon glyphicon-copy"></span>
+      <button mat-mini-fab color="primary" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
+        <mat-icon>file_copy</mat-icon>
       </button>
     </div>
-    <div [hidden]="!content || !_selectedVersion?.valid">
-      <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
-    </div>
+  </div>
+
+  <div [hidden]="!content || !_selectedVersion?.valid">
+    <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>
 </div>

--- a/src/app/container/dockerfile/dockerfile.component.html
+++ b/src/app/container/dockerfile/dockerfile.component.html
@@ -23,16 +23,16 @@
   </div>
   <div *ngIf="!nullContent && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group" role="group">
-      <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
+      <a mat-mini-fab color="primary" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+        <mat-icon>save_alt</mat-icon>
       </a>
       <ng-template #unpublishedDownloadLink>
-        <a [href]="customDownloadHREF" [download]="customDownloadPath" class="btn btn-default" type="button" title="{{filePath}}">
-          <span class="glyphicon glyphicon-download"></span>
+        <a mat-mini-fab color="primary" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+          <mat-icon>save_alt</mat-icon>
         </a>
       </ng-template>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
-        <span class="glyphicon glyphicon-copy"></span>
+      <button mat-mini-fab color="primary" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
+        <mat-icon>file_copy</mat-icon>
       </button>
     </div>
   </div>

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -30,21 +30,21 @@
       &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
     </alert>
   </div>
+  </div>
   <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
-      <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
+      <a mat-mini-fab color="primary" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+        <mat-icon>save_alt</mat-icon>
       </a>
       <ng-template #unpublishedDownloadLink>
-        <a [href]="customDownloadHREF" [download]="customDownloadPath" class="btn btn-default" type="button" title="{{filePath}}">
-          <span class="glyphicon glyphicon-download"></span>
+        <a mat-mini-fab color="primary" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+          <mat-icon>save_alt</mat-icon>
         </a>
       </ng-template>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
-        <span class="glyphicon glyphicon-copy"></span>
+      <button mat-mini-fab color="primary" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
+        <mat-icon>file_copy</mat-icon>
       </button>
     </div>
-  </div>
   <div [hidden]="!content || !_selectedVersion?.valid">
     <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.html
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.html
@@ -1,12 +1,12 @@
 <ngx-md [data]="textData1"></ngx-md>
-<a *ngIf="downloadCli" class="btn btn-primary hori-offset-12 indent" [attr.href]="downloadCli">
-  <span class=" glyphicon glyphicon-download"></span>
+<a mat-raised-button color="primary" *ngIf="downloadCli" class="hori-offset-12 indent" [attr.href]="downloadCli">
+  <mat-icon>save_alt</mat-icon>
   Download CLI
 </a>
 <ngx-md [data]="textData2"></ngx-md>
 <div class="input-group textarea indent">
   <textarea type="textarea" class="form-control textarea clip" readonly #inputTarget>
-    token: {{dsToken}} 
+    token: {{dsToken}}
     server-url: {{dsServerURI}}</textarea>
   <span class="input-group-btn">
     <button class="btn btn-default textarea btn" [ngClass]="{'btn-copy':isCopied2}" type="button" [ngxClipboard]="inputTarget" (cbOnSuccess)="isCopied2 = true">

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.spec.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.spec.ts
@@ -8,6 +8,7 @@ import { GA4GHService } from './../../../shared/swagger/api/gA4GH.service';
 import { RouterLinkStubDirective, RouterOutletStubComponent } from './../../../test/router-stubs';
 import { AuthStubService, GA4GHStubService } from './../../../test/service-stubs';
 import { DownloadCLIClientComponent } from './downloadcliclient.component';
+import { MatIconModule, MatButtonModule } from '@angular/material';
 
 describe('DownloadCLIClientComponent', () => {
   let component: DownloadCLIClientComponent;
@@ -17,7 +18,7 @@ describe('DownloadCLIClientComponent', () => {
     TestBed.configureTestingModule({
       declarations: [DownloadCLIClientComponent,
         RouterLinkStubDirective, RouterOutletStubComponent],
-      imports: [ClipboardModule, NgxMdModule.forRoot()],
+      imports: [ClipboardModule, NgxMdModule.forRoot(), MatIconModule, MatButtonModule],
       providers: [
         { provide: AuthService, useClass: AuthStubService },
         { provide: GA4GHService, useClass: GA4GHStubService },

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -28,16 +28,16 @@
   </div>
   <div *ngIf="!this.nullDescriptors && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group" role="group">
-      <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
+      <a mat-mini-fab color="primary" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+        <mat-icon>save_alt</mat-icon>
       </a>
       <ng-template #unpublishedDownloadLink>
-        <a [href]="customDownloadHREF" [download]="customDownloadPath" class="btn btn-default" type="button" title="{{filePath}}">
-          <span class="glyphicon glyphicon-download"></span>
+        <a mat-mini-fab color="primary" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+            <mat-icon>save_alt</mat-icon>
         </a>
       </ng-template>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content">
-        <span class="glyphicon glyphicon-copy"></span>
+      <button mat-mini-fab color="primary" type="button" ngxClipboard [cbContent]="content">
+          <mat-icon>file_copy</mat-icon>
       </button>
     </div>
   </div>

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -25,16 +25,16 @@
   </span>
   <div *ngIf="content && _selectedVersion?.valid" class="row m-0">
     <div class="btn-group">
-      <a *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" class="btn btn-default" type="button" title="{{filePath}}">
-        <span class="glyphicon glyphicon-download"></span>
+      <a mat-mini-fab color="primary" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+        <mat-icon>save_alt</mat-icon>
       </a>
       <ng-template #unpublishedDownloadLink>
-        <a [href]="customDownloadHREF" [download]="customDownloadPath" class="btn btn-default" type="button" title="{{filePath}}">
-          <span class="glyphicon glyphicon-download"></span>
+        <a mat-mini-fab color="primary" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+          <mat-icon>save_alt</mat-icon>
         </a>
       </ng-template>
-      <button class="btn btn-default" type="button" ngxClipboard [cbContent]="content">
-        <span class="glyphicon glyphicon-copy"></span>
+      <button mat-mini-fab color="primary" type="button" ngxClipboard [cbContent]="content">
+        <mat-icon>file_copy</mat-icon>
       </button>
     </div>
   </div>


### PR DESCRIPTION
Changes the buttons for file copy and download to material. Ideally in the future we should have these floating above the file content.

![download-button](https://user-images.githubusercontent.com/6331159/43595554-f5e4a8a2-964a-11e8-8933-da8245745b9f.png)
