### PR TITLE
only show subset of all events

### DIFF
--- a/src/app/organizations/events/events.component.html
+++ b/src/app/organizations/events/events.component.html
@@ -1,9 +1,4 @@
 <mat-card>
-  <mat-card-header>
-    <mat-card-title>
-      Recent Events
-    </mat-card-title>
-  </mat-card-header>
   <app-loading [loading]="(loading$ | async)">
     <div fxLayout="column wrap">
       <span *ngFor="let event of (events$ | async)">

--- a/src/app/organizations/state/events.service.ts
+++ b/src/app/organizations/state/events.service.ts
@@ -18,10 +18,24 @@ export class EventsService {
    */
   updateOrganizationEvents(id: number): void {
     this.eventsStore.setLoading(true);
-    this.organizationsService.getOrganizationEvents(id).pipe(
+    this.organizationsService.getOrganizationEvents(id, 0, 30).pipe(
       finalize(() => this.eventsStore.setLoading(false)
       ))
     .subscribe((organizationEvents: Array<Event>) => {
+      const EventType = Event.TypeEnum;
+      const importantEvents = [
+        EventType.CREATEORG,
+        EventType.APPROVEORGINVITE,
+        EventType.MODIFYORG,
+        EventType.CREATECOLLECTION,
+        EventType.MODIFYCOLLECTION,
+        EventType.ADDTOCOLLECTION,
+        EventType.REMOVEFROMCOLLECTION
+      ];
+      // Only return important events
+      organizationEvents = organizationEvents.filter((event: Event) => importantEvents.includes(event.type));
+      // Only return at most 10 events
+      organizationEvents = organizationEvents.slice(0, 10);
       this.eventsStore.set(organizationEvents);
     }, () => {
       this.eventsStore.setError(true);


### PR DESCRIPTION
Show at most 10 events in ui. Unfortunately since not all events are shown, grab 30 and hope that at least 10 of them are types to be shown. In the future we need to add support to the events endpoint to filter by type.

https://github.com/ga4gh/dockstore/issues/2166