### PR TITLE
Feature/2160/alias redirect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - ~/.cache
 env:
   global:
-    - WEBSERVICE_VERSION="1.6.0-beta.2"
+    - WEBSERVICE_VERSION="1.6.0-beta.3"
 addons:
   firefox: "latest"
   postgresql: "9.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - ~/.cache
 env:
   global:
-    - WEBSERVICE_VERSION="1.6.0-beta.1"
+    - WEBSERVICE_VERSION="1.6.0-beta.2"
 addons:
   firefox: "latest"
   postgresql: "9.6"

--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -132,25 +132,11 @@ describe('Dockstore Organizations', () => {
       cy.contains('veryFakeCollectionName');
       cy.contains('very fake collection topic');
     });
-
-    it('be able to update a collection description', () => {
-      cy.visit('/organizations/1/collections/1');
-      cy.get('#editCollectionDescription').click();
-      cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled');
-      typeInTextArea('Description', '* fake collection description');
-      cy.contains('Preview Mode').click();
-      cy.contains('fake collection description');
-      cy.contains('* fake collection description').should('not.exist');
-      cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled').click();
-      cy.get('#updateOrganizationDescriptionButton').should('not.be.visible');
-      cy.contains('fake collection description');
-      cy.contains('* fake collection description').should('not.exist');
-    });
   });
 
   describe('Should be able to update description', () => {
     it('be able to update an organization description with markdown', () => {
-      cy.visit('/organizations/1');
+      cy.visit('/organizations/Potatoe');
       cy.get('#editOrgDescription').click();
       cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled');
       typeInTextArea('Description', '* fake organization description');
@@ -166,7 +152,7 @@ describe('Dockstore Organizations', () => {
 
   describe('should be able to view a collection', () => {
     it('be able to see collection information', () => {
-      cy.visit('/organizations/1/collections/1');
+      cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('veryFakeCollectionName').click();
       // Should retrieve the organization
       cy.contains('Potatoe');
@@ -177,6 +163,20 @@ describe('Dockstore Organizations', () => {
 
       // Should have no entries
       cy.contains('This collection has no associated entries');
+    });
+
+    it('be able to update a collection description', () => {
+      cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
+      cy.get('#editCollectionDescription').click();
+      cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled');
+      typeInTextArea('Description', '* fake collection description');
+      cy.contains('Preview Mode').click();
+      cy.contains('fake collection description');
+      cy.contains('* fake collection description').should('not.exist');
+      cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled').click();
+      cy.get('#updateOrganizationDescriptionButton').should('not.be.visible');
+      cy.contains('fake collection description');
+      cy.contains('* fake collection description').should('not.exist');
     });
 
     it('be able to edit collection information', () => {
@@ -205,12 +205,12 @@ describe('Dockstore Organizations', () => {
     });
 
     it('be able to remove an entry from a collection', () => {
-      cy.visit('/organizations/1/collections/1');
+      cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut');
       cy.get('#removeToolButton').click();
       cy.get('#accept-remove-entry-from-org').click();
       cy.contains('This collection has no associated entries');
-      cy.visit('/organizations/1');
+      cy.visit('/organizations/Potatoe');
     });
   });
 
@@ -237,7 +237,7 @@ describe('Dockstore Organizations', () => {
 
       // Need to approve membership and reload for it to be visible
       approvePotatoMembership();
-      cy.visit('/organizations/1');
+      cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
       cy.contains('mat-card-title', 'potato').parent().parent().parent().contains('Member');
     });
@@ -260,13 +260,39 @@ describe('Dockstore Organizations', () => {
 
   describe('Verify title tags ', () => {
     it('Specific organization', () => {
-      cy.visit('/organizations/1');
+      cy.visit('/organizations/Potatoe');
       cy.title().should('eq', 'Dockstore | Organization');
     });
 
     it('Collection', () => {
-      cy.visit('/organizations/1/collections/1');
+      cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.title().should('eq', 'Dockstore | Collection');
+    });
+  });
+
+  describe('Find organisation and collection by alias', () => {
+    it('organisation alias', () => {
+      cy.server();
+      cy.route({
+        url: '/organizations/fakeAlias/aliases',
+        method: 'GET',
+        status: 200,
+        response: { 'name': 'Potatoe' }
+      });
+      cy.visit('/aliases/organizations/fakeAlias');
+      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe');
+    });
+
+    it('collection alias', () => {
+      cy.server();
+      cy.route({
+        url: '/organizations/collections/fakeAlias/aliases',
+        method: 'GET',
+        status: 200,
+        response: { 'organizationName': 'Potatoe', 'name': 'veryFakeCollectionName' }
+      });
+      cy.visit('/aliases/collections/fakeAlias');
+      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe/collections/veryFakeCollectionName');
     });
   });
 });

--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -270,8 +270,8 @@ describe('Dockstore Organizations', () => {
     });
   });
 
-  describe('Find organisation and collection by alias', () => {
-    it('organisation alias', () => {
+  describe('Find organization and collection by alias', () => {
+    it('organization alias', () => {
       cy.server();
       cy.route({
         url: '/organizations/fakeAlias/aliases',

--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -294,5 +294,38 @@ describe('Dockstore Organizations', () => {
       cy.visit('/aliases/collections/fakeAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe/collections/veryFakeCollectionName');
     });
+
+    it('invalid alias type', () => {
+      cy.server();
+      cy.visit('/aliases/foobar/fakeAlias');
+      cy.url().should('eq', Cypress.config().baseUrl + '/aliases/foobar/fakeAlias');
+      cy.contains('foobar is not a valid type');
+    });
+
+    it('organization alias incorrect', () => {
+      cy.server();
+      cy.route({
+        url: '/organizations/incorrectAlias/aliases',
+        method: 'GET',
+        status: 404,
+        response: {}
+      });
+      cy.visit('/aliases/organizations/incorrectAlias');
+      cy.url().should('eq', Cypress.config().baseUrl + '/aliases/organizations/incorrectAlias');
+      cy.contains('No organizations with the alias incorrectAlias found');
+    });
+
+    it('collection alias incorrect', () => {
+      cy.server();
+      cy.route({
+        url: '/organizations/collections/incorrectAlias/aliases',
+        method: 'GET',
+        status: 404,
+        response: {}
+      });
+      cy.visit('/aliases/collections/incorrectAlias');
+      cy.url().should('eq', Cypress.config().baseUrl + '/aliases/collections/incorrectAlias');
+      cy.contains('No collections with the alias incorrectAlias found');
+    });
   });
 });

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -1,5 +1,5 @@
 <app-header>
-  Aliases
+  Redirecting
 </app-header>
 <div class="container">
   <mat-card class="alert alert-warning" role="alert" *ngIf="!validType">

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -8,15 +8,14 @@
   </mat-card>
   <app-loading [loading]="(loading$ | async)">
     <div *ngIf="(organization$ | async) as org">
-      Redirecting...
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
     </div>
     <div *ngIf="(collection$ | async) as coll">
-      Redirecting...
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
     </div>
     <mat-card class="alert alert-warning" role="alert"  *ngIf="types.includes(type) && !(organization$ | async) && !(collection$ | async)">
       <mat-icon>warning</mat-icon>
       &nbsp;No {{ type }} with the alias {{ alias }}
     </mat-card>
   </app-loading>
-  <router-outlet></router-outlet>
 </div>

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -4,7 +4,7 @@
 <div class="container">
   <mat-card class="alert alert-warning" role="alert" *ngIf="!types.includes(type)">
     <mat-icon>warning</mat-icon>
-    &nbsp;{{ type }} is not a valid type
+    &nbsp;<strong>{{ type }}</strong> is not a valid type
   </mat-card>
   <app-loading [loading]="(loading$ | async)">
     <div *ngIf="(organization$ | async) as org">
@@ -15,7 +15,7 @@
     </div>
     <mat-card class="alert alert-warning" role="alert"  *ngIf="types.includes(type) && !(organization$ | async) && !(collection$ | async)">
       <mat-icon>warning</mat-icon>
-      &nbsp;No {{ type }} with the alias {{ alias }}
+      &nbsp;No <strong>{{ type }}</strong> with the alias <strong>{{ alias }}</strong> found
     </mat-card>
   </app-loading>
 </div>

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -7,13 +7,15 @@
     &nbsp;<strong>{{ type }}</strong> is not a valid type
   </mat-card>
   <app-loading [loading]="(loading$ | async)">
-    <div *ngIf="(organization$ | async) as org">
+    <div *ngIf="(organization$ | async) as org" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="10px">
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+      Redirecting to the organization <strong>{{ org.displayName }}</strong>
     </div>
-    <div *ngIf="(collection$ | async) as coll">
+    <div *ngIf="(collection$ | async) as coll" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="10px">
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+      Redirecting to the collection <strong>{{ coll.displayName }}</strong>
     </div>
-    <mat-card class="alert alert-warning" role="alert"  *ngIf="types.includes(type) && !(organization$ | async) && !(collection$ | async)">
+    <mat-card class="alert alert-warning" role="alert" *ngIf="types.includes(type) && !(organization$ | async) && !(collection$ | async)">
       <mat-icon>warning</mat-icon>
       &nbsp;No <strong>{{ type }}</strong> with the alias <strong>{{ alias }}</strong> found
     </mat-card>

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -1,0 +1,22 @@
+<app-header>
+  Aliases
+</app-header>
+<div class="container">
+  <mat-card class="alert alert-warning" role="alert" *ngIf="!types.includes(type)">
+    <mat-icon>warning</mat-icon>
+    &nbsp;{{ type }} is not a valid type
+  </mat-card>
+  <app-loading [loading]="(loading$ | async)">
+    <div *ngIf="(organization$ | async) as org">
+      Redirecting...
+    </div>
+    <div *ngIf="(collection$ | async) as coll">
+      Redirecting...
+    </div>
+    <mat-card class="alert alert-warning" role="alert"  *ngIf="types.includes(type) && !(organization$ | async) && !(collection$ | async)">
+      <mat-icon>warning</mat-icon>
+      &nbsp;No {{ type }} with the alias {{ alias }}
+    </mat-card>
+  </app-loading>
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -2,7 +2,7 @@
   Aliases
 </app-header>
 <div class="container">
-  <mat-card class="alert alert-warning" role="alert" *ngIf="!types.includes(type)">
+  <mat-card class="alert alert-warning" role="alert" *ngIf="!validType">
     <mat-icon>warning</mat-icon>
     &nbsp;<strong>{{ type }}</strong> is not a valid type
   </mat-card>

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -6,7 +6,10 @@
     <mat-icon>warning</mat-icon>
     &nbsp;<strong>{{ type }}</strong> is not a valid type
   </mat-card>
-  <app-loading [loading]="(loading$ | async)">
+  <div *ngIf="(loading$ | async); else doneLoading">
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  </div>
+  <ng-template #doneLoading>
     <div *ngIf="(organization$ | async) as org" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="10px">
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
       Redirecting to the organization <strong>{{ org.displayName }}</strong>
@@ -19,5 +22,5 @@
       <mat-icon>warning</mat-icon>
       &nbsp;No <strong>{{ type }}</strong> with the alias <strong>{{ alias }}</strong> found
     </mat-card>
-  </app-loading>
+  </ng-template>
 </div>

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -18,8 +18,9 @@ export class AliasesComponent extends Base implements OnInit {
   organization$: Observable<Organization>;
   collection$: Observable<Collection>;
 
-  public type;
-  public alias;
+  public type: string;
+  public alias: string;
+  public validType: boolean;
   // Types contains resource types that support aliases
   public types = [ 'organizations', 'collections' ];
   constructor(private aliasesQuery: AliasesQuery,
@@ -33,27 +34,25 @@ export class AliasesComponent extends Base implements OnInit {
   ngOnInit() {
     this.type = this.route.snapshot.paramMap.get('type');
     this.alias = this.route.snapshot.paramMap.get('alias');
-
+    this.validType = this.types.includes(this.type);
     this.loading$ = this.aliasesQuery.loading$;
 
-    if (this.types.includes(this.type)) {
-      if (this.type === 'organizations') {
-        this.aliasesService.updateOrganizationFromAlias(this.alias);
-        this.organization$ = this.aliasesQuery.organization$;
-        this.organization$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((organization: Organization) => {
-          if (organization) {
-            this.router.navigate(['/organizations', organization.name]);
-          }
-        });
-      } else if (this.type === 'collections') {
-        this.aliasesService.updateCollectionFromAlias(this.alias);
-        this.collection$ = this.aliasesQuery.collection$;
-        this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
-          if (collection) {
-            this.router.navigate(['/organizations', collection.organizationName, 'collections', collection.name]);
-          }
-        });
-      }
+    if (this.type === 'organizations') {
+      this.aliasesService.updateOrganizationFromAlias(this.alias);
+      this.organization$ = this.aliasesQuery.organization$;
+      this.organization$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((organization: Organization) => {
+        if (organization) {
+          this.router.navigate(['/organizations', organization.name]);
+        }
+      });
+    } else if (this.type === 'collections') {
+      this.aliasesService.updateCollectionFromAlias(this.alias);
+      this.collection$ = this.aliasesQuery.collection$;
+      this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
+        if (collection) {
+          this.router.navigate(['/organizations', collection.organizationName, 'collections', collection.name]);
+        }
+      });
     }
   }
 }

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -18,10 +18,10 @@ export class AliasesComponent extends Base implements OnInit {
   organization$: Observable<Organization>;
   collection$: Observable<Collection>;
 
-  protected type;
-  protected alias;
+  public type;
+  public alias;
   // Types contains resource types that support aliases
-  types = [ 'organizations', 'collections' ];
+  public types = [ 'organizations', 'collections' ];
   constructor(private aliasesQuery: AliasesQuery,
               private aliasesService: AliasesService,
               private route: ActivatedRoute,

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -21,7 +21,7 @@ export class AliasesComponent extends Base implements OnInit {
   protected type;
   protected alias;
   // Types contains resource types that support aliases
-  protected types = [ 'organizations', 'collections' ];
+  types = [ 'organizations', 'collections' ];
   constructor(private aliasesQuery: AliasesQuery,
               private aliasesService: AliasesService,
               private route: ActivatedRoute,

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -20,6 +20,7 @@ export class AliasesComponent extends Base implements OnInit {
 
   protected type;
   protected alias;
+  // Types contains resource types that support aliases
   protected types = [ 'organizations', 'collections' ];
   constructor(private aliasesQuery: AliasesQuery,
               private aliasesService: AliasesService,
@@ -35,22 +36,24 @@ export class AliasesComponent extends Base implements OnInit {
 
     this.loading$ = this.aliasesQuery.loading$;
 
-    if (this.type === 'organizations') {
-      this.aliasesService.updateOrganizationFromAlias(this.alias);
-      this.organization$ = this.aliasesQuery.organization$;
-      this.organization$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((organization: Organization) => {
-        if (organization) {
-          this.router.navigate(['/organizations', organization.name]);
-        }
-      });
-    } else if (this.type === 'collections') {
-      this.aliasesService.updateCollectionFromAlias(this.alias);
-      this.collection$ = this.aliasesQuery.collection$;
-      this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
-        if (collection) {
-          this.router.navigate(['/organizations', collection.organizationName, 'collections', collection.name]);
-        }
-      });
+    if (this.types.includes(this.type)) {
+      if (this.type === 'organizations') {
+        this.aliasesService.updateOrganizationFromAlias(this.alias);
+        this.organization$ = this.aliasesQuery.organization$;
+        this.organization$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((organization: Organization) => {
+          if (organization) {
+            this.router.navigate(['/organizations', organization.name]);
+          }
+        });
+      } else if (this.type === 'collections') {
+        this.aliasesService.updateCollectionFromAlias(this.alias);
+        this.collection$ = this.aliasesQuery.collection$;
+        this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
+          if (collection) {
+            this.router.navigate(['/organizations', collection.organizationName, 'collections', collection.name]);
+          }
+        });
+      }
     }
   }
 }

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+import { AliasesService } from './state/aliases.service';
+import { AliasesQuery } from './state/aliases.query';
+import { ActivatedRoute, Router } from '../test';
+import { Observable } from 'rxjs';
+import { Organization, Collection } from '../shared/swagger';
+import { Base } from '../shared/base';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'aliases',
+  templateUrl: './aliases.component.html',
+  styleUrls: ['./aliases.component.scss']
+})
+export class AliasesComponent extends Base implements OnInit {
+
+  loading$: Observable<boolean>;
+  organization$: Observable<Organization>;
+  collection$: Observable<Collection>;
+
+  protected type;
+  protected alias;
+  protected types = [ 'organizations', 'collections' ];
+  constructor(private aliasesQuery: AliasesQuery,
+              private aliasesService: AliasesService,
+              private route: ActivatedRoute,
+              private router: Router
+  ) {
+    super();
+  }
+
+  ngOnInit() {
+    this.type = this.route.snapshot.paramMap.get('type');
+    this.alias = this.route.snapshot.paramMap.get('alias');
+
+    this.loading$ = this.aliasesQuery.loading$;
+
+    if (this.type === 'organizations') {
+      this.aliasesService.updateOrganizationFromAlias(this.alias);
+      this.organization$ = this.aliasesQuery.organization$;
+      this.organization$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((organization: Organization) => {
+        if (organization) {
+          this.router.navigate(['/organizations', organization.name]);
+        }
+      });
+    } else if (this.type === 'collections') {
+      this.aliasesService.updateCollectionFromAlias(this.alias);
+      this.collection$ = this.aliasesQuery.collection$;
+      this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
+        if (collection) {
+          this.router.navigate(['/organizations', collection.organizationID, 'collections', collection.id]);
+        }
+      });
+    }
+  }
+}

--- a/src/app/aliases/aliases.component.ts
+++ b/src/app/aliases/aliases.component.ts
@@ -48,7 +48,7 @@ export class AliasesComponent extends Base implements OnInit {
       this.collection$ = this.aliasesQuery.collection$;
       this.collection$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((collection: Collection) => {
         if (collection) {
-          this.router.navigate(['/organizations', collection.organizationID, 'collections', collection.id]);
+          this.router.navigate(['/organizations', collection.organizationName, 'collections', collection.name]);
         }
       });
     }

--- a/src/app/aliases/aliases.module.ts
+++ b/src/app/aliases/aliases.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AliasesComponent } from './aliases.component';
+import { AlertModule } from 'ngx-bootstrap';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { HeaderModule } from '../shared/modules/header.module';
+import { AliasesRouting } from './aliases.routing';
+import { CustomMaterialModule } from '../shared/modules/material.module';
+import { RefreshAlertModule } from '../shared/alert/alert.module';
+
+@NgModule({
+  imports: [ CommonModule, AlertModule.forRoot(), FlexLayoutModule, HeaderModule, AliasesRouting,
+    CustomMaterialModule, RefreshAlertModule ],
+  declarations: [ AliasesComponent ],
+  exports: [ AliasesComponent ]
+})
+export class AliasesModule { }

--- a/src/app/aliases/aliases.module.ts
+++ b/src/app/aliases/aliases.module.ts
@@ -2,15 +2,15 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AliasesComponent } from './aliases.component';
 import { AlertModule } from 'ngx-bootstrap';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { HeaderModule } from '../shared/modules/header.module';
 import { AliasesRouting } from './aliases.routing';
 import { CustomMaterialModule } from '../shared/modules/material.module';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @NgModule({
-  imports: [ CommonModule, AlertModule.forRoot(), FlexLayoutModule, HeaderModule, AliasesRouting,
-    CustomMaterialModule, RefreshAlertModule ],
+  imports: [ CommonModule, AlertModule.forRoot(), HeaderModule, AliasesRouting,
+    CustomMaterialModule, RefreshAlertModule, FlexLayoutModule ],
   declarations: [ AliasesComponent ],
   exports: [ AliasesComponent ]
 })

--- a/src/app/aliases/aliases.routing.ts
+++ b/src/app/aliases/aliases.routing.ts
@@ -1,0 +1,27 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { AliasesComponent } from './aliases.component';
+
+
+const ALIASES_ROUTES: Routes = [
+  {
+    path: ':type/:alias', component: AliasesComponent, data: { title: 'Dockstore | Aliases'}
+  }
+];
+
+export const AliasesRouting = RouterModule.forChild(ALIASES_ROUTES);

--- a/src/app/aliases/state/aliases.query.spec.ts
+++ b/src/app/aliases/state/aliases.query.spec.ts
@@ -1,0 +1,15 @@
+import { AliasesQuery } from './aliases.query';
+import { AliasesStore } from './aliases.store';
+
+describe('AliasesQuery', () => {
+  let query: AliasesQuery;
+
+  beforeEach(() => {
+    query = new AliasesQuery(new AliasesStore);
+  });
+
+  it('should create an instance', () => {
+    expect(query).toBeTruthy();
+  });
+
+});

--- a/src/app/aliases/state/aliases.query.ts
+++ b/src/app/aliases/state/aliases.query.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from '@datorama/akita';
+import { AliasesStore, AliasesState } from './aliases.store';
+
+@Injectable({ providedIn: 'root' })
+export class AliasesQuery extends Query<AliasesState> {
+  organization$ = this.select(state => state.organization);
+  collection$ = this.select(state => state.collection);
+  loading$ = this.selectLoading();
+
+  constructor(protected store: AliasesStore) {
+    super(store);
+  }
+
+}

--- a/src/app/aliases/state/aliases.service.spec.ts
+++ b/src/app/aliases/state/aliases.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AliasesService } from './aliases.service';
+import { AliasesStore } from './aliases.store';
+
+describe('AliasesService', () => {
+  let aliasesService: AliasesService;
+  let aliasesStore: AliasesStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AliasesService, AliasesStore],
+      imports: [ HttpClientTestingModule ]
+    });
+
+    aliasesService = TestBed.get(AliasesService);
+    aliasesStore = TestBed.get(AliasesStore);
+  });
+
+  it('should be created', () => {
+    expect(aliasesService).toBeDefined();
+  });
+
+});

--- a/src/app/aliases/state/aliases.service.ts
+++ b/src/app/aliases/state/aliases.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { AliasesStore } from './aliases.store';
+import { OrganizationsService, Organization, Collection } from '../../shared/swagger';
+import { transaction } from '@datorama/akita';
+import { finalize } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AliasesService {
+
+  constructor(private aliasesStore: AliasesStore,
+              private organizationsService: OrganizationsService) {
+  }
+
+  clearState(): void {
+    this.aliasesStore.setState(state => {
+      return {
+        ...state,
+        organization: null,
+        collection: null
+      }
+    });
+  }
+
+  /**
+   * Make this better, copied from above
+   * @param alias
+   */
+  @transaction()
+  updateOrganizationFromAlias(alias: string): void {
+    this.clearState();
+    this.aliasesStore.setLoading(true);
+    this.organizationsService.getOrganizationByAlias(alias).pipe(finalize(() => this.aliasesStore.setLoading(false)))
+      .subscribe((organization: Organization) => {
+        this.aliasesStore.setError(false);
+        this.updateOrganization(organization);
+      }, () => {
+        this.aliasesStore.setError(true);
+      });
+  }
+
+  updateOrganization(organization: Organization) {
+    this.aliasesStore.setState(state => {
+      return {
+        ...state,
+        organization: organization,
+      };
+    });
+  }
+
+  /**
+   * Make this better, copied from above
+   * @param alias
+   */
+  @transaction()
+  updateCollectionFromAlias(alias: string): void {
+    this.clearState();
+    this.aliasesStore.setLoading(true);
+    this.organizationsService.getCollectionByAlias(alias).pipe(finalize(() => this.aliasesStore.setLoading(false)))
+      .subscribe((collection: Collection) => {
+        this.aliasesStore.setError(false);
+        this.updateCollection(collection);
+      }, () => {
+        this.aliasesStore.setError(true);
+      });
+  }
+
+  updateCollection(collection: Collection) {
+    this.aliasesStore.setState(state => {
+      return {
+        ...state,
+        collection: collection,
+      };
+    });
+  }
+
+}

--- a/src/app/aliases/state/aliases.service.ts
+++ b/src/app/aliases/state/aliases.service.ts
@@ -17,7 +17,7 @@ export class AliasesService {
         ...state,
         organization: null,
         collection: null
-      }
+      };
     });
   }
 

