### PR TITLE
Don't break title

### DIFF
--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -26,8 +26,8 @@
       </mat-form-field>
     </form>
     <div *ngIf="organizations.length > 0; else noOrganizationsFound">
-      <div fxLayoutAlign="start stretch" fxLayout="row wrap">
-        <mat-card fxFlexOffset="10px" fxFlex *ngFor="let org of organizations" class="my-2">
+      <div fxLayoutAlign="start stretch" fxLayout="column">
+        <mat-card fxFlexOffset="10px" *ngFor="let org of organizations" class="my-2">
           <mat-card-header>
             <mat-card-title>
               <a [routerLink]="org.name" [matTooltip]="org?.name">{{org.displayName}}</a>

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -3,3 +3,7 @@
 .mat-icon {
   @extend .pr-5
 }
+
+.mat-card-title {
+  white-space: nowrap
+}


### PR DESCRIPTION
Small fix for the organizations page.  Display name now has spaces and should not be broken up and wrapped.

Overall, I'm still not content with organizations page layout but i'm not content with other alternatives offered so far either.

Currently using option 1.  There's many more alternatives that include some variation of grow, shrink, min-size, max-size but here's 4 major ones.  Everyone vote on it.

## 1. Flexing with flex layout + grow
Makes the size of each item equal to the size of the content.  Variable width.  Each row is always full.  If not enough space in row, tosses the next item to the next row.
Pros: 
   - Most simple to implement, don't need to worry about varying screen sizes
   - Each item will always be large enough to hold the item's contents (and not have a large amount of  empty space)
   - Smooth transitions when changing screen widths

Cons:
   - If there's a lone small content item on the last a row, it will stretch to fill the entire row. 
   - The size of each item varies, may appear as if one organization is more important than another.
   - Looks odd in every case.

Example: See current staging.dockstore.org or 
![image](https://user-images.githubusercontent.com/24548904/54553777-58c28100-4989-11e9-8c73-b7c6bacb2d65.png)
after this fix to the title (imagine a full length item on the next row)

## 2. Fixed width (pixel) layout (make flex-layout to behave like fixed pixel width grid).  
Item sizes are specified to be a certain size (in pixels)
Pros:
   - Smooth transitions when changing screen widths
   - Every item the same size
   - Looks nice in most cases

Cons: 
   - Historically we were terrible at judging how long each item it should be.  There's always this one guy who has a super long name that takes up more space than intended and then we adjust the size over and over again.  Then we have all items too big except for that one organization.  
   - Likely does not work on high DPI screens (is this a UI for ants?!?)
   - Possibly requires setting specific pixel lengths for varying screen sizes
   - Some items will have a lot of empty space
   - Some items will have very little empty space
   - Possibly requires word-wrapping

Example: See https://github.com/denis-yuen pinned repositories  . No custom example or else I'm going to choose some silly size like 100px


## 3. Fixed % layout (make flex-layout to behave like fixed % grid): 
Items sizes are specified to be a certain size (in % size of screen)
Pros: 
   - Every item the same size
   - Looks nice in most cases

Cons:
   - Terrible at judging widths (similar to previous)
   - Some items will have a lot of empty space (similar to previous)
   - Some items will have very little empty space (similar to previous)
   - Possibly requires word-wrapping (similar to previous)
   - Definitely requires setting specific percentages for each screen size.  
   - Also does not work well on ultra wide screens (too much empty space).
   - Not that smooth transitions when changing screens widths (breakpoints)

Example: See https://github.com/denis-yuen pinned repositories but pretend the size changes depending on the screen size.  No custom example or else I'm going to choose some silly size like 50% and then put too much content.

## 4. Grid layout (with max-content): 
Supposedly the best, able to figure out the max size each item should take and then make all items the exact same size as the max.  

Pros:
   - Every item the same size
   - Appears to be the "Angular Material" way
   - Item always long enough to hold content
   - Smooth transitions when changing screen widths

Cons: 
   - Not all browsers support grid layout. 
   - In practice, it just makes it one item per row.
   - Because of the above, there will be too much empty space for ultra-wide screens

Example: 
![image](https://user-images.githubusercontent.com/24548904/54551136-d5526100-4983-11e9-88ab-b222d97b5166.png)

