### PR TITLE
Feature/707/refresh upon add tag

### DIFF
--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -70,10 +70,10 @@
       <div *ngIf="editMode">
         <div class="input-group py-1">
           <input [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="cwlTestParameterFilePath"
-            [(ngModel)]="unsavedTestCWLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a CWL Test Parameter File in the Git repository."
+            [(ngModel)]="unsavedTestCWLFile" (keyup)="updateDuplicateTestJsonCheck()" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a CWL Test Parameter File in the Git repository."
             placeholder="e.g. /test.cwl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''" />
           <span class="input-group-btn">
-            <button title="Add CWL test parameter file" type="button" class="btn btn-default form-sm-button-material" [disabled]="hasDuplicateTestJson(DescriptorType.CWL)"
+            <button title="Add CWL test parameter file" type="button" class="btn btn-default form-sm-button-material" [disabled]="hasDuplicateCWL"
               (click)="addTestParameterFile(DescriptorType.CWL)" *ngIf="editMode && !(model1.invalid || unsavedTestCWLFile.length == 0)">
               <mat-icon>add</mat-icon>
             </button>
@@ -83,14 +83,8 @@
             </button>
           </span>
         </div>
-        <mat-card *ngIf="formErrors.cwlTestParameterFilePath" class="form-error-messages alert alert-danger" role="alert">
-          {{formErrors.cwlTestParameterFilePath}}
-        </mat-card>
-        <div *ngIf="hasDuplicateTestJson(DescriptorType.CWL)">
-          <mat-card class="alert alert-danger" role="alert">
-            <mat-icon>error</mat-icon> Duplicate test json files are not allowed.
-          </mat-card>
-        </div>
+        <mat-error *ngIf="formErrors.cwlTestParameterFilePath">{{formErrors.cwlTestParameterFilePath}}</mat-error>
+        <mat-error *ngIf="hasDuplicateCWL">Duplicate test json files are not allowed.</mat-error>
       </div>
       <div *ngIf="unsavedCWLTestParameterFilePaths.length == 0 && !editMode">
         <input class="form-control" placeholder="None provided" [disabled]="true" />
@@ -114,10 +108,10 @@
       <div *ngIf="editMode">
         <div class="input-group py-1">
           <input [ngClass]="{ 'input-right-button' : editMode }" type="text" #model1="ngModel" class="form-control" name="wdlTestParameterFilePath"
-            [(ngModel)]="unsavedTestWDLFile" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository."
+            [(ngModel)]="unsavedTestWDLFile" (keyup)="updateDuplicateTestJsonCheck()" minlength="3" maxlength="128" [pattern]="validationPatterns.testFilePath" title="Relative path to a WDL Test Parameter File in the Git repository."
             placeholder="e.g. /test.wdl.json" [disabled]="!editMode" ng-class="editMode ? 'test_parameter_input' : ''" />
           <span class="input-group-btn">
-            <button title="Add WDL test parameter file" type="button" class="btn btn-default form-sm-button-material" [disabled]="hasDuplicateTestJson(DescriptorType.WDL)"
+            <button title="Add WDL test parameter file" type="button" class="btn btn-default form-sm-button-material" [disabled]="hasDuplicateWDL"
               (click)="addTestParameterFile(DescriptorType.WDL)" *ngIf="editMode && !(model1.invalid || unsavedTestWDLFile.length == 0)">
               <mat-icon>add</mat-icon>
             </button>
@@ -127,16 +121,8 @@
             </button>
           </span>
         </div>
-        <div *ngIf="formErrors.wdlTestParameterFilePath" class="form-error-messages">
-          <mat-card class="alert alert-danger" role="alert">
-            <mat-icon>error</mat-icon> {{formErrors.wdlTestParameterFilePath}}
-          </mat-card>
-        </div>
-        <div *ngIf="hasDuplicateTestJson(DescriptorType.WDL)">
-          <mat-card class="alert alert-danger" role="alert">
-            <mat-icon>error</mat-icon> Duplicate test json files are not allowed.
-          </mat-card>
-        </div>
+        <mat-error *ngIf="formErrors.wdlTestParameterFilePath">{{formErrors.wdlTestParameterFilePath}}</mat-error>
+        <mat-error *ngIf="hasDuplicateWDL">Duplicate test json files are not allowed.</mat-error>
       </div>
       <div *ngIf="unsavedWDLTestParameterFilePaths.length == 0 && !editMode">
         <input class="form-control" placeholder="None provided" [disabled]="true" />
@@ -156,7 +142,7 @@
 </div>
 <div mat-dialog-actions>
   <button type="button" mat-button color="secondary" mat-dialog-close>Close</button>
-  <button id="addVersionTagButton" type="button" mat-flat-button color="primary" (click)="addTag()" [disabled]="!addTagForm.form.valid || hasDuplicateTestJson(DescriptorType.WDL) || hasDuplicateTestJson(DescriptorType.CWL)">
+  <button id="addVersionTagButton" type="button" mat-flat-button color="primary" (click)="addTag()" [disabled]="!addTagForm.form.valid || hasDuplicateCWL || hasDuplicateWDL">
     Add Tag
   </button>
 </div>

--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -159,8 +159,7 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
           this.containerService.setTool(tool);
           this.alertService.detailedSuccess();
           this.matDialog.closeAll();
-        }, error => {
-          console.log(this.tool);
+        }, (error: HttpErrorResponse) => {
           this.containerService.setTool(this.tool);
           this.alertService.detailedError(error);
         });
