### PR TITLE
Feature/lazy load search

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -63,7 +63,6 @@ import { NavbarComponent } from './navbar/navbar.component';
 import { OrganizationStargazersModule } from './organizations/organization/organization-stargazers/organization-stargazers.module';
 import { OrganizationStarringModule } from './organizations/organization/organization-starring/organization-starring.module';
 import { RegisterService } from './register/register.service';
-import { SearchModule } from './search/search.module';
 import { RefreshAlertModule } from './shared/alert/alert.module';
 import { AuthConfig } from './shared/auth.model';
 import { ContainerService } from './shared/container.service';
@@ -167,7 +166,6 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     StargazersModule,
     MarkdownModule.forRoot(),
     ReactiveFormsModule,
-    SearchModule,
     ApiModule.forRoot(getApiConfig),
     ApiModule2.forRoot(getApiConfig),
     CustomMaterialModule,

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -66,7 +66,11 @@ const APP_ROUTES: Routes = [
   },
   { path: 'githubCallback', component: GithubCallbackComponent },
   { path: 'aliases', loadChildren: 'app/aliases/aliases.module#AliasesModule', data: { title: 'Dockstore | Aliases' } },
-  { path: 'search*', component: SearchComponent, data: { title: 'Dockstore | Search' } },
+  {
+    path: 'search',
+    loadChildren: 'app/search/search.module#SearchModule',
+    data: { title: 'Dockstore | Search' }
+  },
   { path: 'login', component: LoginComponent, data: { title: 'Dockstore | Login' } },
   { path: 'quick-start', component: QuickStartComponent, data: { title: 'Dockstore | Quick Start' } },
   { path: 'onboarding', component: OnboardingComponent, canActivate: [AuthGuard], data: { title: 'Dockstore | Onboarding' } },

--- a/src/app/search/basic-search/basic-search.component.spec.ts
+++ b/src/app/search/basic-search/basic-search.component.spec.ts
@@ -3,10 +3,10 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatAutocompleteModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { ProviderService } from '../../shared/provider.service';
-import { AdvancedSearchStubService } from '../../test/service-stubs';
+import { AdvancedSearchStubService, SearchStubService } from '../../test/service-stubs';
 import { AdvancedSearchService } from '../advancedsearch/advanced-search.service';
