### PR TITLE
Fix for table tool content called twice

### DIFF
--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -594,6 +594,9 @@ export class DateStubService {
 }
 
 export class WorkflowsStubService {
+    getTableToolContent(workflowId: number, workflowVersionId: number, observe?: 'body', reportProgress?: boolean): Observable<string> {
+      return observableOf('tableToolContentString');
+    }
     sharedWorkflows() {
       return observableOf([]);
     }

--- a/src/app/workflow/tool-tab/tool-tab.component.html
+++ b/src/app/workflow/tool-tab/tool-tab.component.html
@@ -23,17 +23,17 @@
             <span class="glyphicon pull-right">
             </span>
           </th>
-          <th *ngIf="workflow.descriptorType === 'cwl'">
+          <th *ngIf="workflow?.descriptorType === 'cwl'">
             Tool Excerpt
             <span class="glyphicon pull-right">
             </span>
           </th>
-          <th *ngIf="workflow.descriptorType === 'wdl'">
+          <th *ngIf="workflow?.descriptorType === 'wdl'">
             Task Excerpt
             <span class="glyphicon pull-right">
             </span>
           </th>
-          <th *ngIf="workflow.descriptorType === 'nfl'">
+          <th *ngIf="workflow?.descriptorType === 'nfl'">
             Process Excerpt
             <span class="glyphicon pull-right">
             </span>
@@ -52,10 +52,10 @@
           </td>
         </tr>
         <tr *ngFor="let tool of toolsContent">
-          <td *ngIf="workflow.descriptorType === 'cwl'">
+          <td *ngIf="workflow?.descriptorType === 'cwl'">
             <strong>tool ID</strong>: {{tool?.id}}
           </td>
-          <td *ngIf="workflow.descriptorType === 'cwl'">
+          <td *ngIf="workflow?.descriptorType === 'cwl'">
             <strong>run</strong>: {{tool?.file}}
             <br>
             <strong>docker</strong>: {{tool?.docker}}
@@ -65,11 +65,11 @@
             <span *ngIf="tool?.link === 'Not Specified'">Not Specified</span>
           </td>
 
-          <td *ngIf="workflow.descriptorType === 'wdl'">
+          <td *ngIf="workflow?.descriptorType === 'wdl'">
             <strong>task ID</strong>: {{tool?.id}}
             <br>
           </td>
-          <td *ngIf="workflow.descriptorType === 'wdl'">
+          <td *ngIf="workflow?.descriptorType === 'wdl'">
             <strong>docker</strong>: {{tool?.docker}}
             <br>
             <strong>link</strong>:
@@ -77,11 +77,11 @@
             <span *ngIf="tool?.link === 'Not Specified'">Not Specified</span>
           </td>
 
-          <td *ngIf="workflow.descriptorType === 'nfl'">
+          <td *ngIf="workflow?.descriptorType === 'nfl'">
             <strong>process name</strong>: {{tool?.id}}
             <br>
           </td>
-          <td *ngIf="workflow.descriptorType === 'nfl'">
+          <td *ngIf="workflow?.descriptorType === 'nfl'">
             <strong>docker</strong>: {{tool?.docker}}
             <br>
             <strong>link</strong>:

--- a/src/app/workflow/tool-tab/tool-tab.component.spec.ts
+++ b/src/app/workflow/tool-tab/tool-tab.component.spec.ts
@@ -49,4 +49,13 @@ describe('ToolTabComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should update table tool content', () => {
+    component.updateTableToolContent(1, null);
+    expect(component.toolsContent).toBe(null);
+    component.updateTableToolContent(null, 1);
+    expect(component.toolsContent).toBe(null);
+    component.updateTableToolContent(1, 1);
+    expect(component.toolsContent).toBe('tableToolContentString');
+  });
 });

--- a/src/app/workflow/tool-tab/tool-tab.component.ts
+++ b/src/app/workflow/tool-tab/tool-tab.component.ts
@@ -13,51 +13,60 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnInit } from '@angular/core';
-import { distinctUntilChanged } from 'rxjs/operators';
+import { Component, Input } from '@angular/core';
+import { first } from 'rxjs/operators';
 
+import { EntryTab } from '../../shared/entry/entry-tab';
+import { WorkflowVersion } from '../../shared/swagger';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { Workflow } from './../../shared/swagger/model/workflow';
 import { WorkflowService } from './../../shared/workflow.service';
-import { EntryTab } from '../../shared/entry/entry-tab';
-import { WorkflowVersion } from '../../shared/swagger';
 
 @Component({
   selector: 'app-tool-tab',
   templateUrl: './tool-tab.component.html',
   styleUrls: ['./tool-tab.component.css']
 })
-export class ToolTabComponent extends EntryTab implements OnInit {
+export class ToolTabComponent extends EntryTab {
   workflow: Workflow;
-  toolsContent: any;
+  toolsContent: string = null;
   _selectedVersion: WorkflowVersion;
   @Input() set selectedVersion(value: WorkflowVersion) {
     if (value != null) {
-      this._selectedVersion = value;
-      this.onChange();
+      this.workflowService.workflow$.pipe(first()).subscribe((workflow: Workflow) => {
+        this.workflow = workflow;
+        if (workflow) {
+          this.updateTableToolContent(workflow.id, value.id);
+        } else {
+          console.error('Should not be able to select version without a workflow');
+        }
+      }, error => {
+        console.error('Something has gone terribly wrong with the workflow$ observable.');
+      });
+    } else {
+      this.toolsContent = null;
     }
   }
   constructor(private workflowService: WorkflowService, private workflowsService: WorkflowsService) {
     super();
   }
 
-  ngOnInit() {
-    this.workflowService.workflow$.pipe(distinctUntilChanged()).subscribe(workflow => {
-      if (workflow) {
-        this.workflow = workflow;
-        if (workflow.workflowVersions) {
-          this.onChange();
-        }
-      }
-    });
-  }
-
-  onChange() {
-    if (this._selectedVersion && this.workflow) {
-      this.workflowsService.getTableToolContent(this.workflow.id, this._selectedVersion.id).subscribe(
+  /**
+   * Update the table tool contents for the current workflow and workflow version
+   *
+   * @param {number} workflowId  The workflow Id
+   * @param {number} versionId   The workflowVersion Id
+   * @memberof ToolTabComponent
+   */
+  updateTableToolContent(workflowId: number, versionId: number): void {
+    if (workflowId && versionId) {
+      this.workflowsService.getTableToolContent(workflowId, versionId).subscribe(
         (toolContent) => {
           this.toolsContent = toolContent;
-        }, error => this.toolsContent = null);
+        }, error => {
+          console.log('Could not retrieve table tool content');
+          this.toolsContent = null;
+        });
     } else {
       this.toolsContent = null;
     }


### PR DESCRIPTION
Fix for table tool content endpoint being called twice:
- first when the tool changes
- 2nd when version selected inevitably changes due to change detection

Now calls the endpoint when version is gotten and then workflow is gotten (relies on workflow$ being updated before version).
