### PR TITLE
Simple fix

### DIFF
--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -109,7 +109,7 @@ export abstract class LaunchService {
       const outputFile = `-O Dockstore.json`;
       const encodedID = encodeURIComponent(`#workflow/${ workflowPath }`);
       const encodedVersion = encodeURIComponent(`${ versionName }`);
-      const url = `${Dockstore.API_URI}${ga4ghPath}/tools/${encodedID}/versions/${encodedVersion}/${urlType}/descriptor/${filePath}`;
+      const url = `${Dockstore.API_URI}${ga4ghPath}/tools/${encodedID}/versions/${encodedVersion}/${urlType}/descriptor/${encodeURIComponent(filePath)}`;
       return `${prefix}' ${url} ${outputFile}`;
     }
 }


### PR DESCRIPTION
Simple fix for launch command for relative file paths that have  `../` in it (like the HCA workflow).  Downside is even perfectly legit `/` are also encoded everywhere else