### PR TITLE
Feature/2180/nextflow dag buttons

### DIFF
--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{'fullscreen-element large-dag': expanded}" class="cwl-viewer" >
+<div class="cwl-viewer" >
   <mat-card *ngIf="cwlViewerError" class="alert alert-warning">
     <mat-icon>warning</mat-icon>&nbsp;
     <div>The Common Workflow Language Viewer was unable to process the CWL. <span *ngIf="errorMessage">It returned the following error:</span></div>
@@ -7,7 +7,7 @@
   <div>
     <span *ngIf="!cwlViewerError">See on <a [href]="cwlViewerDescriptor?.webPageUrl" target="_blank">Common Workflow Language Viewer <mat-icon>open_in_new</mat-icon></a></span>
   </div>
-  <div class="mini-dag image" [ngClass]="{'fullscreen-element large-dag': expanded}">
+  <div class="image">
     <div *ngIf="loading" class="text-center viewer-loading">
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
     </div>

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 <div class="p-3" fxLayout="column" fxLayoutGap="10px">
-  <div fxFlex class="p-0" *ngIf="(isNFL$ | async) && dagType === 'classic'">
+  <div fxFlex *ngIf="(isNFL$ | async) && dagType === 'classic'">
     <!-- alert class not present because it adds too much margin above a DAG that actually exists -->
     <mat-card class="alert-warning" role="alert">
       <mat-icon>warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
@@ -31,14 +31,14 @@
       </span>
     </mat-card>
     <mat-card class="alert alert-warning" role="alert"
-      *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (missingTool$ | async) && selectedVersion?.valid">
+      *ngIf="(missingTool$ | async) && selectedVersion?.valid">
       <mat-icon>warning</mat-icon>&nbsp; DAG cannot be created because some required
       tools
       are missing from Github repo.
     </mat-card>
   </div>
   <div fxFlex #dagHolder id="dag-holder">
-    <div [ngClass]="{'p-3': expanded}" *ngIf="selectedVersion?.valid">
+    <div [ngClass]="{'p-3': expanded}" *ngIf="selectedVersion?.valid && !(missingTool$ | async)">
       <div fxLayout="row" fxLayoutAlign="space-between start">
         <div fxFlex>
           <div

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -15,15 +15,33 @@
   -->
 <div class="p-3">
   <div *ngIf="(isNFL$ | async) && dagType === 'classic'">
-    <mat-card class="alert alert-warning col-md-12" role="alert">
+    <mat-card class="alert alert-warning" role="alert">
       <mat-icon>warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
+    </mat-card>
+  </div>
+  <div *ngIf="dagType === 'classic' && !(isNFL$ | async)">
+    <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
+      <mat-icon>warning</mat-icon>&nbsp;
+      <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
+        A Descriptor associated with this workflow could not be found.
+      </span>
+      <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">
+        Please ensure that the Descriptor is a valid CWL 1.0 workflow.
+      </span>
+    </mat-card>
+    <mat-card class="alert alert-warning" role="alert"
+      *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (missingTool$ | async) && selectedVersion?.valid">
+      <mat-icon>warning</mat-icon>&nbsp; DAG cannot be created because some required
+      tools
+      are missing from Github repo.
     </mat-card>
   </div>
   <div #dagHolder id="dag-holder">
     <div [ngClass]="{'p-3': expanded}" *ngIf="selectedVersion?.valid">
       <div fxLayout="row" fxLayoutAlign="space-between start">
         <div fxFlex>
-          <div *ngIf="enableCwlViewer && (descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (workflow$ | async)?.source_control_provider === 'GITHUB'"
+          <div
+            *ngIf="enableCwlViewer && (descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (workflow$ | async)?.source_control_provider === 'GITHUB'"
             style="line-height: 20px;">
             <label class="radio-inline">
               <input type="radio" name="dagType" [(ngModel)]="dagType" value="classic">Classic
@@ -41,7 +59,8 @@
             </label>
           </div>
           <div>
