### PR TITLE
Fix export as zip for unpublished workflows

### DIFF
--- a/cypress/integration/group1/hostedTools.ts
+++ b/cypress/integration/group1/hostedTools.ts
@@ -14,6 +14,7 @@
  *    limitations under the License.
  */
 import { goToUnexpandedSidebarEntry, resetDB, setTokenUserViewPort, goToTab } from '../../support/commands';
+import { Dockstore } from '../../../src/app/shared/dockstore.model';
 
 describe('Dockstore hosted tools', () => {
   resetDB();
@@ -21,6 +22,16 @@ describe('Dockstore hosted tools', () => {
 
   beforeEach(() => {
     cy.visit('/my-tools');
+
+    cy
+      .server();
+
+    cy.route({
+      method: 'GET',
+      url: /containers\/.+\/zip\/.+/,
+      response: 200
+    }).as('downloadZip');
+
   });
 
   function getTool() {
@@ -99,6 +110,14 @@ describe('Dockstore hosted tools', () => {
       cy
         .get('#downloadZipButton')
         .should('be.visible');
+
+      // Verify that clicking calls the correct endpoint
+      // https://github.com/ga4gh/dockstore/issues/2050
+      cy
+        .get('#downloadZipButton')
+        .click();
+
+      cy.wait('@downloadZip').its('url').should('include', Dockstore.API_URI);
 
       // Add a new version with a second descriptor and a test json
       goToTab('Files');

--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -14,6 +14,7 @@
  *    limitations under the License.
  */
 import { goToUnexpandedSidebarEntry, resetDB, setTokenUserViewPort, goToTab } from '../../support/commands';
+import { Dockstore } from '../../../src/app/shared/dockstore.model';
 
 describe('Dockstore hosted workflows', () => {
   resetDB();
@@ -21,6 +22,14 @@ describe('Dockstore hosted workflows', () => {
 
   beforeEach(() => {
     cy.visit('/my-workflows');
+
+    cy.server();
+
+    cy.route({
+      method: 'GET',
+      url: /workflows\/.+\/zip\/.+/,
+      response: 200
+    }).as('downloadZip');
   });
 
   function getWorkflow() {
@@ -85,6 +94,14 @@ describe('Dockstore hosted workflows', () => {
       cy
         .get('#downloadZipButton')
         .should('be.visible');
+
+      // Verify that clicking calls the correct endpoint
+      // https://github.com/ga4gh/dockstore/issues/2050
+      cy
+        .get('#downloadZipButton')
+        .click();
+
+      cy.wait('@downloadZip').its('url').should('include', Dockstore.API_URI);
 
       // Add a new version with a second descriptor and a test json
       goToTab('Files');

--- a/src/app/shared/extended-tools.service.ts
+++ b/src/app/shared/extended-tools.service.ts
@@ -51,7 +51,7 @@ export class ExtendedToolsService extends ContainersService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/containers/${encodeURIComponent(String(toolId))}/zip/${encodeURIComponent(String(tagId))}`,
+        return this.httpClient.get<any>(`${this.configuration.basePath}/containers/${encodeURIComponent(String(toolId))}/zip/${encodeURIComponent(String(tagId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/src/app/shared/extended-workflows.service.ts
+++ b/src/app/shared/extended-workflows.service.ts
@@ -51,7 +51,7 @@ export class ExtendedWorkflowsService extends WorkflowsService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/workflows/${encodeURIComponent(String(workflowId))}/zip/${encodeURIComponent(String(workflowVersionId))}`,
+        return this.httpClient.get<any>(`${this.configuration.basePath}/workflows/${encodeURIComponent(String(workflowId))}/zip/${encodeURIComponent(String(workflowVersionId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,


### PR DESCRIPTION

ga4gh/dockstore#2050

Generated code in ContainersService and WorkflowsService classes had changed with the switch to OpenAPI client code generator; update ExtendedToolsService and ExtendedWorkflowsService to match.