### PR TITLE
Reactive form for debounce

### DIFF
--- a/src/app/search/basic-search/basic-search.component.html
+++ b/src/app/search/basic-search/basic-search.component.html
@@ -3,8 +3,8 @@
     Search
   </mat-expansion-panel-header>
   <mat-form-field>
-  <input matInput [matAutocomplete]="auto" matTooltip="Find tools and workflows" [matTooltipPosition]="'after'" list="suggestions" class="w-100 mb-3"
-    [(ngModel)]="searchText" (ngModelChange)="onInputChange($event)" placeholder="Enter search term" />
+  <input matInput [matAutocomplete]="auto" [formControl]="searchFormControl" matTooltip="Find tools and workflows" [matTooltipPosition]="'after'" list="suggestions" class="w-100 mb-3"
+    placeholder="Enter search term" type="text"/>
   </mat-form-field>
   <mat-autocomplete #auto="matAutocomplete">
     <mat-option *ngFor="let option of (autocompleteTerms$ | async)" [value]="option">{{option}}</mat-option>

--- a/src/app/search/basic-search/basic-search.component.ts
+++ b/src/app/search/basic-search/basic-search.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { FormControl } from '@angular/forms';
+import { Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-
 import { Base } from '../../shared/base';
 import { formInputDebounceTime } from '../../shared/constants';
 import { AdvancedSearchService } from '../advancedsearch/advanced-search.service';
@@ -17,25 +17,30 @@ export class BasicSearchComponent extends Base implements OnInit {
 
   constructor(private advancedSearchService: AdvancedSearchService, private searchService: SearchService,
     private searchQuery: SearchQuery) {
-      super();
-    }
+    super();
+  }
+  public searchFormControl = new FormControl();
   public autocompleteTerms$: Observable<Array<string>>;
   public hasAutoCompleteTerms$: Observable<boolean>;
-  // The local search text
-  public searchText: string;
-  // The local search text observable
-  private searchText$ = new Subject<string>();
   ngOnInit() {
-    this.searchQuery.searchText$.subscribe(searchText => this.searchText = searchText);
+    this.searchQuery.searchText$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(searchText => {
+      // This keeps the state and the view in sync but this is slightly awkward
+      // Changes to the searchText$ state will change searchFormControl
+      // However, changes to searchFormControl will change searchText$
+      // The ONLY reason why this doesn't go infinite loop is because Akita doesn't emit when it's the same value
+      // Ideally, we should probably be using AkitaFormManager because then there would only be one variable
+      this.searchFormControl.setValue(searchText);
+    });
     this.autocompleteTerms$ = this.searchQuery.autoCompleteTerms$;
     this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
 
-    // Debouncing the local search text before modifying the state
-    this.searchText$.pipe(
+    this.searchFormControl.valueChanges.pipe(
       debounceTime(formInputDebounceTime),
       distinctUntilChanged(),
       takeUntil(this.ngUnsubscribe)
-    ).subscribe(searchText => this.searchService.setSearchText(searchText));
+    ).subscribe(searchText => {
+      this.searchService.setSearchText(searchText);
+    });
   }
 
   /**
@@ -47,15 +52,4 @@ export class BasicSearchComponent extends Base implements OnInit {
   openAdvancedSearch(): void {
     this.advancedSearchService.setShowModal(true);
   }
-
-  /**
-   * Really need to debounce this
-   *
-   * @param {*} event
-   * @memberof BasicSearchComponent
-   */
-  onInputChange(event) {
-    this.searchText$.next(event);
-  }
-
 }

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -16,7 +16,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { TagCloudModule } from 'angular-tag-cloud-module';
@@ -27,7 +27,7 @@ import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
-
+import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HeaderModule } from '../shared/modules/header.module';
 import { CustomMaterialModule } from '../shared/modules/material.module';
 import { PipeModule } from '../shared/pipe/pipe.module';
@@ -42,7 +42,6 @@ import { SearchToolTableComponent } from './search-tool-table/search-tool-table.
 import { SearchWorkflowTableComponent } from './search-workflow-table/search-workflow-table.component';
 import { SearchComponent } from './search.component';
 import { searchRouting } from './search.routing';
-import { RefreshAlertModule } from '../shared/alert/alert.module';
 
 @NgModule({
   declarations: [
@@ -52,7 +51,7 @@ import { RefreshAlertModule } from '../shared/alert/alert.module';
     SearchToolTableComponent,
     SearchWorkflowTableComponent,
     BasicSearchComponent
-],
+  ],
   imports: [
     CommonModule,
     CustomMaterialModule,
@@ -72,9 +71,10 @@ import { RefreshAlertModule } from '../shared/alert/alert.module';
     searchRouting,
     HttpClientModule,
     PrivateIconModule,
+    ReactiveFormsModule,
     RefreshAlertModule
   ],
-  providers: [AdvancedSearchService, QueryBuilderService, {provide: TooltipConfig, useFactory: getTooltipConfig}],
+  providers: [AdvancedSearchService, QueryBuilderService, { provide: TooltipConfig, useFactory: getTooltipConfig }],
   exports: [SearchComponent]
 
 })


### PR DESCRIPTION
For ga4gh/dockstore#2314

The issue says 1.6.x

There were 3 variables for roughly the same thing:

searchText$ from the state
searchText$ from the view
searchText from the view

Using reactive forms, now there are two:
searchText$ from the state
searchFormControl from the view

Ideally, it should just be using the Akita form manager