### PR TITLE
Deleting file in hosted edit mode

### DIFF
--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -63,11 +63,15 @@ export class CodeEditorListComponent {
   }
 
   /**
-   * Deletes the file at the given index
+   * Deletes the file at the given index by setting content to null.
+   * If it is a new file being deleted (not from previous version) then just remove from the list
    * @param  index index of file to delete
    */
   deleteFile(index: number) {
     this.sourcefiles[index].content = null;
+    if (this.sourcefiles[index].id === undefined || this.sourcefiles[index].id === null) {
+      this.sourcefiles.splice(index, 1);
+    }
   }
 
   /**


### PR DESCRIPTION
In the hosted entry edit mode, if you click add file and then delete it, it would previously keep the file in the array of source files even though it is hidden. This can mess some stuff up when saving the new version fails, and possibly other scenarios. Now if the file did not exist in the previous version it will be deleted.

A workaround for this is to simply refresh the page.