--- a/src/app/aliases/state/aliases.service.ts
+++ b/src/app/aliases/state/aliases.service.ts
@@ -21,10 +21,6 @@ export class AliasesService {
     });
   }
 
-  /**
-   * Make this better, copied from above
-   * @param alias
-   */
   @transaction()
   updateOrganizationFromAlias(alias: string): void {
     this.clearState();
@@ -47,10 +43,6 @@ export class AliasesService {
     });
   }
 
-  /**
-   * Make this better, copied from above
-   * @param alias
-   */
   @transaction()
   updateCollectionFromAlias(alias: string): void {
     this.clearState();

--- a/src/app/aliases/state/aliases.store.spec.ts
+++ b/src/app/aliases/state/aliases.store.spec.ts
@@ -1,0 +1,14 @@
+import { AliasesStore } from './aliases.store';
+
+describe('AliasesStore', () => {
+  let store: AliasesStore;
+
+  beforeEach(() => {
+    store = new AliasesStore();
+  });
+
+  it('should create an instance', () => {
+    expect(store).toBeTruthy();
+  });
+
+});

--- a/src/app/aliases/state/aliases.store.ts
+++ b/src/app/aliases/state/aliases.store.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Store, StoreConfig } from '@datorama/akita';
+import { Organization, Collection } from '../../shared/swagger';
+
+export interface AliasesState {
+   organization: Organization;
+   collection: Collection;
+}
+
+export function createInitialState(): AliasesState {
+  return {
+    organization: null,
+    collection: null
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'aliases' })
+export class AliasesStore extends Store<AliasesState> {
+
+  constructor() {
+    super(createInitialState());
+  }
+
+}
+

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -45,6 +45,7 @@ const APP_ROUTES: Routes = [
     data: { title: 'Dockstore | My Tools'}},
   { path: 'my-workflows', loadChildren: 'app/myworkflows/myworkflows.module#MyWorkflowsModule', canActivate: [AuthGuard],
     data: { title: 'Dockstore | My Workflows'}},
