### PR TITLE
Use transaction postgres + DAG fix

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -32,7 +32,7 @@ export function getTab(tabName: string): any {
 
 export function resetDB() {
   before(() => {
-    cy.exec('PGPASSWORD=dockstore psql -h localhost -f scripts/resetDb.sql -U dockstore -d webservice_test', { timeout: 600000 });
+    cy.exec('PGPASSWORD=dockstore psql -h localhost -f scripts/resetDb.sql -U dockstore -d webservice_test');
     cy.exec('PGPASSWORD=dockstore psql -h localhost -f travisci/db_dump.sql webservice_test -U dockstore');
     cy.exec('java -jar dockstore-webservice-*.jar db migrate -i 1.5.0,1.6.0 travisci/web.yml');
   });

--- a/scripts/resetDb.sql
+++ b/scripts/resetDb.sql
@@ -1,10 +1,27 @@
-/* Remove all locks except for this one process */
-SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid IN (SELECT pid FROM pg_locks) AND query NOT LIKE '%pg_stat_activity%';
-/* Ultimately drops all tables (better than dropping database on a running webservice connected to it) */
-DROP SCHEMA public CASCADE;
-/* Recreate the schema for the tables */
-CREATE SCHEMA public;
-/* Recreate the permissions on everything (just in case) */
-GRANT ALL ON SCHEMA public TO postgres;
-GRANT ALL ON SCHEMA public TO public;
-GRANT ALL ON SCHEMA public TO dockstore;
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+BEGIN;
+    /* Remove all locks except for this one process */
+    SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid IN (SELECT pid FROM pg_locks) AND query NOT LIKE '%pg_stat_activity%';
+    /* Ultimately drops all tables (better than dropping database on a running webservice connected to it) */
+    DROP SCHEMA public CASCADE;
+    /* Recreate the schema for the tables */
+    CREATE SCHEMA public;
+    /* Recreate the permissions on everything (just in case) */
+    GRANT ALL ON SCHEMA public TO postgres;
+    GRANT ALL ON SCHEMA public TO public;
+    GRANT ALL ON SCHEMA public TO dockstore;
+COMMIT;

--- a/src/app/workflow/dag/state/dag.service.ts
+++ b/src/app/workflow/dag/state/dag.service.ts
@@ -300,7 +300,7 @@ export class DagService {
         content: () => {
           return this.createPopupHTML(name, runText, element);
         },
-        popper: {removeOnDestroy: true}
+        popper: { removeOnDestroy: true }
       });
       popper.scheduleUpdate();
     };
@@ -332,7 +332,8 @@ export class DagService {
         boxSelectionEnabled: false,
         autounselectify: true,
         layout: {
-          name: 'dagre'
+          name: 'dagre',
+          nodeDimensionsIncludeLabels: true
         },
         style: this.style,
         elements: dagResult


### PR DESCRIPTION
- Fixes DAG labels overlapping ga4gh/dockstore#2281
- Revert the cy.exec timeout back to the default because it appears if it does timeout with the default, it will timeout with a longer one too
- Use transaction for postgres reset script because it's better practice that way