-            <a *ngIf="(dagType === 'classic' && (dagResult$ | async)) || (dagType === 'wdlviewer' && (wdlViewerResult$ | async))" href #exportLink id="exportLink" (click)="download()">
+            <a *ngIf="(dagType === 'classic' && (dagResult$ | async)) || (dagType === 'wdlviewer' && (wdlViewerResult$ | async))"
+              href #exportLink id="exportLink" (click)="download()">
               <mat-icon>save</mat-icon>Save as {{dagType === 'classic' ? 'PNG' : 'SVG'}}
             </a>
           </div>
@@ -60,31 +79,17 @@
         </div>
       </div>
     </div>
-    <div *ngIf="dagType === 'classic' && !(isNFL$ | async)">
-      <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
-        <mat-icon>warning</mat-icon>&nbsp;
-        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
-          A Descriptor associated with this workflow could not be found.
-        </span>
-        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">
-          Please ensure that the Descriptor is a valid CWL 1.0 workflow.
-        </span>
-      </mat-card>
-      <mat-card class="alert alert-warning" role="alert" *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (missingTool$ | async) && selectedVersion?.valid">
-        <mat-icon>warning</mat-icon>&nbsp; DAG cannot be created because some required
-        tools
-        are missing from Github repo.
-      </mat-card>
-    </div>
     <div #dagDisplay data-cy="dag-holder" [className]="expanded ? 'big': 'small'">
-      <app-cwl-viewer *ngIf="enableCwlViewer && (descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (workflow$ | async)?.source_control_provider === 'GITHUB'"
+      <app-cwl-viewer
+        *ngIf="enableCwlViewer && (descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL && (workflow$ | async)?.source_control_provider === 'GITHUB'"
         [hidden]="dagType !== 'cwlviewer'" [selectedVersion]="selectedVersion" [refresh]="refreshCounter"
         [expanded]="expanded">
       </app-cwl-viewer>
-      <app-wdl-viewer *ngIf="(isWDL$ | async) && dagType === 'wdlviewer'"
-        [workflow]="(workflow$ | async)" [selectedVersion]="selectedVersion" [expanded]="expanded">
+      <app-wdl-viewer *ngIf="(isWDL$ | async) && dagType === 'wdlviewer'" [workflow]="(workflow$ | async)"
+        [selectedVersion]="selectedVersion" [expanded]="expanded">
       </app-wdl-viewer>
-      <div #cy id="cy" *ngIf="(dagResult$ | async) && !(missingTool$ | async)" class="h-100 w-100" [hidden]="dagType !== 'classic'"></div>
+      <div #cy id="cy" *ngIf="(dagResult$ | async) && !(missingTool$ | async)" class="h-100 w-100"
+        [hidden]="dagType !== 'classic'"></div>
     </div>
   </div>
 </div>

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -20,7 +20,7 @@
       <mat-icon>warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
     </mat-card>
   </div>
-  <div fxFlex *ngIf="dagType === 'classic' && !(isNFL$ | async)">
+  <div fxFlex *ngIf="dagType === 'classic' && !(isNFL$ | async) && !(dagResult$ | async)">
     <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
       <mat-icon>warning</mat-icon>&nbsp;
       <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -13,13 +13,14 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<div class="p-3">
-  <div *ngIf="(isNFL$ | async) && dagType === 'classic'">
-    <mat-card class="alert alert-warning" role="alert">
+<div class="p-3" fxLayout="column" fxLayoutGap="10px">
+  <div fxFlex class="p-0" *ngIf="(isNFL$ | async) && dagType === 'classic'">
+    <!-- alert class not present because it adds too much margin above a DAG that actually exists -->
+    <mat-card class="alert-warning" role="alert">
       <mat-icon>warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
     </mat-card>
   </div>
-  <div *ngIf="dagType === 'classic' && !(isNFL$ | async)">
+  <div fxFlex *ngIf="dagType === 'classic' && !(isNFL$ | async)">
     <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
       <mat-icon>warning</mat-icon>&nbsp;
       <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
