### PR TITLE
Debounce, material autocomplete

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -30,14 +30,14 @@
           <mat-expansion-panel-header>
             Search
           </mat-expansion-panel-header>
-          <input matTooltip="Find tools and workflows" [matTooltipPosition]="'after'"
-                  type="text" list="suggestions" class="search-box form-control w-100 mb-3" [(ngModel)]="values"
-                  (ngModelChange)="onKey()" placeholder="Enter search term" />
-          <datalist id="suggestions" *ngIf="autocompleteTerms.length > 0">
-            <div *ngFor="let term of autocompleteTerms">
-              <option [value]="term">
-            </div>
-          </datalist>
+          <mat-form-field>
+          <input matInput [matAutocomplete]="auto" matTooltip="Find tools and workflows" [matTooltipPosition]="'after'"
+                  list="suggestions" class="w-100 mb-3" [(ngModel)]="values"
+                  (ngModelChange)="keyUp$.next($event)" placeholder="Enter search term" />
+          </mat-form-field>
+          <mat-autocomplete #auto="matAutocomplete">
+              <mat-option *ngFor="let option of autocompleteTerms" [value]="option">{{option}}</mat-option>
+          </mat-autocomplete>
 
           <button mat-stroked-button color="primary" type="button" class="w-100" (click)="openAdvancedSearch()">
             Open Advanced Search

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -26,6 +26,7 @@ import { MapFriendlyValuesPipe } from './map-friendly-values.pipe';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchComponent } from './search.component';
 import { SearchService } from './search.service';
+import { MatAutocompleteModule } from '@angular/material';
 
 /* tslint:disable:no-unused-variable */
 describe('SearchComponent', () => {
@@ -36,7 +37,7 @@ describe('SearchComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SearchComponent, MapFriendlyValuesPipe ],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [RouterTestingModule, AccordionModule.forRoot(), HttpClientModule],
+      imports: [RouterTestingModule, AccordionModule.forRoot(), HttpClientModule, MatAutocompleteModule],
       providers: [
         {provide: SearchService, useClass: SearchStubService},
         { provide: QueryBuilderService, useClass: QueryBuilderStubService },

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -497,8 +497,7 @@ export class SearchComponent extends Base implements OnInit {
         }
       }
     }).then(hits => {
-      this.autocompleteTerms = [];
-      this.autocompleteTerms = this.setAutoCompleteTerms(hits);
+      this.setAutocompleteTerms(hits);
     }).catch(error => console.log(error));
       this.advancedSearchObject.toAdvanceSearch = false;
       if ((!this.values || 0 === this.values.length)) {
@@ -533,20 +532,18 @@ export class SearchComponent extends Base implements OnInit {
   }
 
   /**
-   * Gets autocomplete terms based on the elasticsearch results
+   * Sets autocomplete terms based on the elasticsearch results
    *
-   * @param {*} hits           Elasticsearch results
-   * @returns {Array<string>}  The array of autocomplete terms
+   * @param {*} hits  Elasticsearch results
    * @memberof SearchComponent
    */
-  setAutoCompleteTerms(hits: any): Array<string> {
-    const autocompleteTerms = [];
-    hits.aggregations.autocomplete.buckets.forEach(
-      term => {
-        autocompleteTerms.push(term.key);
-      }
-    );
-    return autocompleteTerms;
+  setAutocompleteTerms(hits: any): void {
+    try {
+      this.autocompleteTerms = hits.aggregations.autocomplete.buckets.map(term => term.key);
+    } catch (error) {
+      console.error('Could not retrieve autocomplete terms');
+      this.autocompleteTerms = [];
+    }
   }
 
   searchSuggestTerm() {

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -17,6 +17,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material';
 import { TagCloudModule } from 'angular-tag-cloud-module';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -53,6 +54,7 @@ import { SearchService } from './search.service';
     CommonModule,
     CustomMaterialModule,
     AccordionModule.forRoot(),
+    MatAutocompleteModule,
     ModalModule.forRoot(),
     FormsModule,
     HeaderModule,

--- a/src/app/shared/base.ts
+++ b/src/app/shared/base.ts
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import { OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * This class allows other components to easily unsubscribe from it.
+ * One day, when we stop subscribing from within components (by doing so in services instead),
+ * this class easily shows which components will need to be changed later on (even though services can extend it too)
+ *
+ * @export
+ * @abstract
+ * @class Base
+ * @implements {OnDestroy}
+ */
+export abstract class Base implements OnDestroy {
+
+  protected ngUnsubscribe: Subject<{}> = new Subject();
+
+  constructor() { }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+}


### PR DESCRIPTION
For ga4gh/dockstore#1987

Our previous `<datalist>` causes problems somehow with Chrome/Chromium 71.  Not sure why.  Changing it to material autocomplete circumvents the issue.

Also adds a proper debounce to the form input

This is going to cause plenty of merge conflicts with develop :cry: 

