### PR TITLE
Update files in workflow component

### DIFF
--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -38,6 +38,9 @@ export class GA4GHFilesService {
    */
   @transaction()
   updateFiles(id: string, version: string, descriptorTypes?: Array<ToolDescriptor.TypeEnum>) {
+    if (!version) {
+      return;
+    }
     this.clearFiles();
     this.filesService.removeAll();
     if (!descriptorTypes) {

--- a/src/app/workflow/files/files.component.ts
+++ b/src/app/workflow/files/files.component.ts
@@ -16,10 +16,7 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
-import { ga4ghWorkflowIdPrefix } from '../../shared/constants';
-import { DescriptorTypeCompatService } from '../../shared/descriptor-type-compat.service';
 import { Files } from '../../shared/files';
-import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
 import { ToolDescriptor } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 
@@ -34,7 +31,7 @@ export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
   versionsWithParamfiles: Array<any>;
   previousEntryPath: string;
   previousVersionName: string;
-  constructor(private paramfilesService: ParamfilesService, private gA4GHFilesService: GA4GHFilesService) {
+  constructor(private paramfilesService: ParamfilesService) {
     super();
   }
 
@@ -42,14 +39,6 @@ export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
     this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
   ngOnChanges() {
-    // Change detection is messed up because of permissions changing
-    if (this.previousEntryPath !== this.entrypath || this.previousVersionName !== this.selectedVersion.name) {
-      // Only getting files for one descriptor type for workflows (subject to change)
-      this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.entrypath, this.selectedVersion.name,
-        [this.descriptorType]);
-      this.previousEntryPath = this.entrypath;
-      this.previousVersionName = this.selectedVersion.name;
-    }
     this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
 }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -220,9 +220,6 @@ export class WorkflowComponent extends Entry {
       this.workflowsService.getPublishedWorkflowByPath(this.title)
         .subscribe(workflow => {
           this.workflowService.setWorkflow(workflow);
-          this.selectedVersion = this.selectVersion(this.workflow.workflowVersions, this.urlVersion,
-            this.workflow.defaultVersion);
-
           this.selectTab(this.validTabs.indexOf(this.currentTab));
           if (this.workflow != null) {
             this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
@@ -354,6 +351,8 @@ export class WorkflowComponent extends Entry {
    */
   onSelectedVersionChange(version: WorkflowVersion): void {
     this.selectedVersion = version;
+    this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
+      [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
     if (this.workflow != null) {
       this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
     }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -196,8 +196,10 @@ export class WorkflowComponent extends Entry {
           this.setPublishMessage();
           this.selectedVersion = this.selectVersion(this.workflow.workflowVersions, this.urlVersion,
             this.workflow.defaultVersion);
-          this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
-            [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
+          if (this.selectedVersion) {
+            this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
+              [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
+          }
         }
         this.setUpWorkflow(workflow);
       }
@@ -351,8 +353,10 @@ export class WorkflowComponent extends Entry {
    */
   onSelectedVersionChange(version: WorkflowVersion): void {
     this.selectedVersion = version;
-    this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
-      [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
+    if (this.selectVersion) {
+      this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
+        [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
+    }
     if (this.workflow != null) {
       this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
     }

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -15,14 +15,18 @@
  */
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Location } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input } from '@angular/core';
 import { MatChipInputEvent } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { AlertQuery } from '../shared/alert/state/alert.query';
+import { AlertService } from '../shared/alert/state/alert.service';
 import { ga4ghWorkflowIdPrefix } from '../shared/constants';
 import { DateService } from '../shared/date.service';
+import { DescriptorTypeCompatService } from '../shared/descriptor-type-compat.service';
 import { DockstoreService } from '../shared/dockstore.service';
 import { Entry } from '../shared/entry';
 import { GA4GHFilesService } from '../shared/ga4gh-files/ga4gh-files.service';
@@ -44,9 +48,6 @@ import { TrackLoginService } from '../shared/track-login.service';
 import { UrlResolverService } from '../shared/url-resolver.service';
 
 import RoleEnum = Permission.RoleEnum;
-import { AlertService } from '../shared/alert/state/alert.service';
-import { HttpErrorResponse } from '@angular/common/http';
-import { AlertQuery } from '../shared/alert/state/alert.query';
 @Component({
   selector: 'app-workflow',
   templateUrl: './workflow.component.html',
@@ -86,7 +87,8 @@ export class WorkflowComponent extends Entry {
     router: Router, private workflowService: WorkflowService, private extendedWorkflowQuery: ExtendedWorkflowQuery,
     urlResolverService: UrlResolverService, private alertService: AlertService,
     location: Location, activatedRoute: ActivatedRoute, protected sessionQuery: SessionQuery, protected sessionService: SessionService,
-      gA4GHFilesService: GA4GHFilesService, private workflowQuery: WorkflowQuery, private alertQuery: AlertQuery) {
+      gA4GHFilesService: GA4GHFilesService, private workflowQuery: WorkflowQuery, private alertQuery: AlertQuery,
+      private descriptorTypeCompatService: DescriptorTypeCompatService) {
     super(trackLoginService, providerService, router,
       dateService, urlResolverService, activatedRoute, location, sessionService, sessionQuery, gA4GHFilesService);
     this._toolType = 'workflows';
@@ -194,6 +196,8 @@ export class WorkflowComponent extends Entry {
           this.setPublishMessage();
           this.selectedVersion = this.selectVersion(this.workflow.workflowVersions, this.urlVersion,
             this.workflow.defaultVersion);
+          this.gA4GHFilesService.updateFiles(ga4ghWorkflowIdPrefix + this.workflow.full_workflow_path, this.selectedVersion.name,
+            [this.descriptorTypeCompatService.stringToDescriptorType(this.workflow.descriptorType)]);
         }
         this.setUpWorkflow(workflow);
       }


### PR DESCRIPTION
For ga4gh/dockstore#2004 

Gets the GA4GH files in the workflow component instead of files component.  Results in:

- Going to Files tab is slightly faster
- Launch tab correctly has the wget command without needing to visit the Files tab beforehand
- There is no "Expression has changed after it was checked" error when switching from Launch tab to Files tab and back 
- Going to the workflow component (and not visiting files tab) now has slightly higher data usage

This also:
- Removes a redundant select version call (it is already done so in the subscription)

Tool component has still kept the previous flow because none of its tabs use the GA4GH Files (though that can also be changed if needed).

@rjbautis to check if this actually works for his PR. maybe cherry-pick it to avoid merge conflicts