### PR TITLE
Fix tab bounce

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -142,8 +142,8 @@
 <div class="row m-1" *ngIf="!starGazersClicked">
   <div class="col-sm-12 p-0" [ngClass]="{'col-md-9 col-lg-9': isToolPublic}">
     <div class="ds-tabs" [ngClass]="{'mr-3': isToolPublic}">
-      <mat-tab-group dynamicHeight [selectedIndex]="selected.value" id="tool_tabs" #entryTabs mat-stretch-tabs
-        (selectedTabChange)="selectedTabChange($event)">
+      <mat-tab-group dynamicHeight (selectedIndexChange)="selected.setValue($event)" (selectedTabChange)="selectedTabChange($event)" [selectedIndex]="selected.value" id="tool_tabs" #entryTabs mat-stretch-tabs
+        >
         <mat-tab id="infoTab" label="Info">
           <app-info-tab [selectedVersion]="selectedVersion" [privateOnlyRegistry]="privateOnlyRegistry"
             [extendedDockstoreTool]="(extendedTool$ | async)" [validVersions]="validVersions"></app-info-tab>

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -286,7 +286,6 @@ export abstract class Entry implements OnInit, OnDestroy, AfterViewInit {
   }
 
   selectedTabChange(matTabChangeEvent: MatTabChangeEvent) {
-    this.selected.setValue(matTabChangeEvent.index);
     this.setEntryTab(matTabChangeEvent.tab.textLabel.toLowerCase());
   }
 

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -123,7 +123,7 @@
 <div class="row m-1" *ngIf="!starGazersClicked && !showRedirect">
   <div class="col-sm-12 p-0" [ngClass]="{'col-md-10 col-lg-9': isWorkflowPublic}">
     <div class="ds-tabs" [ngClass]="{'mr-3': isWorkflowPublic}">
-    <mat-tab-group [selectedIndex]="selected.value" dynamicHeight class="ds-tabs" id="workflow_tabs" #entryTabs  (selectedTabChange)="selectedTabChange($event)" mat-stretch-tabs>
+    <mat-tab-group [selectedIndex]="selected.value" dynamicHeight class="ds-tabs" id="workflow_tabs" #entryTabs (selectedIndexChange)="selected.setValue($event)" (selectedTabChange)="selectedTabChange($event)" mat-stretch-tabs>
       <mat-tab id="infoTab" label="Info" id="infoTab">
         <app-info-tab [validVersions]="validVersions" [extendedWorkflow]="(extendedWorkflow$ | async)" [defaultVersion]="defaultVersion" [selectedVersion]="selectedVersion" [canRead]="canRead" [canWrite]="canWrite" [isOwner]="isOwner"></app-info-tab>
       </mat-tab>


### PR DESCRIPTION
For ga4gh/dockstore#2265 

Was a fun bug while it lasted.

`[selectedTabChange]` doesn't quite behave the same as `[selectedIndexChange]`.  If there's `[selectedIndex]`, there must be `[selectedIndexChange]`.  It's kind of odd that there's 2 change handlers now but they don't seem to conflict with each other.  The `[selectedTabChange]` is still needed because only it knows the names of the tabs.

Push cancelled because I don't care about it