### PR TITLE
Don't create 2 instances of UserService

### DIFF
--- a/src/app/stargazers/stargazers.module.ts
+++ b/src/app/stargazers/stargazers.module.ts
@@ -20,7 +20,6 @@ import { StargazersComponent } from './stargazers.component';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { StarentryService } from '../shared/starentry.service';
 import { StarringService } from '../starring/starring.service';
-import { UserService } from '../loginComponents/user.service';
 @NgModule({
   imports: [
     CommonModule,
@@ -34,7 +33,6 @@ import { UserService } from '../loginComponents/user.service';
   ],
   providers: [
     StarringService,
-    UserService,
     StarentryService
   ]
 })


### PR DESCRIPTION
ga4gh/dockstore#1764

UserService is listed as a provider in app.module.ts. A second instance
of the UserService was getting loaded due to the 2 declarations, in
here and in app.module.ts, which led to odd behavior:

Logging in and out out would only update one of the instances of the
service, and then when the other instance came into play for some
components, that instances would still have a reference to the previous
user.