### PR TITLE
Feature/angular material custom theme

### DIFF
--- a/src/material.scss
+++ b/src/material.scss
@@ -90,8 +90,8 @@ $my-teal: (
  // Define the palettes for your theme using the Material Design palettes available in palette.scss
  // (imported above). For each palette, you can optionally specify a default, lighter, and darker
  // hue. Available color palettes: https://www.google.com/design/spec/style/color.html
- $candy-app-primary: mat-palette($my-blue, 300, 600, 50);
- $candy-app-accent:  mat-palette($my-teal, 300, 600, 50);
+ $candy-app-primary: mat-palette($my-blue, 300, 50, 600);
+ $candy-app-accent:  mat-palette($my-teal, 300, 50, 600);
 
  // The warn palette is optional (defaults to red).
  $candy-app-warn:    mat-palette($mat-red);

--- a/src/material.scss
+++ b/src/material.scss
@@ -22,16 +22,16 @@
  @include mat-core();
 
  $my-blue: (
-  50: #21335b,
-  100: #21335b,
-  200: #21335b,
+  50: #4e5c88,
+  100: #4e5c88,
+  200: #4e5c88,
   300: #21335b,
   400: #21335b,
   500: #21335b,
-  600: #21335b,
-  700: #21335b,
-  800: #21335b,
-  900: #21335b,
+  600: #000c31,
+  700: #000c31,
+  800: #000c31,
+  900: #000c31,
   A100: #21335b,
   A200: #21335b,
   A400: #21335b,
@@ -55,16 +55,16 @@
 );
 
 $my-teal: (
-  50: #487980,
-  100: #487980,
-  200: #487980,
+  50: #77a8af,
+  100: #77a8af,
+  200: #77a8af,
   300: #487980,
   400: #487980,
   500: #487980,
-  600: #487980,
-  700: #487980,
-  800: #487980,
-  900: #487980,
+  600: #194d54,
+  700: #194d54,
+  800: #194d54,
+  900: #194d54,
   A100: #487980,
   A200: #487980,
   A400: #487980,
@@ -90,8 +90,8 @@ $my-teal: (
  // Define the palettes for your theme using the Material Design palettes available in palette.scss
  // (imported above). For each palette, you can optionally specify a default, lighter, and darker
  // hue. Available color palettes: https://www.google.com/design/spec/style/color.html
- $candy-app-primary: mat-palette($my-blue);
- $candy-app-accent:  mat-palette($my-teal);
+ $candy-app-primary: mat-palette($my-blue, 300, 600, 50);
+ $candy-app-accent:  mat-palette($my-teal, 300, 600, 50);
 
  // The warn palette is optional (defaults to red).
  $candy-app-warn:    mat-palette($mat-red);

--- a/src/material.scss
+++ b/src/material.scss
@@ -21,11 +21,77 @@
  // Be sure that you only ever include this mixin once!
  @include mat-core();
 
+ $my-blue: (
+  50: #21335b,
+  100: #21335b,
+  200: #21335b,
+  300: #21335b,
+  400: #21335b,
+  500: #21335b,
+  600: #21335b,
+  700: #21335b,
+  800: #21335b,
+  900: #21335b,
+  A100: #21335b,
+  A200: #21335b,
+  A400: #21335b,
+  A700: #21335b,
+  contrast: (
+    50: white,
+    100: white,
+    200: white,
+    300: white,
+    400: white,
+    500: white,
+    600: white,
+    700: white,
+    800: white,
+    900: white,
+    A100: white,
+    A200: white,
+    A400: white,
+    A700: white,
+  )
+);
+
+$my-teal: (
+  50: #487980,
+  100: #487980,
+  200: #487980,
+  300: #487980,
+  400: #487980,
+  500: #487980,
+  600: #487980,
+  700: #487980,
+  800: #487980,
+  900: #487980,
+  A100: #487980,
+  A200: #487980,
+  A400: #487980,
+  A700: #487980,
+  contrast: (
+    50: white,
+    100: white,
+    200: white,
+    300: white,
+    400: white,
+    500: white,
+    600: white,
+    700: white,
+    800: white,
+    900: white,
+    A100: white,
+    A200: white,
+    A400: white,
+    A700: white,
+  )
+);
+
  // Define the palettes for your theme using the Material Design palettes available in palette.scss
  // (imported above). For each palette, you can optionally specify a default, lighter, and darker
  // hue. Available color palettes: https://www.google.com/design/spec/style/color.html
- $candy-app-primary: mat-palette($mat-indigo, 800);
- $candy-app-accent:  mat-palette($mat-teal, 500);
+ $candy-app-primary: mat-palette($my-blue);
+ $candy-app-accent:  mat-palette($my-teal);
 
  // The warn palette is optional (defaults to red).
  $candy-app-warn:    mat-palette($mat-red);


### PR DESCRIPTION
This uses a custom material theme that is more like our previous theme (see [link](https://material.io/tools/color/#!/?view.left=0&view.right=0&primary.color=21335b&secondary.color=487980)).

The issue still has some other options for colours, and can be used for other theme options such as button roundness. I thought it would be good to at least get the theme colours to be consistent with the old site before continuing the search for other possible colours.

https://github.com/ga4gh/dockstore/issues/1390