### PR TITLE
feature/2392/org UI fixes

### DIFF
--- a/cypress/integration/group3/starEntry.ts
+++ b/cypress/integration/group3/starEntry.ts
@@ -101,17 +101,17 @@ describe('Tool, Workflow, and Organization starring', () => {
     if (entity === 'tool') {
       cy
         .get('.mat-tab-label-content')
-        .contains('Starred Tools')
+        .contains('Tools')
         .click();
     } else if (entity === 'workflow') {
       cy
         .get('.mat-tab-label-content')
-        .contains('Starred Workflows')
+        .contains('Workflows')
         .click();
      } else {
         cy
           .get('.mat-tab-label-content')
-          .contains('Starred Organizations')
+          .contains('Organizations')
           .click();
     }
     cy

--- a/src/app/organizations/organization.module.ts
+++ b/src/app/organizations/organization.module.ts
@@ -13,7 +13,8 @@ import { RouterModule } from '@angular/router';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { OrganizationMemberRemoveConfirmDialogComponent } from './organization-members/organization-members.component';
 import { OrganizationStarringModule} from './organization/organization-starring/organization-starring.module';
-import {OrganizationStargazersModule} from './organization/organization-stargazers/organization-stargazers.module';
+import { OrganizationStargazersModule } from './organization/organization-stargazers/organization-stargazers.module';
+import { PipeModule } from '../shared/pipe/pipe.module';
 import { MarkdownModule } from 'ngx-markdown';
 
 @NgModule({
@@ -30,7 +31,8 @@ import { MarkdownModule } from 'ngx-markdown';
     RefreshAlertModule,
     OrganizationStarringModule,
     OrganizationStargazersModule,
-    MarkdownModule
+    MarkdownModule,
+    PipeModule
   ],
   declarations: [ OrganizationComponent, OrganizationMemberRemoveConfirmDialogComponent ],
   exports: [ OrganizationComponent, OrganizationMemberRemoveConfirmDialogComponent ],

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <p class="update">
-      <span [matTooltip]="(org)?.dbUpdateDate | date:'medium'">Last updated: {{ getTimeAgoMessage(org?.dbUpdateDate) }}</span>
+      <span [matTooltip]="(org)?.dbUpdateDate | date:'medium'">Last updated: {{ org?.dbUpdateDate | timeAgoMessage }}</span>
     </p>
       <app-organization-stargazers></app-organization-stargazers>
     <button mat-flat-button color="primary" id="backButton" type="button" (click)="organizationStarGazersClicked=false">

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -19,14 +19,14 @@
 </app-header>
 <app-loading [loading]="(loading$ | async)">
   <div class="container" *ngIf="!(organization$ | async)">Organization not found</div>
-  <div class="row ml-4 mx-4" *ngIf="organizationStarGazersClicked">
+  <div class="container" *ngIf="organizationStarGazersClicked">
     <app-organization-stargazers></app-organization-stargazers>
     <button mat-flat-button color="primary" id="backButton" type="button" (click)="organizationStarGazersClicked=false">
       <mat-icon>chevron_left</mat-icon>Back to details
     </button>
   </div>
   <!-- Organization header -->
-  <div class="container" *ngIf="(organization$ | async) as org" fxLayout="column" fxLayoutGap="10px">
+  <div class="container" *ngIf="!organizationStarGazersClicked && (organization$ | async) as org" fxLayout="column" fxLayoutGap="10px">
     <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'PENDING'">
       <mat-icon>info</mat-icon> This organization is pending approval by a Dockstore curator.
       <span *ngIf="(isAdmin$ | async) || (isCurator$ | async); else notAdminOrCurator">

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -19,8 +19,19 @@
 </app-header>
 <app-loading [loading]="(loading$ | async)">
   <div class="container" *ngIf="!(organization$ | async)">Organization not found</div>
-  <div class="container" *ngIf="organizationStarGazersClicked">
-    <app-organization-stargazers></app-organization-stargazers>
+  <div class="container" *ngIf="organizationStarGazersClicked && (organization$ | async) as org">
+    <div fxLayout="row">
+      <div fxFlex="70">
+        <h3>{{org.displayName}}</h3>
+      </div>
+      <div fxFlex="30">
+        <app-organization-starring *ngIf="org?.status === approved" [organization]="org" class="pull-right starring-button" (change)="organizationStarGazersChange()"></app-organization-starring>
+      </div>
+    </div>
+    <p class="update">
+      <span [matTooltip]="(org)?.dbUpdateDate | date:'medium'">Last updated: {{ getTimeAgoMessage(org?.dbUpdateDate) }}</span>
+    </p>
+      <app-organization-stargazers></app-organization-stargazers>
     <button mat-flat-button color="primary" id="backButton" type="button" (click)="organizationStarGazersClicked=false">
       <mat-icon>chevron_left</mat-icon>Back to details
     </button>

--- a/src/app/organizations/organization/organization.component.ts
+++ b/src/app/organizations/organization/organization.component.ts
@@ -27,6 +27,7 @@ import {
   UpdateOrganizationOrCollectionDescriptionComponent
 } from './update-organization-description/update-organization-description.component';
 import { UserQuery } from '../../shared/user/user.query';
+import { DateService } from '../../shared/date.service';
 
 @Component({
   selector: 'organization',
@@ -45,7 +46,7 @@ export class OrganizationComponent implements OnInit {
   approved = Organization.StatusEnum.APPROVED;
 
   constructor(private organizationQuery: OrganizationQuery, private organizationService: OrganizationService, private matDialog: MatDialog,
-    private activatedRoute: ActivatedRoute, private userQuery: UserQuery
+    private activatedRoute: ActivatedRoute, private userQuery: UserQuery, private dateService: DateService
   ) { }
 
   ngOnInit() {
@@ -83,5 +84,9 @@ export class OrganizationComponent implements OnInit {
 
   organizationStarGazersChange(): void {
     this.organizationStarGazersClicked = !this.organizationStarGazersClicked;
+  }
+
+  getTimeAgoMessage(date: Date) {
+    return this.dateService.getAgoMessage(new Date(date).getTime());
   }
 }

--- a/src/app/organizations/organization/organization.component.ts
+++ b/src/app/organizations/organization/organization.component.ts
@@ -27,7 +27,6 @@ import {
   UpdateOrganizationOrCollectionDescriptionComponent
 } from './update-organization-description/update-organization-description.component';
 import { UserQuery } from '../../shared/user/user.query';
-import { DateService } from '../../shared/date.service';
 
 @Component({
   selector: 'organization',
@@ -46,7 +45,7 @@ export class OrganizationComponent implements OnInit {
   approved = Organization.StatusEnum.APPROVED;
 
   constructor(private organizationQuery: OrganizationQuery, private organizationService: OrganizationService, private matDialog: MatDialog,
-    private activatedRoute: ActivatedRoute, private userQuery: UserQuery, private dateService: DateService
+    private activatedRoute: ActivatedRoute, private userQuery: UserQuery
   ) { }
 
   ngOnInit() {
@@ -84,9 +83,5 @@ export class OrganizationComponent implements OnInit {
 
   organizationStarGazersChange(): void {
     this.organizationStarGazersClicked = !this.organizationStarGazersClicked;
-  }
-
-  getTimeAgoMessage(date: Date) {
-    return this.dateService.getAgoMessage(new Date(date).getTime());
   }
 }

--- a/src/app/organizations/organization/time-ago-msg.pipe.ts
+++ b/src/app/organizations/organization/time-ago-msg.pipe.ts
@@ -1,0 +1,31 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+import { DateService } from '../../shared/date.service';
+
+@Pipe({
+  name: 'timeAgoMessage'
+})
+
+export class TimeAgoMsgPipe  implements PipeTransform {
+
+  constructor(private dateService: DateService) {
+  }
+
+  transform(date: Date) {
+    return this.dateService.getAgoMessage(new Date(date).getTime());
+  }
+}

--- a/src/app/organizations/time-ago-message.pipe.spec.ts
+++ b/src/app/organizations/time-ago-message.pipe.spec.ts
@@ -1,0 +1,17 @@
+import { TimeAgoMsgPipe } from './organization/time-ago-msg.pipe';
+import {DateService} from '../shared/date.service';
+
+describe('Pipe: TimeAgoMsgPipe', () => {
+  it('Create instance', () => {
+    const dateService = new DateService();
+    const pipe = new TimeAgoMsgPipe(dateService);
+    const date = new Date();
+    date.setDate(date.getDate() - 1);
+
+    expect(pipe).toBeTruthy();
+    expect(pipe.transform(date)).toEqual('1 day ago');
+
+    date.setDate(date.getDate() - 1);
+    expect(pipe.transform(date)).toEqual('2 days ago');
+  });
+});

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { MapFriendlyValuesPipe } from '../../search/map-friendly-values.pipe';
 import { ExpandPanelPipe } from '../entry/expand-panel.pipe';
 import { SelectTabPipe } from '../entry/select-tab.pipe';
+import { TimeAgoMsgPipe } from '../../organizations/organization/time-ago-msg.pipe';
 
 @NgModule({
   imports: [
@@ -12,12 +13,14 @@ import { SelectTabPipe } from '../entry/select-tab.pipe';
   declarations: [
     ExpandPanelPipe,
     MapFriendlyValuesPipe,
-    SelectTabPipe
+    SelectTabPipe,
+    TimeAgoMsgPipe
   ],
   exports: [
     ExpandPanelPipe,
     MapFriendlyValuesPipe,
-    SelectTabPipe
+    SelectTabPipe,
+    TimeAgoMsgPipe
   ],
 })
 export class PipeModule { }

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -18,7 +18,7 @@
 <div class="panel panel-default p-3">
   <mat-card class="alert alert-info" data-cy="noStargazers" role="alert" *ngIf="starGazers?.length==0">
     <mat-icon>warning</mat-icon>
-    There are no stargazers for this entry.
+    There are no stargazers for this <span>{{organization != null ? 'organization' : 'entry'}}.</span>
   </mat-card>
   <div class="panel-body" *ngIf="starGazers?.length>0">
     <div fxLayout="row wrap">

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -24,7 +24,7 @@
     <div fxLayout="row wrap">
       <div *ngFor="let stargazer of starGazers">
         <div fxFlex="90%">
-          <img src="{{stargazer.avatarUrl}}" width="200" height="200" class="img-responsive stargazer-img"
+          <img src="{{stargazer.avatarUrl}}" width="150" height="150" class="img-responsive stargazer-img"
                alt="{{altAvatarImg}}"/>
           <div class="caption">
             <h5 class="text-center">{{stargazer.username}}</h5>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -17,7 +17,7 @@
 </div>
 
 <mat-tab-group class="container" *ngIf="!starGazersClicked && !organizationStarGazersClicked">
-  <mat-tab label="Starred Tools">
+  <mat-tab label="Tools">
     <div *ngIf="starredTools">
       <div class="container">
         <div class="row">
@@ -50,7 +50,7 @@
     </div>
   </mat-tab>
 
-  <mat-tab label="Starred Workflows">
+  <mat-tab label="Workflows">
     <div *ngIf="starredWorkflows">
       <div class="container">
         <div class="row">
@@ -82,7 +82,7 @@
     </div>
   </mat-tab>
 
-  <mat-tab label="Starred Organizations">
+  <mat-tab label="Organizations">
     <div *ngIf="starredOrganizations">
       <div class="container">
         <div class="row">
@@ -99,8 +99,8 @@
               <a routerLink="/organizations/{{organization.name}}" [matTooltip]="organization?.name" target="_blank" rel="noopener">{{organization.displayName}}</a>
             </h3>
             <span mat-line>
-            <small class="spacing">Email: <a [href]="'mailto:' + organization.email">{{ organization.email }}</a></small>
-            <small class="spacing">Website: <a [href]="organization?.link">{{ organization?.link }}</a> </small>
+            <small class="spacing" *ngIf="organization?.email">Email: <a [href]="'mailto:' + organization?.email">{{ organization.email }}</a></small>
+            <small class="spacing" *ngIf="organization?.link">Website: <a [href]="organization?.link">{{ organization?.link }}</a> </small>
           </span>
             <app-organization-starring class="pull-right" style="width: 100px;" [organization]="organization" (change)="organizationStarGazersChange()"></app-organization-starring>
             <mat-divider></mat-divider>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -61,12 +61,6 @@
     <p class="update">
       <span [matTooltip]="(extendedWorkflow$ | async)?.last_modified_date | date:'medium'">Last Modified: {{ (extendedWorkflow$ | async)?.agoMessage || 'n/a' }}</span>
     </p>
-    <div *ngIf="starGazersClicked">
-      <app-stargazers></app-stargazers>
-      <button id="backButton" type="button" (click)="starGazersClicked=false" mat-flat-button color="primary">
-        <mat-icon>chevron_left</mat-icon>Back to details
-      </button>
-    </div>
   </div>
   <div class="col-md-5">
     <app-starring [workflow]="workflow" class="pull-right starring-button" *ngIf="isWorkflowPublic && workflow" (change)="starGazersChange()"></app-starring>
@@ -119,6 +113,12 @@
       </button>
     </span>
   </div>
+</div>
+<div class="row ml-4 mr-4" *ngIf="starGazersClicked">
+  <app-stargazers></app-stargazers>
+  <button id="backButton" type="button" (click)="starGazersClicked=false" mat-flat-button color="primary">
+    <mat-icon>chevron_left</mat-icon>Back to details
+  </button>
 </div>
 <div class="row m-1" *ngIf="!starGazersClicked && !showRedirect">
   <div class="col-sm-12 p-0" [ngClass]="{'col-md-10 col-lg-9': isWorkflowPublic}">


### PR DESCRIPTION
dockstore/dockstore#2392
Stargazers visually consistent for tools/workflows/organizations
Made stargazer images smaller
remove redundant titles
don't show info on my starred organizations if info null

<img width="1189" alt="Screen Shot 2019-05-14 at 9 36 13 AM" src="https://user-images.githubusercontent.com/16004905/57715587-f655cc00-762b-11e9-8c45-53f3ef81b6f9.png">
<img width="1201" alt="Screen Shot 2019-05-14 at 9 35 19 AM" src="https://user-images.githubusercontent.com/16004905/57715591-f950bc80-762b-11e9-8f9f-e892ecf1eb8e.png">
