### PR TITLE
More form errors

### DIFF
--- a/cypress/integration/mytools.js
+++ b/cypress/integration/mytools.js
@@ -23,7 +23,10 @@ describe('Dockstore my tools', function() {
     function selectUnpublishedTab(org) {
       cy.contains(org)
           .parentsUntil('mat-accordion')
-          .contains("Unpublished")
+          .should('be.visible')
+          .find('mat-tab-group')
+          .should('be.visible')
+          .contains('div', 'Unpublished')
           .should('be.visible')
           .click()
     }

--- a/src/app/loginComponents/accounts/controls/controls.component.html
+++ b/src/app/loginComponents/accounts/controls/controls.component.html
@@ -11,7 +11,7 @@
 
   <mat-card>
     <h3>Delete your Dockstore Account</h3>
-    <p>Only available for accounts with no published tools/workflows.</p>
+    <p>Only available for accounts with no published tools/workflows and have shared no workflows via permissions.</p>
     <button class="mr-1" mat-raised-button color="warn" (click)="deleteAccount()" [disabled]="isDisabled">Delete Dockstore Account</button>
   </mat-card>
 </div>

--- a/src/app/loginComponents/accounts/controls/controls.component.spec.ts
+++ b/src/app/loginComponents/accounts/controls/controls.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { CustomMaterialModule } from '../../../shared/modules/material.module';
-import { ControlsComponent } from './controls.component';
-import { ChangeUsernameComponent } from '../internal/change-username/change-username.component';
-import { UserService } from '../../user.service';
-import { RefreshService } from './../../../shared/refresh.service';
-import { UserStubService, UsersStubService, RefreshStubService } from '../../../test/service-stubs';
 import { UsersService } from '../../../shared/swagger';
+import { RefreshStubService, UsersStubService, UserStubService } from '../../../test/service-stubs';
+import { UserService } from '../../user.service';
+import { ChangeUsernameComponent } from '../internal/change-username/change-username.component';
+import { RefreshService } from '../../../shared/refresh.service';
+import { ControlsComponent } from './controls.component';
 
 describe('ControlsComponent', () => {
   let component: ControlsComponent;
@@ -16,7 +17,7 @@ describe('ControlsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ControlsComponent, ChangeUsernameComponent ],
-      imports: [CustomMaterialModule, BrowserAnimationsModule],
+      imports: [CustomMaterialModule, BrowserAnimationsModule, ReactiveFormsModule],
       providers: [{provide: UserService, useClass: UserStubService},
       {provide: UsersService, useClass: UsersStubService},
       { provide: RefreshService, useClass: RefreshStubService }

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.html
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.html
@@ -13,18 +13,25 @@
 
 <div class="change-username-form">
   <mat-form-field>
-    <!-- TODO: Change to formInputDebounceTime -->
-    <input matInput placeholder="Username" name="username" [(value)]="username" (keyup)="checkIfUsernameExists($event)" id="username">
+    <mat-label>Username</mat-label>
+    <input [errorStateMatcher]="matcher" [formControl]="usernameFormControl" matInput id="username" name="username" [(ngModel)]="username">
+    <mat-error *ngIf="usernameFormControl.hasError('pattern'); else checkRequired">Invalid Username Pattern (Only alphanumeric characters and internal underscores and dashes allowed)</mat-error>
+    <ng-template #checkRequired>
+      <mat-error *ngIf="usernameFormControl.hasError('required'); else checkMaxLength">Username is required</mat-error>
+      <ng-template #checkMaxLength>
+        <mat-error *ngIf="usernameFormControl.hasError('maxlength')">Username is too long (Max 39 characters)</mat-error>
+      </ng-template>
+    </ng-template>
   </mat-form-field>
   <span class="change-username-form-buttons">
-    <button mat-raised-button color="primary" id="updateUsername" [disabled]="!usernameNotTaken || !usernameMeetsRequirements || !extendedUser?.canChangeUsername" (click)="updateUsername()">Update Username</button>
-
-    <span *ngIf="extendedUser?.canChangeUsername">
+    <button mat-raised-button color="primary" id="updateUsername" [disabled]="usernameTaken || usernameFormControl.invalid || !extendedUser?.canChangeUsername"
+      (click)="updateUsername()">Update Username</button>
+    <span *ngIf="extendedUser?.canChangeUsername && usernameFormControl.valid">
       <span *ngIf="!checkingIfValid">
-        <span *ngIf="usernameNotTaken && usernameMeetsRequirements" class="vertical-center">
+        <span *ngIf="!usernameTaken" class="vertical-center">
           <mat-icon style="color: green">check</mat-icon>&nbsp;Username available
         </span>
-        <span *ngIf="!usernameNotTaken || !usernameMeetsRequirements" class="vertical-center">
+        <span *ngIf="usernameTaken" class="vertical-center">
           <mat-icon style="color: red">clear</mat-icon>&nbsp;Username not available
         </span>
       </span>

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.spec.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.spec.ts
@@ -1,21 +1,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
-import { ChangeUsernameComponent } from './change-username.component';
-
-import { UserService } from '../../../../loginComponents/user.service';
-import { UsersService } from './../../../../shared/swagger/api/users.service';
-import { RefreshService } from './../../../../shared/refresh.service';
-import { UsersStubService, UserStubService, RefreshStubService } from './../../../../test/service-stubs';
-
+import { ReactiveFormsModule } from '@angular/forms';
 import {
   MatButtonModule,
+  MatFormFieldModule,
   MatIconModule,
-  MatTooltipModule,
-  MatProgressSpinnerModule,
   MatInputModule,
-  MatFormFieldModule
+  MatProgressSpinnerModule,
+  MatTooltipModule,
 } from '@angular/material';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { UserService } from '../../../../loginComponents/user.service';
+import { RefreshService } from '../../../../shared/refresh.service';
+import { UsersService } from '../../../../shared/swagger/api/users.service';
+import { RefreshStubService, UsersStubService, UserStubService } from '../../../../test/service-stubs';
+import { ChangeUsernameComponent } from './change-username.component';
+
 describe('ChangeUsernameComponent', () => {
   let component: ChangeUsernameComponent;
   let fixture: ComponentFixture<ChangeUsernameComponent>;
@@ -24,6 +24,7 @@ describe('ChangeUsernameComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ ChangeUsernameComponent ],
       imports: [
+        ReactiveFormsModule,
         MatIconModule,
         MatButtonModule,
         MatTooltipModule,

--- a/src/app/shared/error-state-matcher.ts
+++ b/src/app/shared/error-state-matcher.ts
@@ -1,0 +1,26 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import {Component} from '@angular/core';
+import {FormControl, FormGroupDirective, NgForm, Validators} from '@angular/forms';
+import {ErrorStateMatcher} from '@angular/material/core';
+
+/** Error when invalid control is dirty, touched, or submitted. */
+export class MyErrorStateMatcher implements MyErrorStateMatcher {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted));
+  }
+}


### PR DESCRIPTION
Several changes for ga4gh/dockstore#1761

1. Split username exist and invalid username into two separate indicators (current + an additional form error message underneath the input field)
2. Add a debouncer so that it's only checked whether it exists or not every 250ms at most
3. Don't even bother checking if username exists when the username is invalid.
4. Added custom error matcher so form errors are triggered after touched and dirty

Doesn't really do anything for the 2nd part because changing username is optional and button click is required to actually change the username