### PR TITLE
Feature/2216/active workflow clear

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -13,6 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
+<div *ngIf="tool">
 <div class="row m-1" *ngIf="error || missingWarning">
   <div class="col-md-12" *ngIf="!isToolPublic">
     <mat-card class="alert alert-warning" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
@@ -286,4 +287,5 @@
       </div>
     </div> -->
   </div>
+</div>
 </div>

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -38,6 +38,7 @@ import { SessionService } from '../shared/session/session.service';
 import { Tag } from '../shared/swagger/model/tag';
 import { WorkflowVersion } from '../shared/swagger/model/workflowVersion';
 import { ToolQuery } from '../shared/tool/tool.query';
+import { ToolService } from '../shared/tool/tool.service';
 import { TrackLoginService } from '../shared/track-login.service';
 import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
 import { RefreshService } from './../shared/refresh.service';
@@ -89,7 +90,8 @@ export class ContainerComponent extends Entry {
     location: Location,
     activatedRoute: ActivatedRoute, protected sessionService: SessionService, protected sessionQuery: SessionQuery,
     protected gA4GHFilesService: GA4GHFilesService, private toolQuery: ToolQuery, private alertService: AlertService,
-    private extendedDockstoreToolQuery: ExtendedDockstoreToolQuery, private alertQuery: AlertQuery, public dialog: MatDialog) {
+    private extendedDockstoreToolQuery: ExtendedDockstoreToolQuery, private alertQuery: AlertQuery, public dialog: MatDialog,
+    private toolService: ToolService) {
     super(trackLoginService, providerService, router, dateService, urlResolverService, activatedRoute,
       location, sessionService, sessionQuery, gA4GHFilesService);
     this.isRefreshing$ = this.alertQuery.showInfo$;
@@ -97,6 +99,10 @@ export class ContainerComponent extends Entry {
 
     this._toolType = 'containers';
     this.redirectAndCallDiscourse('/my-tools');
+  }
+
+  clearState() {
+    this.toolService.clearActive();
   }
 
   public getDefaultVersionName(): string {

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -66,9 +66,7 @@
                 </mat-card>
               </div>
             </div>
-            <div *ngIf="tool">
-              <app-container [isToolPublic]="false"></app-container>
-            </div>
+            <app-container [isToolPublic]="false"></app-container>
           </mat-sidenav-content>
         </mat-sidenav-container>
       </div>

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -71,9 +71,7 @@
               </mat-card>
             </div>
           </div>
-        <div *ngIf="workflow">
           <app-workflow [isWorkflowPublic]="false" [user]="user"></app-workflow>
-        </div>
       </mat-sidenav-content>
     </mat-sidenav-container>
   </div>

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -121,6 +121,13 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
   abstract resetCopyBtn(): void;
   abstract isPublic(): boolean;
   abstract setupPublicEntry(url: String): void;
+  /**
+   * Upon entry init (either from the my-workflows page or public workflow page),
+   * the previous active entry should be removed so that the component starts displaying with a the correct/current entry
+   *
+   * @abstract
+   * @memberof Entry
+   */
   abstract clearState(): void;
 
   toggleLabelsEditMode(): void {
@@ -161,7 +168,7 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
   // Embed Discourse comments into page
   ngAfterViewInit() {
     if (this.publicPage) {
-      (function() {
+      (function () {
         const d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
         d.src = (<any>window).DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -73,11 +73,12 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnInit() {
+    this.clearState();
     this.subscriptions();
     this.router.events.pipe(filter(event => event instanceof NavigationEnd),
-    takeUntil(this.ngUnsubscribe)).subscribe((event: RouterEvent) => {
+      takeUntil(this.ngUnsubscribe)).subscribe((event: RouterEvent) => {
         this.parseURL(event.url);
-    });
+      });
     this.parseURL(this.router.url);
     this.sessionService.setPublicPage(this.isPublic());
     this.sessionQuery.isPublic$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(publicPage => this.publicPage = publicPage);
@@ -120,6 +121,7 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
   abstract resetCopyBtn(): void;
   abstract isPublic(): boolean;
   abstract setupPublicEntry(url: String): void;
+  abstract clearState(): void;
 
   toggleLabelsEditMode(): void {
     this.labelsEditMode = !this.labelsEditMode;
@@ -260,7 +262,7 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
    * @param {Tag|WorkflowVersion} b - version b
    * @returns {number} - indicates order
    */
-  entryVersionSorting(a: Tag|WorkflowVersion, b: Tag|WorkflowVersion): number {
+  entryVersionSorting(a: Tag | WorkflowVersion, b: Tag | WorkflowVersion): number {
     if (a.verified && !b.verified) {
       return -1;
     } else if (!a.verified && b.verified) {
@@ -288,14 +290,14 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
    * @param {Tag|WorkflowVersion} defaultVersion - Default version of the entry
    * @returns {Array<any>} Sorted array of versions
    */
-  getSortedVersions(versions: Array<Tag|WorkflowVersion>, defaultVersion: Tag|WorkflowVersion): Array<Tag|WorkflowVersion> {
-    let sortedVersions: Array<Tag|WorkflowVersion> = [];
+  getSortedVersions(versions: Array<Tag | WorkflowVersion>, defaultVersion: Tag | WorkflowVersion): Array<Tag | WorkflowVersion> {
+    let sortedVersions: Array<Tag | WorkflowVersion> = [];
 
     // Sort versions by verified date and then last_modified
     sortedVersions = versions.slice().sort((a, b) => this.entryVersionSorting(a, b));
 
     // Get the top 6 versions
-    const recentVersions: Array<Tag|WorkflowVersion> = sortedVersions.slice(0, 6);
+    const recentVersions: Array<Tag | WorkflowVersion> = sortedVersions.slice(0, 6);
     const index = recentVersions.indexOf(defaultVersion);
 
     // Deal with default version if it exists

--- a/src/app/shared/state/workflow.service.ts
+++ b/src/app/shared/state/workflow.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { ID, transaction } from '@datorama/akita';
 import { BehaviorSubject } from 'rxjs';
-
 import { Workflow } from '../swagger';
-import { WorkflowStore } from './workflow.store';
 import { ExtendedWorkflowService } from './extended-workflow.service';
+import { WorkflowStore } from './workflow.store';
+
 
 @Injectable({ providedIn: 'root' })
 export class WorkflowService {
@@ -32,6 +32,10 @@ export class WorkflowService {
   get() {
     // Placeholder
     // this.http.get('https://akita.com').subscribe((entities) => this.workflowStore.set(entities));
+  }
+
+  clearActive() {
+    this.workflowStore.setActive(null);
   }
 
   add(workflow: Workflow) {

--- a/src/app/shared/tool/tool.service.ts
+++ b/src/app/shared/tool/tool.service.ts
@@ -15,9 +15,7 @@
  */
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
-
 import { ExtendedDockstoreToolService } from '../extended-dockstoreTool/extended-dockstoreTool.service';
-import { CheckerWorkflowService } from '../state/checker-workflow.service';
 import { DockstoreTool, Tag } from '../swagger';
 import { ToolQuery } from './tool.query';
 import { ToolStore } from './tool.store';
@@ -28,7 +26,7 @@ import { ToolStore } from './tool.store';
 export class ToolService {
 
   constructor(private toolStore: ToolStore, private extendedDockstoreToolService: ExtendedDockstoreToolService,
-    private toolQuery: ToolQuery, private checkerWorkflowService: CheckerWorkflowService) { }
+    private toolQuery: ToolQuery) { }
 
   @transaction()
   setTool(tool: (DockstoreTool | null)) {
@@ -40,6 +38,10 @@ export class ToolService {
       this.toolStore.remove();
       this.extendedDockstoreToolService.remove();
     }
+  }
+
+  clearActive() {
+    this.toolStore.setActive(null);
   }
 
   @transaction()

--- a/src/app/workflow/tool-tab/tool-tab.component.ts
+++ b/src/app/workflow/tool-tab/tool-tab.component.ts
@@ -36,7 +36,7 @@ export class ToolTabComponent extends EntryTab {
     if (value != null) {
       this.workflow = this.workflowQuery.getActive();
       // Also check that the workflow version belongs to the workflow
-      if (this.workflow && this.workflow.workflowVersions.some(version => version.id === value.id)) {
+      if (this.workflow && this.workflow.workflowVersions && this.workflow.workflowVersions.some(version => version.id === value.id)) {
         this.updateTableToolContent(this.workflow.id, value.id);
       } else {
         console.error('Should not be able to select version without a workflow');

--- a/src/app/workflow/tool-tab/tool-tab.component.ts
+++ b/src/app/workflow/tool-tab/tool-tab.component.ts
@@ -15,7 +15,6 @@
  */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
-
 import { EntryTab } from '../../shared/entry/entry-tab';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { ToolDescriptor, WorkflowVersion } from '../../shared/swagger';
@@ -35,12 +34,13 @@ export class ToolTabComponent extends EntryTab {
   ToolDescriptor = ToolDescriptor;
   @Input() set selectedVersion(value: WorkflowVersion) {
     if (value != null) {
-        this.workflow = this.workflowQuery.getActive();
-        if (this.workflow) {
-          this.updateTableToolContent(this.workflow.id, value.id);
-        } else {
-          console.error('Should not be able to select version without a workflow');
-        }
+      this.workflow = this.workflowQuery.getActive();
+      // Also check that the workflow version belongs to the workflow
+      if (this.workflow && this.workflow.workflowVersions.some(version => version.id === value.id)) {
+        this.updateTableToolContent(this.workflow.id, value.id);
+      } else {
+        console.error('Should not be able to select version without a workflow');
+      }
     } else {
       this.toolsContent = null;
     }

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -13,7 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-
+<div *ngIf="workflow">
 <div class="row m-1" *ngIf="error  || missingWarning">
   <div class="col-md-12" *ngIf="!isWorkflowPublic">
     <mat-card class="alert alert-warning" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
@@ -258,4 +258,5 @@
       </div>
     </div> -->
   </div>
+</div>
 </div>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -21,7 +21,6 @@ import { MatChipInputEvent, MatDialog } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-
 import { AlertQuery } from '../shared/alert/state/alert.query';
 import { AlertService } from '../shared/alert/state/alert.service';
 import { ga4ghWorkflowIdPrefix, includesValidation } from '../shared/constants';
@@ -48,7 +47,6 @@ import { TrackLoginService } from '../shared/track-login.service';
 import { UrlResolverService } from '../shared/url-resolver.service';
 
 import RoleEnum = Permission.RoleEnum;
-import { AddEntryComponent } from '../organizations/collection/add-entry/add-entry.component';
 @Component({
   selector: 'app-workflow',
   templateUrl: './workflow.component.html',
@@ -60,7 +58,6 @@ export class WorkflowComponent extends Entry {
   public workflow: ExtendedWorkflow;
   public missingWarning: boolean;
   public title: string;
-  private workflowCopyBtn: string;
   public sortedVersions: Array<Tag | WorkflowVersion> = [];
   private resourcePath: string;
   public showRedirect = false;
@@ -89,8 +86,8 @@ export class WorkflowComponent extends Entry {
     router: Router, private workflowService: WorkflowService, private extendedWorkflowQuery: ExtendedWorkflowQuery,
     urlResolverService: UrlResolverService, private alertService: AlertService,
     location: Location, activatedRoute: ActivatedRoute, protected sessionQuery: SessionQuery, protected sessionService: SessionService,
-      gA4GHFilesService: GA4GHFilesService, private workflowQuery: WorkflowQuery, private alertQuery: AlertQuery,
-      private descriptorTypeCompatService: DescriptorTypeCompatService, public dialog: MatDialog) {
+    gA4GHFilesService: GA4GHFilesService, private workflowQuery: WorkflowQuery, private alertQuery: AlertQuery,
+    private descriptorTypeCompatService: DescriptorTypeCompatService, public dialog: MatDialog) {
     super(trackLoginService, providerService, router,
       dateService, urlResolverService, activatedRoute, location, sessionService, sessionQuery, gA4GHFilesService);
     this._toolType = 'workflows';
@@ -100,6 +97,10 @@ export class WorkflowComponent extends Entry {
     this.extendedWorkflow$ = this.extendedWorkflowQuery.extendedWorkflow$;
     this.isRefreshing$ = this.alertQuery.showInfo$;
     this.descriptorType$ = this.workflowQuery.descriptorType$;
+  }
+
+  clearState() {
+    this.workflowService.clearActive();
   }
 
   private processPermissions(userPermissions: Permission[]): void {
@@ -180,8 +181,8 @@ export class WorkflowComponent extends Entry {
             if (this.isOwner && this.isHosted()) {
               this.workflowsService.getWorkflowPermissions(this.workflow.full_workflow_path).pipe(takeUntil(this.ngUnsubscribe))
                 .subscribe((userPermissions: Permission[]) => {
-                    this.processPermissions(userPermissions);
-                  }
+                  this.processPermissions(userPermissions);
+                }
                 );
             }
           });
@@ -204,11 +205,6 @@ export class WorkflowComponent extends Entry {
           }
         }
         this.setUpWorkflow(workflow);
-      }
-    );
-    this.workflowService.copyBtn$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(
-      workflowCopyBtn => {
-        this.workflowCopyBtn = workflowCopyBtn;
       }
     );
   }
@@ -365,30 +361,30 @@ export class WorkflowComponent extends Entry {
   }
 
   setEntryTab(tabName: string): void {
-     this.currentTab = tabName;
-     if (this.workflow != null) {
-       this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
-     }
-   }
+    this.currentTab = tabName;
+    if (this.workflow != null) {
+      this.updateUrl(this.workflow.full_workflow_path, 'my-workflows', 'workflows');
+    }
+  }
 
-   getPageIndex(): number {
-     const pageIndex = this.getIndexInURL('/workflows');
-     return pageIndex;
-   }
+  getPageIndex(): number {
+    const pageIndex = this.getIndexInURL('/workflows');
+    return pageIndex;
+  }
 
   addToLabels(event: MatChipInputEvent): void {
-     const input = event.input;
-     const value = event.value;
-     if ((value || '').trim()) {
-       this.workflowEditData.labels.push(value.trim());
-     }
+    const input = event.input;
+    const value = event.value;
+    if ((value || '').trim()) {
+      this.workflowEditData.labels.push(value.trim());
+    }
 
-     if (input) {
-       input.value = '';
-     }
-   }
+    if (input) {
+      input.value = '';
+    }
+  }
 
-   removeLabel(label: any): void {
+  removeLabel(label: any): void {
     const index = this.workflowEditData.labels.indexOf(label);
 
     if (index >= 0) {


### PR DESCRIPTION
For ga4gh/dockstore#2216

Hide whitespace changes when reviewing

Basically sets active workflow and tool to null upon workflow component and tool component init.

But because my-workflow and my-tool checks for tool or workflow, it must be moved down the chain to avoid expressionChangedAfterItHasBeenChecked.

