### PR TITLE
Feature/2059/tooltip search result name

### DIFF
--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -16,7 +16,6 @@
 import { OnInit, ViewChild } from '@angular/core';
 import { MatPaginator, MatSort, MatTableDataSource } from '@angular/material';
 import { Subject } from 'rxjs';
-
 import { DateService } from '../shared/date.service';
 import { DockstoreTool, Workflow } from '../shared/swagger';
 
@@ -25,8 +24,9 @@ export abstract class SearchEntryTable implements OnInit {
   @ViewChild(MatSort) protected sort: MatSort;
   protected verifiedLink: string;
   protected ngUnsubscribe: Subject<{}> = new Subject();
-  abstract displayedColumns: Array<string>;
-  abstract dataSource: (MatTableDataSource<Workflow |DockstoreTool>);
+
+  public readonly displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
+  abstract dataSource: (MatTableDataSource<Workflow | DockstoreTool>);
   abstract privateNgOnInit(): void;
 
   constructor(protected dateService: DateService) {

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -30,8 +30,7 @@
         <span *ngIf="tool.private_access">
           <app-private-icon></app-private-icon>
         </span>
-        <a [routerLink]="('/containers/' + tool.tool_path )">{{ tool?.namespace + '/' + tool?.name +
-                    (tool?.toolname ? '/' + tool?.toolname : '') }}</a>
+        <a [matTooltip]="tool?.tool_path" [routerLink]="('/containers/' + tool.tool_path )">{{ tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '') }}</a>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">
@@ -57,20 +56,6 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let tool">{{ !tool?.starredUsers || tool?.starredUsers.length === 0 ? '' : tool?.starredUsers.length }}
         <mat-icon class="star" *ngIf="tool?.starredUsers?.length > 0 " >star_rate</mat-icon>
-      </mat-cell>
-    </ng-container>
-    <ng-container matColumnDef="dockerPull">
-      <mat-header-cell *matHeaderCellDef>Docker Pull</mat-header-cell>
-      <mat-cell *matCellDef="let tool: Tool">
-        <div class="input-group">
-          <input readonly type="text" class="form-control" value="{{ getFilteredDockerPullCmd(tool.tool_path, tool.defaultVersion) }}" aria-describedby="clipboard"
-            #inputTarget>
-          <span class="input-group-btn" id="clipboard">
-            <button class="btn btn-default" type="button" [ngxClipboard]="inputTarget">
-              <mat-icon>file_copy</mat-icon>
-            </button>
-          </span>
-        </div>
       </mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material';
 import { takeUntil } from 'rxjs/operators';
-
 import { ListContainersService } from '../../containers/list/list.service';
 import { DateService } from '../../shared/date.service';
 import { DockstoreService } from '../../shared/dockstore.service';
@@ -17,10 +16,10 @@ import { SearchService } from '../state/search.service';
 })
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<DockstoreTool>;
-  public displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers', 'dockerPull'];
+  public displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
   constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
     private listContainersService: ListContainersService, private searchQuery: SearchQuery) {
-      super(dateService);
+    super(dateService);
   }
 
   privateNgOnInit(): void {

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material';
 import { takeUntil } from 'rxjs/operators';
-import { ListContainersService } from '../../containers/list/list.service';
 import { DateService } from '../../shared/date.service';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { DockstoreTool } from '../../shared/swagger';
 import { SearchEntryTable } from '../search-entry-table';
 import { SearchQuery } from '../state/search.query';
-import { SearchService } from '../state/search.service';
 
 @Component({
   selector: 'app-search-tool-table',
@@ -16,9 +14,7 @@ import { SearchService } from '../state/search.service';
 })
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<DockstoreTool>;
-  public displayedColumns = this.searchService.displayedColumns;
-  constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
-    private listContainersService: ListContainersService, private searchQuery: SearchQuery) {
+  constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchQuery: SearchQuery) {
     super(dateService);
   }
 
@@ -28,18 +24,6 @@ export class SearchToolTableComponent extends SearchEntryTable implements OnInit
         this.dataSource.data = entries;
       }
     });
