### PR TITLE
Add chip, lengthen description

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -1,3 +1,18 @@
+<!--
+   Copyright 2018 OICR
+ *
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ *
+       http://www.apache.org/licenses/LICENSE-2.0
+ *
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 <div *ngFor="let row of accountsInfo" class="p-3">
   <mat-card class="mb-2">
     <div>
@@ -7,6 +22,7 @@
             <mat-icon>link</mat-icon>
           </mat-chip>
           {{ row.name }} Account&nbsp;
+          <mat-chip [disabled]="true" *ngIf="row.bold" matTooltip="A method of logging into Dockstore">Login Method</mat-chip>
           <span *ngIf="row.isLinked">
             <button class="btn btn-secondary btn-xs" (click)="row.show = !row.show">
               <span *ngIf="row.show" class="glyphicon glyphicon-eye-close"></span>
@@ -28,7 +44,10 @@
       </h3>
     </div>
     <div>
-      <strong>{{ row.bold }} </strong> {{ row.message }}
+      {{ row.message }}
+    </div>
+    <div>
+      {{ row.bold }}
     </div>
     <mat-card-footer class="clearfix">
       <span *ngIf="row.isLinked; else notLinked" class="pull-right">

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -40,35 +40,35 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     {
       name: 'GitHub',
       source: TokenSource.GITHUB,
-      bold: 'Required',
-      message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub.',
+      bold: 'One of GitHub or Google is required.',
+      message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub',
       show: false
     },
     {
       name: 'Google',
       source: TokenSource.GOOGLE,
-      bold: 'Required',
+      bold: 'One of GitHub or Google is required.',
       message: 'Google credentials are used for login purposes and integration with FireCloud.',
       show: false
     },
     {
       name: 'Quay',
       source: TokenSource.QUAY,
-      bold: 'Optional',
+      bold: '',
       message: 'Quay.io credentials are used for pulling information about Docker images and automated builds.',
       show: false
     },
     {
       name: 'Bitbucket',
       source: TokenSource.BITBUCKET,
-      bold: 'Optional',
+      bold: '',
       message: 'Bitbucket credentials are used for pulling source code from Bitbucket.',
       show: false
     },
     {
       name: 'GitLab',
       source: TokenSource.GITLAB,
-      bold: 'Optional',
+      bold: '',
       message: 'GitLab credentials are used for pulling source code from GitLab.',
       show: false
     }


### PR DESCRIPTION
For ga4gh/dockstore#1735

Indicates that GitHub and Google are the login methods and that one of the two are required using a chip + longer descriptions