### PR TITLE
Don't set Authorization header if no token

### DIFF
--- a/src/app/loginComponents/token.service.ts
+++ b/src/app/loginComponents/token.service.ts
@@ -36,7 +36,8 @@ export class TokenService {
       }
     });
     this.hasSourceControlToken$ = this.tokens$.pipe(map(tokens => this.hasSourceControlToken(tokens)));
-    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
+    const token = this.authService.getToken();
+    this.configuration.apiKeys['Authorization'] = token ? ('Bearer ' + token) : null;
     this.tokens$.subscribe(tokens => this.tokens = tokens);
   }
 

--- a/src/app/loginComponents/user.service.ts
+++ b/src/app/loginComponents/user.service.ts
@@ -43,7 +43,8 @@ export class UserService {
   }
 
   updateUser() {
-    this.configuration.apiKeys['Authorization'] = 'Bearer ' + this.authService.getToken();
+    const token = this.authService.getToken();
+    this.configuration.apiKeys['Authorization'] = token ? ('Bearer ' + token) : null;
     this.usersService.getUser().subscribe(
       (user: User) => this.setUser(user),
       error => {


### PR DESCRIPTION
#1818

Header value was getting set to the string `Bearer null`.

We could instead delete the 'Authorization' property, but I think
this approach is better, as you can see the value is intentionally
set to null.