### PR TITLE
Files now display on iOS

### DIFF
--- a/src/app/shared/code-editor/code-editor.component.scss
+++ b/src/app/shared/code-editor/code-editor.component.scss
@@ -1,0 +1,4 @@
+// Set min height or editor not visible on iOS, ga4gh/dockstore#1687
+div.ace_editor {
+  min-height: 1px;
+}


### PR DESCRIPTION
ga4gh/dockstore#1687

In https://github.com/ajaxorg/ace/blob/ded791fcd6f0f346fb01314eaba82d89610284d2/lib/ace/virtual_renderer.js#L351,
the el.clientHeight and el.scrollHeight are always 0 on iOS. This
leads to size.$dirty never getting set to true in https://github.com/ajaxorg/ace/blob/ded791fcd6f0f346fb01314eaba82d89610284d2/lib/ace/virtual_renderer.js#L422,
which means the editor never paints.

Considered scoping this CSS for iOS only, but doesn't seem to change
the behavior on non-iOS devices, so didn't restrict it.

Note: when you look at the installed npm package, the source files
mentioned above have been concatenated into ace.js.