### PR TITLE
Feature/2069/no search text

### DIFF
--- a/cypress/integration/group2/elasticsearch.ts
+++ b/cypress/integration/group2/elasticsearch.ts
@@ -1,0 +1,25 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import { setTokenUserViewPort } from '../../support/commands';
+
+describe('Variations of URL', () => {
+  setTokenUserViewPort();
+  it('Should be able to search entries for using text', () => {
+    cy.visit('/');
+    cy.get('#searchBar').should('have.attr', 'placeholder', 'Enter Keyword...').type('asdf{enter}');
+    cy.url().should('eq', Cypress.config().baseUrl + '/search?search=asdf');
+  });
+});

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -21,7 +21,7 @@
         <h1 class="title">Create, Share, Use</h1>
         <h2 class="title caption">Search Docker Tools and Workflows for the Sciences:</h2>
         <div class="btn-group col-md-10 col-sm-8 col-xs-12">
-          <input #search type="text" placeholder="Enter Keyword..." class="search left fully-rounded search-home form-control"
+          <input id="searchBar" #search type="text" placeholder="Enter Keyword..." class="search left fully-rounded search-home form-control"
           (keyup.enter)="goToSearch(search.value)">
         </div>
       </div>

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -15,6 +15,13 @@
  */
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatAccordion } from '@angular/material';
+import {
+  faSort,
+  faSortAlphaDown,
+  faSortAlphaUp,
+  faSortNumericDown,
+  faSortNumericUp,
+} from '@fortawesome/free-solid-svg-icons';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
@@ -22,13 +29,11 @@ import { formInputDebounceTime } from '../shared/constants';
 import { AdvancedSearchObject } from '../shared/models/AdvancedSearchObject';
 import { CategorySort } from '../shared/models/CategorySort';
 import { SubBucket } from '../shared/models/SubBucket';
-import { ProviderService } from '../shared/provider.service';
 import { AdvancedSearchService } from './advancedsearch/advanced-search.service';
 import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
-import { faSort, faSortAlphaDown, faSortAlphaUp, faSortNumericDown, faSortNumericUp } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-search',
@@ -52,11 +57,6 @@ export class SearchComponent implements OnInit, OnDestroy {
   /*TODO: Bad coding...change this up later (init)..*/
   private setFilter = false;
   public hits: Object[];
-
-  // TODO: Comment on why shard_size is 10,000
-  private readonly shard_size = 10000;
-  private firstInit = true;
-
 
   // Possibly 100 workflows and 100 tools (extra +1 is used to see if there are > 200 results)
   public readonly query_size = 201;
@@ -112,7 +112,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    * This should be parameterised from src/app/shared/dockstore.model.ts
    * @param providerService
    */
-  constructor(private providerService: ProviderService, private queryBuilderService: QueryBuilderService,
+  constructor(private queryBuilderService: QueryBuilderService,
     public searchService: SearchService, private searchQuery: SearchQuery,
     private advancedSearchService: AdvancedSearchService) {
     this.shortUrl$ = this.searchQuery.shortUrl$;
@@ -179,11 +179,10 @@ export class SearchComponent implements OnInit, OnDestroy {
           categoryValue = decodeURIComponent(categoryValue);
           this.filters = this.searchService.handleFilters(key, categoryValue, this.filters);
         });
-        this.firstInit = false;
       } else if (key === 'search') {
         this.searchTerm = true;
         this.advancedSearchObject.toAdvanceSearch = false;
-        this.values = value[0];
+        this.searchService.setSearchText(value[0]);
       } else if (this.advancedSearchOptions.indexOf(key) > -1) {
         if (key.includes('Filter')) {
           useAdvSearch = true;


### PR DESCRIPTION
For ga4gh/dockstore#2069

Fixes the value not being used in the search.  Cause of this.  The store has a default value of empty string which is overwriting the value in gotten from the parseParam() function.  Value is now extracted and tossed into the store.

Also cleaned up a few unused parameters, imports, variables