### PR TITLE
added link to onboarding for CLI info

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -19,6 +19,7 @@
     <h3>Dockstore Account</h3>
     <div>
       Use with our CLI utilities or with our <a [href]="dsServerURI + '/static/swagger-ui/index.html#'" target="_blank">REST web service interface</a> to work with and launch tools and workflows.
+      See the <a href="/onboarding">Onboarding</a> page for more details on using the CLI.
     </div>
     <span fxLayout="row" fxLayoutAlign="start center">
       <strong>Token</strong>


### PR DESCRIPTION
https://github.com/ga4gh/dockstore/issues/1841

After more thought I ended up only linking to the onboarding from the accounts page. I thought that adding the config would be cluttered. I still think this solves the problem, because a user would probably go to the accounts page to figure out how to setup the CLI and the link to onboarding would be right at the top.