### PR TITLE
Feature/random ui fixes

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -55,7 +55,7 @@
       </mat-form-field>
     </div>
     <p class="update">
-      Last build: {{ (extendedTool$ | async)?.agoMessage || 'n/a' }}
+      <span [matTooltip]="(extendedTool$ | async)?.lastBuild | date:'medium'">Last build: {{ (extendedTool$ | async)?.agoMessage || 'n/a' }}</span>
     </p>
   </div>
   <div class="col-md-5">

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -23,9 +23,7 @@
       <mat-card-content class="p-3">
         <ul class="list-unstyled container-info">
           <li *ngIf="tool?.providerUrl">
-            <strong matTooltip="Source code repository for the associated tool descriptors and Dockerfile">
-              {{ tool?.provider}}
-            </strong>:
+            <strong matTooltip="Source code repository for the associated tool descriptors and Dockerfile">{{ tool?.provider}}</strong>:
             <a id="sourceRepository" [href]="tool?.providerUrl | versionProviderUrl : (isPublic ? selectedVersion?.name : '')">
               {{ tool?.providerUrl | urlDeconstruct : (isPublic ? selectedVersion?.name : '') }}
             </a>
@@ -60,7 +58,7 @@
           <li *ngIf="(tool?.default_dockerfile_path || !isPublic)">
             <form #editDockerfileForm="ngForm" class="form-inline">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to the tool's Dockerfile">Dockerfile Path: </strong>
+                <strong matTooltip="Path in Git repository to the tool's Dockerfile">Dockerfile Path</strong>:
                 <span *ngIf="!dockerFileEditing">{{ tool?.default_dockerfile_path }}</span>
                 <input *ngIf="dockerFileEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.dockerfilePath"
                   type="text" class="input-default form-control" name="contDockerfilePath" [(ngModel)]="tool.default_dockerfile_path"
@@ -83,7 +81,7 @@
           <li *ngIf="(tool?.default_cwl_path || !isPublic)">
             <form #editCWLPathForm="ngForm" class="form-inline">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Path: </strong>
+                <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Path</strong>:
                 <span *ngIf="!cwlPathEditing"> {{ tool?.default_cwl_path || 'n/a' }}</span>
                 <input *ngIf="cwlPathEditing" [required]="!tool?.default_wdl_path" minlength="3" maxlength="256"
                   [pattern]="validationPatterns.cwlPath" type="text" class="input-default form-control" name="contCWLPath"
@@ -106,7 +104,7 @@
           <li *ngIf="(tool?.default_wdl_path || !isPublic)">
             <form #editWDLPathForm="ngForm" class="form-inline">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Path:</strong>
+                <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Path</strong>:
                 <span *ngIf="!wdlPathEditing">{{ tool?.default_wdl_path || 'n/a' }}</span>
                 <input *ngIf="wdlPathEditing" [required]="!tool?.default_cwl_path" minlength="3" maxlength="256"
                   [pattern]="validationPatterns.wdlPath" type="text" class="input-default form-control" name="contWDLPath"
@@ -129,8 +127,7 @@
           <li>
             <form #editCWLTestPathForm="ngForm" class="form-inline">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Test Parameter File Path:
-                </strong>
+                <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Test Parameter File Path</strong>:
                 <span *ngIf="!cwlTestPathEditing"> {{ tool?.defaultCWLTestParameterFile || 'n/a' }}</span>
                 <input *ngIf="cwlTestPathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.testFilePath"
                   type="text" class="input-default form-control" name="CWLTestPath" [(ngModel)]="tool.defaultCWLTestParameterFile"
@@ -148,7 +145,7 @@
           <li>
             <form #editWDLTestPathForm="ngForm" class="form-inline">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Test Parameter File Path:</strong>
+                <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Test Parameter File Path</strong>:
                 <span *ngIf="!wdlTestPathEditing">{{ tool?.defaultWDLTestParameterFile || 'n/a' }}</span>
                 <input *ngIf="wdlTestPathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.testFilePath"
                   type="text" class="input-default form-control" name="WDLTestPath" [(ngModel)]="tool.defaultWDLTestParameterFile"