@@ -36,7 +37,7 @@
       are missing from Github repo.
     </mat-card>
   </div>
-  <div #dagHolder id="dag-holder">
+  <div fxFlex #dagHolder id="dag-holder">
     <div [ngClass]="{'p-3': expanded}" *ngIf="selectedVersion?.valid">
       <div fxLayout="row" fxLayoutAlign="space-between start">
         <div fxFlex>

--- a/src/app/workflow/dag/wdl-viewer/wdl-viewer.component.ts
+++ b/src/app/workflow/dag/wdl-viewer/wdl-viewer.component.ts
@@ -17,13 +17,12 @@
 import { AfterViewInit, Component, ElementRef, Input, OnDestroy, Renderer2, ViewChild, ViewEncapsulation } from '@angular/core';
 import * as pipeline from 'pipeline-builder';
 import { Subject } from 'rxjs';
-import { filter, finalize, take, takeUntil } from 'rxjs/operators';
+import { finalize, take, takeUntil } from 'rxjs/operators';
 import { FileService } from '../../../shared/file.service';
 import { GA4GHFilesService } from '../../../shared/ga4gh-files/ga4gh-files.service';
 import { WorkflowQuery } from '../../../shared/state/workflow.query';
 import { ToolDescriptor, Workflow, WorkflowsService, WorkflowVersion } from '../../../shared/swagger';
 import { WdlViewerPipeline, WdlViewerService } from './wdl-viewer.service';
-
 
 @Component({
   selector: 'app-wdl-viewer',
@@ -58,7 +57,7 @@ export class WdlViewerComponent implements AfterViewInit, OnDestroy {
     this.visualizer = new pipeline.Visualizer(this.diagram.nativeElement, false);
 
     // Retrieve all files for this workflow from Ga4ghFiles entity Store
-    this.wdlViewerService.getFiles(ToolDescriptor.TypeEnum.WDL).pipe(filter(file => file != null), takeUntil(this.ngUnsubscribe))
+    this.wdlViewerService.getFiles(ToolDescriptor.TypeEnum.WDL).pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(files => {
         // Do not re-create the WDL visualization if the workflow version is not different
         if (!this.versionChanged) {
@@ -77,12 +76,16 @@ export class WdlViewerComponent implements AfterViewInit, OnDestroy {
               this.wdlViewerError = false;
               this.wdlViewerService.setStatus(true);
             },
-            (error) => {
-              this.errorMessage = error || 'Unknown Error';
-              this.wdlViewerError = true;
-              this.diagram.nativeElement.remove();
-              this.wdlViewerService.setStatus(false);
-            });
+              (error) => {
+                this.errorMessage = error || 'Unknown Error';
+                this.wdlViewerError = true;
+                this.diagram.nativeElement.remove();
+                this.wdlViewerService.setStatus(false);
+              });
+        } else {
+          this.wdlViewerService.setStatus(false);
+          this.wdlViewerError = true;
+          this.loading = false;
         }
       });
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -995,23 +995,6 @@ div.tabs>div:target>div,
   opacity: 0.825;
 }
 
-.fullscreen-element {
-  width: 100%;
-  height: 100%;
-  border: 2px solid #ccc;
-  background: #FFF;
-}
-
-.mini-dag {
-  width: 100%;
-  height: 500px;
-}
-
-.large-dag {
-  height: 90%;
-  border: 1px solid #ccc;
-}
-
 .no-display {
   display: none;
 }


### PR DESCRIPTION
For ga4gh/dockstore#2180
which fixes the controls by putting them in its own div under the possible warnings
Also:
- remove cwlviewer expand styles because the dag.component does the expanding now
- gave WDL workflows the possible "DAG cannot be created because some required tools are missing from Github repo" alert
- only show warning alerts if there actually is no dagResults
- guard against no files in wdl-viewer (if the files endpoint errors out, it should not be in a continuous loading state)
