### PR TITLE
If webservice on port 443, omit port in url

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -29,7 +29,8 @@ export class Dockstore {
   static readonly DISCOURSE_URL = 'http://localhost/';
 
   static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;
-  static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
+  // @ts-ignore
+  static readonly API_URI = Dockstore.HOSTNAME + (Dockstore.API_PORT !== '443' ? (':' + Dockstore.API_PORT) : '');
   static readonly DNASTACK_IMPORT_URL = 'https://app.dnastack.com/#/app/workflow/import/dockstore';
   static readonly FIRECLOUD_IMPORT_URL = 'https://portal.firecloud.org/#import/dockstore';
   static readonly DNANEXUS_IMPORT_URL = 'https://platform.dnanexus.com/panx/tools/import-workflow';


### PR DESCRIPTION
ga4gh/dockstore#1594

This doesn't drop the port 80 if on default port of http, but
doesn't seem worth it.

There are a lot of places that use API_URL; instead of massaging
them one by one to remove the 443 port, it seems like we
should just do it here. A lot of those places have user-facing
URLs, e.g., the TRS url, the launch with instructions...

Will create a corresponding PR in compose_setup if this gets
approved.