### PR TITLE
Feature/1747/linking account error

### DIFF
--- a/cypress/integration/dropdown.js
+++ b/cypress/integration/dropdown.js
@@ -42,7 +42,6 @@ describe('Dropdown test', function () {
       cy
         .get('#dropdown-accounts')
         .click()
-      cy.contains("External Accounts").click()
     });
 
     it('Should show all accounts as linked (except GitLab and Bitbucket)', function () {

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -48,6 +48,9 @@
           <li>
               <a href="https://status.dockstore.org/" class="footer-link">Status</a>
           </li>
+          <li>
+              <a [href]="dsServerURI + '/static/swagger-ui/index.html#'" class="footer-link">Swagger UI</a>
+          </li>
         </ul>
       </div>
       <div class="col-md-4 col-sm-6">

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -19,6 +19,7 @@ import { MetadataService } from '../metadata/metadata.service';
 import { Metadata } from './../shared/swagger/model/metadata';
 import { versions } from './versions';
 import { Subscription } from 'rxjs';
+import { Dockstore } from './../shared/dockstore.model';
 
 @Component({
   selector: 'app-footer',
@@ -30,12 +31,13 @@ export class FooterComponent implements OnInit, OnDestroy {
   tag: string;
   public prod = true;
   mdService: Subscription;
+  public dsServerURI: any;
 
   constructor(private metadataService: MetadataService) { }
 
   ngOnInit() {
     this.tag = versions.tag;
-
+    this.dsServerURI = Dockstore.API_URI;
     this.mdService = this.metadataService.getMetadata()
       .subscribe(
         (metadata: Metadata) => {

--- a/src/app/loginComponents/accounts/accounts.component.html
+++ b/src/app/loginComponents/accounts/accounts.component.html
@@ -4,11 +4,11 @@
 </app-header>
 <div class="container separation">
   <mat-tab-group>
+    <mat-tab label="Accounts">
+      <app-accounts-external></app-accounts-external>
+    </mat-tab>
     <mat-tab label="Profiles">
       <app-accounts-internal></app-accounts-internal>
-    </mat-tab>
-    <mat-tab label="External Accounts">
-      <app-accounts-external></app-accounts-external>
     </mat-tab>
     <mat-tab label="Dockstore Account Controls">
       <app-controls></app-controls>

--- a/src/app/loginComponents/accounts/external/accounts.component.css
+++ b/src/app/loginComponents/accounts/external/accounts.component.css
@@ -12,10 +12,3 @@
 mat-card-footer {
   padding: 24px;
 }
-
-.token-copy-container {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-}

--- a/src/app/loginComponents/accounts/external/accounts.component.css
+++ b/src/app/loginComponents/accounts/external/accounts.component.css
@@ -12,3 +12,10 @@
 mat-card-footer {
   padding: 24px;
 }
+
+.token-copy-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+}

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -1,3 +1,20 @@
+<div class="p-3">
+  <mat-card class="mb-2" *ngIf="dockstoreToken">
+    <h3>Dockstore Account</h3>
+    <span class="token-copy-container">
+      <strong>Token</strong>
+      <button [matTooltip]="show ? 'Hide token' : 'Show token'" mat-icon-button color="secondary" (click)="show = !show">
+        <mat-icon *ngIf="show">visibility_off</mat-icon>
+        <mat-icon *ngIf="!show">visibility</mat-icon>
+      </button>
+      <button mat-icon-button color="secondary" ngxClipboard [cbContent]="dockstoreToken" (cbOnSuccess)="isCopied1 = true" matTooltip="Copy Token">
+        <mat-icon>file_copy</mat-icon>
+      </button>
+      <span *ngIf="show" style="overflow: auto;">{{dockstoreToken}}</span>
+    </span>
+  </mat-card>
+</div>
+
 <div *ngFor="let row of accountsInfo" class="p-3">
   <mat-card class="mb-2">
     <div>
@@ -7,29 +24,25 @@
             <mat-icon>link</mat-icon>
           </mat-chip>
           {{ row.name }} Account&nbsp;
-          <span *ngIf="row.isLinked">
-            <button class="btn btn-secondary btn-xs" (click)="row.show = !row.show">
-              <span *ngIf="row.show" class="glyphicon glyphicon-eye-close"></span>
-              <span *ngIf="!row.show" class="glyphicon glyphicon-eye-open"></span>
-            </button>
-            <span class="form-inline" *ngIf="row.show">
-              <span class="input-group">
-                <!-- TODO: Only have 1 pipe here -->
-                <span class="form-control input-xs">{{row.source | getTokenContent: tokens}}</span>
-                <span class="input-group-btn">
-                  <button class="btn btn-default btn-xs" type="button" ngxClipboard [cbContent]="row.source | getTokenContent: tokens" (cbOnSuccess)="isCopied1 = true">
-                    <span class="glyphicon glyphicon-copy"></span>
-                  </button>
-                </span>
-              </span>
-            </span>
-          </span>
         </mat-chip-list>
       </h3>
     </div>
     <div>
       <strong>{{ row.bold }} </strong> {{ row.message }}
     </div>
+
+    <span class="token-copy-container" *ngIf="row.isLinked">
+      <strong>Token</strong>
+      <button mat-icon-button color="secondary" (click)="row.show = !row.show">
+        <mat-icon *ngIf="row.show">visibility_off</mat-icon>
+        <mat-icon *ngIf="!row.show">visibility</mat-icon>
+      </button>
+      <button mat-icon-button color="secondary" ngxClipboard [cbContent]="row.source | getTokenContent: tokens" (cbOnSuccess)="isCopied1 = true">
+        <mat-icon>file_copy</mat-icon>
+      </button>
+      <span *ngIf="row.show" style="overflow: auto;">{{row.source | getTokenContent: tokens}}</span>
+    </span>
+
     <mat-card-footer class="clearfix">
       <span *ngIf="row.isLinked; else notLinked" class="pull-right">
         <span class="mr-2">Username: {{row.source | getTokenUsername: tokens}}</span>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -1,7 +1,7 @@
 <div class="p-3">
   <mat-card class="mb-2" *ngIf="dockstoreToken">
     <h3>Dockstore Account</h3>
-    <span class="token-copy-container">
+    <span fxLayout="row" fxLayoutAlign="start center">
       <strong>Token</strong>
       <button [matTooltip]="show ? 'Hide token' : 'Show token'" mat-icon-button color="secondary" (click)="show = !show">
         <mat-icon *ngIf="show">visibility_off</mat-icon>
@@ -31,7 +31,7 @@
       <strong>{{ row.bold }} </strong> {{ row.message }}
     </div>
 
-    <span class="token-copy-container" *ngIf="row.isLinked">
+    <span fxLayout="row" fxLayoutAlign="start center" *ngIf="row.isLinked">
       <strong>Token</strong>
       <button mat-icon-button color="secondary" (click)="row.show = !row.show">
         <mat-icon *ngIf="row.show">visibility_off</mat-icon>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -1,6 +1,9 @@
 <div class="p-3">
   <mat-card class="mb-2" *ngIf="dockstoreToken">
     <h3>Dockstore Account</h3>
+    <div>
+      Use with our CLI utilities or with our <a [href]="dsServerURI + '/static/swagger-ui/index.html#'" target="_blank">REST web service interface</a> to work with and launch tools and workflows.
+    </div>
     <span fxLayout="row" fxLayoutAlign="start center">
       <strong>Token</strong>
       <button [matTooltip]="show ? 'Hide token' : 'Show token'" mat-icon-button color="secondary" (click)="show = !show">

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -27,6 +27,7 @@ import { UsersService } from './../../../shared/swagger/api/users.service';
 import { Configuration } from './../../../shared/swagger/configuration';
 import { Token } from './../../../shared/swagger/model/token';
 import { AccountsService } from './accounts.service';
+import { MatSnackBar } from '@angular/material';
 
 @Component({
   selector: 'app-accounts-external',
@@ -77,10 +78,12 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   public tokens: Token[];
   private userId;
   private ngUnsubscribe: Subject<{}> = new Subject();
-
+  public show: false;
+  protected dockstoreToken: string;
   constructor(private trackLoginService: TrackLoginService, private tokenService: TokenService, private userService: UserService,
     private activatedRoute: ActivatedRoute, private router: Router, private usersService: UsersService,
-    private authService: AuthService, private configuration: Configuration, private accountsService: AccountsService) {
+    private authService: AuthService, private configuration: Configuration, private accountsService: AccountsService,
+    private matSnackBar: MatSnackBar) {
     this.trackLoginService.isLoggedIn$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(
       state => {
         if (!state) {
@@ -88,6 +91,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
         }
       }
     );
+    this.dockstoreToken = this.getDockstoreToken();
   }
 
   // Delete token by id
@@ -100,6 +104,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   }
 
   link(source: string): void {
+    this.matSnackBar.open('Linking ' + source + ' account', 'Dismiss');
     this.accountsService.link(source);
   }
 
@@ -108,6 +113,9 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     this.deleteToken(source).pipe(
       first()).subscribe(() => {
         this.userService.updateUser();
+        this.matSnackBar.open('Unlinked ' + source + ' account', 'Dismiss');
+      }, error => {
+        this.matSnackBar.open('Failed to unlink ' + source, 'Dismiss');
       });
   }
 
@@ -129,6 +137,11 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     if (tokens) {
       this.setAvailableTokens(tokens);
     }
+  }
+
+  // TODO: Fix, it is called a bajillion times
+  getDockstoreToken(): string {
+    return this.authService.getToken();
   }
 
   ngOnInit() {

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -79,7 +79,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   private userId;
   private ngUnsubscribe: Subject<{}> = new Subject();
   public show: false;
-  protected dockstoreToken: string;
+  public dockstoreToken: string;
   constructor(private trackLoginService: TrackLoginService, private tokenService: TokenService, private userService: UserService,
     private activatedRoute: ActivatedRoute, private router: Router, private usersService: UsersService,
     private authService: AuthService, private configuration: Configuration, private accountsService: AccountsService,

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -139,7 +139,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     }
   }
 
-  // TODO: Fix, it is called a bajillion times
   getDockstoreToken(): string {
     return this.authService.getToken();
   }

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -28,6 +28,7 @@ import { Configuration } from './../../../shared/swagger/configuration';
 import { Token } from './../../../shared/swagger/model/token';
 import { AccountsService } from './accounts.service';
 import { MatSnackBar } from '@angular/material';
+import { Dockstore } from '../../../shared/dockstore.model';
 
 @Component({
   selector: 'app-accounts-external',
@@ -35,7 +36,7 @@ import { MatSnackBar } from '@angular/material';
   styleUrls: ['./accounts.component.css']
 })
 export class AccountsExternalComponent implements OnInit, OnDestroy {
-
+  public dsServerURI: any;
   // TODO: Uncomment section when GitLab is enabled
   accountsInfo: Array<any> = [
     {
@@ -144,6 +145,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.dsServerURI = Dockstore.API_URI;
     this.tokenService.tokens$.subscribe((tokens: Token[]) => {
       this.setTokens(tokens);
     });

--- a/src/app/loginComponents/accounts/internal/accounts.component.html
+++ b/src/app/loginComponents/accounts/internal/accounts.component.html
@@ -39,21 +39,6 @@
           </h1>
           <p matLine id="account-is-admin">{{ user?.isAdmin ? 'Yes' : 'No' }}</p>
         </mat-list-item>
-        <mat-list-item *ngIf="getDockstoreToken()">
-          <strong>Dockstore Token:</strong>
-          <button class="btn btn-default ml-1" matTooltip="Copy token" type="button" ngxClipboard [cbContent]="getDockstoreToken()" (cbOnSuccess)="isCopied1 = true">
-            <span class="glyphicon glyphicon-copy"></span>
-          </button>
-          <button [matTooltip]="show ? 'Hide token' : 'Show token'" class="btn btn-default" (click)="show = !show">
-            <span *ngIf="show" class="glyphicon glyphicon-eye-close"></span>
-            <span *ngIf="!show" class="glyphicon glyphicon-eye-open"></span>
-          </button>
-        </mat-list-item>
-        <br>
-        <mat-list-item *ngIf="show">
-          <!-- TODO: Only have 1 pipe here -->
-          <textarea type="text" matTextareaAutosize matInput class="small w-100" readonly>{{getDockstoreToken()}}</textarea>
-        </mat-list-item>
       </mat-list>
     </mat-card-content>
   </mat-card>

--- a/src/app/loginComponents/accounts/internal/accounts.component.ts
+++ b/src/app/loginComponents/accounts/internal/accounts.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
-import { AuthService } from 'ng2-ui-auth';
 import { Observable } from 'rxjs';
 
 import { TokenSource } from '../../../shared/enum/token-source.enum';
@@ -21,10 +20,9 @@ export class AccountsInternalComponent implements OnInit {
   gitHubProfile: Profile;
   hasGitHubToken$: Observable<boolean>;
   hasGoogleToken$: Observable<boolean>;
-  show: false;
   public syncing = false;
   constructor(private userService: UserService, private usersService: UsersService, private configuration: Configuration,
-    private authService: AuthService, private tokenService: TokenService, private matSnackBar: MatSnackBar) {
+    private tokenService: TokenService, private matSnackBar: MatSnackBar) {
     this.hasGitHubToken$ = this.tokenService.hasGitHubToken$;
     this.hasGoogleToken$ = this.tokenService.hasGoogleToken$;
   }
@@ -44,11 +42,6 @@ export class AccountsInternalComponent implements OnInit {
       this.syncing = false;
     },
     );
-  }
-
-  // TODO: Fix, it is called a bajillion times
-  getDockstoreToken(): string {
-    return this.authService.getToken();
   }
 
   private getUser() {


### PR DESCRIPTION
* switches order of external accounts and profiles pages
* snackbar message for linking account (not success or failure, only that the process is starting) and for unlinking account (one for unlinking success and one for failure)
* moves the dockstore token to the accounts page, in a new dockstore section
* makes the copy/view token nicer (material)

Note that I wasn't able to get the error snackbar message for when linking accounts don't work, so that issue cannot be closed yet. But at least now you are redirected to the same page, so that you can see that the account was not linked.

https://github.com/ga4gh/dockstore/issues/1747

Swagger UI link in footer
https://github.com/ga4gh/dockstore/issues/1375

![screenshot from 2018-08-27 10-07-27](https://user-images.githubusercontent.com/6331159/44664361-07e53e00-a9e1-11e8-9e99-abf240388de2.png)
