### PR TITLE
Links Zenodo credentials in Dockstore

### DIFF
--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -54,6 +54,11 @@ export class ConfigurationService {
     Dockstore.GITLAB_REDIRECT_URI = Dockstore.HOSTNAME + config.gitlabRedirectPath;
     Dockstore.GITLAB_SCOPE = config.gitlabScope;
 
+    Dockstore.ZENODO_AUTH_URL = config.zenodoAuthUrl;
+    Dockstore.ZENODO_CLIENT_ID = config.zenodoClientId;
+    Dockstore.ZENODO_REDIRECT_URI = Dockstore.HOSTNAME + config.zenodoRedirectPath;
+    Dockstore.ZENODO_SCOPE = config.zenodoScope;
+
     Dockstore.GOOGLE_CLIENT_ID = config.googleClientId;
     Dockstore.GOOGLE_SCOPE = config.googleScope;
 

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -74,6 +74,13 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
       bold: '',
       message: 'GitLab credentials are used for pulling source code from GitLab.',
       show: false
+    },
+    {
+      name: 'Zenodo',
+      source: TokenSource.ZENODO,
+      bold: '',
+      message: 'Zenodo credentials are used for creating Digital Object Identifiers (DOIs) on Zenodo.',
+      show: false
     }
   ];
 

