### PR TITLE
Feature/pretty organizations

### DIFF
--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -64,7 +64,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('https://www.google.ca');
       cy.contains('Basement');
       cy.contains('asdf@asdf.ca');
-      cy.contains('Collections not found');
+      cy.contains('No collections found');
     });
     it('be able to edit organization', () => {
       cy.get('#editOrgInfo').should('be.visible').click();

--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -67,7 +67,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('Collections not found');
     });
     it('be able to edit organization', () => {
-      cy.contains('EDIT ORGANIZATION INFO').should('be.visible').click();
+      cy.get('#editOrgInfo').should('be.visible').click();
       typeInInput('Name', 'Potatoe');
       typeInTextArea('Topic', 'Boil them, mash them, stick them in a stew');
       typeInInput('Link to Organization Website', 'https://www.google.com');
@@ -87,7 +87,7 @@ describe('Dockstore my workflows', () => {
 
   describe('Should be able to add/update collection', () => {
     it('be able to add a collection', () => {
-      cy.contains('CREATE COLLECTION').click();
+      cy.get('#createCollection').click();
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('be.disabled');
       typeInInput('Name', 'fakeCollectionName');
       typeInTextArea('Description', 'fake collection description');
@@ -97,7 +97,7 @@ describe('Dockstore my workflows', () => {
     });
 
     it('be able to update a collection', () => {
-      cy.contains('EDIT COLLECTION').click();
+      cy.get('#editCollection').click();
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('not.be.disabled');
       typeInInput('Name', 'veryFakeCollectionName');
       typeInTextArea('Description', 'very fake collection description');

--- a/src/app/organizations/collection.module.ts
+++ b/src/app/organizations/collection.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CollectionComponent } from './collection/collection.component';
+import { MatCardModule, MatProgressBarModule, MatIconModule, MatChipsModule } from '@angular/material';
+import { HeaderModule } from '../shared/modules/header.module';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  imports: [ CommonModule, HeaderModule,
+  MatCardModule, MatProgressBarModule, MatIconModule,
+  FlexLayoutModule, RouterModule, MatChipsModule ],
+  declarations: [ CollectionComponent ]
+})
+export class CollectionModule { }

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -15,7 +15,7 @@
 -->
 <app-header>
   <mat-icon>people</mat-icon>
-  Available Collections
+  Collections
 </app-header>
 <div *ngIf="(loading$ | async); else placeholder">
   <mat-progress-bar mode="indeterminate"></mat-progress-bar>

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -34,6 +34,10 @@
       </mat-card-header>
     </mat-card>
 
+    <mat-card class="alert alert-info" *ngIf="collection?.entries?.length == 0">
+      This collection has no associated entries
+    </mat-card>
+
     <div fxLayoutGap="16px grid" fxLayout="row wrap">
       <div *ngFor="let entry of collection?.entries" fxFlex="{{ 100/3 }}%">
         <mat-card class="entryCard">

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -1,0 +1,75 @@
+<!--
+   Copyright 2019 OICR
+ *
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ *
+       http://www.apache.org/licenses/LICENSE-2.0
+ *
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<app-header>
+  <mat-icon>people</mat-icon>
+  Available Collections
+</app-header>
+<div *ngIf="(loading$ | async); else placeholder">
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+</div>
+<ng-template #placeholder>
+  <div class="pt-2"></div>
+  <div class="container" *ngIf="(collection$ | async) as collection" fxLayout="column" fxLayoutGap="10px">
+    <mat-card fxFlex class="my-3">
+      <mat-card-header>
+        <mat-card-title>
+          <h1>{{collection.name}}</h1>
+        </mat-card-title>
+        <mat-card-subtitle>
+          {{collection.description}}
+        </mat-card-subtitle>
+      </mat-card-header>
+    </mat-card>
+
+    <div fxLayoutGap="16px grid" fxLayout="row wrap">
+      <div *ngFor="let entry of collection?.entries" fxFlex="{{ 100/3 }}%">
+        <mat-card class="entryCard">
+          <mat-card-header *ngIf="entry?.full_workflow_path">
+            <mat-card-title>
+              <h4>
+                <a [routerLink]="['/workflows/', entry.full_workflow_path]">
+                  {{entry.full_workflow_path}}
+                </a>
+              </h4>
+            </mat-card-title>
+            <mat-card-subtitle>
+              Last updated {{ entry.dbUpdateDate | date }}
+            </mat-card-subtitle>
+          </mat-card-header>
+
+          <mat-card-header *ngIf="entry?.tool_path">
+            <mat-card-title>
+              <h4>
+                <a [routerLink]="['/tools/', entry.tool_path]">
+                  {{entry.tool_path}}
+                </a>
+              </h4>
+            </mat-card-title>
+            <mat-card-subtitle>
+              Last updated {{ entry.dbUpdateDate | date }}
+            </mat-card-subtitle>
+          </mat-card-header>
+
+          <mat-card-content class="p-3">
+            <mat-chip-list>
+              <mat-chip *ngFor="let label of entry?.labels">{{ label.value }}</mat-chip>
+            </mat-chip-list>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/organizations/collection/collection.component.scss
+++ b/src/app/organizations/collection/collection.component.scss
@@ -1,0 +1,5 @@
+.entryCard {
+  height: 200px;
+  max-height: 200px;
+  min-height: 200px;
+}

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CollectionService } from '../state/collection.service';
+import { CollectionQuery } from '../state/collection.query';
+import { Observable } from 'rxjs';
+import { Collection } from '../../shared/swagger';
+
+@Component({
+  selector: 'collection',
+  templateUrl: './collection.component.html',
+  styleUrls: ['./collection.component.scss']
+})
+export class CollectionComponent implements OnInit {
+  collection$: Observable<Collection>;
+  loading$: Observable<boolean>;
+  constructor(private collectionQuery: CollectionQuery,
+              private collectionService: CollectionService
+  ) { }
+
+  ngOnInit() {
+    this.loading$ = this.collectionQuery.loading$;
+    this.collectionService.updateCollectionFromName();
+    this.collection$ = this.collectionQuery.collection$;
+  }
+}

--- a/src/app/organizations/collections.module.ts
+++ b/src/app/organizations/collections.module.ts
@@ -13,6 +13,7 @@ import {
 
 import { CollectionsComponent } from './collections/collections.component';
 import { CreateCollectionModule } from './collections/create-collection.module';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   imports: [
@@ -25,7 +26,8 @@ import { CreateCollectionModule } from './collections/create-collection.module';
     MatExpansionModule,
     MatProgressBarModule,
     MatIconModule,
-    MatTooltipModule
+    MatTooltipModule,
+    RouterModule
   ],
   declarations: [CollectionsComponent],
   exports: [CollectionsComponent]

--- a/src/app/organizations/collections.module.ts
+++ b/src/app/organizations/collections.module.ts
@@ -7,6 +7,8 @@ import {
   MatDialogModule,
   MatExpansionModule,
   MatProgressBarModule,
+  MatIconModule,
+  MatTooltipModule,
 } from '@angular/material';
 
 import { CollectionsComponent } from './collections/collections.component';
@@ -21,7 +23,9 @@ import { CreateCollectionModule } from './collections/create-collection.module';
     MatCardModule,
     MatDialogModule,
     MatExpansionModule,
-    MatProgressBarModule
+    MatProgressBarModule,
+    MatIconModule,
+    MatTooltipModule
   ],
   declarations: [CollectionsComponent],
   exports: [CollectionsComponent]

--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -29,7 +29,11 @@
         <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
           <div fxFlex fxGrow="3">
             <mat-card-header>
-              <mat-card-title>{{collection.value.name}}</mat-card-title>
+              <mat-card-title>
+                <a [routerLink]="['/organizations/', organizationID, 'collections', collection?.value?.id]">
+                {{collection.value.name}}
+              </a>
+            </mat-card-title>
               <mat-card-subtitle>{{collection.value.description}}</mat-card-subtitle>
             </mat-card-header>
           </div>

--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -13,40 +13,41 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<mat-expansion-panel [expanded]="true">
-  <mat-expansion-panel-header>
-    <mat-panel-title>
-      Collections
-    </mat-panel-title>
-  </mat-expansion-panel-header>
-  <div *ngIf="(loading$ | async); else notLoading">
-    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+<div *ngIf="(loading$ | async); else notLoading">
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+</div>
+<ng-template #notLoading>
+  <div class="pt-2"></div>
+  <div *ngIf="(collections$ | async | json) === '{}' ; else hasCollections">
+    <mat-card class="alert alert-info" role="alert">
+      No collections found.
+    </mat-card>
   </div>
-  <ng-template #notLoading>
-    <div class="pt-2"></div>
-    <div *ngIf="(collections$ | async | json) === '{}' ; else hasCollections">Collections not found</div>
-    <ng-template #hasCollections>
-      <div fxLayout="row wrap" fxLayoutAlign="space-evenly stretch">
-        <mat-card fxFlex="400px" *ngFor="let collection of ((collections$ | async) | keyvalue)" class="m-1">
-          <mat-card-header>
-            <mat-card-title>{{collection.value.name}}</mat-card-title>
-            <mat-card-subtitle>{{collection.value.description}}</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content>
-            <p>
-              The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.
-              A small, agile dog that copes very well with mountainous terrain, the Shiba Inu was originally
-              bred for hunting.
-            </p>
-          </mat-card-content>
-          <mat-card-actions *ngIf="(canEdit$ | async)">
-            <button mat-button class="pull-right" (click)="editCollection(collection)">EDIT COLLECTION</button>
-          </mat-card-actions>
-        </mat-card>
-      </div>
-    </ng-template>
+  <ng-template #hasCollections>
+    <div fxLayout="column">
+      <mat-card fxFlex *ngFor="let collection of ((collections$ | async) | keyvalue)" class="m-1">
+        <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
+          <div fxFlex fxGrow="3">
+            <mat-card-header>
+              <mat-card-title>{{collection.value.name}}</mat-card-title>
+              <mat-card-subtitle>{{collection.value.description}}</mat-card-subtitle>
+            </mat-card-header>
+          </div>
+          <div fxFlex fxGrow="1" fxLayoutAlign="flex-end center">
+            <mat-card-content fxLayout="row" fxLayoutGap="10px" class="m-0">
+              <button color="basic" *ngIf="(canEdit$ | async)" mat-icon-button (click)="editCollection(collection)" id="editCollection"
+              matTooltip="Edit the collection">
+                <mat-icon>edit</mat-icon>
+              </button>
+            </mat-card-content>
+          </div>
+        </div>
+      </mat-card>
+    </div>
   </ng-template>
-  <mat-action-row *ngIf="(canEdit$ | async)">
-    <button mat-button (click)="createCollection()">CREATE COLLECTION</button>
-  </mat-action-row>
-</mat-expansion-panel>
+</ng-template>
+<mat-action-row *ngIf="(canEdit$ | async)">
+  <button mat-flat-button class="pull-right" (click)="createCollection()" id="createCollection" matTooltip="Create a new collection">
+    <mat-icon>add</mat-icon>Create collection
+  </button>
+</mat-action-row>

--- a/src/app/organizations/events.module.ts
+++ b/src/app/organizations/events.module.ts
@@ -2,8 +2,9 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EventsComponent } from './events/events.component';
 import { CustomMaterialModule } from './../shared/modules/material.module';
+import { FlexLayoutModule } from '@angular/flex-layout';
 @NgModule({
-  imports: [ CommonModule, CustomMaterialModule ],
+  imports: [ CommonModule, CustomMaterialModule, FlexLayoutModule ],
   declarations: [ EventsComponent ],
   exports: [ EventsComponent ]
 })

--- a/src/app/organizations/events/events.component.html
+++ b/src/app/organizations/events/events.component.html
@@ -1,53 +1,52 @@
-
 <ng-template #loading>Loading...</ng-template>
 
 <div *ngIf="!(isLoading$ | async); else loading">
 
-  <mat-expansion-panel [expanded]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          Events
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <mat-list>
-        <span *ngFor="let event of (events$ | async)">
-          <mat-list-item *ngIf="event?.type === EventType.CREATEORG">
-            <mat-chip-list>
-              <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
-              &nbsp;created&nbsp;organization
-            </mat-chip-list>
-          </mat-list-item>
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>
+        Recent Events
+      </mat-card-title>
+    </mat-card-header>
+    <div fxLayout="column wrap" fxLayoutGap="20px">
+      <span *ngFor="let event of (events$ | async)" class="px-3">
+        <div *ngIf="event?.type === EventType.CREATEORG">
+          <mat-chip-list>
+            <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
+            &nbsp;created&nbsp;organization
+          </mat-chip-list>
+        </div>
 
-          <mat-list-item *ngIf="event?.type === EventType.APPROVEORGINVITE">
-            <mat-chip-list>
-              <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
-              &nbsp;joined&nbsp;organization
-            </mat-chip-list>
-          </mat-list-item>
+        <div *ngIf="event?.type === EventType.APPROVEORGINVITE">
+          <mat-chip-list>
+            <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
+            &nbsp;joined&nbsp;organization
+          </mat-chip-list>
+        </div>
 
-          <mat-list-item *ngIf="event?.type === EventType.MODIFYORG">
-            <mat-chip-list>
-              <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
-              &nbsp;updated&nbsp;organization
-            </mat-chip-list>
-          </mat-list-item>
+        <div *ngIf="event?.type === EventType.MODIFYORG">
+          <mat-chip-list>
+            <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
+            &nbsp;updated&nbsp;organization
+          </mat-chip-list>
+        </div>
 
-          <mat-list-item *ngIf="event?.type === EventType.CREATECOLLECTION">
-            <mat-chip-list>
-              <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
-              &nbsp;created&nbsp;the&nbsp;collection&nbsp;
-              <mat-chip>{{ event.collection.name }}</mat-chip>
-            </mat-chip-list>
-          </mat-list-item>
+        <div *ngIf="event?.type === EventType.CREATECOLLECTION">
+          <mat-chip-list>
+            <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
+            &nbsp;created&nbsp;the&nbsp;collection&nbsp;
+            <mat-chip>{{ event.collection.name }}</mat-chip>
+          </mat-chip-list>
+        </div>
 
-          <mat-list-item *ngIf="event?.type === EventType.MODIFYCOLLECTION || event?.type === EventType.ADDTOCOLLECTION || event?.type === EventType.REMOVEFROMCOLLECTION">
-            <mat-chip-list>
-              <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
-              &nbsp;updated&nbsp;the&nbsp;collection&nbsp;
-              <mat-chip>{{ event.collection.name }}</mat-chip>
-            </mat-chip-list>
-          </mat-list-item>
-        </span>
-      </mat-list>
-    </mat-expansion-panel>
-  </div>
+        <div *ngIf="event?.type === EventType.MODIFYCOLLECTION || event?.type === EventType.ADDTOCOLLECTION || event?.type === EventType.REMOVEFROMCOLLECTION">
+          <mat-chip-list>
+            <mat-chip>{{ event.initiatorUser.username }}</mat-chip>
+            &nbsp;updated&nbsp;the&nbsp;collection&nbsp;
+            <mat-chip>{{ event.collection.name }}</mat-chip>
+          </mat-chip-list>
+        </div>
+      </span>
+    </div>
+  </mat-card>
+</div>

--- a/src/app/organizations/organization.module.ts
+++ b/src/app/organizations/organization.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { MatButtonModule, MatCardModule, MatExpansionModule, MatIconModule, MatProgressBarModule } from '@angular/material';
+import { MatButtonModule, MatCardModule, MatExpansionModule, MatIconModule, MatProgressBarModule, MatTabsModule } from '@angular/material';
 
 import { HeaderModule } from '../shared/modules/header.module';
 import { CollectionsModule } from './collections.module';
@@ -18,6 +18,7 @@ import { OrganizationComponent } from './organization/organization.component';
     MatCardModule,
     MatExpansionModule,
     MatIconModule,
+    MatTabsModule,
     MatProgressBarModule,
     OrganizationMembersModule
   ],

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -15,7 +15,7 @@
 -->
 <app-header>
   <mat-icon>people</mat-icon>
-  Available Organizations
+  Organizations
 </app-header>
 <div *ngIf="(loading$ | async); else placeholder">
   <mat-progress-bar mode="indeterminate"></mat-progress-bar>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -23,56 +23,70 @@
 <ng-template #placeholder>
   <div class="pt-2"></div>
   <div class="container" *ngIf="!(organization$ | async)">Organization not found</div>
-<div class="container" *ngIf="(organization$ | async) as org" fxLayout="column" fxLayoutGap="10px">
-  <mat-card fxFlex class="my-2">
-    <mat-card-header>
-      <mat-card-title>
-        <h1>{{org.name}}</h1>
-      </mat-card-title>
-      <mat-card-subtitle>
-        {{org.topic}}
-      </mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div fxLayout="column" fxLayoutGap="10px">
-        <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.email">
-          <mat-icon>email</mat-icon>
-          <span><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span>
-        </span>
-        <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.link">
-          <mat-icon>link</mat-icon>
-          <span><a [href]="org.link" target="_blank">{{ org.link }}</a></span>
-        </span>
-        <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
-          <mat-icon>location_on</mat-icon>
-          <span class="ellipsis-lines">{{ org.location }}</span>
-        </span>
-        <p>Markdown description placeholder</p>
+  <div class="container" *ngIf="(organization$ | async) as org" fxLayout="column" fxLayoutGap="10px">
+    <mat-card fxFlex class="my-3">
+      <div fxLayout="row" fxLayoutGap="10px">
+        <div>
+          <img src="https://via.placeholder.com/150" alt="Logo" class="img-circle">
+        </div>
+        <div>
+          <mat-card-header>
+            <mat-card-title>
+              <h1>{{org.name}}</h1>
+            </mat-card-title>
+            <mat-card-subtitle>
+              {{org.topic}}
+            </mat-card-subtitle>
+          </mat-card-header>
+        </div>
       </div>
-    </mat-card-content>
-    <mat-card-actions *ngIf="(canEdit$ | async)">
-      <button mat-button class="pull-right" (click)="editOrganization()">EDIT ORGANIZATION INFO</button>
-    </mat-card-actions>
-  </mat-card>
-  <div fxFlex>
-    <collections [organizationID]="org.id"></collections>
-  </div>
-  <div fxFlex>
-    <mat-expansion-panel [expanded]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          Events
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-        enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-        in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </mat-expansion-panel>
-  </div>
-  <div fxFlex>
-    <organization-members></organization-members>
+      <mat-card-content>
+        <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-evenly">
+          <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.email">
+            <mat-icon>email</mat-icon>
+            <span><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span>
+          </span>
+          <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.link">
+            <mat-icon>link</mat-icon>
+            <span><a [href]="org.link" target="_blank">{{ org.link }}</a></span>
+          </span>
+          <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
+            <mat-icon>location_on</mat-icon>
+            <span class="ellipsis-lines">{{ org.location }}</span>
+          </span>
+        </div>
+      </mat-card-content>
+      <mat-card-actions *ngIf="(canEdit$ | async)">
+        <div fxFlex></div>
+        <button mat-button (click)="editOrganization()" id="editOrgInfo"><mat-icon>edit</mat-icon></button>
+      </mat-card-actions>
+    </mat-card>
 
+    <div fxLayout="row" fxLayoutGap="15px" class="my-3">
+      <div fxFlex fxGrow="3">
+        <mat-tab-group>
+          <mat-tab label="Collections">
+            <collections [organizationID]="org.id"></collections>
+          </mat-tab>
+          <mat-tab label="Readme">
+            <p>Readme goes here</p>
+          </mat-tab>
+          <mat-tab label="Members">
+            <organization-members></organization-members>
+          </mat-tab>
+        </mat-tab-group>
+      </div>
+      <div fxFlex fxGrow="1">
+        <mat-card>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+          dolore magna aliqua. Ut
+          enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+          cupidatat non proident, sunt
+          in culpa qui officia deserunt mollit anim id est laborum.
+        </mat-card>
+      </div>
+    </div>
   </div>
-</div>
 </ng-template>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -63,7 +63,7 @@
     </mat-card>
 
     <div fxLayout="row" fxLayoutGap="15px" class="my-3">
-      <div fxFlex fxGrow="3">
+      <div fxFlex fxGrow="4">
         <mat-tab-group>
           <mat-tab label="Collections">
             <collections [organizationID]="org.id"></collections>
@@ -76,7 +76,7 @@
           </mat-tab>
         </mat-tab-group>
       </div>
-      <div fxFlex fxGrow="1">
+      <div fxFlex fxGrow="2">
         <events [organizationID]="org.id"></events>
       </div>
     </div>

--- a/src/app/organizations/organizations.module.ts
+++ b/src/app/organizations/organizations.module.ts
@@ -9,6 +9,7 @@ import { OrganizationModule } from './organization.module';
 import { OrganizationsRouting } from './organizations.routing';
 import { OrganizationsComponent } from './organizations/organizations.component';
 import { RegisterOrganizationModule } from './register-organization.module';
+import { CollectionModule } from './collection.module';
 
 @NgModule({
   imports: [
@@ -23,7 +24,8 @@ import { RegisterOrganizationModule } from './register-organization.module';
     OrganizationModule,
     OrganizationsRouting,
     ReactiveFormsModule,
-    RegisterOrganizationModule
+    RegisterOrganizationModule,
+    CollectionModule
   ],
   declarations: [OrganizationsComponent]
 })

--- a/src/app/organizations/organizations.routing.ts
+++ b/src/app/organizations/organizations.routing.ts
@@ -18,10 +18,12 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { OrganizationComponent } from './organization/organization.component';
 import { OrganizationsComponent } from './organizations/organizations.component';
+import { CollectionComponent } from './collection/collection.component';
 
 const ORGANIZATIONS_ROUTES: Routes = [
   { path: '', component: OrganizationsComponent },
   { path: ':id', component: OrganizationComponent },
+  { path: ':id/collections/:cid', component: CollectionComponent },
   { path: '**', redirectTo: '' }
 ];
 

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -33,7 +33,7 @@
               <a [routerLink]="org.name">{{org.name}}</a>
             </mat-card-title>
             <mat-card-subtitle>
-                {{ org.description }}
+                {{ org.topic }}
             </mat-card-subtitle>
           </mat-card-header>
           <mat-card-content>

--- a/src/app/organizations/state/collection.query.spec.ts
+++ b/src/app/organizations/state/collection.query.spec.ts
@@ -1,0 +1,15 @@
+import { CollectionQuery } from './collection.query';
+import { CollectionStore } from './collection.store';
+
+describe('CollectionQuery', () => {
+  let query: CollectionQuery;
+
+  beforeEach(() => {
+    query = new CollectionQuery(new CollectionStore);
+  });
+
+  it('should create an instance', () => {
+    expect(query).toBeTruthy();
+  });
+
+});

--- a/src/app/organizations/state/collection.query.ts
+++ b/src/app/organizations/state/collection.query.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Query } from '@datorama/akita';
+import { CollectionStore, CollectionState } from './collection.store';
+
+@Injectable({ providedIn: 'root' })
+export class CollectionQuery extends Query<CollectionState> {
+  collection$ = this.select(state => state.collection);
+  loading$ = this.selectLoading();
+  constructor(protected store: CollectionStore) {
+    super(store);
+  }
+
+}

--- a/src/app/organizations/state/collection.service.spec.ts
+++ b/src/app/organizations/state/collection.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CollectionService } from './collection.service';
 import { CollectionStore } from './collection.store';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CollectionService', () => {
   let collectionService: CollectionService;
@@ -10,7 +11,7 @@ describe('CollectionService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [CollectionService, CollectionStore],
-      imports: [ HttpClientTestingModule ]
+      imports: [ HttpClientTestingModule, RouterTestingModule ]
     });
 
     collectionService = TestBed.get(CollectionService);

--- a/src/app/organizations/state/collection.service.spec.ts
+++ b/src/app/organizations/state/collection.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CollectionService } from './collection.service';
+import { CollectionStore } from './collection.store';
+
+describe('CollectionService', () => {
+  let collectionService: CollectionService;
+  let collectionStore: CollectionStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CollectionService, CollectionStore],
+      imports: [ HttpClientTestingModule ]
+    });
+
+    collectionService = TestBed.get(CollectionService);
+    collectionStore = TestBed.get(CollectionStore);
+  });
+
+  it('should be created', () => {
+    expect(collectionService).toBeDefined();
+  });
+
+});

