### PR TITLE
Fix error message not going away

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -34,6 +34,7 @@ import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
+import { AlertService } from '../shared/alert/state/alert.service';
 
 @Component({
   selector: 'app-search',
@@ -114,7 +115,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    */
   constructor(private queryBuilderService: QueryBuilderService,
     public searchService: SearchService, private searchQuery: SearchQuery,
-    private advancedSearchService: AdvancedSearchService) {
+    private advancedSearchService: AdvancedSearchService, private alertService: AlertService) {
     this.shortUrl$ = this.searchQuery.shortUrl$;
     this.filterKeys$ = this.searchQuery.filterKeys$;
     this.suggestTerm$ = this.searchQuery.suggestTerm$;
@@ -134,6 +135,8 @@ export class SearchComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    // Set alert store back to its initial state. Otherwise an error created on another page might appear when search page is loaded.
+    this.alertService.clearEverything();
     this.searchService.toSaveSearch$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(toSaveSearch => {
       if (toSaveSearch) {
         this.saveSearchFilter();

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -42,6 +42,7 @@ import { SearchToolTableComponent } from './search-tool-table/search-tool-table.
 import { SearchWorkflowTableComponent } from './search-workflow-table/search-workflow-table.component';
 import { SearchComponent } from './search.component';
 import { searchRouting } from './search.routing';
+import { RefreshAlertModule } from '../shared/alert/alert.module';
 
 @NgModule({
   declarations: [
@@ -70,7 +71,8 @@ import { searchRouting } from './search.routing';
     ClipboardModule,
     searchRouting,
     HttpClientModule,
-    PrivateIconModule
+    PrivateIconModule,
+    RefreshAlertModule
   ],
   providers: [AdvancedSearchService, QueryBuilderService, {provide: TooltipConfig, useFactory: getTooltipConfig}],
   exports: [SearchComponent]


### PR DESCRIPTION
ga4gh/dockstore#2124
After looking more into it, seems like the error message wouldn't disappear only if you navigated to the search page. Fixed by calling alertService.clearEverything() in search component.