--- a/src/app/loginComponents/accounts/external/accounts.service.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.ts
@@ -36,7 +36,7 @@ export class AccountsService {
                 this.openWindowPreserveSpaces(Links.GITLAB());
                 break;
             case TokenSource.ZENODO:
-                this.openWindow(Links.ZENODO());
+                this.openWindowPreserveSpaces(Links.ZENODO());
                 break;
             case TokenSource.QUAY:
                 this.openWindow(Links.QUAY());

--- a/src/app/loginComponents/accounts/external/accounts.service.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.ts
@@ -35,6 +35,9 @@ export class AccountsService {
             case TokenSource.GITLAB:
                 this.openWindowPreserveSpaces(Links.GITLAB());
                 break;
+            case TokenSource.ZENODO:
+                this.openWindow(Links.ZENODO());
+                break;
             case TokenSource.QUAY:
                 this.openWindow(Links.QUAY());
                 break;

--- a/src/app/loginComponents/accounts/external/links.model.ts
+++ b/src/app/loginComponents/accounts/external/links.model.ts
@@ -28,6 +28,8 @@ export class Links {
   static readonly ZENODO = () => `${ Dockstore.ZENODO_AUTH_URL }
                             ?client_id=${ Dockstore.ZENODO_CLIENT_ID }
                             &redirect_uri=${ Dockstore.ZENODO_REDIRECT_URI }
-                            &scope=${ Dockstore.ZENODO_SCOPE }`
+                            &response_type=code`.replace(/\s/g, '') +
+                            `&scope=${ Dockstore.ZENODO_SCOPE }`
+
 
 }

--- a/src/app/loginComponents/accounts/external/links.model.ts
+++ b/src/app/loginComponents/accounts/external/links.model.ts
@@ -25,4 +25,9 @@ export class Links {
                             &response_type=code`.replace(/\s/g, '') +
                             `&scope=${ Dockstore.GITLAB_SCOPE }`
 
+  static readonly ZENODO = () => `${ Dockstore.ZENODO_AUTH_URL }
+                            ?client_id=${ Dockstore.ZENODO_CLIENT_ID }
+                            &redirect_uri=${ Dockstore.ZENODO_REDIRECT_URI }
+                            &scope=${ Dockstore.ZENODO_SCOPE }`
+
 }

--- a/src/app/loginComponents/auth/auth.component.ts
+++ b/src/app/loginComponents/auth/auth.component.ts
@@ -42,6 +42,9 @@ export class AuthComponent extends Base implements OnInit {
     const addGitLabToken = queryObservable.pipe(
       mergeMap(query => this.tokenService.registerToken(query['code'], Provider.GITLAB)));
 
+    const addZenodoToken = queryObservable.pipe(
+      mergeMap(query => this.tokenService.registerToken(query['code'], Provider.ZENODO)));
+
     const addBitbucketToken = queryObservable.pipe(mergeMap(query =>
       this.tokenService.registerToken(query['code'], Provider.BITBUCKET)));
 
@@ -58,6 +61,8 @@ export class AuthComponent extends Base implements OnInit {
             return addBitbucketToken;
           case Provider.GITLAB:
             return addGitLabToken;
+          case Provider.ZENODO:
+            return addZenodoToken;
           default: {
             console.log('Unknown provider: ' + provider);
             return observableOf(null);

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -58,7 +58,7 @@ export class Dockstore {
   static ZENODO_AUTH_URL = 'https://sandbox.zenodo.org/oauth/authorize';
   static ZENODO_CLIENT_ID = 'fill_this_in';
   static ZENODO_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.ZENODO;
-  static ZENODO_SCOPE = 'deposit:write,deposit:actions';
+  static ZENODO_SCOPE = 'deposit:write deposit:actions';
 
   static GOOGLE_CLIENT_ID = 'fill_this_in';
   static GOOGLE_SCOPE = 'profile email';

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -55,6 +55,11 @@ export class Dockstore {
   // static GITLAB_SCOPE = 'read_user openid';
   static GITLAB_SCOPE = 'api';
 
+  static ZENODO_AUTH_URL = 'https://sandbox.zenodo.org/oauth/authorize';
+  static ZENODO_CLIENT_ID = 'fill_this_in';
+  static ZENODO_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.ZENODO;
+  static ZENODO_SCOPE = 'deposit:write,deposit:actions';
+
   static GOOGLE_CLIENT_ID = 'fill_this_in';
   static GOOGLE_SCOPE = 'profile email';
 

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -34,7 +34,7 @@ export class Dockstore {
   static DNANEXUS_IMPORT_URL = 'https://platform.dnanexus.com/panx/tools/import-workflow';
   static TERRA_IMPORT_URL = 'https://app.terra.bio/#import-tool/dockstore';
 
-  static GITHUB_CLIENT_ID = 'fill_this_in';
+  static GITHUB_CLIENT_ID = 'will be filled in by configuration.service';
   static GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 
   static GITHUB_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.GITHUB;
@@ -43,24 +43,24 @@ export class Dockstore {
   static QUAYIO_AUTH_URL = 'https://quay.io/oauth/authorize';
   static QUAYIO_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.QUAY;
   static QUAYIO_SCOPE = 'repo:read,user:read';
-  static QUAYIO_CLIENT_ID = 'fill_this_in';
+  static QUAYIO_CLIENT_ID = 'will be filled in by configuration.service';
 
   static BITBUCKET_AUTH_URL = 'https://bitbucket.org/site/oauth2/authorize';
-  static BITBUCKET_CLIENT_ID = 'fill_this_in';
+  static BITBUCKET_CLIENT_ID = 'will be filled in by configuration.service';
 
   static GITLAB_AUTH_URL = 'https://gitlab.com/oauth/authorize';
-  static GITLAB_CLIENT_ID = 'fill_this_in';
+  static GITLAB_CLIENT_ID = 'will be filled in by configuration.service';
   static GITLAB_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.GITLAB;
   // getting ready for gitlab scopes, this seems to request a token with the correct scope but it doesn't work to retrieve membership
   // static GITLAB_SCOPE = 'read_user openid';
   static GITLAB_SCOPE = 'api';
 
   static ZENODO_AUTH_URL = 'https://zenodo.org/oauth/authorize';
-  static ZENODO_CLIENT_ID = 'fill_this_in';
+  static ZENODO_CLIENT_ID = 'will be filled in by configuration.service';
   static ZENODO_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.ZENODO;
   static ZENODO_SCOPE = 'deposit:write deposit:actions';
 
-  static GOOGLE_CLIENT_ID = 'fill_this_in';
+  static GOOGLE_CLIENT_ID = 'will be filled in by configuration.service';
   static GOOGLE_SCOPE = 'profile email';
 
   static CWL_VISUALIZER_URI = 'https://view.commonwl.org';

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -55,7 +55,7 @@ export class Dockstore {
   // static GITLAB_SCOPE = 'read_user openid';
   static GITLAB_SCOPE = 'api';
 
-  static ZENODO_AUTH_URL = 'https://sandbox.zenodo.org/oauth/authorize';
+  static ZENODO_AUTH_URL = 'https://zenodo.org/oauth/authorize';
   static ZENODO_CLIENT_ID = 'fill_this_in';
   static ZENODO_REDIRECT_URI = Dockstore.HOSTNAME + '/auth/' + Provider.ZENODO;
   static ZENODO_SCOPE = 'deposit:write deposit:actions';

--- a/src/app/shared/enum/provider.enum.ts
+++ b/src/app/shared/enum/provider.enum.ts
@@ -3,5 +3,6 @@ export enum Provider {
     GITHUB = 'github.com', // This does not need to match anything
     QUAY = 'quay.io', // this does not need to match anything, it can be whatever
     BITBUCKET = 'bitbucket.org', // This can be anything as long as it matches the redirect URI on bitbucket
-    GITLAB = 'gitlab.com' // This must match the redirect URL in the dockstore.yml and GitLab authorized applications
+    GITLAB = 'gitlab.com', // This must match the redirect URL in the dockstore.yml and GitLab authorized applications
+    ZENODO = 'zenodo.org'
 }

--- a/src/app/shared/enum/token-source.enum.ts
+++ b/src/app/shared/enum/token-source.enum.ts
@@ -3,6 +3,7 @@ export enum TokenSource {
     QUAY = 'quay.io',
     BITBUCKET = 'bitbucket.org',
     GITLAB = 'gitlab.com',
+    ZENODO = 'zenodo.org',
     GOOGLE = 'google.com',
     DOCKSTORE = 'dockstore'
 }

--- a/src/app/shared/state/token.query.ts
+++ b/src/app/shared/state/token.query.ts
@@ -36,7 +36,8 @@ export class TokenQuery extends QueryEntity<TokenState, Token> {
       github: false,
       bitbucket: false,
       quayio: false,
-      gitlab: false
+      gitlab: false,
+      zenodo: false
     };
     if (tokens) {
       tokens.forEach(token => {
@@ -55,6 +56,9 @@ export class TokenQuery extends QueryEntity<TokenState, Token> {
             break;
           case TokenSource.GITLAB:
             tokenStatusSet.gitlab = true;
+            break;
+          case TokenSource.ZENODO:
+            tokenStatusSet.zenodo = true;
             break;
         }
       });

--- a/src/app/shared/state/token.service.ts
+++ b/src/app/shared/state/token.service.ts
@@ -54,6 +54,8 @@ export class TokenService {
         return this.tokensService.addGithubToken(token);
       case Provider.GITLAB:
         return this.tokensService.addGitlabToken(token);
+      case Provider.ZENODO:
+        return this.tokensService.addZenodoToken(token);
       default: {
         console.log('Unknown provider: ' + provider);
         return throwError('Unknown provider.');


### PR DESCRIPTION
Enables the Dockstore user to link their Zenodo credentials to Dockstore so they can create DOIs for workflows through the Dockstore UI
DOCK-763