### PR TITLE
Suppress cwltool instructions for workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '8.11.1'
+  - '10.13.0'
 services:
   - postgresql
 jdk:
@@ -21,7 +21,6 @@ addons:
   chrome: stable
 
 install:
-  - npm i -g @angular/cli@6.0.2 --unsafe
   - ./scripts/install-travis-script.sh
 
 jobs:
@@ -32,7 +31,7 @@ jobs:
         - ng lint
         - ng test --watch=false --code-coverage --browsers ChromeHeadless
         - ng version
-        - travis_wait 30 npm run build.prod
+        - npm run build.prod
     - stage: integration test
       name: "Cypress Group 1"
       env:

--- a/scripts/install-travis-script.sh
+++ b/scripts/install-travis-script.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-npm install
+npm ci
 
 wget --no-verbose --tries=10 https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${WEBSERVICE_VERSION}/dockstore-webservice-${WEBSERVICE_VERSION}.jar
 chmod u+x dockstore-webservice-${WEBSERVICE_VERSION}.jar

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -65,6 +65,7 @@
             {{cwlrunnerDescription}}
             <pre>{{ cwl }}</pre>
           </div>
+          <!-- cwltool instructions for workflows will need to wait for https://github.com/common-workflow-language/cwltool/pull/1093
           <div [matTooltip]="cwltoolTooltip">
             Alternatively, <a href="https://github.com/common-workflow-language/cwltool">cwltool</a> can conveniently
             run
@@ -73,6 +74,7 @@
             <pre>{{ dockstoreSupportedCwlLaunch }}</pre> cwltool can also be used to create the input template:
             <pre>{{ dockstoreSupportedCwlMakeTemplate }}</pre>
           </div>
+          -->
         </mat-card>
         <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
       </div>

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -36,6 +36,14 @@ export class WorkflowLaunchService extends LaunchService {
             \nvim Dockstore.json`;
   }
 
+  getDockstoreSupportedCwlLaunchString(path: string, versionName: string) {
+    return `cwltool \\#workflow/${path}:${versionName} Dockstore.json`;
+  }
+
+  getDockstoreSupportedCwlMakeTemplateString(path: string, versionName: string) {
+    return `cwltool --make-template \\#workflow/${path}:${versionName} > input.yaml`;
+  }
+
   getCliString(path: string, versionName: string, currentDescriptor: string) {
     return `dockstore ${this.type} launch --entry ${path}:${versionName} --json Dockstore.json`;
   }


### PR DESCRIPTION
* Note workflow id also needs an escaped prefix

This is a follow-up for https://github.com/ga4gh/dockstore/issues/2300 discovered during testing. 
Commented code relies on and is reactivated after https://github.com/common-workflow-language/cwltool/pull/1093  