+  { path: 'aliases', loadChildren: 'app/aliases/aliases.module#AliasesModule', data: { title: 'Dockstore | Aliases' } },
   { path: 'search*', component: SearchComponent, data: { title: 'Dockstore | Search'} },
   { path: 'login', component: LoginComponent, data: { title: 'Dockstore | Login'} },
   { path: 'quick-start', component: QuickStartComponent, data: { title: 'Dockstore | Quick Start'} },

--- a/src/app/entry/current-collections/current-collections.component.html
+++ b/src/app/entry/current-collections/current-collections.component.html
@@ -19,7 +19,7 @@
   </div>
   <mat-list>
       <mat-list-item *ngFor="let collectionOrganizations of (currentCollections$ | async)">
-          <a [routerLink]="['/organizations', collectionOrganizations.organizationId, 'collections', collectionOrganizations.collectionId]" routerLinkActive="router-link-active" >{{collectionOrganizations.organizationName}}/{{collectionOrganizations.collectionName}}</a>
+          <a [routerLink]="['/organizations', collectionOrganizations.organizationName, 'collections', collectionOrganizations.collectionName]" routerLinkActive="router-link-active" >{{collectionOrganizations.organizationName}}/{{collectionOrganizations.collectionName}}</a>
       </mat-list-item>
     </mat-list>
   <div class="p-3 panel-body">

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -33,7 +33,7 @@
       <mat-card fxFlex class="my-3">
         <mat-card-header>
           <mat-card-title>
