### PR TITLE
Search organization by all string properties

### DIFF
--- a/src/app/organizations/state/organizations.query.spec.ts
+++ b/src/app/organizations/state/organizations.query.spec.ts
@@ -13,38 +13,54 @@ describe('OrganizationsQuery', () => {
     expect(query).toBeTruthy();
   });
 
-  it('should filter organizations', () => {
+  fit('should filter organizations', () => {
+    const potatoOrganization: Organization = {
+      name: 'potato',
+      status: Organization.StatusEnum.APPROVED,
+      users: [],
+      topic: 'someTopic',
+      displayName: 'someDisplayName',
+      email: 'someEmail',
+      description: 'someDescription',
+      link: 'someLink',
+      location: 'someLocation'
+    };
+
+    const beefOrganization: Organization = { name: 'beef', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevent' };
+    const chickenOrganization: Organization = {
+      name: 'chicken',
+      status: Organization.StatusEnum.APPROVED,
+      users: [],
+      topic: 'nothing relevent'
+    };
+    const porkOrganization: Organization = { name: 'pork', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevent' };
+    const muttonOrganization: Organization = {
+      name: 'mutton',
+      status: Organization.StatusEnum.APPROVED,
+      users: [],
+      topic: 'nothing relevent'
+    };
+    const duckOrganization: Organization = { name: 'duck', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevent' };
     const exampleOrganizations: Array<Organization> = [
-      { name: 'potato', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'beef', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'chicken', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'pork', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'mutton', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'duck', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
+      potatoOrganization,
+      beefOrganization,
+      chickenOrganization,
+      porkOrganization,
+      muttonOrganization,
+      duckOrganization
     ];
-    expect(query.filterOrganizations(exampleOrganizations, 'potato')).toEqual([
-      { name: 'potato', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(exampleOrganizations, 'po')).toEqual([
-      { name: 'potato', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'pork', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(exampleOrganizations, 'POTATO')).toEqual([
-      { name: 'potato', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(exampleOrganizations, 'PO')).toEqual([
-      { name: 'potato', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'pork', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(exampleOrganizations, 'ck')).toEqual([
-      { name: 'chicken', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'duck', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(exampleOrganizations, 'CK')).toEqual([
-      { name: 'chicken', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' },
-      { name: 'duck', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevant' }
-    ]);
-    expect(query.filterOrganizations(null, 'CK')).toEqual(null);
+    expect(query.filterOrganizations(exampleOrganizations, 'potato')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'po')).toEqual([potatoOrganization, porkOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'POTATO')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'PO')).toEqual([potatoOrganization, porkOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'ck')).toEqual([chickenOrganization, duckOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'CK')).toEqual([chickenOrganization, duckOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someTopic')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someDisplayName')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someEmail')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someDescription')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someLink')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someLocation')).toEqual([potatoOrganization]);
     expect(query.filterOrganizations([], 'CK')).toEqual([]);
   });
 });

--- a/src/app/organizations/state/organizations.query.spec.ts
+++ b/src/app/organizations/state/organizations.query.spec.ts
@@ -13,7 +13,7 @@ describe('OrganizationsQuery', () => {
     expect(query).toBeTruthy();
   });
 
-  fit('should filter organizations', () => {
+  it('should filter organizations', () => {
     const potatoOrganization: Organization = {
       name: 'potato',
       status: Organization.StatusEnum.APPROVED,
@@ -23,7 +23,8 @@ describe('OrganizationsQuery', () => {
       email: 'someEmail',
       description: 'someDescription',
       link: 'someLink',
-      location: 'someLocation'
+      location: 'someLocation',
+      avatarUrl: 'someAvatarUrl'
     };
 
     const beefOrganization: Organization = { name: 'beef', status: Organization.StatusEnum.APPROVED, users: [], topic: 'nothing relevent' };
@@ -61,6 +62,7 @@ describe('OrganizationsQuery', () => {
     expect(query.filterOrganizations(exampleOrganizations, 'someDescription')).toEqual([potatoOrganization]);
     expect(query.filterOrganizations(exampleOrganizations, 'someLink')).toEqual([potatoOrganization]);
     expect(query.filterOrganizations(exampleOrganizations, 'someLocation')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someAvatarUrl')).toEqual([]);
     expect(query.filterOrganizations([], 'CK')).toEqual([]);
   });
 });

--- a/src/app/organizations/state/organizations.query.spec.ts
+++ b/src/app/organizations/state/organizations.query.spec.ts
@@ -58,9 +58,9 @@ describe('OrganizationsQuery', () => {
     expect(query.filterOrganizations(exampleOrganizations, 'CK')).toEqual([chickenOrganization, duckOrganization]);
     expect(query.filterOrganizations(exampleOrganizations, 'someTopic')).toEqual([potatoOrganization]);
     expect(query.filterOrganizations(exampleOrganizations, 'someDisplayName')).toEqual([potatoOrganization]);
-    expect(query.filterOrganizations(exampleOrganizations, 'someEmail')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someEmail')).toEqual([]);
     expect(query.filterOrganizations(exampleOrganizations, 'someDescription')).toEqual([potatoOrganization]);
-    expect(query.filterOrganizations(exampleOrganizations, 'someLink')).toEqual([potatoOrganization]);
+    expect(query.filterOrganizations(exampleOrganizations, 'someLink')).toEqual([]);
     expect(query.filterOrganizations(exampleOrganizations, 'someLocation')).toEqual([potatoOrganization]);
     expect(query.filterOrganizations(exampleOrganizations, 'someAvatarUrl')).toEqual([]);
     expect(query.filterOrganizations([], 'CK')).toEqual([]);

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -40,8 +40,6 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
             const matchOptions: string[] = [
               organization.description,
               organization.displayName,
-              organization.email,
-              organization.link,
               organization.location,
               organization.name,
               organization.topic

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Query } from '@datorama/akita';
 import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import { Organization } from '../../shared/swagger';
 import { OrganizationsState, OrganizationsStore } from './organizations.store';
 
@@ -26,6 +25,7 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
    * Filters the organization based on a string
    * Case insensitive
    * Partial match
+   * Searches every property of an organization (does not search its collections)
    *
    * @param {Array<Organization>} organizations  List of all approved organizations
    * @param {string} searchName                  Search string
@@ -36,9 +36,11 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
     searchName = searchName.toLowerCase();
     if (organizations) {
       return searchName
-        ? organizations.filter(
-            organization => organization.name.toLowerCase().includes(searchName) || organization.topic.toLowerCase().includes(searchName)
-          )
+        ? organizations.filter(organization => {
+            const matchOptions: any[] = Object.values(organization).filter(objectValue => typeof objectValue === 'string');
+            console.log(matchOptions);
+            return matchOptions.some(stringIdentifier => stringIdentifier.toLowerCase().includes(searchName));
+          })
         : organizations;
     }
     return null;

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -25,7 +25,7 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
    * Filters the organization based on a string
    * Case insensitive
    * Partial match
-   * Searches every 5 name, description, displayName, location, and topic of an organization (does not search its collections)
+   * Searches the name, description, displayName, location, and topic of each organization (does not search its collections)
    *
    * @param {Array<Organization>} organizations  List of all approved organizations
    * @param {string} searchName                  Search string

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -25,7 +25,7 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
    * Filters the organization based on a string
    * Case insensitive
    * Partial match
-   * Searches every property of an organization (does not search its collections)
+   * Searches every 5 name, description, displayName, location, and topic of an organization (does not search its collections)
    *
    * @param {Array<Organization>} organizations  List of all approved organizations
    * @param {string} searchName                  Search string

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -37,7 +37,15 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
     if (organizations) {
       return searchName
         ? organizations.filter(organization => {
-            const matchOptions: any[] = Object.values(organization).filter(objectValue => typeof objectValue === 'string');
+            const matchOptions: string[] = [
+              organization.description,
+              organization.displayName,
+              organization.email,
+              organization.link,
+              organization.location,
+              organization.name,
+              organization.topic
+            ].filter(matchOption => !!matchOption);
             return matchOptions.some(stringIdentifier => stringIdentifier.toLowerCase().includes(searchName));
           })
         : organizations;

--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -38,7 +38,6 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
       return searchName
         ? organizations.filter(organization => {
             const matchOptions: any[] = Object.values(organization).filter(objectValue => typeof objectValue === 'string');
-            console.log(matchOptions);
             return matchOptions.some(stringIdentifier => stringIdentifier.toLowerCase().includes(searchName));
           })
         : organizations;


### PR DESCRIPTION
For dockstore/dockstore#2282

Can't search by collections still, but now can search all string properties of the organizations.