### PR TITLE
Handle 204

### DIFF
--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -1,10 +1,23 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 import { Component, Input } from '@angular/core';
-
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileEditing } from '../../shared/file-editing';
-import { ToolDescriptor } from '../../shared/swagger';
+import { DockstoreTool, ToolDescriptor } from '../../shared/swagger';
 import { ContainerService } from './../../shared/container.service';
-import { RefreshService } from './../../shared/refresh.service';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { SourceFile } from './../../shared/swagger/model/sourceFile';
 import { Tag } from './../../shared/swagger/model/tag';
@@ -25,20 +38,20 @@ export class ToolFileEditorComponent extends FileEditing {
   ToolDescriptor = ToolDescriptor;
   @Input() entrypath: string;
   @Input() set selectedVersion(value: Tag) {
-      this.currentVersion = value;
-      this.isNewestVersion = this.checkIfNewestVersion();
-      this.editing = false;
-      this.clearSourceFiles();
-      if (value != null) {
-        // Fix the JSON.parse later.  Currently used to deep copy values but not keep the read-only attribute of state management.
-        this.originalSourceFiles =  JSON.parse(JSON.stringify(value.sourceFiles));
-        this.loadVersionSourcefiles();
-      }
+    this.currentVersion = value;
+    this.isNewestVersion = this.checkIfNewestVersion();
+    this.editing = false;
+    this.clearSourceFiles();
+    if (value != null) {
+      // Fix the JSON.parse later.  Currently used to deep copy values but not keep the read-only attribute of state management.
+      this.originalSourceFiles = JSON.parse(JSON.stringify(value.sourceFiles));
+      this.loadVersionSourcefiles();
+    }
   }
 
-  constructor(private hostedService: HostedService, private containerService: ContainerService, private refreshService: RefreshService,
-    private alertService: AlertService) {
-    super();
+  constructor(private hostedService: HostedService, private containerService: ContainerService,
+    protected alertService: AlertService) {
+    super(alertService);
   }
 
   checkIfNewestVersion(): boolean {
@@ -81,22 +94,26 @@ export class ToolFileEditorComponent extends FileEditing {
    * Creates a new version based on changes made
    */
   saveVersion(): void {
-    const message = 'Save Version';
     const combinedSourceFiles = this.getCombinedSourceFiles();
     const newSourceFiles = this.commonSaveVersion(this.originalSourceFiles, combinedSourceFiles);
     this.alertService.start('Updating hosted tool');
     this.hostedService.editHostedTool(
-        this.id,
-        newSourceFiles).subscribe(result => {
+      this.id,
+      newSourceFiles).subscribe((editedDockstoreTool: DockstoreTool) => {
+        if (editedDockstoreTool) {
+          // Only stop editing when version change was successful (not 204)
           this.toggleEdit();
-          this.containerService.setTool(result);
+          this.containerService.setTool(editedDockstoreTool);
           this.alertService.detailedSuccess();
-        }, error =>  {
-          if (error) {
-            this.alertService.detailedError(error);
-          }
+        } else {
+          // Probably encountered a 204
+          this.handleNoContentResponse();
         }
-      );
+      }, error => {
+        if (error) {
+          this.alertService.detailedError(error);
+        }
+      });
   }
 
   /**

--- a/src/app/shared/alert/state/alert.service.ts
+++ b/src/app/shared/alert/state/alert.service.ts
@@ -16,9 +16,9 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
-
 import { AlertQuery } from './alert.query';
 import { AlertStore } from './alert.store';
+
 
 /**
  * How to use this service:
@@ -42,12 +42,17 @@ export class AlertService {
   /**
    * Handles successful HTTP response and shows success to the user by matSnackBar
    *
+   * @param {string} [message]  Optimal message to override previous message
    * @memberof AlertService
    */
-  public detailedSuccess() {
-    const previousMessage = this.alertQuery.getSnapshot().message;
+  public detailedSuccess(message?: string) {
     this.setInfo('');
-    this.matSnackBar.open(previousMessage + ' succeeded', 'Dismiss');
+    if (message) {
+      this.matSnackBar.open(message, 'Dismiss');
+    } else {
+      const previousMessage = this.alertQuery.getSnapshot().message;
+      this.matSnackBar.open(previousMessage + ' succeeded', 'Dismiss');
+    }
   }
 
   /**

--- a/src/app/shared/alert/state/alert.service.ts
+++ b/src/app/shared/alert/state/alert.service.ts
@@ -19,7 +19,6 @@ import { MatSnackBar } from '@angular/material';
 import { AlertQuery } from './alert.query';
 import { AlertStore } from './alert.store';
 
-
 /**
  * How to use this service:
  * Before doing an HTTP call, use the start() method with some message indicating what is happening
@@ -42,17 +41,17 @@ export class AlertService {
   /**
    * Handles successful HTTP response and shows success to the user by matSnackBar
    *
-   * @param {string} [message]  Optimal message to override previous message
+   * @param {string} [message]  Optional message to override previous message
    * @memberof AlertService
    */
   public detailedSuccess(message?: string) {
-    this.setInfo('');
     if (message) {
       this.matSnackBar.open(message, 'Dismiss');
     } else {
       const previousMessage = this.alertQuery.getSnapshot().message;
       this.matSnackBar.open(previousMessage + ' succeeded', 'Dismiss');
     }
+    this.setInfo('');
   }
 
   /**

--- a/src/app/shared/file-editing.ts
+++ b/src/app/shared/file-editing.ts
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-import { Input } from '@angular/core';
+import { AlertService } from './alert/state/alert.service';
 import { Files } from './files';
 import { SourceFile } from './swagger/model/sourceFile';
 
@@ -25,6 +25,14 @@ export class FileEditing extends Files {
    */
   toggleEdit() {
     this.editing = !this.editing;
+  }
+
+  constructor(protected alertService: AlertService) {
+    super();
+  }
+
+  handleNoContentResponse() {
+    this.alertService.detailedSuccess('Version did not change (no changes detected in file contents)');
   }
 
   /**

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
@@ -5,11 +20,9 @@ import { FileEditing } from '../../shared/file-editing';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { ToolDescriptor, Workflow } from '../../shared/swagger';
-import { RefreshService } from './../../shared/refresh.service';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
-
 
 @Component({
   selector: 'app-workflow-file-editor',
@@ -35,9 +48,9 @@ export class WorkflowFileEditorComponent extends FileEditing {
       this.loadVersionSourcefiles();
     }
   }
-  constructor(private hostedService: HostedService, private workflowService: WorkflowService, private refreshService: RefreshService,
-    private workflowsService: WorkflowsService, private alertService: AlertService, private workflowQuery: WorkflowQuery) {
-    super();
+  constructor(private hostedService: HostedService, private workflowService: WorkflowService,
+    private workflowsService: WorkflowsService, protected alertService: AlertService, private workflowQuery: WorkflowQuery) {
+    super(alertService);
     this.selectedDescriptorType$ = this.workflowQuery.descriptorType$;
     this.isNFL$ = this.workflowQuery.isNFL$;
   }
@@ -82,25 +95,26 @@ export class WorkflowFileEditorComponent extends FileEditing {
     this.alertService.start('Updating hosted workflow');
     this.hostedService.editHostedWorkflow(
       this.id,
-      newSourceFiles).subscribe((workflow: Workflow) => {
-        this.toggleEdit();
-        if (workflow) {
-          this.workflowsService.getWorkflow(workflow.id).subscribe((workflow2: Workflow) => {
+      newSourceFiles).subscribe((editedWorkflow: Workflow) => {
+        if (editedWorkflow) {
+          // Only stop editing when version change was successful (not 204)
+          this.toggleEdit();
+          // TODO: Comment why workflow is explicitly gotten again when tool does not
+          this.workflowsService.getWorkflow(editedWorkflow.id).subscribe((newlyGottenWorkflow: Workflow) => {
+            this.workflowService.setWorkflow(newlyGottenWorkflow);
             this.alertService.detailedSuccess();
-            this.workflowService.setWorkflow(workflow2);
           }, error => {
             this.alertService.detailedError(error);
           });
         } else {
           // Probably encountered a 204
-          this.alertService.detailedSuccess('Version did not change');
+          this.alertService.detailedSuccess('Version did not change (no changes detected in file contents)');
         }
       }, error => {
         if (error) {
           this.alertService.detailedError(error);
         }
-      }
-      );
+      });
   }
 
   /**

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -93,8 +93,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
           });
         } else {
           // Probably encountered a 204
-          this.alertService.detailedSuccess();
-          console.log('Version did not change');
+          this.alertService.detailedSuccess('Version did not change');
         }
       }, error => {
         if (error) {

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -108,7 +108,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
           });
         } else {
           // Probably encountered a 204
-          this.alertService.detailedSuccess('Version did not change (no changes detected in file contents)');
+          this.handleNoContentResponse();
         }
       }, error => {
         if (error) {


### PR DESCRIPTION
For issue ga4gh/dockstore#2164 

It was expected that the endpoint would always return a workflow object on success.  But since there's a possible 204 now, the UI needs to know how to handle it.

Edit: This also has the same problems with tools