### PR TITLE
Show all descriptor types. Revert later!

### DIFF
--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -33,10 +33,7 @@
     <div *ngIf="content">
       <span class="row m-0">
         <span class="col-sm-4">
-          <app-select *ngIf="!publicPage" [placeholder]="'Descriptor Type'" [items]="descriptors"
-            [default]="currentDescriptor" (select)="onDescriptorChange($event); checkIfValid(true, _selectedVersion)">
-          </app-select>
-          <app-select *ngIf="publicPage" [placeholder]="'Descriptor Type'" [items]="validDescriptors"
+          <app-select [placeholder]="'Descriptor Type'" [items]="descriptors"
             [default]="currentDescriptor" (select)="onDescriptorChange($event); checkIfValid(true, _selectedVersion)">
           </app-select>
         </span>

--- a/src/app/container/launch/launch.component.html
+++ b/src/app/container/launch/launch.component.html
@@ -31,7 +31,7 @@
         <div class="col-sm-4">
           <mat-form-field class="m-2">
             <mat-select name="toolVersions" [(value)]="currentDescriptor" (selectionChange)="reactToDescriptor($event)">
-              <mat-option *ngFor="let descriptor of validDescriptors" [value]="descriptor">{{descriptor}}</mat-option>
+              <mat-option *ngFor="let descriptor of descriptors" [value]="descriptor">{{descriptor}}</mat-option>
             </mat-select>
           </mat-form-field>
         </div>

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -35,10 +35,7 @@
     <div *ngIf="content">
       <span class="row m-0">
         <span class="col-sm-4">
-          <app-select *ngIf="!publicPage" [placeholder]="'Descriptor Type'" [items]="descriptors"
-            [default]="currentDescriptor" (select)="onDescriptorChange($event); checkIfValid(false, _selectedVersion)">
-          </app-select>
-          <app-select *ngIf="publicPage" [placeholder]="'Descriptor Type'" [items]="validDescriptors"
+          <app-select [placeholder]="'Descriptor Type'" [items]="descriptors"
             [default]="currentDescriptor" (select)="onDescriptorChange($event); checkIfValid(false, _selectedVersion)">
           </app-select>
         </span>


### PR DESCRIPTION
For ga4gh/dockstore#2257

The tools should now have the descriptor types again.