### PR TITLE
Feature/1864/export as zip

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -166,8 +166,8 @@
     </li>
   </ul>
 
-  <span *ngIf="isValidVersion">
-    <button id="downloadZipButton" *ngIf="!tool?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+  <span *ngIf="isValidVersion" id="downloadZipButton">
+    <button *ngIf="!tool?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
     <a [href]="downloadZipLink" *ngIf="tool?.is_published"  mat-raised-button>Export as ZIP</a>
   </span>
 

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -166,7 +166,11 @@
     </li>
   </ul>
 
-  <button id="downloadZipButton" *ngIf="isValidVersion"  mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+  <span *ngIf="isValidVersion">
+    <button id="downloadZipButton" *ngIf="!tool?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+    <a [href]="downloadZipLink" *ngIf="tool?.is_published"  mat-raised-button>Export as ZIP</a>
+  </span>
+
 
   <div *ngIf="tool?.description || !isPublic">
     <label matTooltip="Description of tool obtained from tool descriptor">

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -106,7 +106,10 @@
   </li>
 </ul>
 
-<button id="downloadZipButton" *ngIf="isValidVersion" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+<span *ngIf="isValidVersion">
+  <button id="downloadZipButton" *ngIf="!workflow?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+  <a [href]="downloadZipLink" *ngIf="workflow?.is_published"  mat-raised-button>Export as ZIP</a>
+</span>
 
 <div *ngIf="workflow && workflow?.mode !== WorkflowType.ModeEnum.STUB">
   <div *ngIf="workflow?.description || !isPublic">

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -106,8 +106,8 @@
   </li>
 </ul>
 
-<span *ngIf="isValidVersion">
-  <button id="downloadZipButton" *ngIf="!workflow?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
+<span *ngIf="isValidVersion" id="downloadZipButton">
+  <button *ngIf="!workflow?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
   <a [href]="downloadZipLink" *ngIf="workflow?.is_published"  mat-raised-button>Export as ZIP</a>
 </span>
 


### PR DESCRIPTION
Better approach for download ZIP. Unfortunately can only use this for published entries. Benefits is that it is not blocked by popup blockers in the browser, and also the name of the ZIP file isn't random numbers.

https://github.com/ga4gh/dockstore/issues/1864