@@ -168,7 +167,7 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
         this.containerService.setTool(this.tool);
         this.alertService.detailedError(error);
       });
-    }, error => this.alertService.detailedError(error));
+    }, (error: HttpErrorResponse) => this.alertService.detailedError(error));
   }
 
   // Validation starts here, should move most of these to a service somehow

--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -49,6 +49,9 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
   unsavedTestWDLFile = '';
   unsavedCWLTestParameterFilePaths = [];
   unsavedWDLTestParameterFilePaths = [];
+  // Originally set to false because we made the defaults not duplicate of each other
+  public hasDuplicateCWL = false;
+  public hasDuplicateWDL = false;
   constructor(private containerService: ContainerService, private containertagsService: ContainertagsService,
     private containersService: ContainersService, private toolQuery: ToolQuery, private alertService: AlertService,
     private matDialog: MatDialog) {
@@ -203,18 +206,15 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
     }
   }
 
-  // Validation ends here
-  // Checks if the currently edited test parameter file already exists
-  // TODO: This code is repeated in version-modal.component.ts for tools, move it somewhere common
-  // TODO: This is also executed a bajillion times
-  hasDuplicateTestJson(type: ToolDescriptor.TypeEnum): boolean {
-    if (type === this.DescriptorType.CWL) {
-      return this.hasDuplicateTestJsonCommon(this.unsavedTestCWLFile, this.unsavedTestWDLFile);
-    } else if (type === this.DescriptorType.WDL) {
-      return this.hasDuplicateTestJsonCommon(this.unsavedTestWDLFile, this.unsavedTestCWLFile);
-    } else {
-      return false;
-    }
+  /**
+   * Checks if there's a duplicate CWL or WDL test parameter file
+   * TODO: Not have this run on keyup, there should be a debouncer for when the user types rapidly
+   *
+   * @memberof AddTagComponent
+   */
+  updateDuplicateTestJsonCheck() {
+    this.hasDuplicateCWL = this.hasDuplicateTestJsonCommon(this.unsavedTestCWLFile, this.unsavedTestWDLFile);
+    this.hasDuplicateWDL = this.hasDuplicateTestJsonCommon(this.unsavedTestWDLFile, this.unsavedTestCWLFile);
   }
 
   /**

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -71,19 +71,12 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
   }
 
   friendlyRegistryKeys(): Array<string> {
-    // TODO: Remove this section when GitLab is enabled
-    const friendlyRegistryKeys = this.registerToolService.friendlyRegistryKeys();
-    return friendlyRegistryKeys.filter(key => key !== 'GitLab');
-    // TODO: Uncomment this section when GitLab is enabled
-    // return this.registerToolService.friendlyRegistryKeys();
+    return this.registerToolService.friendlyRegistryKeys();
   }
 
   friendlyRepositoryKeys(): Array<string> {
-    // TODO: Remove this section when GitLab is enabled
     const friendlyRepositoryKeys = this.registerToolService.friendlyRepositoryKeys();
-    return friendlyRepositoryKeys.filter(key => key !== 'GitLab' && key !== 'Dockstore');
-    // TODO: Uncomment this section when GitLab is enabled
-    // return this.registerToolService.friendlyRepositoryKeys();
+    return friendlyRepositoryKeys.filter(key => key !== 'Dockstore');
   }
 
   isInvalidPrivateTool() {


### PR DESCRIPTION
For ga4gh/dockstore#707

Did some basic manual tests with GitLab git repo and GitLab image registry.  It appears to work, so enabling it again.


Refreshing a tool after:
- The tag has been created successfully
- The CWL and WDL test parameter files have been added successfully