-  }
-
-  /**
-   * This gets the docker pull command
-   *
-   * @param {string} path The path of the tool (quay.io/namespace/toolname)
-   * @param {string} [tagName=''] The specific version of the docker image to get
-   * @returns {string} The docker pull command
-   * @memberof SearchToolTableComponent
-   */
-  getFilteredDockerPullCmd(path: string, tagName: string = ''): string {
-    return this.listContainersService.getDockerPullCmd(path, tagName);
   }
 
   getVerified(tool: DockstoreTool): boolean {

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -16,7 +16,7 @@ import { SearchService } from '../state/search.service';
 })
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<DockstoreTool>;
-  public displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
+  public displayedColumns = this.searchService.displayedColumns;
   constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
     private listContainersService: ListContainersService, private searchQuery: SearchQuery) {
     super(dateService);

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -11,7 +11,7 @@
             <mat-icon matTooltip="Verified">done</mat-icon>
           </a>
         </span>
-        <a [routerLink]="('/workflows/' + workflow?.full_workflow_path )">{{ workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}</a>
+        <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="('/workflows/' + workflow?.full_workflow_path )">{{ workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}</a>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -3,7 +3,7 @@
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
   <mat-table [hidden]="!dataSource" class="mat-elevation-z4" [dataSource]="dataSource" matSort matSortActive="starredUsers" matSortDirection="desc" matSortDisableClear>
-    <ng-container matColumnDef="repository">
+    <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
       <mat-cell *matCellDef="let workflow: Workflow">
         <span id="verifiedIcon" *ngIf="getVerified(workflow)">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -21,7 +21,6 @@ import { DockstoreService } from '../../shared/dockstore.service';
 import { Workflow } from '../../shared/swagger';
 import { SearchEntryTable } from '../search-entry-table';
 import { SearchQuery } from '../state/search.query';
-import { SearchService } from '../state/search.service';
 
 @Component({
   selector: 'app-search-workflow-table',
@@ -29,10 +28,8 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['./search-workflow-table.component.scss']
 })
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
-  public displayedColumns = this.searchService.displayedColumns;
   public dataSource: MatTableDataSource<Workflow>;
-  constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
-    private searchQuery: SearchQuery) {
+  constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchQuery: SearchQuery) {
     super(dateService);
   }
 

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material';
 import { takeUntil } from 'rxjs/operators';
-
 import { DateService } from '../../shared/date.service';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { Workflow } from '../../shared/swagger';
@@ -15,7 +14,7 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['./search-workflow-table.component.scss']
 })
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
-  public displayedColumns = ['repository', 'author', 'descriptorType', 'starredUsers', 'projectLinks'];
+  public displayedColumns = ['repository', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
   public dataSource: MatTableDataSource<Workflow>;
   constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
     private searchQuery: SearchQuery) {

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material';
 import { takeUntil } from 'rxjs/operators';
@@ -14,7 +29,7 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['./search-workflow-table.component.scss']
 })
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
-  public displayedColumns = ['repository', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
+  public displayedColumns = this.searchService.displayedColumns;
   public dataSource: MatTableDataSource<Workflow>;
   constructor(private dockstoreService: DockstoreService, protected dateService: DateService, private searchService: SearchService,
     private searchQuery: SearchQuery) {

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -41,9 +41,6 @@ export class SearchService {
    */
   public exclusiveFilters = ['tags.verified', 'private_access', '_type', 'has_checker'];
 
-  // Columns displayed in both tool and workflow search results table
-  public readonly displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
-
   constructor(private searchStore: SearchStore, private searchQuery: SearchQuery, private providerService: ProviderService,
     private router: Router, private location: Location) {
   }

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -13,18 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { URLSearchParams } from '@angular/http';
-import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router/';
+import { BehaviorSubject } from 'rxjs';
 import { Dockstore } from '../../shared/dockstore.model';
 import { SubBucket } from '../../shared/models/SubBucket';
-import { SearchStore } from './search.store';
-import { SearchQuery } from './search.query';
 import { ProviderService } from '../../shared/provider.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
-import { Location } from '@angular/common';
+import { SearchQuery } from './search.query';
+import { SearchStore } from './search.store';
 
 @Injectable({ providedIn: 'root' })
 export class SearchService {
@@ -42,6 +41,8 @@ export class SearchService {
    */
   public exclusiveFilters = ['tags.verified', 'private_access', '_type', 'has_checker'];
 
+  // Columns displayed in both tool and workflow search results table
+  public readonly displayedColumns = ['name', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
 
   constructor(private searchStore: SearchStore, private searchQuery: SearchQuery, private providerService: ProviderService,
     private router: Router, private location: Location) {


### PR DESCRIPTION
For ga4gh/dockstore#2059

- Adds a tooltip for the names in the name column of the search tables
- Reorders columns a bit so that they are exactly the same between tools and workflows
