### PR TITLE
Feature/1947/search table bug

### DIFF
--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -26,6 +26,7 @@ import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { SearchResultsComponent } from './search-results.component';
 import { SearchService } from '../state/search.service';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('SearchResultsComponent', () => {
   let component: SearchResultsComponent;
@@ -35,7 +36,7 @@ describe('SearchResultsComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SearchResultsComponent ],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [TabsModule.forRoot(), TagCloudModule],
+      imports: [TabsModule.forRoot(), TagCloudModule, RouterTestingModule],
       providers: [
         {provide: SearchService, useClass: SearchStubService},
         { provide: QueryBuilderService, useClass: QueryBuilderStubService }

--- a/src/app/search/search-tool-table/search-tool-table.component.spec.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.spec.ts
@@ -10,6 +10,7 @@ import { CustomMaterialModule } from '../../shared/modules/material.module';
 import { DockstoreStubService, ListContainersStubService, SearchStubService } from '../../test/service-stubs';
 import { SearchToolTableComponent } from './search-tool-table.component';
 import { SearchService } from '../state/search.service';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('SearchToolTableComponent', () => {
   let component: SearchToolTableComponent;
@@ -19,7 +20,7 @@ describe('SearchToolTableComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SearchToolTableComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [CustomMaterialModule, BrowserAnimationsModule],
+      imports: [CustomMaterialModule, BrowserAnimationsModule, RouterTestingModule],
       providers: [{ provide: DockstoreService, useClass: DockstoreStubService }, DateService,
       { provide: ListContainersService, useClass: ListContainersStubService },
       { provide: SearchService, useClass: SearchStubService }]

--- a/src/app/search/search-workflow-table/search-workflow-table.component.spec.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.spec.ts
@@ -10,6 +10,7 @@ import { DockstoreStubService, SearchStubService } from '../../test/service-stub
 import { DateService } from '../../shared/date.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SearchService } from '../state/search.service';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('SearchWorkflowTableComponent', () => {
   let component: SearchWorkflowTableComponent;
@@ -19,7 +20,7 @@ describe('SearchWorkflowTableComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ SearchWorkflowTableComponent ],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [CustomMaterialModule, BrowserAnimationsModule],
+      imports: [CustomMaterialModule, BrowserAnimationsModule, RouterTestingModule],
       providers: [{provide: DockstoreService, useClass: DockstoreStubService}, DateService,
       {provide: SearchService, useClass: SearchStubService}]
     })

--- a/src/app/search/state/search.query.ts
+++ b/src/app/search/state/search.query.ts
@@ -4,7 +4,7 @@ import { SearchStore, SearchState } from './search.store';
 import { Workflow, DockstoreTool } from '../../shared/swagger';
 import { Observable, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Dockstore } from '../../shared/dockstore.model';
+import { ActivatedRoute } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class SearchQuery extends Query<SearchState> {
@@ -33,7 +33,7 @@ export class SearchQuery extends Query<SearchState> {
   public hasAutoCompleteTerms$: Observable<boolean> = this.autoCompleteTerms$.pipe(map(terms => terms.length > 0));
   public suggestTerm$: Observable<string> = this.select(state => state.suggestTerm);
 
-  constructor(protected store: SearchStore) {
+  constructor(protected store: SearchStore, private route: ActivatedRoute) {
     super(store);
   }
 
@@ -47,10 +47,14 @@ export class SearchQuery extends Query<SearchState> {
     if (!tools || !workflows) {
       return true;
     }
+    const param = this.route.snapshot.queryParams['_type'];
+
     if (tools.length === 0 && workflows.length > 0) {
       return false;
     } else if (workflows.length === 0 && tools.length > 0) {
       return true;
+    } else if (workflows.length === 0 && param === 'workflow') {
+      return false;
     } else {
       return true;
     }

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -13,17 +13,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { URLSearchParams } from '@angular/http';
-import { Router } from '@angular/router/';
 import { BehaviorSubject } from 'rxjs';
+import { Router } from '@angular/router/';
 import { Dockstore } from '../../shared/dockstore.model';
 import { SubBucket } from '../../shared/models/SubBucket';
+import { SearchStore } from './search.store';
+import { SearchQuery } from './search.query';
 import { ProviderService } from '../../shared/provider.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
-import { SearchQuery } from './search.query';
-import { SearchStore } from './search.store';
 
 @Injectable({ providedIn: 'root' })
 export class SearchService {
@@ -42,7 +41,7 @@ export class SearchService {
   public exclusiveFilters = ['tags.verified', 'private_access', '_type', 'has_checker'];
 
   constructor(private searchStore: SearchStore, private searchQuery: SearchQuery, private providerService: ProviderService,
-    private router: Router, private location: Location) {
+    private router: Router) {
   }
 
   // Given a URL, will attempt to shorten it
@@ -226,7 +225,7 @@ export class SearchService {
   }
 
   handleLink(linkArray: Array<string>) {
-    this.location.go('search?' + linkArray[1]);
+    this.router.navigateByUrl('search?' + linkArray[1]);
     this.setShortUrl(linkArray[0] + '?' + linkArray[1]);
   }
 


### PR DESCRIPTION
ga4gh/dockstore#1947
Fixed by setting workflow tab to be active when workflow facet is selected and search request has no hits.