### PR TITLE
Feature/2264/incompatibleVersions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '10.13.0'
+  - '8.11.1'
 services:
   - postgresql
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   chrome: stable
 
 install:
+  - npm i -g @angular/cli@6.0.2 --unsafe
   - ./scripts/install-travis-script.sh
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - ng lint
         - ng test --watch=false --code-coverage --browsers ChromeHeadless
         - ng version
-        - npm run build.prod
+        - travis_wait 30 npm run build.prod
     - stage: integration test
       name: "Cypress Group 1"
       env:

--- a/scripts/install-travis-script.sh
+++ b/scripts/install-travis-script.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-npm ci
+npm install
 
 wget --no-verbose --tries=10 https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${WEBSERVICE_VERSION}/dockstore-webservice-${WEBSERVICE_VERSION}.jar
 chmod u+x dockstore-webservice-${WEBSERVICE_VERSION}.jar


### PR DESCRIPTION
Use incompatible versions for ga4gh/dockstore#2264

Revert later!  Or maybe don't merge at all!

Previous tests using compatible versions take less than 11 mins on Travis.  This PR changed it to over 28 mins, but it doesn't affect me since I'm using Semaphore CI!