+import { SearchService } from '../state/search.service';
 import { BasicSearchComponent } from './basic-search.component';
 
 describe('BasicSearchComponent', () => {
@@ -18,7 +18,11 @@ describe('BasicSearchComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
       imports: [MatAutocompleteModule, RouterTestingModule],
       declarations: [BasicSearchComponent],
-      providers: [ProviderService, { provide: AdvancedSearchService, useClass: AdvancedSearchStubService }]
+      providers: [
+        ProviderService,
+        { provide: AdvancedSearchService, useClass: AdvancedSearchStubService },
+        { provide: SearchService, useClass: SearchStubService }
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -42,6 +42,7 @@ import { SearchToolTableComponent } from './search-tool-table/search-tool-table.
 import { SearchWorkflowTableComponent } from './search-workflow-table/search-workflow-table.component';
 import { SearchComponent } from './search.component';
 import { searchRouting } from './search.routing';
+import { SearchService } from './state/search.service';
 
 @NgModule({
   declarations: [
@@ -74,7 +75,7 @@ import { searchRouting } from './search.routing';
     ReactiveFormsModule,
     RefreshAlertModule
   ],
-  providers: [AdvancedSearchService, QueryBuilderService, { provide: TooltipConfig, useFactory: getTooltipConfig }],
+  providers: [SearchService, AdvancedSearchService, QueryBuilderService, { provide: TooltipConfig, useFactory: getTooltipConfig }],
   exports: [SearchComponent]
 })
 export class SearchModule {}

--- a/src/app/search/search.routing.ts
+++ b/src/app/search/search.routing.ts
@@ -15,15 +15,13 @@
  */
 
 import { RouterModule, Routes } from '@angular/router';
-
 import { SearchComponent } from './search.component';
 
 const CONTAINERS_ROUTES: Routes = [
   {
-    path: 'search',
+    path: '**',
     component: SearchComponent,
-    data: { title: 'Dockstore | Search' },
-    children: [{ path: 'search?**', component: SearchComponent }]
+    data: { title: 'Dockstore | Search' }
   }
 ];
 

--- a/src/app/search/search.routing.ts
+++ b/src/app/search/search.routing.ts
@@ -25,4 +25,4 @@ const CONTAINERS_ROUTES: Routes = [
   }
 ];
 
-export const searchRouting = RouterModule.forRoot(CONTAINERS_ROUTES);
+export const searchRouting = RouterModule.forChild(CONTAINERS_ROUTES);

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -24,7 +24,7 @@ import { SearchQuery } from './search.query';
 import { ProviderService } from '../../shared/provider.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class SearchService {
   private searchInfoSource = new BehaviorSubject<any>(null);
   public toSaveSearch$ = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
I have no idea why search routing was done that way

Before:
```
Date: 2019-08-15T13:57:29.243Z
Hash: 74a7713e343de1efe382
Time: 128982ms
chunk {0} common.feac484f496a5613204d.js (common) 2.54 kB  [rendered]
chunk {1} 1.68fcf105fe1aa17d4cec.js () 624 kB  [rendered]
chunk {2} 2.482c1e3728ecd06762c1.js () 1.53 MB  [rendered]
chunk {3} runtime.7271923acbf21b382f83.js (runtime) 2.5 kB [entry] [rendered]
chunk {4} 4.24900f6cb6b4c99e210c.js () 14.1 kB  [rendered]
chunk {5} 5.636b651e50357561920f.js () 345 kB  [rendered]
chunk {6} 6.b99e39908768ed3d1331.js () 98.8 kB  [rendered]
chunk {7} main.c985b184bb93ca05044e.js (main) 2.6 MB [initial] [rendered]
chunk {8} polyfills.5d1538de6392fd4b22d0.js (polyfills) 129 kB [initial] [rendered]
chunk {9} styles.b24de1aa4b307a98d97e.css (styles) 257 kB [initial] [rendered]
chunk {10} 10.0ebb7f2ae3d89406f1d2.js () 20.8 kB  [rendered]
chunk {11} 11.7159ad2cbf8e2870331d.js () 237 kB  [rendered]
chunk {12} 12.131cfc318b2a9766dc2f.js () 8.06 kB  [rendered]
chunk {13} 13.8cd004ca43ee79ce1f9d.js () 6.34 kB  [rendered]
chunk {14} 14.d30ee72f4c86ccf43f08.js () 6.16 kB  [rendered]
chunk {15} 15.20990b34ac341947003d.js () 104 kB  [rendered]
chunk {16} 16.fe4b997eb541163d81ac.js () 6.16 kB  [rendered]
chunk {17} 17.66dfdb3d46f22a82fe8c.js () 6.03 kB  [rendered]
chunk {18} 18.b62770b1eae684a74f26.js () 6.04 kB  [rendered]
chunk {scripts} scripts.2a62947661994f8223dc.js (scripts) 718 kB [entry] [rendered]

```

After:

```
Date: 2019-08-15T13:32:30.749Z
Hash: e6de2d3cae9f369b87d2
Time: 96247ms
chunk {0} common.feac484f496a5613204d.js (common) 2.54 kB  [rendered]
chunk {1} 1.63607fd54f185455e79f.js () 627 kB  [rendered]
chunk {2} 2.b2336756373ea7f81076.js () 37.1 kB  [rendered]
chunk {3} 3.59d6b1220742595832af.js () 1.53 MB  [rendered]
chunk {4} runtime.ace9a73abc17983bc8f4.js (runtime) 2.55 kB [entry] [rendered]
chunk {5} 5.4d92dc8b9d7ed6c57c2d.js () 19.6 kB  [rendered]
chunk {6} 6.c5c677e6b3e3a3a72adc.js () 354 kB  [rendered]
chunk {7} 7.fe646d188e350c5552e2.js () 98.8 kB  [rendered]
chunk {8} main.6a3657263e88dc978c02.js (main) 1.9 MB [initial] [rendered]
chunk {9} polyfills.b75e547de3cd69bdd838.js (polyfills) 129 kB [initial] [rendered]
chunk {10} styles.b24de1aa4b307a98d97e.css (styles) 257 kB [initial] [rendered]
chunk {11} 11.16b1c709983f0012840c.js () 673 kB  [rendered]
chunk {12} 12.4176ea1dd837e638967d.js () 241 kB  [rendered]
chunk {13} 13.cc84aa3d23c10f25f23e.js () 108 kB  [rendered]
chunk {14} 14.d821211c6af307fdd067.js () 20.8 kB  [rendered]
chunk {15} 15.93fcbac61c954350cb05.js () 8.06 kB  [rendered]
chunk {16} 16.83bc1a264effe68bc422.js () 6.34 kB  [rendered]
chunk {17} 17.0aa49cba63160895b223.js () 6.16 kB  [rendered]
chunk {18} 18.efd904a06eaddbf634bd.js () 6.16 kB  [rendered]
chunk {19} 19.be7ec6eb8abedac1857d.js () 6.03 kB  [rendered]
chunk {20} 20.a86aa1e54b1504d24e3d.js () 6.04 kB  [rendered]
chunk {scripts} scripts.2a62947661994f8223dc.js (scripts) 718 kB [entry] [rendered]
```

main.js got ~27% smaller or so.  Other files got a slight bump.

I have no idea why the routing was done that way originally.  Any insight would be nice.