### PR TITLE
Feature/1945/google refresh token error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,29 +25,26 @@ install:
 
 jobs:
   include:
-    - stage: test
+    - stage: unit test
+      name: "Lint, Unit Test, and Prod Test"
       script:
         - ng lint
         - ng test --watch=false --code-coverage --browsers ChromeHeadless
         - ng version
         - npm run build.prod
+    - stage: integration test
+      name: "Cypress Group 1"
       env:
-        - NAME='Lint, Unit Test, and Prod Test'
-    - stage: test
-      env:
-        - NAME='Integration test 1'
         - TEST='cypress/integration/group1/**/*'
       script: ./scripts/run-travis-script.sh
-
-    - stage: test
+    - stage: integration test
+      name: "Cypress Group 2"
       env:
-        - NAME='Integration test 2'
         - TEST='cypress/integration/group2/**/*'
       script: ./scripts/run-travis-script.sh
-
-    - stage: test
+    - stage: integration test
+      name: "Cypress Group 3"
       env:
-        - NAME='Integration test 3'
         - TEST='cypress/integration/group3/**/*'
       script: ./scripts/run-travis-script.sh
 

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -41,6 +41,7 @@ import { UserQuery } from '../../shared/user/user.query';
 import { RegisterWorkflowModalComponent } from '../../workflow/register-workflow-modal/register-workflow-modal.component';
 import { RegisterWorkflowModalService } from '../../workflow/register-workflow-modal/register-workflow-modal.service';
 import { MyWorkflowsService } from '../myworkflows.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 /**
  * How the workflow selection works:
@@ -111,13 +112,13 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
       if (user) {
         this.user = user;
         this.alertService.start('Fetching workflows');
-        forkJoin(this.usersService.userWorkflows(user.id).pipe(catchError(error => {
-          this.alertService.detailedError(error);
+        forkJoin(this.usersService.userWorkflows(user.id).pipe(catchError((error: HttpErrorResponse) => {
+          this.alertService.detailedSnackBarError(error);
           return observableOf([]);
-        })), this.workflowsService.sharedWorkflows().pipe(catchError(error => {
-          this.alertService.detailedError(error);
+        })), this.workflowsService.sharedWorkflows().pipe(catchError((error: HttpErrorResponse) => {
+          this.alertService.detailedSnackBarError(error);
           return observableOf([]);
-        }))).pipe(finalize(() => this.alertService.detailedSuccess()),
+        }))).pipe(finalize(() => this.alertService.simpleSuccess()),
           takeUntil(this.ngUnsubscribe)).subscribe(([workflows, sharedWorkflows]) => {
             this.workflowService.setWorkflows(workflows);
             this.workflowService.setSharedWorkflows(sharedWorkflows);

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -108,6 +108,11 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
     this.workflowQuery.workflow$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(workflow => this.workflow = workflow);
 
     // Retrieve all of the workflows for the user and update the workflow service
+    // TODO: Fix this. What should happen is:
+    // If none of the two calls error, there should be a simple snackBar displayed
+    // If one of the two calls error, there should be a detailed card displayed
+    // If two of the calls error, there should be a weird combined detailed card displayed
+    // Any errors should still return an empty array for that set of workflows
     this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(user => {
       if (user) {
         this.user = user;

--- a/src/app/shared/alert/state/alert.service.ts
+++ b/src/app/shared/alert/state/alert.service.ts
@@ -82,6 +82,20 @@ export class AlertService {
   }
 
   /**
+   * Handles HTTP error response and show a detailed message only in the matSnackBar.
+   * Use when there's is no alert component which normally displays the detailed message.
+   *
+   * @param {HttpErrorResponse} error  The HttpErrorResponse return by the failed Http call
+   * @memberof AlertService
+   */
+  public detailedSnackBarError(error: HttpErrorResponse) {
+    this.clearEverything();
+    const detailedError = '[HTTP ' + error.status + '] ' + error.statusText + ': ' +
+      (error.error && error.error.message ? error.error.message : error.error);
+    this.matSnackBar.open(detailedError);
+  }
+
+  /**
    * Handles error HTTP response and show matSnackBar
    *
    * @memberof AlertService


### PR DESCRIPTION
UI change for ga4gh/dockstore#1945.
There is also a webservice change.

Handles the error in a slightly better way.  Previously, the error alert card would show for a split second before disappearing because the other GET request succeeded and overwrites the error.

Also changes the Lint, Unit, and Prod Test to be its own stage so that integration tests don't trigger if something simple like 'ng build' fails