### PR TITLE
Feature/1933/no checker search default

### DIFF
--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -20,6 +20,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { TwitterService } from '../shared/twitter.service';
 import { HomeComponent } from './home.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -31,6 +32,7 @@ describe('HomeComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
         TabsModule.forRoot(),
+        RouterTestingModule,
         MatButtonModule,
         MatIconModule,
         MatDialogModule

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -13,8 +13,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { AfterViewInit, Component, ElementRef, OnInit, Renderer2, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material';
+import { Router } from '@angular/router';
 import { TabDirective } from 'ngx-bootstrap/tabs';
 import { Observable } from 'rxjs';
 
@@ -49,8 +50,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
   @ViewChild('youtube') youtube: ElementRef;
 
-  constructor(private dialog: MatDialog, private renderer: Renderer2, private twitterService: TwitterService,
-    private userQuery: UserQuery) {
+  constructor(private dialog: MatDialog, private twitterService: TwitterService,
+    private userQuery: UserQuery, private router: Router) {
   }
 
   ngOnInit() {
@@ -61,7 +62,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   goToSearch(searchValue: string) {
-    window.location.href = '/search?search=' + searchValue;
+    this.router.navigate(['/search'], {queryParams: {is_checker: 0, search: searchValue}});
   }
 
   onSelect(data: TabDirective): void {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -26,7 +26,7 @@
         <a mat-button class="icon" (click)="resetPageNumber()" routerLink="/workflows">
             <img class="site-icons-small hidden-sm" src="../assets/images/dockstore/dockstore-workflows-purple.png"> Workflows
         </a>
-        <a mat-button class="icon" routerLink="/search">
+        <a mat-button class="icon" [routerLink]="['/search']" [queryParams]="{is_checker: '0'}">
             <img class="site-icons-small hidden-sm" src="../assets/images/dockstore/search-button.png"> Search
         </a>
         <a mat-button class="icon" href="http://docs.dockstore.org/">

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -52,11 +52,12 @@ export class MapFriendlyValuesPipe implements PipeTransform {
    * This pipe searches the friendly value names map for the key whose value is 'subBucket'
    *
    * @param {string} key The key (e.g. file_formats.keyword)
-   * @param {string} subBucket The sub-bucket value (e.g. http://edamontology.org/data_9090)
+   * @param {(string | number)} subBucket The sub-bucket value (e.g. http://edamontology.org/data_9090)
    * @returns {string} The friendly name if found, otherwise the same name
    * @memberof MapFriendlyValuesPipe
    */
-  transform(key: string, subBucket: string): string {
+  transform(key: string, subBucket: string | number): string {
+    subBucket = subBucket.toString();
     if (!subBucket) {
       return subBucket;
     }


### PR DESCRIPTION
For ga4gh/dockstore#1933
By default, home search will search non-checker workflows
By default, clicking the search at navbar will search non-checker workflows

Also:
- Fixes the map friendly value pipe to handle numbers (for some reason my elasticsearch was returning number 0 instead of string '0').  First time truthy check has failed me :cry: 
- Speeds up the home search by using routerlink
