### PR TITLE
Feature/1739/hosted entry copy download buttons

### DIFF
--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -24,38 +24,37 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <div *ngIf="content; else noContent">
+  <div *ngIf="content">
     <span class="row m-0">
       <span class="col-sm-4">
         <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
       </span>
-      <span class="col-sm-4">
-        <app-select [placeholder]="'File'" [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-      </span>
     </span>
-    <div class="row m-0">
-      <div class="btn-group pull-right">
-        <a mat-button color="primary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" matTooltip="Download {{filePath}}">
-          Download
-        </a>
-        <ng-template #unpublishedDownloadLink>
-          <a mat-button color="primary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" matTooltip="Download {{filePath}}">
-            Download
-          </a>
-        </ng-template>
-        <button mat-button color="primary" type="button" ngxClipboard [cbContent]="content" matTooltip="Copy to clipboard">
-          Copy
-        </button>
-      </div>
-    </div>
   </div>
   <div [hidden]="!content">
+    <mat-toolbar color="primary">
+      <mat-toolbar-row>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+        <span class="spacer"></span>
+        <div class="btn-group pull-right" role="group">
+          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+            <mat-icon>save_alt</mat-icon>
+          </a>
+          <ng-template #unpublishedDownloadLink>
+            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+              <mat-icon>save_alt</mat-icon>
+            </a>
+          </ng-template>
+          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+            <mat-icon>file_copy</mat-icon>
+          </button>
+        </div>
+      </mat-toolbar-row>
+    </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>
-  <ng-template #noContent>
-    <alert type="warning">
-      <span class="glyphicon glyphicon-warning-sign"></span>
-      &nbsp;A Descriptor File associated with this Docker container could not be found.
-    </alert>
-  </ng-template>
+  <alert type="warning" *ngIf="!content">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    &nbsp;A Descriptor File associated with this Docker container could not be found.
+  </alert>
 </div>

--- a/src/app/container/descriptors/descriptors.component.scss
+++ b/src/app/container/descriptors/descriptors.component.scss
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017 OICR
+ *    Copyright 2018 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -29,7 +29,8 @@ import { ToolDescriptorService } from './tool-descriptor.service';
 @Component({
   selector: 'app-descriptors-container',
   templateUrl: './descriptors.component.html',
-  providers: [ToolDescriptorService]
+  providers: [ToolDescriptorService],
+  styleUrls: ['./descriptors.component.scss']
 })
 
 export class DescriptorsComponent extends EntryFileSelector {

--- a/src/app/container/dockerfile/dockerfile.component.html
+++ b/src/app/container/dockerfile/dockerfile.component.html
@@ -24,28 +24,30 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <div *ngIf="content; else noContent" class="row m-0">
-    <div class="btn-group pull-right" role="group">
-      <a mat-button color="primary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-        Download
-      </a>
-      <ng-template #unpublishedDownloadLink>
-        <a mat-button color="primary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
-          Download
-        </a>
-      </ng-template>
-      <button mat-button color="primary" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
-        Copy
-      </button>
-    </div>
-  </div>
-  <ng-template #noContent>
-    <alert type="warning">
-      <span class="glyphicon glyphicon-warning-sign"></span>
-      &nbsp;A Dockerfile associated with this Docker container could not be found.
-    </alert>
-  </ng-template>
+  <alert type="warning" *ngIf="!content">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    &nbsp;A Dockerfile associated with this Docker container could not be found.
+  </alert>
   <div [hidden]="!content || !_selectedVersion?.valid">
+    <mat-toolbar color="primary">
+      <mat-toolbar-row>
+        <span>{{filePath}}</span>
+        <span class="spacer"></span>
+        <div class="btn-group pull-right" role="group">
+          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+            <mat-icon>save_alt</mat-icon>
+          </a>
+          <ng-template #unpublishedDownloadLink>
+            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+              <mat-icon>save_alt</mat-icon>
+            </a>
+          </ng-template>
+          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+            <mat-icon>file_copy</mat-icon>
+          </button>
+        </div>
+      </mat-toolbar-row>
+    </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>
 </div>

--- a/src/app/container/dockerfile/dockerfile.component.scss
+++ b/src/app/container/dockerfile/dockerfile.component.scss
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017 OICR
+ *    Copyright 2018 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -28,6 +28,7 @@ import { Tag } from '../../shared/swagger/model/tag';
 @Component({
   selector: 'app-dockerfile',
   templateUrl: './dockerfile.component.html',
+  styleUrls: ['./dockerfile.component.scss']
 })
 export class DockerfileComponent {
 

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -24,38 +24,37 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <div *ngIf="content; else noContent">
+  <div *ngIf="content">
     <span class="row m-0">
       <span class="col-sm-4">
         <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
       </span>
-      <span class="col-sm-4">
-        <app-select [placeholder]="'File'" [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-      </span>
     </span>
-    <div class="row m-0">
-      <div class="btn-group pull-right">
-        <a mat-button color="primary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-          Download
-        </a>
-        <ng-template #unpublishedDownloadLink>
-          <a mat-button color="primary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
-            Download
-          </a>
-        </ng-template>
-        <button mat-button color="primary" type="button" ngxClipboard [cbContent]="content" title="Copy to clipboard">
-          Copy
-        </button>
-      </div>
-    </div>
   </div>
-  <ng-template #noContent>
-    <alert type="warning">
-      <span class="glyphicon glyphicon-warning-sign"></span>
-      &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
-    </alert>
-  </ng-template>
+  <alert type="warning" *ngIf="!content">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
+  </alert>
   <div [hidden]="!content || !_selectedVersion?.valid">
+    <mat-toolbar color="primary">
+      <mat-toolbar-row>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+        <span class="spacer"></span>
+        <div class="btn-group pull-right" role="group">
+          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+            <mat-icon>save_alt</mat-icon>
+          </a>
+          <ng-template #unpublishedDownloadLink>
+            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+              <mat-icon>save_alt</mat-icon>
+            </a>
+          </ng-template>
+          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+            <mat-icon>file_copy</mat-icon>
+          </button>
+        </div>
+      </mat-toolbar-row>
+    </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>
 </div>

--- a/src/app/container/paramfiles/paramfiles.component.scss
+++ b/src/app/container/paramfiles/paramfiles.component.scss
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017 OICR
+ *    Copyright 2018 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 mat-toolbar-row {
   font-size: 16px;
 }

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -28,7 +28,8 @@ import { ParamfilesService } from './paramfiles.service';
 
 @Component({
   selector: 'app-paramfiles-container',
-  templateUrl: './paramfiles.component.html'
+  templateUrl: './paramfiles.component.html',
+  styleUrls: ['./paramfiles.component.scss']
 })
 
 export class ParamfilesComponent extends EntryFileSelector {

--- a/src/app/container/tool-file-editor/tool-file-editor.component.html
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.html
@@ -16,7 +16,7 @@
 
 <tabset [justified]="true">
   <tab heading="Dockerfile" id="dockerfileTab">
-    <app-code-editor-list [sourcefiles]="dockerFile" [editing]="editing" [fileType]="'dockerfile'"></app-code-editor-list>
+    <app-code-editor-list [sourcefiles]="dockerFile" [editing]="editing" [fileType]="'dockerfile'" [selectedVersion]="currentVersion" [entryType]="'tool'" [entrypath]="entrypath"></app-code-editor-list>
   </tab>
   <tab heading="Descriptor Files" id="descriptorFilesTab">
     <mat-form-field>
@@ -26,7 +26,7 @@
         <!-- <mat-option value="nfl">nextflow</mat-option> -->
       </mat-select>
     </mat-form-field>
-    <app-code-editor-list [sourcefiles]="descriptorFiles" [editing]="editing" [fileType]="'descriptor'" [descriptorType]="selectedDescriptorType"></app-code-editor-list>
+    <app-code-editor-list [sourcefiles]="descriptorFiles" [editing]="editing" [fileType]="'descriptor'" [descriptorType]="selectedDescriptorType" [selectedVersion]="currentVersion" [entryType]="'tool'" [entrypath]="entrypath"></app-code-editor-list>
   </tab>
   <tab heading="Test Parameter Files" id="testParameterFilesTab">
     <mat-form-field>
@@ -36,7 +36,7 @@
         <!-- <mat-option value="nfl">nextflow</mat-option> -->
       </mat-select>
     </mat-form-field>
-    <app-code-editor-list [sourcefiles]="testParameterFiles" [editing]="editing" [fileType]="'testParam'" [descriptorType]="selectedDescriptorType"></app-code-editor-list>
+    <app-code-editor-list [sourcefiles]="testParameterFiles" [editing]="editing" [fileType]="'testParam'" [descriptorType]="selectedDescriptorType" [selectedVersion]="currentVersion" [entryType]="'tool'" [entrypath]="entrypath"></app-code-editor-list>
   </tab>
 </tabset>
 <div class="editor-button-container" *ngIf="!publicPage">

--- a/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
@@ -5,23 +5,32 @@ import { TabsModule } from 'ngx-bootstrap';
 import { CodeEditorListComponent } from './../../shared/code-editor-list/code-editor-list.component';
 import { CodeEditorComponent } from './../../shared/code-editor/code-editor.component';
 import { MatButtonModule, MatTabsModule, MatToolbarModule, MatIconModule, MatInputModule,
-  MatFormFieldModule, MatSelectModule } from '@angular/material';
+  MatFormFieldModule, MatSelectModule, MatTooltipModule } from '@angular/material';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { ContainerService } from './../../shared/container.service';
 import { RefreshService } from './../../shared/refresh.service';
-import { HostedStubService, ContainerStubService, RefreshStubService } from './../../test/service-stubs';
+import { HostedStubService, ContainerStubService, RefreshStubService, WorkflowStubService } from './../../test/service-stubs';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { PublicFileDownloadPipe } from './../../shared/entry/public-file-download.pipe';
+import { PrivateFileDownloadPipe } from './../../shared/entry/private-file-download.pipe';
+import { PrivateFilePathPipe } from './../../shared/entry/private-file-path.pipe';
+import { ClipboardModule } from 'ngx-clipboard';
+import { WorkflowService } from './../../shared/workflow.service';
+import { FileService } from './../../shared/file.service';
 
 describe('ToolFileEditorComponent', () => {
   let component: ToolFileEditorComponent;
   let fixture: ComponentFixture<ToolFileEditorComponent>;
-
+  class FileStubService { }
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         ToolFileEditorComponent,
         CodeEditorListComponent,
-        CodeEditorComponent
+        CodeEditorComponent,
+        PublicFileDownloadPipe,
+        PrivateFileDownloadPipe,
+        PrivateFilePathPipe
       ],
       imports: [
         TabsModule.forRoot(),
@@ -32,12 +41,16 @@ describe('ToolFileEditorComponent', () => {
         MatInputModule,
         MatFormFieldModule,
         MatSelectModule,
-        BrowserAnimationsModule
+        MatTooltipModule,
+        BrowserAnimationsModule,
+        ClipboardModule
       ],
       providers: [
         { provide: HostedService, useClass: HostedStubService },
         { provide: ContainerService, useClass: ContainerStubService },
-        { provide: RefreshService, useClass: RefreshStubService }
+        { provide: RefreshService, useClass: RefreshStubService },
+        { provide: WorkflowService, useClass: WorkflowStubService },
+        { provide: FileService, useClass: FileStubService }
       ]
     })
     .compileComponents();

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -18,6 +18,7 @@ export class ToolFileEditorComponent extends FileEditing {
   originalSourceFiles = [];
   currentVersion: Tag;
   selectedDescriptorType = 'cwl';
+  @Input() entrypath: string;
   @Input() set selectedVersion(value: Tag) {
       this.currentVersion = value;
       this.clearSourceFiles();

--- a/src/app/shared/code-editor-list/code-editor-list.component.html
+++ b/src/app/shared/code-editor-list/code-editor-list.component.html
@@ -16,9 +16,22 @@
           </span>
           <span class="spacer"></span>
           <span>
-          <button mat-mini-fab class="delete-editor-file" color="warn" (click)="deleteFile(i)" *ngIf="editing && !isPrimaryDescriptor(sourcefile?.path) && !isDockerFile(sourcefile?.path)">
-            <mat-icon>delete</mat-icon>
-          </button>
+            <button mat-icon-button class="delete-editor-file mr-2" color="warn" (click)="deleteFile(i)" *ngIf="editing && !isPrimaryDescriptor(sourcefile?.path) && !isDockerFile(sourcefile?.path)">
+              <mat-icon>delete</mat-icon>
+            </button>
+            <span *ngIf="!editing">
+              <a mat-icon-button color="secondary" class="mr-2" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="getDescriptorPath(sourcefile)" type="button" matTooltip="Download {{sourcefile?.path}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+              <ng-template #unpublishedDownloadLink>
+                <a mat-icon-button color="secondary" class="mr-2" [href]="getPrivateHREF(sourcefile?.content)" [download]="getPrivatePath(sourcefile?.path)" type="button" title="{{sourcefile?.path}}">
+                  <mat-icon>save_alt</mat-icon>
+                </a>
+              </ng-template>
+              <button mat-icon-button color="secondary" type="button" class="mr-2" matTooltip="Copy to clipboard" ngxClipboard [cbContent]="sourcefile?.content">
+                <mat-icon>file_copy</mat-icon>
+              </button>
+            </span>
           </span>
         </mat-toolbar-row>
       </mat-toolbar>

--- a/src/app/shared/code-editor-list/code-editor-list.component.html
+++ b/src/app/shared/code-editor-list/code-editor-list.component.html
@@ -20,11 +20,11 @@
               <mat-icon>delete</mat-icon>
             </button>
             <span *ngIf="!editing">
-              <a mat-icon-button color="secondary" class="mr-2" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="getDescriptorPath(sourcefile)" type="button" matTooltip="Download {{sourcefile?.path}}">
+              <a mat-icon-button color="secondary" class="mr-2 link-button" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="getDescriptorPath(sourcefile)" type="button" matTooltip="Download {{sourcefile?.path}}">
                 <mat-icon>save_alt</mat-icon>
               </a>
               <ng-template #unpublishedDownloadLink>
-                <a mat-icon-button color="secondary" class="mr-2" [href]="getPrivateHREF(sourcefile?.content)" [download]="getPrivatePath(sourcefile?.path)" type="button" title="{{sourcefile?.path}}">
+                <a mat-icon-button color="secondary" class="mr-2 link-button" [href]="getPrivateHREF(sourcefile?.content)" [download]="getPrivatePath(sourcefile?.path)" type="button" matTooltip="Download {{sourcefile?.path}}">
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>

--- a/src/app/shared/code-editor-list/code-editor-list.component.html
+++ b/src/app/shared/code-editor-list/code-editor-list.component.html
@@ -16,15 +16,15 @@
           </span>
           <span class="spacer"></span>
           <span>
-            <button mat-icon-button class="delete-editor-file mr-2" color="warn" (click)="deleteFile(i)" *ngIf="editing && !isPrimaryDescriptor(sourcefile?.path) && !isDockerFile(sourcefile?.path)">
+            <button mat-icon-button class="delete-editor-file mr-2" color="warn" (click)="deleteFile(i)" *ngIf="editing && !isPrimaryDescriptor(sourcefile?.path) && !isDockerFile(sourcefile?.path)" matTooltip="Delete the file">
               <mat-icon>delete</mat-icon>
             </button>
             <span *ngIf="!editing">
-              <a mat-icon-button color="secondary" class="mr-2 link-button" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="getDescriptorPath(sourcefile)" type="button" matTooltip="Download {{sourcefile?.path}}">
+              <a mat-icon-button color="secondary" class="mr-2 link-button" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="(sourcefile | publicFileDownload : entrypath: selectedVersion: descriptorType: entryType)" type="button" matTooltip="Download {{sourcefile?.path}}">
                 <mat-icon>save_alt</mat-icon>
               </a>
               <ng-template #unpublishedDownloadLink>
-                <a mat-icon-button color="secondary" class="mr-2 link-button" [href]="getPrivateHREF(sourcefile?.content)" [download]="getPrivatePath(sourcefile?.path)" type="button" matTooltip="Download {{sourcefile?.path}}">
+                <a mat-icon-button color="secondary" class="mr-2 link-button" [href]="(sourcefile?.content | privateFileDownload)" [download]="(sourcefile?.path | privateFilePath)" type="button" matTooltip="Download {{sourcefile?.path}}">
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>

--- a/src/app/shared/code-editor-list/code-editor-list.component.scss
+++ b/src/app/shared/code-editor-list/code-editor-list.component.scss
@@ -1,3 +1,7 @@
 .spacer {
   flex: 1 1 auto;
 }
+
+.link-button {
+  color: inherit;
+}

--- a/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
@@ -1,18 +1,29 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CodeEditorListComponent } from './code-editor-list.component';
-import { MatButtonModule, MatTabsModule, MatToolbarModule, MatIconModule, MatInputModule, MatFormFieldModule } from '@angular/material';
+import { MatButtonModule, MatTabsModule, MatToolbarModule, MatIconModule, MatInputModule, MatFormFieldModule,
+  MatTooltipModule } from '@angular/material';
 import { CodeEditorComponent } from './../code-editor/code-editor.component';
+import { WorkflowStubService } from './../../test/service-stubs';
+import { WorkflowService } from './../workflow.service';
+import { PublicFileDownloadPipe } from './../../shared/entry/public-file-download.pipe';
+import { PrivateFileDownloadPipe } from './../../shared/entry/private-file-download.pipe';
+import { PrivateFilePathPipe } from './../../shared/entry/private-file-path.pipe';
+import { ClipboardModule } from 'ngx-clipboard';
+import { FileService } from './../../shared/file.service';
 
 describe('CodeEditorListComponent', () => {
   let component: CodeEditorListComponent;
   let fixture: ComponentFixture<CodeEditorListComponent>;
-
+  class FileStubService { }
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         CodeEditorListComponent,
-        CodeEditorComponent
+        CodeEditorComponent,
+        PublicFileDownloadPipe,
+        PrivateFileDownloadPipe,
+        PrivateFilePathPipe
       ],
       imports: [
         MatButtonModule,
@@ -20,7 +31,13 @@ describe('CodeEditorListComponent', () => {
         MatToolbarModule,
         MatIconModule,
         MatInputModule,
-        MatFormFieldModule
+        MatFormFieldModule,
+        MatTooltipModule,
+        ClipboardModule
+      ],
+      providers: [
+        { provide: WorkflowService, useClass: WorkflowStubService },
+        { provide: FileService, useClass: FileStubService }
       ]
     })
     .compileComponents();

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -22,7 +22,6 @@ export class CodeEditorListComponent {
   NEXTFLOW_CONFIG_PATH = '/nextflow.config';
   NEXTFLOW_PATH = '/main.nf';
   public DescriptorType = ToolDescriptor.TypeEnum;
-  publishDownloadLinks: Array<string>;
 
   constructor(private workflowService: WorkflowService) {
     this.published$ = this.workflowService.workflowIsPublished$;

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -2,10 +2,7 @@ import { Component, Input } from '@angular/core';
 import { ToolDescriptor } from './../../shared/swagger/model/toolDescriptor';
 import { WorkflowService } from '../../shared/workflow.service';
 import { Observable } from 'rxjs';
-import { FileService } from '../file.service';
-import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
-import { SafeUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-code-editor-list',
@@ -27,7 +24,7 @@ export class CodeEditorListComponent {
   public DescriptorType = ToolDescriptor.TypeEnum;
   publishDownloadLinks: Array<string>;
 
-  constructor(private workflowService: WorkflowService, protected fileService: FileService) {
+  constructor(private workflowService: WorkflowService) {
     this.published$ = this.workflowService.workflowIsPublished$;
   }
 
@@ -213,17 +210,4 @@ export class CodeEditorListComponent {
     }
     return false;
   }
-
-  protected getDescriptorPath(sourcefile: SourceFile): string {
-    return this.fileService.getDescriptorPath(this.entrypath, this.selectedVersion, sourcefile, this.descriptorType, this.entryType);
-  }
-
-  getPrivateHREF(content: string): SafeUrl {
-    return this.fileService.getFileData(content);
-  }
-
-  getPrivatePath(filePath: string): string {
-    return this.fileService.getFileName(filePath);
-  }
-
 }

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -1,6 +1,11 @@
 import { Component, Input } from '@angular/core';
-import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { ToolDescriptor } from './../../shared/swagger/model/toolDescriptor';
+import { WorkflowService } from '../../shared/workflow.service';
+import { Observable } from 'rxjs';
+import { FileService } from '../file.service';
+import { SourceFile } from '../../shared/swagger/model/sourceFile';
+import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
+import { SafeUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-code-editor-list',
@@ -12,10 +17,19 @@ export class CodeEditorListComponent {
   @Input() editing: boolean;
   @Input() fileType: string;
   @Input() descriptorType: string;
+  @Input() entryType: string;
+  @Input() entrypath: string;
+  @Input() selectedVersion: WorkflowVersion;
+  protected published$: Observable<boolean>;
+  public downloadFilePath: string;
   NEXTFLOW_CONFIG_PATH = '/nextflow.config';
   NEXTFLOW_PATH = '/main.nf';
   public DescriptorType = ToolDescriptor.TypeEnum;
-  constructor() { }
+  publishDownloadLinks: Array<string>;
+
+  constructor(private workflowService: WorkflowService, protected fileService: FileService) {
+    this.published$ = this.workflowService.workflowIsPublished$;
+  }
 
   /**
    * Adds a new file editor
@@ -199,4 +213,17 @@ export class CodeEditorListComponent {
     }
     return false;
   }
+
+  protected getDescriptorPath(sourcefile: SourceFile): string {
+    return this.fileService.getDescriptorPath(this.entrypath, this.selectedVersion, sourcefile, this.descriptorType, this.entryType);
+  }
+
+  getPrivateHREF(content: string): SafeUrl {
+    return this.fileService.getFileData(content);
+  }
+
+  getPrivatePath(filePath: string): string {
+    return this.fileService.getFileName(filePath);
+  }
+
 }

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -35,7 +35,9 @@ import { VerifiedDisplayComponent } from './verified-display/verified-display.co
 import { VerifiedPlatformsPipe } from './verified-platforms.pipe';
 import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
 import { ClipboardModule } from 'ngx-clipboard';
-
+import { PublicFileDownloadPipe } from '../entry/public-file-download.pipe';
+import { PrivateFileDownloadPipe } from './private-file-download.pipe';
+import { PrivateFilePathPipe } from './private-file-path.pipe';
 
 @NgModule({
   imports: [
@@ -57,7 +59,10 @@ import { ClipboardModule } from 'ngx-clipboard';
     VerifiedByComponent,
     VerifiedDisplayComponent,
     VerifiedPlatformsPipe,
-    VersionProviderUrlPipe
+    VersionProviderUrlPipe,
+    PublicFileDownloadPipe,
+    PrivateFileDownloadPipe,
+    PrivateFilePathPipe
   ],
   providers: [
     GA4GHFilesStateService
@@ -73,6 +78,7 @@ import { ClipboardModule } from 'ngx-clipboard';
     VerifiedDisplayComponent,
     VerifiedPlatformsPipe,
     VersionProviderUrlPipe,
+    PublicFileDownloadPipe,
     NgxJsonLdModule
   ]
 })

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -34,6 +34,7 @@ import { VerifiedByComponent } from './verified-by/verified-by.component';
 import { VerifiedDisplayComponent } from './verified-display/verified-display.component';
 import { VerifiedPlatformsPipe } from './verified-platforms.pipe';
 import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
+import { ClipboardModule } from 'ngx-clipboard';
 
 
 @NgModule({
@@ -43,7 +44,8 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     FormsModule,
     ModalModule,
     CustomMaterialModule,
-    NgxJsonLdModule
+    NgxJsonLdModule,
+    ClipboardModule
   ],
   declarations: [
     InfoTabCheckerWorkflowPathComponent,

--- a/src/app/shared/entry/private-file-download.pipe.spec.ts
+++ b/src/app/shared/entry/private-file-download.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PrivateFileDownloadPipe } from './private-file-download.pipe';
+
+describe('PrivateFileDownloadPipe', () => {
+  it('create an instance', () => {
+    const pipe = new PrivateFileDownloadPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/entry/private-file-download.pipe.spec.ts
+++ b/src/app/shared/entry/private-file-download.pipe.spec.ts
@@ -2,7 +2,7 @@ import { PrivateFileDownloadPipe } from './private-file-download.pipe';
 
 describe('PrivateFileDownloadPipe', () => {
   it('create an instance', () => {
-    const pipe = new PrivateFileDownloadPipe();
+    const pipe = new PrivateFileDownloadPipe(null);
     expect(pipe).toBeTruthy();
   });
 });

--- a/src/app/shared/entry/private-file-download.pipe.ts
+++ b/src/app/shared/entry/private-file-download.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FileService } from '../file.service';
+
+@Pipe({
+  name: 'privateFileDownload'
+})
+export class PrivateFileDownloadPipe implements PipeTransform {
+
+  constructor(protected fileService: FileService) {}
+
+  transform(content: string): any {
+    return this.fileService.getFileData(content);
+  }
+
+}

--- a/src/app/shared/entry/private-file-download.pipe.ts
+++ b/src/app/shared/entry/private-file-download.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { FileService } from '../file.service';
+import { SafeUrl } from '@angular/platform-browser';
 
 @Pipe({
   name: 'privateFileDownload'
@@ -8,7 +9,7 @@ export class PrivateFileDownloadPipe implements PipeTransform {
 
   constructor(protected fileService: FileService) {}
 
-  transform(content: string): any {
+  transform(content: string): SafeUrl {
     return this.fileService.getFileData(content);
   }
 

--- a/src/app/shared/entry/private-file-path.pipe.spec.ts
+++ b/src/app/shared/entry/private-file-path.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PrivateFilePathPipe } from './private-file-path.pipe';
+
+describe('PrivateFilePathPipe', () => {
+  it('create an instance', () => {
+    const pipe = new PrivateFilePathPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/entry/private-file-path.pipe.spec.ts
+++ b/src/app/shared/entry/private-file-path.pipe.spec.ts
@@ -2,7 +2,7 @@ import { PrivateFilePathPipe } from './private-file-path.pipe';
 
 describe('PrivateFilePathPipe', () => {
   it('create an instance', () => {
-    const pipe = new PrivateFilePathPipe();
+    const pipe = new PrivateFilePathPipe(null);
     expect(pipe).toBeTruthy();
   });
 });

--- a/src/app/shared/entry/private-file-path.pipe.ts
+++ b/src/app/shared/entry/private-file-path.pipe.ts
@@ -8,7 +8,7 @@ export class PrivateFilePathPipe implements PipeTransform {
 
   constructor(protected fileService: FileService) {}
 
-  transform(filePath: string): any {
+  transform(filePath: string): string {
     return this.fileService.getFileName(filePath);
   }
 

--- a/src/app/shared/entry/private-file-path.pipe.ts
+++ b/src/app/shared/entry/private-file-path.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FileService } from '../file.service';
+
+@Pipe({
+  name: 'privateFilePath'
+})
+export class PrivateFilePathPipe implements PipeTransform {
+
+  constructor(protected fileService: FileService) {}
+
+  transform(filePath: string): any {
+    return this.fileService.getFileName(filePath);
+  }
+
+}

--- a/src/app/shared/entry/public-file-download.pipe.spec.ts
+++ b/src/app/shared/entry/public-file-download.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PublicFileDownloadPipe } from './public-file-download.pipe';
+
+describe('PublicFileDownloadPipe', () => {
+  it('create an instance', () => {
+    const pipe = new PublicFileDownloadPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/entry/public-file-download.pipe.spec.ts
+++ b/src/app/shared/entry/public-file-download.pipe.spec.ts
@@ -2,7 +2,7 @@ import { PublicFileDownloadPipe } from './public-file-download.pipe';
 
 describe('PublicFileDownloadPipe', () => {
   it('create an instance', () => {
-    const pipe = new PublicFileDownloadPipe();
+    const pipe = new PublicFileDownloadPipe(null);
     expect(pipe).toBeTruthy();
   });
 });

--- a/src/app/shared/entry/public-file-download.pipe.ts
+++ b/src/app/shared/entry/public-file-download.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FileService } from '../file.service';
+import { SourceFile } from '../../shared/swagger/model/sourceFile';
+
+@Pipe({
+  name: 'publicFileDownload'
+})
+export class PublicFileDownloadPipe implements PipeTransform {
+
+  constructor(protected fileService: FileService) {}
+
+  transform(sourcefile: SourceFile, entrypath: string, selectedVersion: any, descriptorType: string, entryType: string): any {
+    return this.fileService.getDescriptorPath(entrypath, selectedVersion, sourcefile, descriptorType, entryType);
+  }
+
+}

--- a/src/app/shared/entry/public-file-download.pipe.ts
+++ b/src/app/shared/entry/public-file-download.pipe.ts
@@ -9,7 +9,7 @@ export class PublicFileDownloadPipe implements PipeTransform {
 
   constructor(protected fileService: FileService) {}
 
-  transform(sourcefile: SourceFile, entrypath: string, selectedVersion: any, descriptorType: string, entryType: string): any {
+  transform(sourcefile: SourceFile, entrypath: string, selectedVersion: any, descriptorType: string, entryType: string): string {
     return this.fileService.getDescriptorPath(entrypath, selectedVersion, sourcefile, descriptorType, entryType);
   }
 

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -12,12 +12,12 @@ import { SelectTabPipe } from '../entry/select-tab.pipe';
   declarations: [
     ExpandPanelPipe,
     MapFriendlyValuesPipe,
-    SelectTabPipe,
+    SelectTabPipe
   ],
   exports: [
     ExpandPanelPipe,
     MapFriendlyValuesPipe,
-    SelectTabPipe,
+    SelectTabPipe
   ],
 })
 export class PipeModule { }

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -31,8 +31,8 @@ export abstract class EntryFileSelector {
   public nullDescriptors: boolean;
   public filePath: string;
   public currentFile;
-  protected files: Array<any>;
-  protected published$: Observable<boolean>;
+  public files: Array<any>;
+  public published$: Observable<boolean>;
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -18,35 +18,30 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the workflow is invalid.
   </alert>
-  <div *ngIf="content; else noContent">
-    <span class="row m-0">
-      <span class="col-sm-4">
-        <app-select [placeholder]="'File'" [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-      </span>
-    </span>
-    <div class="row m-0">
-      <div class="btn-group pull-right" role="group">
-        <a mat-button color="primary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-          Download
-        </a>
-        <ng-template #unpublishedDownloadLink>
-          <a mat-button color="primary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
-            Download
-          </a>
-        </ng-template>
-        <button mat-button color="primary" type="button" ngxClipboard [cbContent]="content">
-          Copy
-        </button>
-      </div>
-    </div>
-  </div>
   <div [hidden]="!content">
+    <mat-toolbar color="primary">
+      <mat-toolbar-row>
+        <app-select  [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+        <span class="spacer"></span>
+        <div class="btn-group pull-right" role="group">
+          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+            <mat-icon>save_alt</mat-icon>
+          </a>
+          <ng-template #unpublishedDownloadLink>
+            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+              <mat-icon>save_alt</mat-icon>
+            </a>
+          </ng-template>
+          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+            <mat-icon>file_copy</mat-icon>
+          </button>
+        </div>
+      </mat-toolbar-row>
+    </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
   </div>
-  <ng-template #noContent>
-    <alert type="warning">
-      <span class="glyphicon glyphicon-warning-sign"></span>
-      &nbsp;A Descriptor File associated with this Docker container could not be found.
-    </alert>
-  </ng-template>
+  <alert type="warning" *ngIf="!content">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    &nbsp;A Descriptor File associated with this Docker container could not be found.
+  </alert>
 </div>

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -21,7 +21,7 @@
   <div [hidden]="!content">
     <mat-toolbar color="primary">
       <mat-toolbar-row>
-        <app-select  [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
         <span class="spacer"></span>
         <div class="btn-group pull-right" role="group">
           <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">

--- a/src/app/workflow/paramfiles/paramfiles.component.css
+++ b/src/app/workflow/paramfiles/paramfiles.component.css
@@ -14,3 +14,6 @@
  *    limitations under the License.
  */
 
+mat-toolbar-row {
+  font-size: 16px;
+}

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -18,35 +18,30 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the workflow is invalid.
   </alert>
-  <div *ngIf="content; else noContent">
-    <span class="row m-0">
-      <span class="col-sm-4">
-        <app-select [placeholder]="'File'" [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-      </span>
-    </span>
-    <div class="row m-0">
-      <div class="btn-group pull-right">
-        <a mat-button color="primary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-          Download
-        </a>
-        <ng-template #unpublishedDownloadLink>
-          <a mat-button color="primary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
-            Download
-          </a>
-        </ng-template>
-        <button mat-button color="primary" type="button" ngxClipboard [cbContent]="content">
-          Copy
-        </button>
-      </div>
-    </div>
-  </div>
-  <ng-template #noContent>
-    <alert type="warning">
-      <span class="glyphicon glyphicon-warning-sign"></span>
-      &nbsp; A Test Parameter File associated with this workflow could not be found.
-    </alert>
-  </ng-template>
+  <alert type="warning" *ngIf="!content">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    &nbsp; A Test Parameter File associated with this workflow could not be found.
+  </alert>
   <div [hidden]="!content">
+      <mat-toolbar color="primary">
+        <mat-toolbar-row>
+          <app-select  [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+          <span class="spacer"></span>
+          <div class="btn-group pull-right" role="group">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+              <mat-icon>save_alt</mat-icon>
+            </a>
+            <ng-template #unpublishedDownloadLink>
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+            </ng-template>
+            <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+              <mat-icon>file_copy</mat-icon>
+            </button>
+          </div>
+        </mat-toolbar-row>
+      </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
   </div>
 </div>

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
@@ -16,10 +16,10 @@
 
 <tabset [justified]="true">
   <tab heading="Descriptor Files" id="descriptorFilesTab">
-    <app-code-editor-list [sourcefiles]="descriptorFiles" [editing]="editing" [descriptorType]="descriptorType" [fileType]="'descriptor'"></app-code-editor-list>
+    <app-code-editor-list [sourcefiles]="descriptorFiles" [editing]="editing" [descriptorType]="descriptorType" [fileType]="'descriptor'" [selectedVersion]="_selectedVersion" [entryType]="'workflow'" [entrypath]="entrypath"></app-code-editor-list>
   </tab>
   <tab heading="Test Parameter Files" id="testParameterFilesTab">
-    <app-code-editor-list [sourcefiles]="testParameterFiles" [editing]="editing" [descriptorType]="descriptorType" [fileType]="'testParam'"></app-code-editor-list>
+    <app-code-editor-list [sourcefiles]="testParameterFiles" [editing]="editing" [descriptorType]="descriptorType" [fileType]="'testParam'" [selectedVersion]="_selectedVersion" [entryType]="'workflow'" [entrypath]="entrypath"></app-code-editor-list>
   </tab>
 </tabset>
 <div class="editor-button-container" *ngIf="!publicPage && canWrite">

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
@@ -4,23 +4,32 @@ import { WorkflowFileEditorComponent } from './workflow-file-editor.component';
 import { TabsModule } from 'ngx-bootstrap';
 import { CodeEditorListComponent } from './../../shared/code-editor-list/code-editor-list.component';
 import { CodeEditorComponent } from './../../shared/code-editor/code-editor.component';
-import { MatButtonModule, MatTabsModule, MatToolbarModule, MatIconModule, MatInputModule, MatFormFieldModule } from '@angular/material';
+import { MatButtonModule, MatTabsModule, MatToolbarModule, MatIconModule, MatInputModule, MatFormFieldModule,
+  MatTooltipModule } from '@angular/material';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { WorkflowService } from './../../shared/workflow.service';
 import { RefreshService } from './../../shared/refresh.service';
 import { HostedStubService, WorkflowStubService, RefreshStubService, WorkflowsStubService } from './../../test/service-stubs';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
+import { PublicFileDownloadPipe } from './../../shared/entry/public-file-download.pipe';
+import { PrivateFileDownloadPipe } from './../../shared/entry/private-file-download.pipe';
+import { PrivateFilePathPipe } from './../../shared/entry/private-file-path.pipe';
+import { ClipboardModule } from 'ngx-clipboard';
+import { FileService } from './../../shared/file.service';
 
 describe('WorkflowFileEditorComponent', () => {
   let component: WorkflowFileEditorComponent;
   let fixture: ComponentFixture<WorkflowFileEditorComponent>;
-
+  class FileStubService { }
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         WorkflowFileEditorComponent,
         CodeEditorListComponent,
-        CodeEditorComponent
+        CodeEditorComponent,
+        PublicFileDownloadPipe,
+        PrivateFileDownloadPipe,
+        PrivateFilePathPipe
       ],
       imports: [
         TabsModule.forRoot(),
@@ -29,13 +38,16 @@ describe('WorkflowFileEditorComponent', () => {
         MatToolbarModule,
         MatIconModule,
         MatInputModule,
-        MatFormFieldModule
+        MatFormFieldModule,
+        MatTooltipModule,
+        ClipboardModule
       ],
       providers: [
         { provide: HostedService, useClass: HostedStubService },
         { provide: WorkflowService, useClass: WorkflowStubService },
         { provide: WorkflowsService, useClass: WorkflowsStubService },
-        { provide: RefreshService, useClass: RefreshStubService }
+        { provide: RefreshService, useClass: RefreshStubService },
+        { provide: FileService, useClass: FileStubService }
       ]
     })
     .compileComponents();

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -18,6 +18,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
   originalSourceFiles = [];
   _selectedVersion: WorkflowVersion;
   @Input() descriptorType: string;
+  @Input() entrypath: string;
   @Input() set selectedVersion(value: WorkflowVersion) {
     this._selectedVersion = value;
     this.clearSourceFiles();

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -806,3 +806,7 @@ mat-panel-title.org-accordion-header {
   right:30px;
   z-index: 99999;
 }
+
+.spacer {
+  flex: 1 1 auto;
+}


### PR DESCRIPTION
Adds copy and download buttons to hosted entries.
https://github.com/ga4gh/dockstore/issues/1739

Currently for hosted workflows we have a toolbar with the filename and delete button (fab). For other workflows we have the filename in a dropdown and then the download and copy button above and to the right of the code editor.

Including this PR, the following two images represent the currents state of hosted and remote workflows respectively.

I feel like it is a bit weird to not be consistent. We could add a toolbar to the remote workflows along with the icons for copy/download, but then would it look weird with the dropdown above? or could we move the dropdown into the toolbar? But then would people expect that with hosted workflows?

![hosted](https://user-images.githubusercontent.com/6331159/44466713-fa9a0f00-a5ee-11e8-9ba0-e20f62a2996f.png)
![remote-workflows](https://user-images.githubusercontent.com/6331159/44466715-fb32a580-a5ee-11e8-9463-fb85770439ff.png)

Edit:
Here is the remote workflows using a similar ui to the hosted workflows.
![remote-workflows-updated](https://user-images.githubusercontent.com/6331159/44471902-e825d280-a5fa-11e8-964b-36f9faa47b13.png)

