### PR TITLE
Same hacky fix like organization

### DIFF
--- a/src/app/organizations/collections/state/create-collection.service.spec.ts
+++ b/src/app/organizations/collections/state/create-collection.service.spec.ts
@@ -19,12 +19,12 @@ import { FormBuilder } from '@angular/forms';
 import { MatDialog, MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of as observableOf, throwError } from 'rxjs';
-
 import { OrganizationsService } from '../../../shared/swagger';
 import { CollectionsService } from '../../state/collections.service';
 import { OrganizationQuery } from '../../state/organization.query';
 import { CreateCollectionService } from './create-collection.service';
 import { CreateCollectionStore } from './create-collection.store';
+
 
 let organizationsServiceSpy: jasmine.SpyObj<OrganizationsService>;
 let organizationQuerySpy: jasmine.SpyObj<OrganizationQuery>;
@@ -93,7 +93,7 @@ describe('CreateCollectionService', () => {
     organizationsServiceSpy.updateCollection.and.returnValue(observableOf(null));
     matDialogSpy.closeAll.and.returnValue(null);
 
-    createCollectionService.updateCollection(exampleFormState, 1);
+    createCollectionService.updateCollection(exampleFormState, 1, 'description');
 
     // Expected createCollection call to be called (and it will succeed)
     expect(organizationsServiceSpy.updateCollection.calls.count()).toBe(1, 'spy method was called once');
@@ -105,7 +105,7 @@ describe('CreateCollectionService', () => {
     organizationQuerySpy.getSnapshot.and.returnValue({ organization: { id: 1 } });
     organizationsServiceSpy.updateCollection.and.returnValue(throwError('test 404 error'));
 
-    createCollectionService.updateCollection(exampleFormState, 1);
+    createCollectionService.updateCollection(exampleFormState, 1, 'description');
 
     // Expected createCollection call to be called (even though it will fail)
     expect(organizationsServiceSpy.updateCollection.calls.count()).toBe(1, 'spy method was called once');

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -4,13 +4,13 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatSnackBar } from '@angular/material';
 import { AkitaNgFormsManager } from '@datorama/akita-ng-forms-manager';
 import { finalize } from 'rxjs/operators';
-
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { TagEditorMode } from '../../../shared/enum/tagEditorMode.enum';
 import { Collection, OrganizationsService } from '../../../shared/swagger';
 import { CollectionsService } from '../../state/collections.service';
 import { OrganizationQuery } from '../../state/organization.query';
 import { CreateCollectionStore } from './create-collection.store';
+
 
 export interface FormsState {
   createOrUpdateCollection: {
@@ -78,7 +78,7 @@ export class CreateCollectionService {
     if (data.mode === TagEditorMode.Add) {
       this.createCollection(createCollectionForm.value);
     } else {
-      this.updateCollection(createCollectionForm.value, data.collection.value.id);
+      this.updateCollection(createCollectionForm.value, data.collection.value.id, data.collection.value.description);
     }
   }
 
@@ -94,12 +94,14 @@ export class CreateCollectionService {
     let name = null;
     let topic = null;
     let displayName = null;
+    let description = null;
     formsManager.remove('createOrUpdateCollection');
     if (mode !== TagEditorMode.Add) {
       const collection: Collection = data.collection.value;
       name = collection.name;
       topic = collection.topic;
       displayName = collection.displayName;
+      description = collection.description;
     }
 
     const createOrUpdateCollectionForm = this.builder.group({
@@ -141,14 +143,16 @@ export class CreateCollectionService {
    *
    * @param {FormsState['createOrUpdateCollection']} collectionFormState
    * @param {number} collectionID  ID of the collection to update
+   * @param {string} collectionDescripton
    * @memberof CreateCollectionService
    */
-  updateCollection(collectionFormState: FormsState['createOrUpdateCollection'], collectionID: number) {
+  updateCollection(collectionFormState: FormsState['createOrUpdateCollection'], collectionID: number, collectionDescripton: string) {
     let collection: Collection;
     collection = {
       name: collectionFormState.name,
       topic: collectionFormState.topic,
-      displayName: collectionFormState.displayName
+      displayName: collectionFormState.displayName,
+      description: collectionDescripton
     };
     const organizationID = this.organizationQuery.getSnapshot().organization.id;
     this.beforeCall();

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -143,7 +143,7 @@ export class CreateCollectionService {
    *
    * @param {FormsState['createOrUpdateCollection']} collectionFormState
    * @param {number} collectionID  ID of the collection to update
-   * @param {string} collectionDescripton
+   * @param {string} collectionDescripton The unedited description because formState isn't updating description and doesn't know it
    * @memberof CreateCollectionService
    */
   updateCollection(collectionFormState: FormsState['createOrUpdateCollection'], collectionID: number, collectionDescripton: string) {


### PR DESCRIPTION
For ga4gh/dockstore#2294

We have a PUT and don't have the entire object, so it was setting it to null every time. Now giving it more of the entire object.