### PR TITLE
improved default version tooltip

### DIFF
--- a/src/app/shared/tooltip.ts
+++ b/src/app/shared/tooltip.ts
@@ -4,7 +4,7 @@ export const Tooltip = {
     'workflowPath': 'Path in Git repository to main descriptor file',
     'defaultVersionUser': 'The branch that the tool/workflow author intends others to use',
     'defaultVersionAuthor': 'Set default version. The default version denotes the version of the tool/workflow you intend others to use. ' +
-    'The default version determines what is displayed in the Info tab (Description, Launch With, etc)',
+    'The default version determines the authorship information and description displayed in the info tab.',
     'workflowName': 'Name to distinguish between multiple workflows within the same repository'
 };
 


### PR DESCRIPTION
Updates the tooltip for default versions, before it was too general.

https://github.com/ga4gh/dockstore/issues/1230