### PR TITLE
Fix for permissions killing non-hosted workflow viewing

### DIFF
--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -166,7 +166,9 @@ export class WorkflowComponent extends Entry {
           this.canRead = actions.indexOf('READ') !== -1;
           this.canWrite = actions.indexOf('WRITE') !== -1;
           this.isOwner = actions.indexOf('SHARE') !== -1;
-          if (this.isOwner) {
+          // TODO: when expanding permissions beyond hosted workflows, this component will need to tolerate a 401
+          // for users that are not on FireCloud
+          if (this.isOwner && this.isHosted()) {
             this.workflowsService.getWorkflowPermissions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe))
               .subscribe((userPermissions: Permission[]) => {
                 this.processPermissions(userPermissions);


### PR DESCRIPTION
Looks like we were asking for permissions for all workflows, not just hosted workflows. 
This is a quick patch, but the UI should be tolerant of a 401 long term, showing a workflow to its owner in this example, rather than dying completely. 