--- a/src/app/organizations/state/collection.service.ts
+++ b/src/app/organizations/state/collection.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { CollectionStore } from './collection.store';
+import { transaction } from '@datorama/akita';
+import { UrlSegment, Router, PRIMARY_OUTLET } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { Collection, OrganisationsService } from '../../shared/swagger';
+
+@Injectable({ providedIn: 'root' })
+export class CollectionService {
+
+  constructor(private collectionStore: CollectionStore,
+              private http: HttpClient, private router: Router, private organizationsService: OrganisationsService) {
+  }
+
+  getCollectionId(): number {
+    const thing: Array<UrlSegment> = this.router.parseUrl(this.router.url).root.children[PRIMARY_OUTLET].segments;
+    const collectionId = thing[thing.length - 1];
+    return parseInt(collectionId.path, 10);
+  }
+
+  getOrganizationId(): number {
+    const thing: Array<UrlSegment> = this.router.parseUrl(this.router.url).root.children[PRIMARY_OUTLET].segments;
+    const collectionId = thing[1];
+    return parseInt(collectionId.path, 10);
+  }
+
+  clearState(): void {
+    this.collectionStore.setState(state => {
+      return {
+        ...state,
+        collection: null
+      };
+    });
+  }
+
+  updateCollection(collection: Collection) {
+    this.collectionStore.setState(state => {
+      return {
+        ...state,
+        collection: collection,
+      };
+    });
+  }
+
+  @transaction()
+  updateCollectionFromName() {
+    this.clearState();
+    const collectionId = this.getCollectionId();
+    const organizationId = this.getOrganizationId();
+    this.collectionStore.setLoading(true);
+    this.organizationsService.getCollectionById(organizationId, collectionId).pipe(finalize(() => this.collectionStore.setLoading(false)))
+    .subscribe((collection: Collection) => {
+      this.collectionStore.setError(false);
+      this.updateCollection(collection);
+    }, () => {
+      this.collectionStore.setError(true);
+    });
+  }
+}

