### PR TITLE
Remove scrollspy

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@ Please keep the two in sync when making changes, pending a better solution via g
   </script>
 </head>
 
-<body data-spy="scroll" data-target="#toc">
+<body>
   <app-root>
     <style>
       app-root {


### PR DESCRIPTION
Kind of for ga4gh/dockstore#1899

The TOC which uses the scrollspy no longer exists. Removing it.