### PR TITLE
Cut size of sidenav tabs by half

### DIFF
--- a/cypress/integration/mytools.js
+++ b/cypress/integration/mytools.js
@@ -24,6 +24,7 @@ describe('Dockstore my tools', function() {
       cy.contains(org)
           .parentsUntil('mat-accordion')
           .contains("Unpublished")
+          .should('be.visible')
           .click()
     }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1191,3 +1191,10 @@ tabset.homeComponent {
 .align-middle {
   vertical-align: middle;
 }
+
+// Reduces the width of the sidebar tab by half (160px default). Can't seem to move this to the sidebar scss for some reason
+app-sidebar-accordion .mat-accordion > .mat-expansion-panel > .mat-expansion-panel-content > .mat-expansion-panel-body > .mat-tab-group > .mat-tab-header > .mat-tab-label-container > .mat-tab-list > .mat-tab-labels {
+  .mat-tab-label[role^='tab'] {
+    min-width: 80px;
+  }
+}


### PR DESCRIPTION
Reduces the tabs of the sidebar by half so that the "Unpublished" tab is not hidden too early.  Works for screens 1265px or wider.  Previously only works for screens 1605 and wider.