### PR TITLE
Feature/2592/shared workflows error

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -150,10 +150,6 @@ span {
   }
 }
 
-.youtube {
-  z-index: 1070;
-}
-
 .small-card,
 .small-card > mat-card {
   min-height: 150px;

--- a/src/app/myworkflows/my-bio-workflows.service.ts
+++ b/src/app/myworkflows/my-bio-workflows.service.ts
@@ -7,7 +7,7 @@ import { BioWorkflow } from 'app/shared/swagger/model/bioWorkflow';
 import { forkJoin, of as observableOf } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 import { WorkflowService } from '../shared/state/workflow.service';
-import { UsersService, Workflow, WorkflowsService } from '../shared/swagger';
+import { SharedWorkflows, UsersService, Workflow, WorkflowsService } from '../shared/swagger';
 
 @Injectable()
 export class MyBioWorkflowsService {
@@ -26,20 +26,27 @@ export class MyBioWorkflowsService {
     });
   }
 
+  /**
+   * Very strange function that gets both the user's workflows and the user's shared workflows
+   * If one of them errors, the other should still continue executing.  This is done by catching it.
+   * Once both of them finish, the error is determined whether the type is Array (which is normal) or not (which means HttpErrorResponse
+   * If both errors, then only the user's workflows error message is displayed
+   *
+   * @param {number} id  The user ID
+   * @memberof MyBioWorkflowsService
+   */
   getMyBioWorkflows(id: number): void {
     this.alertService.start('Fetching workflows');
     this.myEntryService.setRefreshingMyEntries(true);
     forkJoin(
       this.usersService.userWorkflows(id).pipe(
         catchError((error: HttpErrorResponse) => {
-          this.alertService.detailedSnackBarError(error);
-          return observableOf([]);
+          return observableOf(error);
         })
       ),
       this.workflowsService.sharedWorkflows().pipe(
         catchError((error: HttpErrorResponse) => {
-          this.alertService.detailedSnackBarError(error);
-          return observableOf([]);
+          return observableOf(error);
         })
       )
     )
@@ -50,7 +57,21 @@ export class MyBioWorkflowsService {
         })
       )
       .subscribe(
-        ([workflows, sharedWorkflows]) => {
+        ([workflows, sharedWorkflows]: [(Array<BioWorkflow> | HttpErrorResponse), (Array<SharedWorkflows> | HttpErrorResponse)]) => {
+          if (!Array.isArray(workflows) && !Array.isArray(sharedWorkflows)) {
+            this.alertService.detailedSnackBarError(workflows);
+            workflows = [];
+            sharedWorkflows = [];
+          } else {
+            if (!Array.isArray(workflows)) {
+              this.alertService.detailedSnackBarError(workflows);
+              workflows = [];
+            }
+            if (!Array.isArray(sharedWorkflows)) {
+              this.alertService.detailedSnackBarError(sharedWorkflows);
+              sharedWorkflows = [];
+            }
+          }
           this.workflowService.setWorkflows(workflows);
           this.workflowService.setSharedWorkflows(sharedWorkflows);
         },


### PR DESCRIPTION
dockstore/dockstore#2592

Very odd way of handling getting user's shared workflows and normal workflows but it works.

What happened was the failure of any of the two endpoints would remove the progress bar immediately. 

This waits for both endpoints even when it fails.  If not individually caught, forkJoin typically abandons everything once there's an error.  This catches the error and continues.  Once both calls finish, it figures out if there's was a caught error.

dockstore/dockstore#2693 also