### PR TITLE
Feature/2227/org logo should not be circle

### DIFF
--- a/cypress/integration/group3/organizations.ts
+++ b/cypress/integration/group3/organizations.ts
@@ -77,7 +77,7 @@ describe('Dockstore Organizations', () => {
       cy.contains('Basement');
       cy.contains('asdf@asdf.ca');
       cy.contains('No collections found');
-      cy.get('.img-circle').should('have.attr', 'src').should('include', '../../../assets/images/dockstore/PlaceholderLC.png');
+      cy.get('.orgLogo').should('have.attr', 'src').should('include', '../../../assets/images/dockstore/PlaceholderLC.png');
     });
     it('be able to edit organization', () => {
       cy.get('#editOrgInfo').should('be.visible').click();
@@ -105,7 +105,7 @@ describe('Dockstore Organizations', () => {
       cy.contains('https://www.google.com');
       cy.contains('UCSC Basement');
       cy.contains('asdf@asdf.com');
-      cy.get('.img-circle').should('have.attr', 'src').should('include', 'https://www.gravatar.com/avatar/000?d=https://res.cloudinary.com/hellofresh/image/upload/f_auto,fl_lossy,q_auto,w_640/v1/hellofresh_s3/image/554a3abff8b25e1d268b456d.png');
+      cy.get('.orgLogo').should('have.attr', 'src').should('include', 'https://www.gravatar.com/avatar/000?d=https://res.cloudinary.com/hellofresh/image/upload/f_auto,fl_lossy,q_auto,w_640/v1/hellofresh_s3/image/554a3abff8b25e1d268b456d.png');
     });
   });
 

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -34,7 +34,7 @@
 
         <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px">
           <div>
-            <img [src]="(gravatarUrl$ | async ) || '../../../assets/images/dockstore/PlaceholderLC.png'" class="img-circle" height="150" width="150">
+            <img [src]="(gravatarUrl$ | async ) || '../../../assets/images/dockstore/PlaceholderLC.png'" class="orgLogo">
           </div>
           <div>
             <mat-card-header>

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -41,7 +41,7 @@ export interface DialogData {
 @Component({
   selector: 'collection',
   templateUrl: './collection.component.html',
-  styleUrls: ['./collection.component.scss']
+  styleUrls: ['./collection.component.scss', '../organization/organization.component.scss']
 })
 export class CollectionComponent implements OnInit {
   collection$: Observable<Collection>;

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -34,7 +34,7 @@
     <mat-card fxFlex class="my-3">
       <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px">
         <div>
-          <img [src]="(gravatarUrl$ | async ) || '../../../assets/images/dockstore/PlaceholderLC.png'" class="img-circle" height="150" width="150">
+          <img [src]="(gravatarUrl$ | async ) || '../../../assets/images/dockstore/PlaceholderLC.png'" class = "orgLogo">
         </div>
         <div>
           <mat-card-header>

--- a/src/app/organizations/organization/organization.component.scss
+++ b/src/app/organizations/organization/organization.component.scss
@@ -1,0 +1,4 @@
+.orgLogo {
+  max-height: 150px;
+  max-width: 200px;
+}


### PR DESCRIPTION
ga4gh/dockstore#2227
Org logo is now a square or rectangle depending on the original image's dimensions. Uses `max-width` and `max-height` so image doesn't get distorted. Max-width is bigger because it seems more likely that logos would have larger widths than heights.