-            <h1><a [routerLink]="['/organizations/', organization.id]"><span [matTooltip]="organization?.name">{{ organization.displayName }}</span></a> /
+            <h1><a [routerLink]="['/organizations/', organization.name]"><span [matTooltip]="organization?.name">{{ organization.displayName }}</span></a> /
               <span [matTooltip]="collection?.name">{{ collection.displayName }}</span></h1>
           </mat-card-title>
           <mat-card-subtitle>

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -63,8 +63,8 @@ export class CollectionComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    const organizationName = this.activatedRoute.snapshot.paramMap.get('id');
-    const collectionName = this.activatedRoute.snapshot.paramMap.get('cid');
+    const organizationName = this.activatedRoute.snapshot.paramMap.get('organizationName');
+    const collectionName = this.activatedRoute.snapshot.paramMap.get('collectionName');
     this.loadingCollection$ = this.collectionsQuery.loading$;
     this.collection$ = this.collectionsQuery.selectActive();
     this.loadingOrganization$ = this.organizationQuery.loading$;

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -65,18 +65,13 @@ export class CollectionComponent implements OnInit {
   ngOnInit() {
     const organizationId = this.activatedRoute.snapshot.paramMap.get('id');
     const collectionId = this.activatedRoute.snapshot.paramMap.get('cid');
-    const alias = this.activatedRoute.snapshot.paramMap.get('alias');
     this.loadingCollection$ = this.collectionsQuery.loading$;
     this.collection$ = this.collectionsQuery.selectActive();
     this.loadingOrganization$ = this.organizationQuery.loading$;
     this.canEdit$ = this.organizationQuery.canEdit$;
     this.organization$ = this.organizationQuery.organization$;
-    if (alias) {
-      this.collectionsService.updateCollectionFromAlias(alias, this.organizationService);
-    } else {
-      this.organizationService.updateOrganizationFromNameORID(organizationId);
-      this.collectionsService.updateCollectionFromName(organizationId, collectionId);
-    }
+    this.organizationService.updateOrganizationFromName(organizationId);
+    this.collectionsService.updateCollectionFromName(organizationId, collectionId);
     this.isAdmin$ = this.userQuery.isAdmin$;
     this.isCurator$ = this.userQuery.isCurator$;
   }

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -63,15 +63,15 @@ export class CollectionComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    const organizationId = this.activatedRoute.snapshot.paramMap.get('id');
-    const collectionId = this.activatedRoute.snapshot.paramMap.get('cid');
+    const organizationName = this.activatedRoute.snapshot.paramMap.get('id');
+    const collectionName = this.activatedRoute.snapshot.paramMap.get('cid');
     this.loadingCollection$ = this.collectionsQuery.loading$;
     this.collection$ = this.collectionsQuery.selectActive();
     this.loadingOrganization$ = this.organizationQuery.loading$;
     this.canEdit$ = this.organizationQuery.canEdit$;
     this.organization$ = this.organizationQuery.organization$;
-    this.organizationService.updateOrganizationFromName(organizationId);
-    this.collectionsService.updateCollectionFromName(organizationId, collectionId);
+    this.organizationService.updateOrganizationFromName(organizationName);
+    this.collectionsService.updateCollectionFromName(organizationName, collectionName);
     this.isAdmin$ = this.userQuery.isAdmin$;
     this.isCurator$ = this.userQuery.isCurator$;
   }

