### PR TITLE
Feature/2244/rejected orgs should be hidden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - ~/.cache
 env:
   global:
-    - WEBSERVICE_VERSION="1.6.0-beta.3"
+    - WEBSERVICE_VERSION="1.6.0-beta.4"
 addons:
   firefox: "latest"
   postgresql: "9.6"

--- a/cypress/integration/group1/dropdown.ts
+++ b/cypress/integration/group1/dropdown.ts
@@ -28,6 +28,14 @@ describe('Dropdown test', () => {
         response: { 'canChangeUsername': true }
       });
 
+    cy
+      .server()
+      .route({
+        method: 'GET',
+        url: '/users/user',
+        response: { username: 'user_curator', name: 'user_curator', curator: true, isAdmin: false }
+      });
+
     cy.visit('');
 
     // Select dropdown
@@ -91,7 +99,8 @@ describe('Dropdown test', () => {
       // Logged in user has two memberships, one is not accepted
       const memberships = [
         {id: 1, role: 'MAINTAINER', accepted: false, organization: { id: 1000, status: 'PENDING', name: 'orgOne'}},
-        {id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo'}}
+        {id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo'}},
+        {id: 3, role: 'MAINTAINER', accepted: true, organization: { id: 1002, status: 'REJECTED', name: 'orgThree'}}
       ];
       cy
         .server()
@@ -105,6 +114,63 @@ describe('Dropdown test', () => {
         .get('#dropdown-accounts')
         .click();
       cy.contains('Requests').click();
+    });
+
+    it('Should have one rejected org', () => {
+      // Mock request re-review
+      cy
+        .server()
+        .route({
+          method: 'POST',
+          url: '/organizations/1002/request',
+          response: { id: 1002, name: 'OrgThree', status: 'PENDING' }
+      });
+
+      // Mock new pending orgs
+      const pendingOrganizations = [
+        { id: 1000, name: 'OrgOne', status: 'PENDING' },
+        { id: 1001, name: 'OrgTwo', status: 'PENDING' },
+        { id: 1002, name: 'OrgThree', status: 'PENDING' }
+      ];
+
+      cy
+        .server()
+        .route({
+          method: 'GET',
+          url: '/organizations/all?type=pending',
+          response: pendingOrganizations
+        });
+
+      // Mock new my pending orgs
+      const memberships = [
+        {id: 1, role: 'MAINTAINER', accepted: false, organization: { id: 1000, status: 'PENDING', name: 'orgOne'}},
+        {id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo'}},
+        {id: 3, role: 'MAINTAINER', accepted: true, organization: { id: 1002, status: 'PENDING', name: 'orgThree'}}
+      ];
+      cy
+        .server()
+        .route({
+          method: 'GET',
+          url: '/users/user/memberships',
+          response: memberships
+      });
+
+      // Ensure that there is one org
+      cy.get('#my-rejected-org-card-0').should('be.visible');
+      cy.get('#my-rejected-org-card-1').should('not.be.visible');
+
+      // Request re-review
+      cy.get('#request-re-review-0').should('be.visible').click();
+      cy.get('#my-rejected-org-card-0').should('not.be.visible');
+
+      // Should now have org in pending (3 Total)
+      cy.get('#pending-org-card-0').should('be.visible');
+      cy.get('#pending-org-card-1').should('be.visible');
+      cy.get('#pending-org-card-2').should('be.visible');
+
+      // Should now have org in my pending (2 Total)
+      cy.get('#my-pending-org-card-0').should('be.visible');
+      cy.get('#my-pending-org-card-1').should('be.visible');
     });
 
     it('Should have two pending orgs', () => {

--- a/cypress/integration/group1/dropdown.ts
+++ b/cypress/integration/group1/dropdown.ts
@@ -33,7 +33,7 @@ describe('Dropdown test', () => {
       .route({
         method: 'GET',
         url: '/users/user',
-        response: { username: 'user_curator', name: 'user_curator', curator: true, isAdmin: false }
+        response: { id: 4, username: 'user_curator', name: 'user_curator', curator: true, isAdmin: false }
       });
 
     cy.visit('');

--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -151,6 +151,19 @@ describe('Dockstore Organizations', () => {
   });
 
   describe('should be able to view a collection', () => {
+    beforeEach(() => {
+      const memberships = [
+        {id: 1, role: 'MAINTAINER', accepted: true, organization: { id: 1, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe'}},
+      ];
+      cy
+        .server()
+        .route({
+          method: 'GET',
+          url: '/users/user/memberships',
+          response: memberships
+      });
+    });
+
     it('be able to see collection information', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('veryFakeCollectionName').click();

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -46,9 +46,9 @@
 
   <!-- My Pending Organization Requests -->
   <div class="p-3">
-    <h3>My Pending Requests</h3>
+    <h3>My Requests</h3>
     <p>The following organizations that you have created are pending approval.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length == 0">
+    <mat-card class="alert alert-info" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length == 0 && (myRejectedOrganizationRequests$ | async)?.length == 0">
       <mat-icon>info</mat-icon> You have no organizations pending approval.
     </mat-card>
 
@@ -56,6 +56,21 @@
       <mat-card *ngFor="let membership of (myPendingOrganizationRequests$ | async); let i = index" [id]="'my-pending-org-card-' + i">
         <mat-card-header>
           <mat-card-title>
+            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+          </mat-card-title>
+          <mat-card-subtitle>
+            Requested on {{ membership.dbCreateDate | date}}
+          </mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content class="px-4">
+          {{ membership.organization.topic }}
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card *ngFor="let membership of (myRejectedOrganizationRequests$ | async); let i = index" [id]="'my-pending-org-card-' + i">
+        <mat-card-header>
+          <mat-card-title>
+            <mat-icon color="warn" matTooltip="This organization has been rejected">warning</mat-icon>
             <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -31,12 +31,11 @@
           {{ org.topic }}
         </mat-card-content>
 
-        <mat-card-actions>
-          <div fxFlex></div>
-          <button mat-flat-button [id]="'reject-pending-org-' + i" class="mr-1" (click)="openDialog(org.displayName, org.id, false)">
+        <mat-card-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
+          <button mat-flat-button [id]="'reject-pending-org-' + i" class="mr-1" (click)="openDialog(org.displayName, org.id, false)" matTooltip="Reject an organization request">
             <mat-icon>clear</mat-icon>Reject
           </button>
-          <button mat-flat-button color="primary" [id]="'approve-pending-org-' + i" (click)="openDialog(org.displayName, org.id, true)">
+          <button mat-flat-button color="primary" [id]="'approve-pending-org-' + i" (click)="openDialog(org.displayName, org.id, true)" matTooltip="Approve an organization request">
             <mat-icon>done</mat-icon>Approve
           </button>
         </mat-card-actions>
@@ -48,7 +47,7 @@
   <div class="p-3">
     <h3>My Requests</h3>
     <p>The following organizations that you have created are pending approval.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length == 0 && (myRejectedOrganizationRequests$ | async)?.length == 0">
+    <mat-card class="alert alert-info" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length == 0">
       <mat-icon>info</mat-icon> You have no organizations pending approval.
     </mat-card>
 
@@ -66,11 +65,17 @@
           {{ membership.organization.topic }}
         </mat-card-content>
       </mat-card>
+    </div>
 
-      <mat-card *ngFor="let membership of (myRejectedOrganizationRequests$ | async); let i = index" [id]="'my-pending-org-card-' + i">
+    <p class="pt-2">The following organizations that you have created are rejected.</p>
+    <mat-card class="alert alert-info" role="alert" *ngIf="(myRejectedOrganizationRequests$ | async)?.length == 0">
+      <mat-icon>info</mat-icon> You have no rejected organizations.
+    </mat-card>
+    <div fxLayout="column" fxLayoutGap="32px">
+      <mat-card *ngFor="let membership of (myRejectedOrganizationRequests$ | async); let i = index" [id]="'my-rejected-org-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <mat-icon color="warn" matTooltip="This organization has been rejected">warning</mat-icon>
+            <mat-icon color="primary" matTooltip="This organization has been rejected">warning</mat-icon>
             <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
@@ -80,6 +85,11 @@
         <mat-card-content class="px-4">
           {{ membership.organization.topic }}
         </mat-card-content>
+        <mat-card-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
+          <button mat-flat-button color="primary" [id]="'rerequest-review-' + i" (click)="rerequestReview(membership)" matTooltip="Request a re-review of a rejected organization">
+            <mat-icon>cached</mat-icon>Request Re-review
+          </button>
+        </mat-card-actions>
       </mat-card>
     </div>
   </div>
@@ -106,12 +116,13 @@
           {{ membership.organization.topic }}
           You have been invited to join the organization with the role <strong>{{ membership.role | lowercase }}</strong>.
         </mat-card-content>
-        <mat-card-actions>
-          <div fxFlex></div>
-          <button mat-flat-button class="mr-1" [id]="'reject-invite-org-' + i" (click)="openInviteDialog(membership.organization.displayName, membership.organization.id, false)">
+        <mat-card-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
+          <button mat-flat-button class="mr-1" [id]="'reject-invite-org-' + i" (click)="openInviteDialog(membership.organization.displayName, membership.organization.id, false)"
+            matTooltip="Decline an organization invite">
             <mat-icon>clear</mat-icon>Decline
           </button>
-          <button mat-flat-button color="primary" [id]="'accept-invite-org-' + i" (click)="openInviteDialog(membership.organization.displayName, membership.organization.id, true)">
+          <button mat-flat-button color="primary" [id]="'accept-invite-org-' + i" (click)="openInviteDialog(membership.organization.displayName, membership.organization.id, true)"
+            matTooltip="Accept an organization invite">
             <mat-icon>done</mat-icon>Accept
           </button>
         </mat-card-actions>

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -55,7 +55,7 @@
       <mat-card *ngFor="let membership of (myPendingOrganizationRequests$ | async); let i = index" [id]="'my-pending-org-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+            <a [routerLink]="('/organizations/' + membership.organization?.name )" [matTooltip]="membership.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             Requested on {{ membership.dbCreateDate | date}}
@@ -76,7 +76,7 @@
         <mat-card-header>
           <mat-card-title>
             <mat-icon color="primary" matTooltip="This organization has been rejected">warning</mat-icon>
-            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+            <a [routerLink]="('/organizations/' + membership.organization?.name )" [matTooltip]="membership.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             Requested on {{ membership.dbCreateDate | date}}
@@ -106,7 +106,7 @@
       <mat-card *ngFor="let membership of (myOrganizationInvites$ | async); let i = index" [id]="'my-org-invites-card-' + i">
         <mat-card-header>
           <mat-card-title>
-            <a [routerLink]="('/organizations/' + membership.organization.name )" [matTooltip]="membership?.organization?.name">{{membership.organization.displayName}}</a>
+            <a [routerLink]="('/organizations/' + membership.organization?.name )" [matTooltip]="membership.organization?.name">{{membership.organization.displayName}}</a>
           </mat-card-title>
           <mat-card-subtitle>
             Requested on {{ membership.dbCreateDate | date}}

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -86,7 +86,7 @@
           {{ membership.organization.topic }}
         </mat-card-content>
         <mat-card-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
-          <button mat-flat-button color="primary" [id]="'rerequest-review-' + i" (click)="rerequestReview(membership)" matTooltip="Request a re-review of a rejected organization">
+          <button mat-flat-button color="primary" [id]="'request-re-review-' + i" (click)="rerequestReview(membership)" matTooltip="Request a re-review of a rejected organization">
             <mat-icon>cached</mat-icon>Request Re-review
           </button>
         </mat-card-actions>

--- a/src/app/loginComponents/requests/requests.component.ts
+++ b/src/app/loginComponents/requests/requests.component.ts
@@ -54,6 +54,7 @@ export class RequestsComponent implements OnInit {
   public allPendingOrganizations$: Observable<Array<Organization>>;
   public myOrganizationInvites$: Observable<Array<OrganizationUser>>;
   public myPendingOrganizationRequests$: Observable<Array<OrganizationUser>>;
+  public myRejectedOrganizationRequests$: Observable<Array<OrganizationUser>>;
   isLoading$: Observable<boolean>;
   currentOrgId: number;
   isAdmin$: Observable<boolean>;
@@ -74,6 +75,7 @@ export class RequestsComponent implements OnInit {
     this.allPendingOrganizations$ = this.requestsQuery.allPendingOrganizations$;
     this.myOrganizationInvites$ = this.requestsQuery.myOrganizationInvites$;
     this.myPendingOrganizationRequests$ = this.requestsQuery.myPendingOrganizationRequests$;
+    this.myRejectedOrganizationRequests$ = this.requestsQuery.myRejectedOrganizationRequests$;
 
     this.isAdmin$ = this.userQuery.isAdmin$;
     this.isCurator$ = this.userQuery.isCurator$;

--- a/src/app/loginComponents/requests/requests.component.ts
+++ b/src/app/loginComponents/requests/requests.component.ts
@@ -111,4 +111,8 @@ export class RequestsComponent implements OnInit {
       }
     });
   }
+
+  rerequestReview(membership: OrganizationUser) {
+    this.requestsService.requestRereview(membership.organization.id);
+  }
 }

--- a/src/app/loginComponents/state/requests.query.ts
+++ b/src/app/loginComponents/state/requests.query.ts
@@ -13,6 +13,7 @@ export class RequestsQuery extends QueryEntity<RequestsState, Request> {
   myMemberships$: Observable<Array<OrganizationUser>> = this.select(state => state.myMemberships);
   myOrganizationInvites$: Observable<Array<OrganizationUser>> = this.select(state => state.myOrganizationInvites);
   myPendingOrganizationRequests$: Observable<Array<OrganizationUser>> = this.select(state => state.myPendingOrganizationRequests);
+  myRejectedOrganizationRequests$: Observable<Array<OrganizationUser>> = this.select(state => state.myRejectedOrganizationRequests);
   isLoading$: Observable<boolean> = this.selectLoading();
 
   constructor(protected store: RequestsStore) {

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -144,4 +144,20 @@ export class RequestsService {
         this.alertService.simpleError();
       });
   }
+
+  requestRereview(id: number): void {
+    this.alertService.start('Rerquesting review for organization ' + id);
+    this.organizationsService.requestOrganizationReview(id).pipe(
+      finalize(() => this.requestsStore.setLoading(false)
+      ))
+      .subscribe((organization: Organization) => {
+        this.alertService.simpleSuccess();
+        this.updateCuratorOrganizations();
+        this.updateMyMemberships();
+      }, () => {
+        this.updateMyMembershipState(null, null, null, null);
+        this.requestsStore.setError(true);
+        this.alertService.simpleError();
+      });
+  }
 }

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -94,10 +94,13 @@ export class RequestsService {
       const myOrganizationInvites = myMemberships.filter(membership => !membership.accepted);
       const myPendingOrganizationRequests = myMemberships.filter(membership => membership.organization.status === 'PENDING'
       && membership.accepted);
-      this.updateMyMembershipState(myMemberships, myOrganizationInvites, myPendingOrganizationRequests);
+      const myRejectedOrganizationRequests = myMemberships.filter(membership => membership.organization.status === 'REJECTED'
+      && membership.accepted);
+
+      this.updateMyMembershipState(myMemberships, myOrganizationInvites, myPendingOrganizationRequests, myRejectedOrganizationRequests);
       this.alertService.simpleSuccess();
     }, () => {
-      this.updateMyMembershipState(null, null, null);
+      this.updateMyMembershipState(null, null, null, null);
       this.requestsStore.setError(true);
       this.alertService.simpleError();
     });
@@ -110,13 +113,14 @@ export class RequestsService {
    * @param myPendingOrganizationRequests
    */
   updateMyMembershipState(myMemberships: Array<OrganizationUser>, myOrganizationInvites: Array<OrganizationUser>,
-    myPendingOrganizationRequests: Array<OrganizationUser>): void {
+    myPendingOrganizationRequests: Array<OrganizationUser>, myRejectedOrganizationRequests: Array<OrganizationUser>): void {
     this.requestsStore.setState((state: RequestsState) => {
       return {
         ...state,
         myMemberships: myMemberships,
         myOrganizationInvites: myOrganizationInvites,
-        myPendingOrganizationRequests: myPendingOrganizationRequests
+        myPendingOrganizationRequests: myPendingOrganizationRequests,
+        myRejectedOrganizationRequests: myRejectedOrganizationRequests
       };
     });
   }
@@ -135,7 +139,7 @@ export class RequestsService {
         this.alertService.simpleSuccess();
         this.updateMyMemberships();
       }, () => {
-        this.updateMyMembershipState(null, null, null);
+        this.updateMyMembershipState(null, null, null, null);
         this.requestsStore.setError(true);
         this.alertService.simpleError();
       });

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -146,7 +146,7 @@ export class RequestsService {
   }
 
   requestRereview(id: number): void {
-    this.alertService.start('Rerquesting review for organization ' + id);
+    this.alertService.start('Rerequesting review for organization ' + id);
     this.organizationsService.requestOrganizationReview(id).pipe(
       finalize(() => this.requestsStore.setLoading(false)
       ))

--- a/src/app/loginComponents/state/requests.store.ts
+++ b/src/app/loginComponents/state/requests.store.ts
@@ -8,6 +8,7 @@ export interface RequestsState extends EntityState<Request> {
   myMemberships: Array<OrganizationUser>;
   myOrganizationInvites: Array<OrganizationUser>;
   myPendingOrganizationRequests: Array<OrganizationUser>;
+  myRejectedOrganizationRequests: Array<OrganizationUser>;
 }
 
 export function createInitialState(): RequestsState {
@@ -15,7 +16,8 @@ export function createInitialState(): RequestsState {
     allPendingOrganizations: null,
     myMemberships: null,
     myOrganizationInvites: null,
-    myPendingOrganizationRequests: null
+    myPendingOrganizationRequests: null,
+    myRejectedOrganizationRequests: null
   };
 }
 

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -30,6 +30,10 @@
           You can view your pending organization requests on the requests tab of the <a [routerLink]="('/accounts')" style="text-decoration: underline">accounts page</a>.
         </ng-template>
       </mat-card>
+
+      <mat-card fxFlex class="my-3 alert alert-info" *ngIf="organization?.status === 'REJECTED'">
+          <mat-icon>info</mat-icon> This collection is part of an organization that has been rejected by a curator. Members can re-request approval on the <a [routerLink]="('/accounts')" style="text-decoration: underline">accounts page</a>.
+        </mat-card>
       <mat-card fxFlex class="my-3">
 
         <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px">

--- a/src/app/organizations/collection/state/add-entry.service.ts
+++ b/src/app/organizations/collection/state/add-entry.service.ts
@@ -23,6 +23,9 @@ export class AddEntryService {
       finalize(() => this.addEntryStore.setLoading(false)
       ))
       .subscribe((memberships: Array<OrganizationUser>) => {
+        // Only show approved organizations
+        memberships = memberships.filter(membership => membership.organization.status === 'APPROVED'
+          && membership.accepted);
         this.updateMembershipsState(memberships);
         this.addEntryStore.setError(false);
       }, () => {

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -31,6 +31,11 @@
         You can view your pending organization requests on the requests tab of the <a [routerLink]="('/accounts')" style="text-decoration: underline">accounts page</a>.
       </ng-template>
     </mat-card>
+
+    <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'REJECTED'">
+      <mat-icon>info</mat-icon> This organization has been rejected by a curator.
+    </mat-card>
+
     <mat-card fxFlex class="my-3">
       <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px">
         <div>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -33,7 +33,7 @@
     </mat-card>
 
     <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'REJECTED'">
-      <mat-icon>info</mat-icon> This organization has been rejected by a curator.
+      <mat-icon>info</mat-icon> This organization has been rejected by a curator. Members can re-request approval on the <a [routerLink]="('/accounts')" style="text-decoration: underline">accounts page</a>.
     </mat-card>
 
     <mat-card fxFlex class="my-3">


### PR DESCRIPTION
Depends on https://github.com/ga4gh/dockstore/pull/2245

When an organisation is rejected:
* It appears under my requests on the accounts page (request tab)
* Users can request a re-review from the accounts page
* There is now an alert on organisations and collections that are rejected

Also https://github.com/ga4gh/dockstore/issues/2244