### PR TITLE
Feature/1937/loading default true

### DIFF
--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -53,7 +53,7 @@
     </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
   </div>
-  <alert type="warning" *ngIf="!content">
+  <alert type="warning" *ngIf="!nullDescriptors">
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;A Descriptor File associated with this Docker container could not be found.
   </alert>

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -24,37 +24,44 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <div *ngIf="content">
+  <mat-progress-bar mode="indeterminate" *ngIf="loading; else loaded"></mat-progress-bar>
+  <ng-template #loaded>
+    <div *ngIf="content">
     <span class="row m-0">
       <span class="col-sm-4">
-        <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
+        <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor"
+                    (select)="onDescriptorChange($event)"></app-select>
       </span>
     </span>
-  </div>
-  <div [hidden]="!content">
-    <mat-toolbar color="primary">
-      <mat-toolbar-row>
-        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-        <span class="spacer"></span>
-        <div class="btn-group pull-right" role="group">
-          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-            <mat-icon>save_alt</mat-icon>
-          </a>
-          <ng-template #unpublishedDownloadLink>
-            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+    </div>
+    <div [hidden]="!content">
+      <mat-toolbar color="primary">
+        <mat-toolbar-row>
+          <app-select [items]="files" [default]="currentFile" [field]="'path'"
+                      (select)="onFileChange($event)"></app-select>
+          <span class="spacer"></span>
+          <div class="btn-group pull-right" role="group">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink"
+               download [href]="downloadFilePath" type="button" title="{{filePath}}">
               <mat-icon>save_alt</mat-icon>
             </a>
-          </ng-template>
-          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
-            <mat-icon>file_copy</mat-icon>
-          </button>
-        </div>
-      </mat-toolbar-row>
-    </mat-toolbar>
-    <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
-  </div>
-  <alert type="warning" *ngIf="!nullDescriptors">
-    <span class="glyphicon glyphicon-warning-sign"></span>
-    &nbsp;A Descriptor File associated with this Docker container could not be found.
-  </alert>
+            <ng-template #unpublishedDownloadLink>
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF"
+                 [download]="customDownloadPath" type="button" title="{{filePath}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+            </ng-template>
+            <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+              <mat-icon>file_copy</mat-icon>
+            </button>
+          </div>
+        </mat-toolbar-row>
+      </mat-toolbar>
+      <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
+    </div>
+    <alert type="warning" *ngIf="nullDescriptors">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      &nbsp;A Descriptor File associated with this Docker container could not be found.
+    </alert>
+  </ng-template>
 </div>

--- a/src/app/container/dockerfile/dockerfile.component.html
+++ b/src/app/container/dockerfile/dockerfile.component.html
@@ -24,30 +24,35 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <alert type="warning" *ngIf="!content">
-    <span class="glyphicon glyphicon-warning-sign"></span>
-    &nbsp;A Dockerfile associated with this Docker container could not be found.
-  </alert>
-  <div [hidden]="!content || !_selectedVersion?.valid">
-    <mat-toolbar color="primary">
-      <mat-toolbar-row>
-        <span>{{filePath}}</span>
-        <span class="spacer"></span>
-        <div class="btn-group pull-right" role="group">
-          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-            <mat-icon>save_alt</mat-icon>
-          </a>
-          <ng-template #unpublishedDownloadLink>
-            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+  <mat-progress-bar mode="indeterminate" *ngIf="loading; else loaded"></mat-progress-bar>
+  <ng-template #loaded>
+    <alert type="warning" *ngIf="!content">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      &nbsp;A Dockerfile associated with this Docker container could not be found.
+    </alert>
+    <div [hidden]="!content || !_selectedVersion?.valid">
+      <mat-toolbar color="primary">
+        <mat-toolbar-row>
+          <span>{{filePath}}</span>
+          <span class="spacer"></span>
+          <div class="btn-group pull-right" role="group">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink"
+               download [href]="downloadFilePath" type="button" title="{{filePath}}">
               <mat-icon>save_alt</mat-icon>
             </a>