--- a/src/app/organizations/state/collection.store.spec.ts
+++ b/src/app/organizations/state/collection.store.spec.ts
@@ -1,0 +1,14 @@
+import { CollectionStore } from './collection.store';
+
+describe('CollectionStore', () => {
+  let store: CollectionStore;
+
+  beforeEach(() => {
+    store = new CollectionStore();
+  });
+
+  it('should create an instance', () => {
+    expect(store).toBeTruthy();
+  });
+
+});

--- a/src/app/organizations/state/collection.store.ts
+++ b/src/app/organizations/state/collection.store.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Store, StoreConfig } from '@datorama/akita';
+import { Collection } from '../../shared/swagger';
+
+export interface CollectionState {
+  collection: Collection;
+}
+
+export function createInitialState(): CollectionState {
+  return {
+    collection: null
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'collection' })
+export class CollectionStore extends Store<CollectionState> {
+
+  constructor() {
+    super(createInitialState());
+  }
+
+}
+


### PR DESCRIPTION
Updates the organisations page to look nicer. Also adds very basic collection page. Note that both pages are still in their infancy and will require more modifications. It is being split up into multiple PRs to make it easier to manage and review.

Currently retrieving collection by id, but in future update will use either id or name, similar to what was done with orgs.

Organisation Page
![prettyorg](https://user-images.githubusercontent.com/6331159/51926600-9f4f2280-23bf-11e9-81e7-376cc63003be.png)

Collection Page
![prettycollection](https://user-images.githubusercontent.com/6331159/51926605-a118e600-23bf-11e9-998a-b14c92c2f887.png)
