### PR TITLE
Feature/hide change username onboarding

### DIFF
--- a/src/app/loginComponents/accounts/controls/controls.component.html
+++ b/src/app/loginComponents/accounts/controls/controls.component.html
@@ -11,7 +11,7 @@
 
   <mat-card>
     <h3>Delete your Dockstore Account</h3>
+    <p>Only available for accounts with no published tools/workflows.</p>
     <button class="mr-1" mat-raised-button color="warn" (click)="deleteAccount()" [disabled]="isDisabled">Delete Dockstore Account</button>
-    <span *ngIf="isDisabled">Only available for accounts with no published tools/workflows</span>
   </mat-card>
 </div>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let row of accountsInfo" class="p-3">
   <mat-card class="mb-2">
     <div>
-      <h4>
+      <h3>
         <mat-chip-list>
           <mat-chip *ngIf="row.isLinked" color="accent" selected matTooltip="Account is linked">
             <mat-icon>link</mat-icon>
@@ -25,7 +25,7 @@
             </span>
           </span>
         </mat-chip-list>
-      </h4>
+      </h3>
     </div>
     <div>
       <strong>{{ row.bold }} </strong> {{ row.message }}

--- a/src/app/loginComponents/accounts/internal/accounts.component.html
+++ b/src/app/loginComponents/accounts/internal/accounts.component.html
@@ -19,12 +19,12 @@
 </ng-template>
 <div fxLayout="row wrap" fxLayoutAlign.md="space-evenly" fxLayoutAlign.sm="space-around" fxLayoutAlign.xs="space-around">
   <mat-card fxFlex="300px" class="my-2 mx-2">
+    <img mat-card-image *ngIf="user?.avatarUrl" [src]="user?.avatarUrl">
     <mat-card-header>
       <mat-card-title>
-        Dockstore Profile
+        <h3>Dockstore Profile</h3>
       </mat-card-title>
     </mat-card-header>
-    <img mat-card-image *ngIf="user?.avatarUrl" [src]="user?.avatarUrl">
     <mat-card-content>
       <mat-list>
         <mat-list-item>
@@ -58,12 +58,12 @@
     </mat-card-content>
   </mat-card>
   <mat-card fxFlex="300px" class="my-2 mx-2" *ngIf="(hasGitHubToken$ | async)">
+    <img mat-card-image *ngIf="gitHubProfile?.avatarURL" [src]="gitHubProfile?.avatarURL">
     <mat-card-header>
       <mat-card-title>
-        GitHub Profile
+        <h3>GitHub Profile</h3>
       </mat-card-title>
     </mat-card-header>
-    <img mat-card-image *ngIf="gitHubProfile?.avatarURL" [src]="gitHubProfile?.avatarURL">
     <mat-card-content>
       <mat-list>
         <mat-list-item *ngIf="gitHubProfile?.name">
@@ -106,12 +106,12 @@
     </mat-card-actions>
   </mat-card>
   <mat-card fxFlex="300px" class="my-2  mx-2" *ngIf="(hasGoogleToken$ | async)">
+    <img mat-card-image *ngIf="googleProfile?.avatarURL" [src]="googleProfile?.avatarURL">
     <mat-card-header>
       <mat-card-title>
-        Google Profile
+        <h3>Google Profile</h3>
       </mat-card-title>
     </mat-card-header>
-    <img mat-card-image *ngIf="googleProfile?.avatarURL" [src]="googleProfile?.avatarURL">
     <mat-card-content>
       <mat-list>
         <mat-list-item *ngIf="googleProfile?.name">

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -7,7 +7,7 @@
   <ng-template matStepperIcon="edit">
     <mat-icon>check</mat-icon>
   </ng-template>
-  <mat-step>
+  <mat-step *ngIf="extendedUser?.canChangeUsername">
     <ng-template matStepLabel>Confirm Your Username</ng-template>
 
     <h3>Choose Your Username</h3>

--- a/src/app/loginComponents/onboarding/onboarding.component.ts
+++ b/src/app/loginComponents/onboarding/onboarding.component.ts
@@ -1,16 +1,18 @@
 import { TokenService } from '../token.service';
 import { UsersService } from '../../shared/swagger';
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { UserService } from '../user.service';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'app-onboarding',
   templateUrl: './onboarding.component.html'
 })
 export class OnboardingComponent implements OnInit {
-  public curStep = 1;
   public tokenSetComplete;
+  protected ngUnsubscribe: Subject<{}> = new Subject();
+  extendedUser: any;
   constructor(private userService: UserService, private usersService: UsersService, private tokenService: TokenService) {
   }
   ngOnInit() {
@@ -25,24 +27,7 @@ export class OnboardingComponent implements OnInit {
         }
       }
     );
-  }
-  prevStep() {
-    if (this.curStep > 1) {
-      this.curStep--;
-    }
-  }
-  nextStep() {
-    if (!this.tokenSetComplete) {
-      return;
-    }
-    switch (this.curStep) {
-      case 1:
-      case 2:
-        this.curStep++;
-        break;
-      default:
-        localStorage.setItem('page', '/onboarding');
-    }
-  }
 
+    this.userService.extendedUser$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(extendedUser => this.extendedUser = extendedUser);
+  }
 }


### PR DESCRIPTION
When a user logs in who has already published an entry, they will no longer see the change username page (can still be accessed on the accounts page).

https://github.com/ga4gh/dockstore/issues/1711