### PR TITLE
Feature/2606/route tabs

### DIFF
--- a/cypress/integration/group1/dropdown.ts
+++ b/cypress/integration/group1/dropdown.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { setTokenUserViewPortCurator } from '../../support/commands';
+import {goToTab, setTokenUserViewPortCurator} from '../../support/commands';
 
 describe('Dropdown test', () => {
   // TODO: GitLab tests are commented out
@@ -76,6 +76,41 @@ describe('Dropdown test', () => {
 
     it('Should show all accounts as linked (except GitLab and Bitbucket)', () => {
       everythingOk();
+    });
+    setTokenUserViewPortCurator();
+    // Check that changing the tab changes the url
+    it('should default to accounts tab', () => {
+      cy.visit('/accounts');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
+    it('Change tab to profiles', () => {
+      goToTab('Profiles');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=profiles');
+    });
+    it('Change tab to dockstore account controls', () => {
+      goToTab('Dockstore Account Controls');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=dockstore%20account%20controls');
+    });
+    it('Change tab to requests', () => {
+      goToTab('Requests');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=requests');
+    });
+    // Check that changing the url changes the tab
+    it('Link to accounts tab', () => {
+      cy.visit('/accounts?tab=accounts');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
+    it('Link to profiles tab', () => {
+      cy.visit('/accounts?tab=profiles');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=profiles');
+    });
+    it('Link to dockstore account controls tab', () => {
+      cy.visit('/accounts?tab=dockstore%20account%20controls');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=dockstore%20account%20controls');
+    });
+    it('Link to requests tab', () => {
+      cy.visit('/accounts?tab=requests');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=requests');
     });
   });
 

--- a/cypress/integration/group1/dropdown.ts
+++ b/cypress/integration/group1/dropdown.ts
@@ -83,6 +83,10 @@ describe('Dropdown test', () => {
       cy.visit('/accounts');
       cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
     });
+    it('should default to accounts tab when tab name misspelled', () => {
+      cy.visit('/accounts?tab=abcd');
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
     it('Change tab to profiles', () => {
       goToTab('Profiles');
       cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=profiles');

--- a/cypress/integration/group1/dropdown.ts
+++ b/cypress/integration/group1/dropdown.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import {goToTab, setTokenUserViewPortCurator} from '../../support/commands';
+import {getTab, goToTab, setTokenUserViewPortCurator} from '../../support/commands';
 
 describe('Dropdown test', () => {
   // TODO: GitLab tests are commented out
@@ -102,19 +102,19 @@ describe('Dropdown test', () => {
     // Check that changing the url changes the tab
     it('Link to accounts tab', () => {
       cy.visit('/accounts?tab=accounts');
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+      getTab('Accounts').parent().should('have.class', 'mat-tab-label-active');
     });
     it('Link to profiles tab', () => {
       cy.visit('/accounts?tab=profiles');
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=profiles');
+      getTab('Profiles').parent().should('have.class', 'mat-tab-label-active');
     });
     it('Link to dockstore account controls tab', () => {
       cy.visit('/accounts?tab=dockstore%20account%20controls');
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=dockstore%20account%20controls');
+      getTab('Dockstore Account Controls').parent().should('have.class', 'mat-tab-label-active');
     });
     it('Link to requests tab', () => {
       cy.visit('/accounts?tab=requests');
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=requests');
+      getTab('Requests').parent().should('have.class', 'mat-tab-label-active');
     });
   });
 

--- a/src/app/loginComponents/accounts/accounts.component.html
+++ b/src/app/loginComponents/accounts/accounts.component.html
@@ -5,9 +5,6 @@
 <div class="container separation">
   <mat-tab-group
     [selectedIndex]="selected.value"
-    class="ds-tabs"
-    id="workflow_tabs"
-    #entryTabs
     (selectedIndexChange)="selected.setValue($event)"
     (selectedTabChange)="selectedTabChange($event)"
     mat-stretch-tabs

--- a/src/app/loginComponents/accounts/accounts.component.html
+++ b/src/app/loginComponents/accounts/accounts.component.html
@@ -3,7 +3,15 @@
   Profiles, Accounts and Controls
 </app-header>
 <div class="container separation">
-  <mat-tab-group>
+  <mat-tab-group
+    [selectedIndex]="selected.value"
+    class="ds-tabs"
+    id="workflow_tabs"
+    #entryTabs
+    (selectedIndexChange)="selected.setValue($event)"
+    (selectedTabChange)="selectedTabChange($event)"
+    mat-stretch-tabs
+  >
     <mat-tab label="Accounts">
       <app-accounts-external></app-accounts-external>
     </mat-tab>

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -19,15 +19,15 @@ export class AccountsComponent implements OnInit {
     this.parseURL(this.router.url);
   }
 
-  private parseURL(url: String): void {
+  private parseURL(url: string): void {
     const decodedUrl: string = decodeURIComponent(url.toString()); // decode any encoded spaces, etc. in the string
-    const strippedUrl: String = decodedUrl.endsWith('/') ? decodedUrl.slice(0, -1) : decodedUrl; // remove any trailing slash
+    const strippedUrl: string = decodedUrl.endsWith('/') ? decodedUrl.slice(0, -1) : decodedUrl; // remove any trailing slash
     this.setupTab(strippedUrl);
   }
 
-  public setupTab(url: String) {
-    const regexp: RegExp = new RegExp('\\?tab=(.*)');
-    const match = regexp.exec(url.toString());
+  public setupTab(url: string) {
+    const u = new URL(url);
+    const match = u.searchParams.get('tab');
     if (match) {
       // look for a tab name in the url
       const tabIndex = this.validTabs.indexOf(match[1]);

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -30,7 +30,10 @@ export class AccountsComponent implements OnInit {
     const match = regexp.exec(url.toString());
     if (match) {
       // look for a tab name in the url
-      this.currentTab = match[1]; // if found, set the tab accordingly
+      const tabIndex = this.validTabs.indexOf(match[1]);
+      if (tabIndex >= 0) {
+        this.currentTab = match[1]; // if found, set the tab accordingly
+      }
     } // if not found, default to the 'accounts' tab
     this.selectTab(this.validTabs.indexOf(this.currentTab));
     this.setAccountsTab(this.currentTab);
@@ -38,9 +41,7 @@ export class AccountsComponent implements OnInit {
 
   selectTab(tabIndex: number): void {
     // called on setup
-    if (tabIndex >= 0) {
-      this.selected.setValue(tabIndex);
-    }
+    this.selected.setValue(tabIndex);
   }
 
   selectedTabChange(matTabChangeEvent: MatTabChangeEvent) {

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -1,19 +1,19 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { MatTabChangeEvent } from '@angular/material';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import Dictionary = cytoscape.Css.Dictionary;
 
 @Component({
   selector: 'app-accounts',
   templateUrl: './accounts.component.html'
 })
-export class AccountsComponent implements OnInit {
+export class AccountsComponent implements OnInit, OnDestroy {
   public currentTab = 'accounts'; // default to the 'accounts' tab
   selected = new FormControl();
   validTabs = ['accounts', 'profiles', 'dockstore account controls', 'requests'];
+  subscription = null;
   constructor(private location: Location, private router: Router, private activatedRoute: ActivatedRoute) {}
 
   ngOnInit() {
@@ -22,12 +22,12 @@ export class AccountsComponent implements OnInit {
   }
 
   private parseParam(params: Observable<Params>): void {
-    params.subscribe(next => {
+    this.subscription = params.subscribe(next => {
       this.setupTab(next);
     });
   }
 
-  public setupTab(u: Dictionary) {
+  public setupTab(u: Params) {
     const match: string = u['tab'];
     if (match) {
       // look for a tab name in the url
@@ -53,5 +53,9 @@ export class AccountsComponent implements OnInit {
 
   setAccountsTab() {
     this.location.replaceState('accounts?tab=' + this.currentTab);
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 }

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -38,7 +38,9 @@ export class AccountsComponent implements OnInit {
 
   selectTab(tabIndex: number): void {
     // called on setup
-    this.selected.setValue(tabIndex);
+    if (tabIndex >= 0) {
+      this.selected.setValue(tabIndex);
+    }
   }
 
   selectedTabChange(matTabChangeEvent: MatTabChangeEvent) {

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 })
 export class AccountsComponent implements OnInit {
   public currentTab = 'accounts'; // default to the 'accounts' tab
-  protected selected = new FormControl(0);
+  selected = new FormControl(0);
   validTabs = ['accounts', 'profiles', 'dockstore account controls', 'requests'];
   constructor(private location: Location, private router: Router) {}
 

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -1,12 +1,53 @@
 import { Component, OnInit } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Location } from '@angular/common';
+import { MatTabChangeEvent } from '@angular/material';
+import { FormControl } from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-accounts',
   templateUrl: './accounts.component.html'
 })
 export class AccountsComponent implements OnInit {
+  public currentTab = 'accounts'; // default to the 'accounts' tab
+  protected selected = new FormControl(0);
+  validTabs = ['accounts', 'profiles', 'dockstore account controls', 'requests'];
+  constructor(private location: Location, private router: Router) {}
+
   ngOnInit() {
     localStorage.setItem('page', '/accounts');
+    this.parseURL(this.router.url);
+  }
+
+  private parseURL(url: String): void {
+    const decodedUrl: string = decodeURIComponent(url.toString()); // decode any encoded spaces, etc. in the string
+    const strippedUrl: String = decodedUrl.endsWith('/') ? decodedUrl.slice(0, -1) : decodedUrl; // remove any trailing slash
+    this.setupTab(strippedUrl);
+  }
+
+  public setupTab(url: String) {
+    const regexp: RegExp = new RegExp('\\?tab=(.*)');
+    const match = regexp.exec(url.toString());
+    if (match) {
+      // look for a tab name in the url
+      this.currentTab = match[1]; // if found, set the tab accordingly
+    } // if not found, default to the 'accounts' tab
+    this.selectTab(this.validTabs.indexOf(this.currentTab));
+    this.setAccountsTab(this.currentTab);
+  }
+
+  selectTab(tabIndex: number): void {
+    // called on setup
+    this.selected.setValue(tabIndex);
+  }
+
+  selectedTabChange(matTabChangeEvent: MatTabChangeEvent) {
+    // called on tab change event
+    this.setAccountsTab(matTabChangeEvent.tab.textLabel.toLowerCase());
+  }
+
+  setAccountsTab(tabName: string) {
+    this.currentTab = tabName;
+    this.location.replaceState('accounts?tab=' + tabName);
   }
 }

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -4,17 +4,20 @@ import { MatTabChangeEvent } from '@angular/material';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Observable } from 'rxjs';
+import { Base } from '../../shared/base';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-accounts',
   templateUrl: './accounts.component.html'
 })
-export class AccountsComponent implements OnInit, OnDestroy {
+export class AccountsComponent extends Base implements OnInit {
   public currentTab = 'accounts'; // default to the 'accounts' tab
   selected = new FormControl();
   validTabs = ['accounts', 'profiles', 'dockstore account controls', 'requests'];
-  subscription = null;
-  constructor(private location: Location, private router: Router, private activatedRoute: ActivatedRoute) {}
+  constructor(private location: Location, private router: Router, private activatedRoute: ActivatedRoute) {
+    super();
+  }
 
   ngOnInit() {
     localStorage.setItem('page', '/accounts');
@@ -22,13 +25,13 @@ export class AccountsComponent implements OnInit, OnDestroy {
   }
 
   private parseParam(params: Observable<Params>): void {
-    this.subscription = params.subscribe(next => {
+    params.pipe(takeUntil(this.ngUnsubscribe)).subscribe(next => {
       this.setupTab(next);
     });
   }
 
-  public setupTab(u: Params) {
-    const match: string = u['tab'];
+  public setupTab(params: Params) {
+    const match: string = params['tab'];
     if (match) {
       // look for a tab name in the url
       const tabIndex = this.validTabs.indexOf(match);
@@ -53,9 +56,5 @@ export class AccountsComponent implements OnInit, OnDestroy {
 
   setAccountsTab() {
     this.location.replaceState('accounts?tab=' + this.currentTab);
-  }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
   }
 }


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2606
Added query components to accounts page URL so that each tab can be linked individually, e.g. dockstore.org/accounts?tab=profile. This is consistent with how the info, launch, etc. tabs on a workflow's page currently work. The Angular documentation suggests a different strategy giving each tab its own route, e.g. dockstore.org/accounts/profile (https://material.angular.io/components/tabs/overview, tabs and navigation section). Not sure if that method is better in some way, if so maybe it would be a separate ticket to switch over all tabs on the website.
Added tests for the accounts page tabs into cypress/integration/group1/dropdown.ts