### PR TITLE
Fix refreshing Google tokens

### DIFF
--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -3,6 +3,7 @@ import { Config, MetadataService } from './shared/swagger';
 import { Dockstore } from './shared/dockstore.model';
 import { ConfigService } from 'ng2-ui-auth';
 import { AuthConfig } from './shared/auth.model';
+import { IOauth1Options, IOauth2Options } from 'ng2-ui-auth/lib/config-interfaces';
 
 @Injectable({
   providedIn: 'root'
@@ -74,8 +75,16 @@ export class ConfigurationService {
    * executed. Update the providers here.
    */
   private updateAuthProviders() {
-    AuthConfig.providers.github.clientId = Dockstore.GITHUB_CLIENT_ID;
-    AuthConfig.providers.google.clientId = Dockstore.GOOGLE_CLIENT_ID;
+    if (this.isIOauth2Options(AuthConfig.providers.github)) {
+      AuthConfig.providers.github.clientId = Dockstore.GITHUB_CLIENT_ID;
+    }
+    if (this.isIOauth2Options(AuthConfig.providers.google)) {
+      AuthConfig.providers.google.clientId = Dockstore.GOOGLE_CLIENT_ID;
+    }
     this.configService.updateProviders(AuthConfig.providers);
+  }
+
+  private isIOauth2Options(arg: any): arg is IOauth2Options {
+    return arg.hasOwnProperty('clientId');
   }
 }

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -3,7 +3,7 @@ import { Config, MetadataService } from './shared/swagger';
 import { Dockstore } from './shared/dockstore.model';
 import { ConfigService } from 'ng2-ui-auth';
 import { AuthConfig } from './shared/auth.model';
-import { IOauth1Options, IOauth2Options } from 'ng2-ui-auth/lib/config-interfaces';
+import { IOauth2Options } from 'ng2-ui-auth/lib/config-interfaces';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/shared/auth.model.ts
+++ b/src/app/shared/auth.model.ts
@@ -14,9 +14,9 @@
  *    limitations under the License.
  */
 import { Dockstore } from '../shared/dockstore.model';
+import { IPartialConfigOptions } from 'ng2-ui-auth/lib/config-interfaces';
 
-export const AuthConfig = {
-  defaultHeaders: { 'Content-Type': 'application/json' },
+export const AuthConfig: IPartialConfigOptions = {
   providers: {
     github: {
       url: Dockstore.API_URI + '/auth/tokens/github',
@@ -27,8 +27,10 @@ export const AuthConfig = {
       url: Dockstore.API_URI + '/auth/tokens/google',
       clientId: Dockstore.GOOGLE_CLIENT_ID,
       scope: [Dockstore.GOOGLE_SCOPE],
-      access_type: 'offline',
-      approval_prompt: 'force'
+      additionalUrlParams: {
+        access_type: 'offline',
+        prompt: 'consent'
+      }
     }
   }
 };


### PR DESCRIPTION
dockstore/dockstore#2745

Problem was we weren't getting a refresh token back in the
initial authentication dance.

Looks like a dependabot update of ng2-ui-auth caused this.

Changed AuthConfig in auth.model to have a type (when I changed
it, compilation errors happened), then adjusted the code. Note
the defaultHeaders gave a compilation error as well, so I removed
it.

Regarding, changing the value of prompt to "consent", this page,
https://developers.google.com/identity/protocols/OpenIDConnect#prompt,
says the only allowed values are none, consent, and select_account.
I went with consent, because you may not get a refresh token if
you already requested an access token only before. See
https://github.com/googleapis/google-api-python-client/issues/213.

Had to use TypeScript User Defined Type Guards for the first time in
configuration.service.ts to fix compilation errors.