### PR TITLE
Check modal is closed before opening another

### DIFF
--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -99,9 +99,12 @@ describe('Dockstore Organizations', () => {
         'https://res.cloudinary.com/hellofresh/image/upload/f_auto,fl_lossy,q_auto,w_640/v1/hellofresh_s3/image/554a3abff8b25e1d268b456d.png'
       );
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.get('#createOrUpdateOrganizationButton')
+        .should('not.be.visible')
       cy.get('#editOrgInfo').should('be.visible').click();
       cy.get('[data-cy=image-url-input').clear();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.get('#createOrUpdateOrganizationButton').should('not.be.visible');
       cy.get('#editOrgInfo').should('be.visible').click();
       cy.get('[data-cy=image-url-input').clear().type('https://res.cloudinary.com/hellofresh/image/upload/f_auto,fl_lossy,q_auto,w_640/v1/hellofresh_s3/image/554a3abff8b25e1d268b456d.png');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();


### PR DESCRIPTION
Sometimes the get image-url and click fails because it is not visible.  This appears to be caused by Cypress seeing two image-url fields instead of one.  My guess is that the previous modal was not closed before opening it again to edit.  This ensures the previous modal is closed before trying.