### PR TITLE
Upload build to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
   everything:
     jobs:
       # Add the tags filter to all jobs so they will run before upload_to_s3
-      - lint_unit_test_coverage
+      - lint_unit_test_coverage:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  aws-s3: circleci/aws-s3@1.0.0
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
@@ -65,20 +67,63 @@ jobs:
       - run:
           name: Test
           command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --spec cypress/integration/group3/**/*'
+  upload_to_s3:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:2.7
+    parameters:
+      aws_bucket:
+        type: string
+        default: "${AWS_BUCKET}"
+    steps:
+      - when:
+          condition: <<parameters.aws_bucket>>
+          steps:
+            - attach_workspace:
+                at: .
+            - aws-s3/copy:
+                from: dist
+                to: 's3://${AWS_BUCKET}/${CIRCLE_TAG}-$(echo $CIRCLE_SHA1 | cut -c -7)'
+                arguments: '--recursive'
+
 workflows:
   version: 2
   everything:
     jobs:
+      # Add the tags filter to all jobs so they will run before upload_to_s3
       - lint_unit_test_coverage
+          filters:
+            tags:
+              only: /.*/
       - integration_test_1:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - lint_unit_test_coverage
       - integration_test_2:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - lint_unit_test_coverage
       - integration_test_3:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - lint_unit_test_coverage
+      # Upload builds for tags to s3. We can add branches later
+      - upload_to_s3:
+          requires:
+            - integration_test_1
+            - integration_test_2
+            - integration_test_3
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
 commands:
   install_container_dependencies:
     steps:


### PR DESCRIPTION
dockstore/dockstore#2446

* Only run for tags (for now)
* Requires the following environment variables to be set in CircleCI
   1. AWS_ACCESS_KEY_ID
   2. AWS_SECRET_ACCESS_KEY
   3. AWS_BUCKET
   4. AWS_REGION (needed even though no region is needed for s3 API)
* If the AWS_BUCKET is not set, the upload is skipped.

For now, upload the builds to <TAG NAME>-<sha> folder.

This ticket only uploads to s3; subsequent tickets will handle
the actual serving of content from s3. Some tweaks may need to be
made then, but this gets the core uploading in place.