### PR TITLE
Feature/search layout fix

### DIFF
--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -34,7 +34,7 @@ export class MapFriendlyValuesPipe implements PipeTransform {
       ['SEVEN_BRIDGES', 'Seven Bridges']
     ])],
     ['source_control_provider.keyword', new Map([
-      ['GITHUB', 'github.com'], ['BITBUCKET', 'bitbucket.org'], ['GITLAB', 'gitlab.com']
+      ['GITHUB', 'github.com'], ['BITBUCKET', 'bitbucket.org'], ['GITLAB', 'gitlab.com'], ['DOCKSTORE', 'dockstore.org']
     ])]
   ]);
 

--- a/src/app/shared/provider.service.spec.ts
+++ b/src/app/shared/provider.service.spec.ts
@@ -50,10 +50,10 @@ describe('ProviderService', () => {
         tool2.gitUrl = 'git@github.com:denis-yuen/dockstore-tool-bamstats.git';
         expect(service.setUpProvider(tool2).providerUrl).toContain('https://github.com/');
         const tool3 = tool;
-        tool3.gitUrl = 'https://garyluu@bitbucket.org/garyluu/dockstore-tool-md5sum.git';
+        tool3.gitUrl = 'git@bitbucket.org:garyluu/dockstore-tool-md5sum.git';
         expect(service.setUpProvider(tool3).providerUrl).toContain('https://bitbucket.org/');
         const tool4 = tool;
-        tool4.gitUrl = 'https://gitlab.com/garyluu/dockstore-tool-md5sum.git';
+        tool4.gitUrl = 'git@gitlab.com:garyluu/dockstore-tool-md5sum.git';
         expect(service.setUpProvider(tool3).providerUrl).toContain('https://gitlab.com/');
         const tool5 = tool;
         tool5.gitUrl = '';

--- a/src/app/shared/provider.service.spec.ts
+++ b/src/app/shared/provider.service.spec.ts
@@ -16,7 +16,7 @@
 
 import { DockstoreTool } from './swagger/model/dockstoreTool';
 import { ProviderService } from './provider.service';
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 describe('ProviderService', () => {
     beforeEach(() => {
@@ -54,14 +54,17 @@ describe('ProviderService', () => {
         expect(service.setUpProvider(tool3).providerUrl).toContain('https://bitbucket.org/');
         const tool4 = tool;
         tool4.gitUrl = 'git@gitlab.com:garyluu/dockstore-tool-md5sum.git';
-        expect(service.setUpProvider(tool3).providerUrl).toContain('https://gitlab.com/');
+        expect(service.setUpProvider(tool4).providerUrl).toContain('https://gitlab.com/');
         const tool5 = tool;
         tool5.gitUrl = '';
-        expect(service.setUpProvider(tool3).providerUrl).toBeFalsy();
-        expect(service.setUpProvider(tool3).provider).toBeFalsy();
+        expect(service.setUpProvider(tool5).providerUrl).toBeFalsy();
+        expect(service.setUpProvider(tool5).provider).toBeFalsy();
         const tool6 = tool;
-        tool5.gitUrl = 'https://someprivateregistry.com/garyluu/dockstore-tool-md5sum.git';
-        expect(service.setUpProvider(tool3).providerUrl).toBeFalsy();
-        expect(service.setUpProvider(tool3).provider).toBeFalsy();
+        tool6.gitUrl = 'https://someprivateregistry.com/garyluu/dockstore-tool-md5sum.git';
+        expect(service.setUpProvider(tool6).providerUrl).toBeFalsy();
+        expect(service.setUpProvider(tool6).provider).toBeFalsy();
+        const tool7 = tool;
+        tool7.gitUrl = 'git@dockstore.org:garyluu/dockstore-tool-md5sum.git';
+        expect(service.setUpProvider(tool7).providerUrl).toContain('https://dockstore.org/');
     }));
 });

--- a/src/app/shared/provider.service.ts
+++ b/src/app/shared/provider.service.ts
@@ -31,16 +31,20 @@ export class ProviderService {
 
 // TODO: Without an anchor, this looks fragile (for example if you had a github repo that included the string " bitbucket.org" in its name.
   private getProvider(gitUrl: string): string {
-    if (gitUrl.includes('github.com')) {
+    if (gitUrl.startsWith('git@github.com')) {
       return 'GitHub';
     }
 
-    if (gitUrl.includes('bitbucket.org')) {
+    if (gitUrl.startsWith('git@bitbucket.org')) {
       return 'Bitbucket';
     }
 
-    if (gitUrl.includes('gitlab.com')) {
+    if (gitUrl.startsWith('git@gitlab.com')) {
       return 'GitLab';
+    }
+
+    if (gitUrl.startsWith('git@dockstore.org')) {
+      return 'Dockstore';
     }
 
     return null;
@@ -69,6 +73,9 @@ export class ProviderService {
           break;
         case 'GitLab':
           providerUrl = 'https://gitlab.com/';
+          break;
+        case 'Dockstore':
+          providerUrl = 'https://dockstore.org/';
           break;
         default:
           return null;


### PR DESCRIPTION
Working on https://github.com/ga4gh/dockstore/issues/1746 
Ironically named since this fixes the blank source control and starring link for hosted workflows 
But not the search layout (which seems to occur for all facets when the screen is shrinked, the largest when not shrinked)