### PR TITLE
Hide view checker workflow button on error

### DIFF
--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -6,7 +6,7 @@
       <a
         [routerLink]="checkerWorkflowURL$ | async"
         id="viewCheckerWorkflowButton"
-        *ngIf="(checkerId$ | async) && !(isRefreshing$ | async)"
+        *ngIf="(checkerWorkflowURL$ | async) && !(isRefreshing$ | async)"
         type="button"
         class="btn btn-link"
       >

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
@@ -24,6 +24,7 @@ import { CheckerWorkflowService } from '../../state/checker-workflow.service';
 import { RegisterCheckerWorkflowService } from '../register-checker-workflow/register-checker-workflow.service';
 import { RegisterCheckerWorkflowComponent } from '../register-checker-workflow/register-checker-workflow.component';
 import { MatDialog } from '@angular/material';
+import { Workflow } from 'app/shared/swagger';
 
 @Component({
   selector: 'app-info-tab-checker-workflow-path',
@@ -39,6 +40,7 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
   checkerId$: Observable<number>;
   canAdd$: Observable<boolean>;
   canView$: Observable<boolean>;
+  checkerWorkflow$: Observable<Workflow>;
   @Input() canRead: boolean;
   @Input() canWrite: boolean;
   @Input() isOwner: boolean;
@@ -58,6 +60,7 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
     this.parentId$ = this.checkerWorkflowQuery.parentId$;
     this.isPublic$ = this.sessionQuery.isPublic$;
     this.isStub$ = this.checkerWorkflowQuery.isStub$;
+    this.checkerWorkflow$ = this.checkerWorkflowQuery.checkerWorkflow$;
     this.checkerWorkflowURL$ = this.checkerWorkflowService.getCheckerWorkflowURLObservable(
       this.checkerWorkflowQuery.checkerWorkflow$,
       this.isPublic$


### PR DESCRIPTION
UI portion of dockstore/dockstore#2330

When getting the checker workflow errors out (for whatever reason), the checker ID is still known but the actual checker workflow URL is unknown.   This checks that the actual checker workflow URL exists before showing the view checker workflow button.

No error is displayed to the user though because it might not be relevant enough (can easily change it though)