-          </ng-template>
-          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
-            <mat-icon>file_copy</mat-icon>
-          </button>
-        </div>
-      </mat-toolbar-row>
-    </mat-toolbar>
-    <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
-  </div>
+            <ng-template #unpublishedDownloadLink>
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF"
+                 [download]="customDownloadPath" type="button" title="{{filePath}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+            </ng-template>
+            <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+              <mat-icon>file_copy</mat-icon>
+            </button>
+          </div>
+        </mat-toolbar-row>
+      </mat-toolbar>
+      <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -42,11 +42,11 @@ export class DockerfileComponent {
   }
   content: string;
   filePath: string;
-  nullContent: boolean;
   public published$: Observable<boolean>;
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
+  public loading = false;
   constructor(public fileService: FileService, private toolQuery: ToolQuery,
               private containerService: ContainerService, private containersService: ContainersService) {
     this.filePath = '/Dockerfile';
@@ -55,14 +55,17 @@ export class DockerfileComponent {
 
   reactToVersion(): void {
     if (this._selectedVersion) {
+      this.loading = true;
       this.containersService.dockerfile(this.id, this._selectedVersion.name).pipe(first())
         .subscribe(file => {
+            this.loading = false;
             this.content = file.content;
             this.filePath = file.path;
             this.downloadFilePath = this.getContainerfilePath();
             this.customDownloadFile();
           }, error => {
             this.content = null;
+            this.loading = false;
           }
         );
     } else {

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -16,7 +16,7 @@
 import { Component, Input } from '@angular/core';
 import { SafeUrl } from '@angular/platform-browser';
 import { Observable } from 'rxjs';
-import { first } from 'rxjs/operators';
+import {finalize, first} from 'rxjs/operators';
 
 import { ga4ghPath } from '../../shared/constants';
 import { ContainerService } from '../../shared/container.service';
@@ -46,7 +46,7 @@ export class DockerfileComponent {
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
-  public loading = false;
+  public loading = true;
   constructor(public fileService: FileService, private toolQuery: ToolQuery,
               private containerService: ContainerService, private containersService: ContainersService) {
     this.filePath = '/Dockerfile';
@@ -56,20 +56,20 @@ export class DockerfileComponent {
   reactToVersion(): void {
     if (this._selectedVersion) {
       this.loading = true;
-      this.containersService.dockerfile(this.id, this._selectedVersion.name).pipe(first())
+      this.containersService.dockerfile(this.id, this._selectedVersion.name).pipe(first(),
+        finalize(() => this.loading = false))
         .subscribe(file => {
-            this.loading = false;
             this.content = file.content;
             this.filePath = file.path;
             this.downloadFilePath = this.getContainerfilePath();
             this.customDownloadFile();
           }, error => {
             this.content = null;
-            this.loading = false;
           }
         );
     } else {
       this.content = null;
+      this.loading = false;
     }
   }
 

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -24,37 +24,44 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the tool is invalid.
   </alert>
-  <div *ngIf="content">
+  <mat-progress-bar mode="indeterminate" *ngIf="loading; else loaded"></mat-progress-bar>
+  <ng-template #loaded>
+    <div *ngIf="content">
     <span class="row m-0">
       <span class="col-sm-4">
-        <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor" (select)="onDescriptorChange($event)"></app-select>
+        <app-select [placeholder]="'Descriptor Type'" [items]="descriptors" [default]="currentDescriptor"
+                    (select)="onDescriptorChange($event)"></app-select>
       </span>
     </span>
-  </div>
-  <alert type="warning" *ngIf="!content">
-    <span class="glyphicon glyphicon-warning-sign"></span>
-    &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
-  </alert>
-  <div [hidden]="!content || !_selectedVersion?.valid">
-    <mat-toolbar color="primary">
-      <mat-toolbar-row>
-        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-        <span class="spacer"></span>
-        <div class="btn-group pull-right" role="group">
-          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-            <mat-icon>save_alt</mat-icon>
-          </a>
-          <ng-template #unpublishedDownloadLink>
-            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+    </div>
+    <alert type="warning" *ngIf="!content">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
+    </alert>
+    <div [hidden]="!content || !_selectedVersion?.valid">
+      <mat-toolbar color="primary">
+        <mat-toolbar-row>
+          <app-select [items]="files" [default]="currentFile" [field]="'path'"
+                      (select)="onFileChange($event)"></app-select>
+          <span class="spacer"></span>
+          <div class="btn-group pull-right" role="group">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink"
+               download [href]="downloadFilePath" type="button" title="{{filePath}}">
               <mat-icon>save_alt</mat-icon>
             </a>
-          </ng-template>
-          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
-            <mat-icon>file_copy</mat-icon>
-          </button>
-        </div>
-      </mat-toolbar-row>
-    </mat-toolbar>
-    <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
-  </div>
+            <ng-template #unpublishedDownloadLink>
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF"
+                 [download]="customDownloadPath" type="button" title="{{filePath}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+            </ng-template>
+            <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+              <mat-icon>file_copy</mat-icon>
+            </button>
+          </div>
+        </mat-toolbar-row>
+      </mat-toolbar>
+      <app-code-editor [(content)]="content" [filepath]="filePath"></app-code-editor>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/shared/ga4gh-files/ga4gh-files.query.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.query.ts
@@ -31,10 +31,10 @@ export class GA4GHFilesQuery extends QueryEntity<GA4GHFilesState, GA4GHFiles> {
     if (descriptorType) {
       let toolFiles$: Observable<Array<ToolFile>>;
       toolFiles$ = this.selectEntity(descriptorType).pipe(
-        map((gA4GHFile: GA4GHFiles) => gA4GHFile ? gA4GHFile.toolFiles : [])
+        map((gA4GHFile: GA4GHFiles) => gA4GHFile ? gA4GHFile.toolFiles : null)
       );
       return toolFiles$.pipe(
-        map((toolFiles: Array<ToolFile>) => toolFiles ? toolFiles.filter(toolFile => fileTypes.includes(toolFile.file_type)) : [])
+        map((toolFiles: Array<ToolFile>) => toolFiles ? toolFiles.filter(toolFile => fileTypes.includes(toolFile.file_type)) : null)
       );
     } else {
       return observableOf([]);

--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -46,7 +46,8 @@ export class GA4GHFilesService {
     this.injectAuthorizationToken(this.ga4ghService);
     descriptorTypes.forEach(descriptorType => {
       this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(descriptorType, id, version).subscribe(
-        files => this.ga4ghFilesStore.createOrReplace(descriptorType, { toolFiles: files }));
+        files => this.ga4ghFilesStore.createOrReplace(descriptorType, { toolFiles: files }),
+        () => this.ga4ghFilesStore.createOrReplace(descriptorType, { toolFiles: []}));
     });
   }
 

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -128,7 +128,9 @@ export abstract class EntryFileSelector implements OnDestroy {
    * @memberof EntryFileSelector
    */
   reactToFile(): void {
-    if (this._selectedVersion.valid) {this.loading = true;}
+    if (this._selectedVersion.valid) {
+      this.loading = true;
+    }
     this.gA4GHFilesService.injectAuthorizationToken(this.gA4GHService);
     const existingFileWrapper = this.filesQuery.getEntity(this.currentFile.path);
     if (existingFileWrapper) {

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -18,12 +18,12 @@ import { SafeUrl } from '@angular/platform-browser';
 import { Observable, Subject } from 'rxjs';
 import {finalize, takeUntil} from 'rxjs/operators';
 
+import { FilesQuery } from '../../workflow/files/state/files.query';
+import { FilesService } from '../../workflow/files/state/files.service';
 import { ga4ghWorkflowIdPrefix } from '../constants';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
-import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile, ToolVersion, WorkflowVersion } from '../swagger';
-import { FilesService } from '../../workflow/files/state/files.service';
-import { FilesQuery } from '../../workflow/files/state/files.query';
+import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile } from '../swagger';
 
 /**
 * Abstract class to be implemented by components that have select boxes for a given entry and version
@@ -42,7 +42,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
-  public loading = false;
+  public loading = true;
   abstract entrypath: string;
   protected abstract entryType: ('tool' | 'workflow');
   content: string = null;
@@ -67,6 +67,7 @@ export abstract class EntryFileSelector implements OnDestroy {
       }
     } else {
       this.nullDescriptors = true;
+      this.setContent(null);
     }
   }
 
@@ -88,10 +89,8 @@ export abstract class EntryFileSelector implements OnDestroy {
             this.onFileChange(this.files[0]);
           } else {
             this.currentFile = null;
-            this.content = null;
+            this.setContent(null);
           }
-        },
-        () => {
         }
       );
   }
@@ -109,7 +108,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   }
 
   clearContent() {
-    this.content = null;
+    this.setContent(null);
   }
 
   /**
@@ -152,5 +151,17 @@ export abstract class EntryFileSelector implements OnDestroy {
           this.updateCustomDownloadFileButtonAttributes();
       });
     }
+  }
+
+  /**
+   * Sets the content and clears the loading state
+   *
+   * @private
+   * @param {string} content  The file contents
+   * @memberof EntryFileSelector
+   */
+  private setContent(content: string | null) {
+    this.content = content;
+    this.loading = false;
   }
 }

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -84,6 +84,9 @@ export abstract class EntryFileSelector implements OnDestroy {
   reactToDescriptor() {
     this.getFiles(this.currentDescriptor).pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(files => {
+        if (!files) {
+          this.content = null;
+        } else {
           this.files = files;
           if (this.files.length) {
             this.onFileChange(this.files[0]);
@@ -92,6 +95,7 @@ export abstract class EntryFileSelector implements OnDestroy {
             this.setContent(null);
           }
         }
+      }
       );
   }
 

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -21,7 +21,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ga4ghWorkflowIdPrefix } from '../constants';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
-import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile } from '../swagger';
+import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile, ToolVersion, WorkflowVersion } from '../swagger';
 import { FilesService } from '../../workflow/files/state/files.service';
 import { FilesQuery } from '../../workflow/files/state/files.query';
 
@@ -42,7 +42,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
-  public loading = true;
+  public loading = false;
   abstract entrypath: string;
   protected abstract entryType: ('tool' | 'workflow');
   content: string = null;
@@ -81,7 +81,6 @@ export abstract class EntryFileSelector implements OnDestroy {
   }
 
   reactToDescriptor() {
-    this.loading = true;
     this.getFiles(this.currentDescriptor).pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(files => {
           this.files = files;
@@ -91,9 +90,9 @@ export abstract class EntryFileSelector implements OnDestroy {
             this.currentFile = null;
             this.content = null;
           }
-          this.loading = false;
-          },
-        () => {}
+        },
+        () => {
+        }
       );
   }
 
@@ -129,7 +128,7 @@ export abstract class EntryFileSelector implements OnDestroy {
    * @memberof EntryFileSelector
    */
   reactToFile(): void {
-    this.loading = true;
+    if (this._selectedVersion.valid) {this.loading = true;}
     this.gA4GHFilesService.injectAuthorizationToken(this.gA4GHService);
     const existingFileWrapper = this.filesQuery.getEntity(this.currentFile.path);
     if (existingFileWrapper) {

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -42,6 +42,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   public downloadFilePath: string;
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
+  public loading = true;
   abstract entrypath: string;
   protected abstract entryType: ('tool' | 'workflow');
   content: string = null;
@@ -80,15 +81,19 @@ export abstract class EntryFileSelector implements OnDestroy {
   }
 
   reactToDescriptor() {
+    this.loading = true;
     this.getFiles(this.currentDescriptor).pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(files => {
-        this.files = files;
-        if (this.files.length) {
-          this.onFileChange(this.files[0]);
-        } else {
-          this.currentFile = null;
-          this.content = null;
-        }}
+          this.files = files;
+          if (this.files.length) {
+            this.onFileChange(this.files[0]);
+          } else {
+            this.currentFile = null;
+            this.content = null;
+          }
+          this.loading = false;
+          },
+        () => {}
       );
   }
 
@@ -124,9 +129,11 @@ export abstract class EntryFileSelector implements OnDestroy {
    * @memberof EntryFileSelector
    */
   reactToFile(): void {
+    this.loading = true;
     this.gA4GHFilesService.injectAuthorizationToken(this.gA4GHService);
     const existingFileWrapper = this.filesQuery.getEntity(this.currentFile.path);
     if (existingFileWrapper) {
+      this.loading = false;
       this.content = existingFileWrapper.content;
         this.downloadFilePath = this.getDescriptorPath(this.entrypath, this.entryType);
         this.filePath = this.fileService.getFilePath(this.currentFile);
@@ -139,6 +146,7 @@ export abstract class EntryFileSelector implements OnDestroy {
         this.content = file.content;
         this.downloadFilePath = this.getDescriptorPath(this.entrypath, this.entryType);
         this.filePath = this.fileService.getFilePath(this.currentFile);
+        this.loading = false;
         this.updateCustomDownloadFileButtonAttributes();
       });
     }

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -45,7 +45,7 @@
       </mat-toolbar>
       <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
     </div>
-    <alert type="warning" *ngIf="nullDescriptors">
+    <alert type="warning" *ngIf="!content">
       <span class="glyphicon glyphicon-warning-sign"></span>
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </alert>

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -18,30 +18,36 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the workflow is invalid.
   </alert>
-  <div [hidden]="!content">
-    <mat-toolbar color="primary">
-      <mat-toolbar-row>
-        <app-select [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
-        <span class="spacer"></span>
-        <div class="btn-group pull-right" role="group">
-          <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
-            <mat-icon>save_alt</mat-icon>
-          </a>
-          <ng-template #unpublishedDownloadLink>
-            <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+  <mat-progress-bar mode="indeterminate" *ngIf="loading; else loaded"></mat-progress-bar>
+  <ng-template #loaded>
+    <div [hidden]="!content">
+      <mat-toolbar color="primary">
+        <mat-toolbar-row>
+          <app-select [items]="files" [default]="currentFile" [field]="'path'"
+                      (select)="onFileChange($event)"></app-select>
+          <span class="spacer"></span>
+          <div class="btn-group pull-right" role="group">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink"
+               download [href]="downloadFilePath" type="button" title="{{filePath}}">
               <mat-icon>save_alt</mat-icon>
             </a>
-          </ng-template>
-          <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
-            <mat-icon>file_copy</mat-icon>
-          </button>
-        </div>
-      </mat-toolbar-row>
-    </mat-toolbar>
-    <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
-  </div>
-  <alert type="warning" *ngIf="nullDescriptors">
-    <span class="glyphicon glyphicon-warning-sign"></span>
-    &nbsp;A Descriptor File associated with this Docker container could not be found.
-  </alert>
+            <ng-template #unpublishedDownloadLink>
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF"
+                 [download]="customDownloadPath" type="button" title="{{filePath}}">
+                <mat-icon>save_alt</mat-icon>
+              </a>
+            </ng-template>
+            <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="content">
+              <mat-icon>file_copy</mat-icon>
+            </button>
+          </div>
+        </mat-toolbar-row>
+      </mat-toolbar>
+      <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
+    </div>
+    <alert type="warning" *ngIf="nullDescriptors">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      &nbsp;A Descriptor File associated with this Docker container could not be found.
+    </alert>
+  </ng-template>
 </div>

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -40,7 +40,7 @@
     </mat-toolbar>
     <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
   </div>
-  <alert type="warning" *ngIf="!content">
+  <alert type="warning" *ngIf="nullDescriptors">
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;A Descriptor File associated with this Docker container could not be found.
   </alert>

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -41,7 +41,6 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
 
   protected entryType: ('tool' | 'workflow') = 'workflow';
 
-  public descriptorPath: string;
   constructor(private descriptorService: DescriptorService, public gA4GHService: GA4GHService,
     public fileService: FileService, protected gA4GHFilesService: GA4GHFilesService,
     private workflowQuery: WorkflowQuery, private gA4GHFilesQuery: GA4GHFilesQuery, protected filesService: FilesService,

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -108,7 +108,7 @@ export class LaunchWorkflowComponent extends EntryTab {
       let toolFiles$: Observable<Array<ToolFile>>;
       toolFiles$ = this.gA4GHFilesQuery.getToolFiles(descriptorType, [ToolFile.FileTypeEnum.TESTFILE]);
       toolFiles$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((toolFiles: Array<ToolFile>) => {
-        if (toolFiles.length > 0) {
+        if (toolFiles && toolFiles.length > 0) {
           this.testParameterPath = toolFiles[0].path;
         } else {
           this.testParameterPath = null;

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -18,26 +18,31 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;This version of the workflow is invalid.
   </alert>
-  <alert type="warning" *ngIf="!content && !(isNFL$ | async)">
-    <span class="glyphicon glyphicon-warning-sign"></span>
-    &nbsp; A Test Parameter File associated with this workflow could not be found.
-  </alert>
   <alert type="info" *ngIf="(isNFL$ | async)">
     <span class="glyphicon glyphicon-warning-sign"></span>
     &nbsp;
     Nextflow does not have the concept of a test parameter file.
   </alert>
-  <div [hidden]="!content">
+  <mat-progress-bar mode="indeterminate" *ngIf="loading; else loaded"></mat-progress-bar>
+  <ng-template #loaded>
+    <alert type="warning" *ngIf="!content && !(isNFL$ | async)">
+      <span class="glyphicon glyphicon-warning-sign"></span>
+      &nbsp; A Test Parameter File associated with this workflow could not be found.
+    </alert>
+    <div [hidden]="!content">
       <mat-toolbar color="primary">
         <mat-toolbar-row>
-          <app-select  [items]="files" [default]="currentFile" [field]="'path'" (select)="onFileChange($event)"></app-select>
+          <app-select [items]="files" [default]="currentFile" [field]="'path'"
+                      (select)="onFileChange($event)"></app-select>
           <span class="spacer"></span>
           <div class="btn-group pull-right" role="group">
-            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink" download [href]="downloadFilePath" type="button" title="{{filePath}}">
+            <a mat-icon-button color="secondary" class="mr-1" *ngIf="(published$ | async); else unpublishedDownloadLink"
+               download [href]="downloadFilePath" type="button" title="{{filePath}}">
               <mat-icon>save_alt</mat-icon>
             </a>
             <ng-template #unpublishedDownloadLink>
-              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF" [download]="customDownloadPath" type="button" title="{{filePath}}">
+              <a mat-icon-button color="secondary" class="mr-1" [href]="customDownloadHREF"
+                 [download]="customDownloadPath" type="button" title="{{filePath}}">
                 <mat-icon>save_alt</mat-icon>
               </a>
             </ng-template>
@@ -47,6 +52,7 @@
           </div>
         </mat-toolbar-row>
       </mat-toolbar>
-    <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
-  </div>
+      <app-code-editor [(content)]="content" [filepath]="filePath" [editing]="false"></app-code-editor>
+    </div>
+  </ng-template>
 </div>


### PR DESCRIPTION
When in cleared state, set entity to null or undefined (something with a falsy value).  Only when there's legitimately nothing returned do we set to empty array.  For errors, it's not currently handled well, just setting it to empty array (which will eventually clear the loading state)

This makes the code a fair bit more complicated as there is now nulls to deal with.