### PR TITLE
Don't cache index.html

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,15 @@ jobs:
             - aws-s3/copy:
                 from: dist
                 to: 's3://${AWS_BUCKET}/${CIRCLE_TAG}-$(echo $CIRCLE_SHA1 | cut -c -7)'
-                arguments: '--recursive'
-
+                arguments: |
+                  --recursive \
+                  --exclude index.html
+            - aws-s3/copy:
+                from: dist
+                to: 's3://${AWS_BUCKET}/${CIRCLE_TAG}-$(echo $CIRCLE_SHA1 | cut -c -7)'
+                arguments: |
+                  --include index.html \
+                  --cache-control max-age=0
 workflows:
   version: 2
   everything:


### PR DESCRIPTION
Part of dockstore/dockstore-ui2#2447

We don't want browser to cache index.html; when we
do a new a release, we want latest index.html to be
fetched.