### PR TITLE
Clear searchtext upon component (and form) init

### DIFF
--- a/src/app/organizations/organizations/organizations.component.ts
+++ b/src/app/organizations/organizations/organizations.component.ts
@@ -18,16 +18,15 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material';
 import { Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-
 import { AlertQuery } from '../../shared/alert/state/alert.query';
 import { Base } from '../../shared/base';
 import { formInputDebounceTime } from '../../shared/constants';
+import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
 import { Organization } from '../../shared/swagger';
 import { TrackLoginService } from '../../shared/track-login.service';
 import { RegisterOrganizationComponent } from '../registerOrganization/register-organization.component';
 import { OrganizationsQuery } from '../state/organizations.query';
 import { OrganizationsStateService } from '../state/organizations.service';
-import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
 
 @Component({
   selector: 'organizations',
@@ -48,6 +47,7 @@ export class OrganizationsComponent extends Base implements OnInit {
 
   ngOnInit() {
     this.isLoggedIn$ = this.trackLoginService.isLoggedIn$;
+    this.organizationsStateService.updateSearchNameState('');
     this.organizationSearchForm = this.formBuilder.group({ name: '' });
     this.loading$ = this.alertQuery.showInfo$;
     // The real loading$ is currently not being used because the alertQuery global loading is used instead
@@ -70,6 +70,6 @@ export class OrganizationsComponent extends Base implements OnInit {
    * @memberof OrganizationsComponent
    */
   createOrganization(): void {
-    this.matDialog.open(RegisterOrganizationComponent, {data: {organization: null, mode: TagEditorMode.Add}, width: '600px'});
+    this.matDialog.open(RegisterOrganizationComponent, { data: { organization: null, mode: TagEditorMode.Add }, width: '600px' });
   }
 }


### PR DESCRIPTION
For ga4gh/dockstore#2285

Clear store during initial form creation.  Forms are always recreated upon component init, but the store stays.  Apparently valueChanges doesn't emit the first value so I have to set it the first time on init.

Still doesn't clear search if you're on the organizations page and you click it again (no route change)

http://dockstore-ui2.herokuapp.com/organizations for demo