### PR TITLE
Feature/2742/hide snapshot public page

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -65,6 +65,23 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=save-version').click();
       cy.get('[data-cy=save-version').should('not.be.visible');
     });
+    it('Should be able to snapshot', () => {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+      goToTab('Versions');
+      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+
+      cy.get('[data-cy=dockstore-snapshot-unlocked]')
+        .its('length')
+        .should('be.gt', 0);
+
+      cy.get('[data-cy=dockstore-snapshot]')
+        .first()
+        .click();
+
+      cy.wait(250);
+      cy.get('[data-cy=dockstore-snapshot-locked').should('have.length', 1);
+    });
   });
 
   describe('Look at an invalid workflow', () => {

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -61,7 +61,7 @@ describe('Dockstore Workflow Details', () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=launch');
   });
 
-  it('Change tab to versions and snapshot', () => {
+  it('Change tab to versions and not see snapshot', () => {
     goToTab('Versions');
     cy
       .get('tbody>tr')
@@ -74,23 +74,6 @@ describe('Dockstore Workflow Details', () => {
       .should('be.gt', 0);
         cy.get('[data-cy=dockstore-snapshot]')
           .should('not.be.visible');
-    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l:master?tab=versions');
-    goToTab('Versions');
-    cy
-      .get('[data-cy=dockstore-snapshot-locked]')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-cy=dockstore-snapshot-unlocked]')
-      .its('length')
-      .should('be.gt', 0);
-
-    cy
-      .get('[data-cy=dockstore-snapshot]').first().click();
-
-    cy.wait(250);
-    cy
-      .get('[data-cy=dockstore-snapshot-locked').should('have.length', 1);
    });
 
   describe('Change tab to files', () => {

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -67,7 +67,15 @@ describe('Dockstore Workflow Details', () => {
       .get('tbody>tr')
       .should('have.length', 1); // 1 Version and no warning line
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=versions');
+    cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
 
+    cy.get('[data-cy=dockstore-snapshot-unlocked]')
+      .its('length')
+      .should('be.gt', 0);
+        cy.get('[data-cy=dockstore-snapshot]')
+          .should('not.be.visible');
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l:master?tab=versions');
+    goToTab('Versions');
     cy
       .get('[data-cy=dockstore-snapshot-locked]')
       .should('have.length', 0);
@@ -78,7 +86,7 @@ describe('Dockstore Workflow Details', () => {
       .should('be.gt', 0);
 
     cy
-      .get('[data-cy=dockstore-snapshot]').first().click()
+      .get('[data-cy=dockstore-snapshot]').first().click();
 
     cy.wait(250);
     cy

--- a/src/app/workflow/view/view.component.html
+++ b/src/app/workflow/view/view.component.html
@@ -17,24 +17,26 @@
 <button type="button" mat-button color="accent" class="btn-block" (click)="showVersionModal()">
   {{ isPublic || !canWrite || (entryType$ | async) === EntryType.Service ? 'View' : 'Edit' }}
 </button>
-<button
-  type="button"
-  mat-button
-  color="accent"
-  class="btn-block"
-  *ngIf="!version.frozen && version.referenceType !== 'BRANCH'"
-  (click)="snapshotVersion()"
-  data-cy="dockstore-snapshot"
->
-  Snapshot
-</button>
-<button
-  type="button"
-  mat-button
-  color="warn"
-  class="btn-block deleteVersionButton"
-  *ngIf="!isPublic && workflow?.mode === WorkflowType.ModeEnum.HOSTED && canWrite"
-  (click)="deleteHostedVersion(); (false)"
->
-  Delete
-</button>
+<ng-container *ngIf="!isPublic">
+  <button
+    type="button"
+    mat-button
+    color="accent"
+    class="btn-block"
+    *ngIf="!version.frozen && version.referenceType !== 'BRANCH'"
+    (click)="snapshotVersion()"
+    data-cy="dockstore-snapshot"
+  >
+    Snapshot
+  </button>
+  <button
+    type="button"
+    mat-button
+    color="warn"
+    class="btn-block deleteVersionButton"
+    *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED && canWrite"
+    (click)="deleteHostedVersion(); (false)"
+  >
+    Delete
+  </button>
+</ng-container>


### PR DESCRIPTION
For dockstore/dockstore#2742

Hide the snapshot button in the versions tab when in public page
There is now a test for each of them