### PR TITLE
Put all prebuild steps into prebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ jobs:
     - stage: test
       script:
         - ng lint
-        - npm run prebuild
         - ng test --watch=false --code-coverage --browsers ChromeHeadless
         - ng version
         - npm run build.prod

--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ os: linux x64
 If you wish to serve the dist folder in a VM, make sure you have nginx and security rules set up properly.
 [Nginx](https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-16-04)
 
-## Swagger
-
-You will need to generate the Dockstore client classes (version numbers may change frequently).
-Look at the setup in the [travis.yml](.travis.yml)
-
 ## Project Set Up
 
 The Dockstore class in [src/app/shared/dockstore.model.ts](src/app/shared/dockstore.model.ts) is for integrating supported services.
@@ -100,7 +95,10 @@ In `dockstore-webservice`, the `dockstore.yml` being served <b>must be edited to
 
 ## Pre-build/serve
 
-Run `npm run prebuild` before running or building the project. This command will automatically generate a file which contains the UI tag version.
+Run `npm run prebuild` before running or building the project. This command will:
+- generate a file which contains the UI tag version 
+- download the openapi codegen
+- generate code from the swagger.yaml
 
 ## Development server
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "prebuild.prod": "ts-node git.version.ts",
-    "prebuild": "ts-node git.version.ts",
+    "prebuild:tsnode": "ts-node git.version.ts",
+    "prebuild:downloadcodegen": "wget --no-verbose http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.1/openapi-generator-cli-3.3.1.jar -O swagger-codegen-cli.jar",
+    "prebuild:generatecode": "java -jar swagger-codegen-cli.jar generate -i https://raw.githubusercontent.com/ga4gh/dockstore/${WEBSERVICE_VERSION}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json", 
+    "prebuild": "npm run prebuild:tsnode && npm run prebuild:downloadcodegen && npm run prebuild:generatecode",
+    "prebuild.prod": "npm run prebuild:tsnode && npm run prebuild:downloadcodegen && npm run prebuild:generatecode",
     "build.prod": "ng build --progress false --prod",
     "build": "ng build --progress false",
     "test": "ng test",

--- a/scripts/install-travis-script.sh
+++ b/scripts/install-travis-script.sh
@@ -11,5 +11,4 @@ chmod u+x dockstore-webservice-${WEBSERVICE_VERSION}.jar
 ng version
 npm install codecov
 
-wget --no-verbose http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.1/openapi-generator-cli-3.3.1.jar -O swagger-codegen-cli.jar
-java -jar swagger-codegen-cli.jar generate -i https://raw.githubusercontent.com/ga4gh/dockstore/${WEBSERVICE_VERSION}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
+npm run prebuild


### PR DESCRIPTION
Generating the code from swagger.yaml was getting a little annoying.  Making a script for it and adding it to prebuild