--- a/src/app/organizations/collection/state/add-entry.query.ts
+++ b/src/app/organizations/collection/state/add-entry.query.ts
@@ -11,7 +11,7 @@ export class AddEntryQuery extends Query<AddEntryState> {
   memberships$: Observable<Array<OrganizationUser>> = this.select(state => state.memberships);
   collections$: Observable<Array<Collection>> = this.select(state => state.collections);
   filteredCollections$: Observable<Array<Collection>> = combineLatest(this.collections$, this.currentCollectionsQuery.currentCollectionIds$)
-    .pipe(map(([collections, collectionOrganisation]) => this.filteredCollections(collections, collectionOrganisation)));
+    .pipe(map(([collections, collectionOrganization]) => this.filteredCollections(collections, collectionOrganization)));
   isLoading$: Observable<boolean> = this.selectLoading();
   constructor(protected store: AddEntryStore, private currentCollectionsQuery: CurrentCollectionsQuery) {
     super(store);

--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -26,7 +26,7 @@
           <div fxFlex fxGrow="3">
             <mat-card-header>
               <mat-card-title>
-                <a [routerLink]="['/organizations/', organizationID, 'collections', collection?.value?.id]" [matTooltip]="collection?.value?.name">
+                <a [routerLink]="['/organizations/', organizationName, 'collections', collection?.value?.name]" [matTooltip]="collection?.value?.name">
                   {{collection.value.displayName}}
                 </a>
               </mat-card-title>

--- a/src/app/organizations/collections/collections.component.ts
+++ b/src/app/organizations/collections/collections.component.ts
@@ -31,6 +31,7 @@ import { CreateCollectionComponent } from './create-collection/create-collection
 })
 export class CollectionsComponent implements OnInit, OnChanges {
   @Input() organizationID: number;
+  @Input() organizationName: string;
   loading$: Observable<boolean>;
   canEdit$: Observable<boolean>;
   collections$: Observable<HashMap<Collection>>;

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -74,7 +74,7 @@
       <div fxFlex fxGrow="1" fxFlex.lt-md="100%">
         <mat-tab-group>
           <mat-tab label="Collections">
-            <collections [organizationID]="org.id"></collections>
+            <collections [organizationID]="org.id" [organizationName]="org.name"></collections>
           </mat-tab>
           <mat-tab label="Members">
             <organization-members></organization-members>

--- a/src/app/organizations/organization/organization.component.ts
+++ b/src/app/organizations/organization/organization.component.ts
@@ -46,14 +46,9 @@ export class OrganizationComponent implements OnInit {
 
   ngOnInit() {
     const organizationId = this.activatedRoute.snapshot.paramMap.get('id');
-    const alias = this.activatedRoute.snapshot.paramMap.get('alias');
     this.loading$ = this.organizationQuery.loading$;
     this.canEdit$ = this.organizationQuery.canEdit$;
-    if (organizationId) {
-      this.organizationService.updateOrganizationFromNameORID(organizationId);
-    } else if (alias) {
-      this.organizationService.updateOrganizationFromAlias(alias);
-    }
+    this.organizationService.updateOrganizationFromName(organizationId);
     this.organization$ = this.organizationQuery.organization$;
     this.gravatarUrl$ = this.organizationQuery.gravatarUrl$;
     this.isAdmin$ = this.userQuery.isAdmin$;

--- a/src/app/organizations/organization/organization.component.ts
+++ b/src/app/organizations/organization/organization.component.ts
@@ -45,10 +45,10 @@ export class OrganizationComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    const organizationId = this.activatedRoute.snapshot.paramMap.get('id');
+    const organizationName = this.activatedRoute.snapshot.paramMap.get('organizationName');
     this.loading$ = this.organizationQuery.loading$;
     this.canEdit$ = this.organizationQuery.canEdit$;
-    this.organizationService.updateOrganizationFromName(organizationId);
+    this.organizationService.updateOrganizationFromName(organizationName);
     this.organization$ = this.organizationQuery.organization$;
     this.gravatarUrl$ = this.organizationQuery.gravatarUrl$;
     this.isAdmin$ = this.userQuery.isAdmin$;

--- a/src/app/organizations/organization/state/update-organization-description.service.ts
+++ b/src/app/organizations/organization/state/update-organization-description.service.ts
@@ -44,13 +44,14 @@ export class UpdateOrganizationOrCollectionDescriptionService {
 
   updateOrganizationDescription(formGroup: FormGroup): void {
     const newDescription = formGroup.get('description').value || '';
-    const organizationID = this.organizationQuery.getSnapshot().organization.id;
+    const organizationName = this.organizationQuery.getSnapshot().organization.name;
+    const organizationId = this.organizationQuery.getSnapshot().organization.id;
     this.updateOrganizationOrCollectionDescriptionStore.setError(false);
     this.updateOrganizationOrCollectionDescriptionStore.setLoading(true);
-    this.organizationsService.updateOrganizationDescription(organizationID, newDescription)
+    this.organizationsService.updateOrganizationDescription(organizationId, newDescription)
       .pipe(finalize(() => this.updateOrganizationOrCollectionDescriptionStore.setLoading(false)))
       .subscribe((updatedOrganization: Organization) => {
-        this.organizationService.updateOrganizationFromID(organizationID);
+        this.organizationService.updateOrganizationFromName(organizationName);
         this.matDialog.closeAll();
       }, error => {
         this.updateOrganizationOrCollectionDescriptionStore.setError(true);

--- a/src/app/organizations/organization/state/update-organization-description.service.ts
+++ b/src/app/organizations/organization/state/update-organization-description.service.ts
@@ -44,14 +44,13 @@ export class UpdateOrganizationOrCollectionDescriptionService {
 
   updateOrganizationDescription(formGroup: FormGroup): void {
     const newDescription = formGroup.get('description').value || '';
-    const organizationName = this.organizationQuery.getSnapshot().organization.name;
-    const organizationId = this.organizationQuery.getSnapshot().organization.id;
+    const organizationID = this.organizationQuery.getSnapshot().organization.id;
     this.updateOrganizationOrCollectionDescriptionStore.setError(false);
     this.updateOrganizationOrCollectionDescriptionStore.setLoading(true);
-    this.organizationsService.updateOrganizationDescription(organizationId, newDescription)
+    this.organizationsService.updateOrganizationDescription(organizationID, newDescription)
       .pipe(finalize(() => this.updateOrganizationOrCollectionDescriptionStore.setLoading(false)))
       .subscribe((updatedOrganization: Organization) => {
-        this.organizationService.updateOrganizationFromName(organizationName);
+        this.organizationService.updateOrganizationFromID(organizationID);
         this.matDialog.closeAll();
       }, error => {
         this.updateOrganizationOrCollectionDescriptionStore.setError(true);

--- a/src/app/organizations/organizations.routing.ts
+++ b/src/app/organizations/organizations.routing.ts
@@ -23,9 +23,7 @@ import { CollectionComponent } from './collection/collection.component';
 const ORGANIZATIONS_ROUTES: Routes = [
   { path: '', component: OrganizationsComponent, data: {title: 'Dockstore | Organizations'} },
   { path: ':id', component: OrganizationComponent, data: {title: 'Dockstore | Organization'} },
-  { path: 'aliases/:alias', component: OrganizationComponent, data: {title: 'Dockstore | Organization'} },
   { path: ':id/collections/:cid', component: CollectionComponent, data: {title: 'Dockstore | Collection'} },
-  { path: 'aliases_collections/:alias', component: CollectionComponent, data: {title: 'Dockstore | Collection'} },
   { path: '**', redirectTo: '' }
 ];
 

--- a/src/app/organizations/organizations.routing.ts
+++ b/src/app/organizations/organizations.routing.ts
@@ -22,8 +22,8 @@ import { CollectionComponent } from './collection/collection.component';
 
 const ORGANIZATIONS_ROUTES: Routes = [
   { path: '', component: OrganizationsComponent, data: {title: 'Dockstore | Organizations'} },
-  { path: ':id', component: OrganizationComponent, data: {title: 'Dockstore | Organization'} },
-  { path: ':id/collections/:cid', component: CollectionComponent, data: {title: 'Dockstore | Collection'} },
+  { path: ':organizationName', component: OrganizationComponent, data: {title: 'Dockstore | Organization'} },
+  { path: ':organizationName/collections/:collectionName', component: CollectionComponent, data: {title: 'Dockstore | Collection'} },
   { path: '**', redirectTo: '' }
 ];
 

--- a/src/app/organizations/state/collections.service.ts
+++ b/src/app/organizations/state/collections.service.ts
@@ -75,39 +75,15 @@ export class CollectionsService {
   }
 
   @transaction()
-  updateCollectionFromName(organizationIdString: string, collectionIdString: string) {
-    const organizationId: number = parseInt(organizationIdString, 10);
-    const collectionId: number = parseInt(collectionIdString, 10);
-    if (isNaN(organizationId)) {
-      console.error('Organization name (instead of ID) currently not handled');
-      return;
-    }
+  updateCollectionFromName(organizationName: string, collectionName: string) {
+    this.clearState();
     this.collectionsStore.setError(false);
     this.collectionsStore.setLoading(true);
-    this.organizationsService.getCollectionById(organizationId, collectionId).pipe(finalize(() => this.collectionsStore.setLoading(false)))
+    this.organizationsService.getCollectionByName(organizationName, collectionName).pipe(finalize(() => this.collectionsStore.setLoading(false)))
       .subscribe((collection: Collection) => {
         this.collectionsStore.setError(false);
         this.collectionsStore.createOrReplace(collection.id, collection);
         this.collectionsStore.setActive(collection.id);
-      }, () => {
-        this.collectionsStore.setError(true);
-      });
-  }
-
-  /**
-   * Make this better, copied from above
-   * @param alias
-   */
-  @transaction()
-  updateCollectionFromAlias(alias: string, organizationService: OrganizationService) {
-    this.collectionsStore.setError(false);
-    this.collectionsStore.setLoading(true);
-    this.organizationsService.getCollectionByAlias(alias).pipe(finalize(() => this.collectionsStore.setLoading(false)))
-      .subscribe((collection: Collection) => {
-        this.collectionsStore.setError(false);
-        this.collectionsStore.createOrReplace(collection.id, collection);
-        this.collectionsStore.setActive(collection.id);
-        organizationService.updateOrganizationFromID(collection.organizationID);
       }, () => {
         this.collectionsStore.setError(true);
       });

--- a/src/app/organizations/state/organization.service.ts
+++ b/src/app/organizations/state/organization.service.ts
@@ -38,17 +38,6 @@ export class OrganizationService {
     });
   }
 
-  @transaction()
-  updateOrganizationFromNameORID(organizationIdString: string) {
-    this.clearState();
-    const organizationID: number = parseInt(organizationIdString, 10);
-    if (isNaN(organizationID)) {
-      this.updateOrganizationFromName(organizationIdString);
-    } else {
-      this.updateOrganizationFromID(organizationID);
-    }
-  }
-
   updateOrganizationFromID(organizationID: number): void {
     this.organizationStore.setLoading(true);
     this.organizationsService.getOrganizationById(organizationID).pipe(finalize(() => this.organizationStore.setLoading(false)))
@@ -70,27 +59,11 @@ export class OrganizationService {
     });
   }
 
-  updateOrganizationFromName(name: string): void {
-    this.organizationStore.setLoading(true);
-    this.organizationsService.getOrganizationByName(name).pipe(finalize(() => this.organizationStore.setLoading(false)))
-      .subscribe((organization: Organization) => {
-        this.organizationStore.setError(false);
-        this.updateOrganization(organization);
-        this.organizationMembersService.updateCanEdit(organization.id);
-      }, () => {
-        this.organizationStore.setError(true);
-      });
-  }
-
-  /**
-   * Make this better, copied from above
-   * @param alias
-   */
   @transaction()
-  updateOrganizationFromAlias(alias: string): void {
+  updateOrganizationFromName(organizationName: string): void {
     this.clearState();
     this.organizationStore.setLoading(true);
-    this.organizationsService.getOrganizationByAlias(alias).pipe(finalize(() => this.organizationStore.setLoading(false)))
+    this.organizationsService.getOrganizationByName(organizationName).pipe(finalize(() => this.organizationStore.setLoading(false)))
       .subscribe((organization: Organization) => {
         this.organizationStore.setError(false);
         this.updateOrganization(organization);


### PR DESCRIPTION
Removes previous alias code, now instead does the following:
* Added an aliases component at /aliases/type/alias, where `type` is in the set {organisations, collections} and `alias` is the alias
* If type is valid, will attempt to find the associated object for that alias using the appropriate alias endpoint
* If found object, redirect to page
* If not found, message saying no object with given alias found of some type

The benefit of this approach is that the organisations/collections code doesn't need to worry about aliases, they are all done in a separate component. Any new entity types (ex. entry) can be added to this component pretty easily.

The alias page shows the following, though this will only be visible for a split second, if that, unless on a slow connection.
![redirect-alias](https://user-images.githubusercontent.com/6331159/54038921-b556bc80-418f-11e9-8238-04e1a786d2f3.png)


This PR also removes any links to organisations or collections using DB ids. **Now ONLY names will be used for these links.**