@@ -208,8 +205,8 @@
 
         <div *ngIf="tool?.description || !isPublic">
           <label matTooltip="Description of tool obtained from tool descriptor">
-            Description:
-          </label>
+            Description
+          </label>:
           <div *ngIf="tool?.description" class="well well-sm">
             <ngx-md [data]="tool?.description"></ngx-md>
           </div>

--- a/src/app/entry/current-collections/current-collections.component.html
+++ b/src/app/entry/current-collections/current-collections.component.html
@@ -15,7 +15,7 @@
 -->
 <div class="panel panel-default mb-3" *ngIf="(isLoggedIn$ | async)">
   <div class="panel-heading">
-    <h3>Current Collections</h3>
+    <h3>Collections</h3>
   </div>
   <mat-list>
       <mat-list-item *ngFor="let collectionOrganizations of (currentCollections$ | async)">

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -16,7 +16,7 @@
       <mat-card *ngFor="let org of (allPendingOrganizations$ | async); let i = index" [id]="'pending-org-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <a [routerLink]="('/organizations/' + org.id )" [matTooltip]="org?.name">{{org.displayName}}</a>
+            <a [routerLink]="('/organizations/' + org.name )" [matTooltip]="org?.name">{{org.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             <p>Requested by user(s)
@@ -29,20 +29,6 @@
         </mat-card-header>
         <mat-card-content class="px-4">
           {{ org.topic }}
-          <div fxLayout="row" fxLayoutGap="10px">
-            <span fxLayout="row" *ngIf="org?.email">
-              <mat-icon>email</mat-icon>
-              <span><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="org?.link">
-              <mat-icon>link</mat-icon>
-              <span><a [href]="org.link" target="_blank">{{ org.link }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="org?.location">
-              <mat-icon>location_on</mat-icon>
-              <span class="ellipsis-lines">{{ org.location }}</span>
-            </span>
-          </div>
         </mat-card-content>
 
         <mat-card-actions>
@@ -70,7 +56,7 @@
       <mat-card *ngFor="let membership of (myPendingOrganizationRequests$ | async); let i = index" [id]="'my-pending-org-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <a [routerLink]="('/organizations/' + membership.organization.id )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             Requested on {{ membership.dbCreateDate | date}}
@@ -78,20 +64,6 @@
         </mat-card-header>
         <mat-card-content class="px-4">
           {{ membership.organization.topic }}
-          <div fxLayout="row" fxLayoutGap="10px">
-            <span fxLayout="row" *ngIf="membership?.organization?.email">
-              <mat-icon>email</mat-icon>
-              <span><a [href]="'mailto:' + membership.organization.email" target="_top">{{ membership.organization.email }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="membership?.organization?.link">
-              <mat-icon>link</mat-icon>
-              <span><a [href]="membership.organization.link" target="_blank">{{ membership.organization.link }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="membership?.organization?.location">
-              <mat-icon>location_on</mat-icon>
-              <span class="ellipsis-lines">{{ membership.organization.location }}</span>
-            </span>
-          </div>
         </mat-card-content>
       </mat-card>
     </div>
@@ -109,7 +81,7 @@
       <mat-card *ngFor="let membership of (myOrganizationInvites$ | async); let i = index" [id]="'my-org-invites-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <a [routerLink]="('/organizations/' + membership.organization.id )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             Requested on {{ membership.dbCreateDate | date}}
@@ -117,20 +89,6 @@
         </mat-card-header>
         <mat-card-content class="px-4">
           {{ membership.organization.topic }}
-          <div fxLayout="row" fxLayoutGap="10px">
-            <span fxLayout="row" *ngIf="membership?.organization?.email">
-              <mat-icon>email</mat-icon>
-              <span><a [href]="'mailto:' + membership.organization.email" target="_top">{{ membership.organization.email }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="membership?.organization?.link">
-              <mat-icon>link</mat-icon>
-              <span><a [href]="membership.organization.link" target="_blank">{{ membership.organization.link }}</a></span>
-            </span>
-            <span fxLayout="row" *ngIf="membership?.organization?.location">
-              <mat-icon>location_on</mat-icon>
-              <span class="ellipsis-lines">{{ membership.organization.location }}</span>
-            </span>
-          </div>
           You have been invited to join the organization with the role <strong>{{ membership.role | lowercase }}</strong>.
         </mat-card-content>
         <mat-card-actions>

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -41,6 +41,7 @@ export class RequestsService {
       .subscribe((organization: Organization) => {
         this.alertService.simpleSuccess();
         this.updateCuratorOrganizations();
+        this.updateMyMemberships();
       }, () => {
         this.updateOrganizationState(null);
         this.requestsStore.setError(true);
@@ -60,6 +61,7 @@ export class RequestsService {
       .subscribe((organization: Organization) => {
         this.alertService.simpleSuccess();
         this.updateCuratorOrganizations();
+        this.updateMyMemberships();
       }, () => {
         this.updateOrganizationState(null);
         this.requestsStore.setError(true);

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -31,15 +31,24 @@
         </ng-template>
       </mat-card>
       <mat-card fxFlex class="my-3">
-        <mat-card-header>
-          <mat-card-title>
-            <h1><a [routerLink]="['/organizations/', organization.name]"><span [matTooltip]="organization?.name">{{ organization.displayName }}</span></a> /
-              <span [matTooltip]="collection?.name">{{ collection.displayName }}</span></h1>
-          </mat-card-title>
-          <mat-card-subtitle>
-            {{collection.topic}}
-          </mat-card-subtitle>
-        </mat-card-header>
+
+        <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px">
+          <div>
+            <img [src]="(gravatarUrl$ | async ) || '../../../assets/images/dockstore/PlaceholderLC.png'" class="img-circle" height="150" width="150">
+          </div>
+          <div>
+            <mat-card-header>
+              <mat-card-title>
+                <h1><a [routerLink]="['/organizations/', organization.name]"><span [matTooltip]="organization?.name">{{ organization.displayName }}</span></a> /
+                  <span [matTooltip]="collection?.name">{{ collection.displayName }}</span></h1>
+              </mat-card-title>
+              <mat-card-subtitle>
+                {{collection.topic}}
+              </mat-card-subtitle>
+            </mat-card-header>
+          </div>
+        </div>
+
         <mat-card-actions>
           <div fxFlex></div>
           <button color="basic" *ngIf="(canEdit$ | async)" mat-button (click)="editCollection(collection)" id="editCollection"

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -51,6 +51,7 @@ export class CollectionComponent implements OnInit {
   loadingOrganization$: Observable<boolean>;
   canEdit$: Observable<boolean>;
   pendingEnum = Organization.StatusEnum.PENDING;
+  gravatarUrl$: Observable<string>;
 
   isAdmin$: Observable<boolean>;
   isCurator$: Observable<boolean>;
@@ -70,6 +71,7 @@ export class CollectionComponent implements OnInit {
     this.loadingOrganization$ = this.organizationQuery.loading$;
     this.canEdit$ = this.organizationQuery.canEdit$;
     this.organization$ = this.organizationQuery.organization$;
+    this.gravatarUrl$ = this.organizationQuery.gravatarUrl$;
     this.organizationService.updateOrganizationFromName(organizationName);
     this.collectionsService.updateCollectionFromName(organizationName, collectionName);
     this.isAdmin$ = this.userQuery.isAdmin$;

--- a/src/app/organizations/collections/collections.component.scss
+++ b/src/app/organizations/collections/collections.component.scss
@@ -1,0 +1,3 @@
+.mat-action-row {
+  border: 0;
+}

--- a/src/app/organizations/organization-members/organization-members.component.scss
+++ b/src/app/organizations/organization-members/organization-members.component.scss
@@ -6,3 +6,7 @@
   height: 90px !important;
   width: 90px !important;
 }
+
+.mat-action-row {
+  border: 0;
+}

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -48,7 +48,7 @@
         </div>
       </div>
       <mat-card-content>
-        <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px" fxLayoutAlign="space-evenly">
+        <div fxLayout="row wrap" fxLayout.lt-sm="column wrap" fxLayoutGap="10px" fxLayoutAlign="space-between" class="px-4 py-1">
           <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.email">
             <mat-icon>email</mat-icon>
             <span><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span>

--- a/src/app/organizations/organization/organization.component.ts
+++ b/src/app/organizations/organization/organization.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import {Observable, Subject} from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
 import { Organization } from '../../shared/swagger';

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -37,7 +37,7 @@
             </mat-card-subtitle>
           </mat-card-header>
           <mat-card-content>
-            <div fxLayout="row" fxLayoutGap="10px">
+            <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
               <span fxLayout="row" *ngIf="org?.email">
                 <mat-icon>email</mat-icon>
                 <span><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -23,9 +23,7 @@
       <ul class="list-unstyled container-info" *ngIf="workflow">
         <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
-            <strong matTooltip="Git repository for the associated descriptors">
-              {{ workflow?.provider}}
-            </strong>:
+            <strong matTooltip="Git repository for the associated descriptors">{{ workflow?.provider}}</strong>:
             <a id="sourceRepository" [href]="workflow?.providerUrl | versionProviderUrl : (isPublic ? selectedVersion?.name : '')">
               {{ workflow?.providerUrl | urlDeconstruct : (isPublic ? selectedVersion?.name : '')}}
             </a>
@@ -66,7 +64,7 @@
             </form>
             <form #editTestFilePathForm="ngForm" class="form-inline" *ngIf="!(isNFL$ | async)">
               <div class="form-group">
-                <strong matTooltip="Path in Git repository to main descriptor file">Test File Path: </strong>
+                <strong matTooltip="Path in Git repository to main descriptor file">Test File Path</strong>:
                 <span *ngIf="!defaultTestFilePathEditing"> {{ workflow?.defaultTestParameterFilePath }} </span>
                 <input *ngIf="defaultTestFilePathEditing" minlength="3" maxlength="256" [pattern]="validationPatterns.testFilePath"
                   type="text" class="input-default form-control" name="workflowPath" [(ngModel)]="workflow.defaultTestParameterFilePath"
@@ -102,14 +100,14 @@
         </li>
         <li>
           <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.STUB" class="form-inline">
-            <Strong matTooltip="Type of descriptor language used">Descriptor Type: </Strong>
+            <Strong matTooltip="Type of descriptor language used">Descriptor Type</Strong>:
             <select class="form-control input-sm" (change)="update()" [(ngModel)]="workflow.descriptorType">
               <option *ngFor="let descriptorLanguage of descriptorLanguages()" value="{{descriptorLanguage | lowercase}}">{{'descriptor_type'
                 | mapFriendlyValue: descriptorLanguage }}</option>
             </select>
           </div>
           <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.STUB && workflow?.descriptorType">
-            <Strong matTooltip="Type of descriptor language used">Descriptor Type: </Strong>{{ 'descriptor_type' |
+            <Strong matTooltip="Type of descriptor language used">Descriptor Type</Strong>: {{ 'descriptor_type' |
             mapFriendlyValue : workflow?.descriptorType }}</div>
         </li>
       </ul>
@@ -144,8 +142,8 @@
       <div>
         <div *ngIf="workflow?.description || !isPublic">
           <label matTooltip="Description of workflow obtained from workflow descriptor">
-            Description:
-          </label>
+            Description
+          </label>:
           <div *ngIf="workflow?.description" class="well well-sm">
             <ngx-md [data]="workflow?.description"></ngx-md>
           </div>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -59,7 +59,7 @@
     </div>
 
     <p class="update">
-      Last Modified: {{ (extendedWorkflow$ | async)?.agoMessage || 'n/a' }}
+      <span [matTooltip]="(extendedWorkflow$ | async)?.last_modified_date | date:'medium'">Last Modified: {{ (extendedWorkflow$ | async)?.agoMessage || 'n/a' }}</span>
     </p>
     <div *ngIf="starGazersClicked">
       <app-stargazers></app-stargazers>


### PR DESCRIPTION
* Cleanup info tab
* Remove border on collections and members lists
* Org logo is shown on collections page
* Timestamp tooltip for last build/modified for tools and workflows
* On requests page, do not show location, email, link, as this isn't that useful in this context and clutters up the page
* On approve/reject an org as a curator, reload my memberships, on the off chance that you are also a member of the pending org request
* Links to organisations on request page now use names in links and not ids