### PR TITLE
feature/2755/service-versions-view-edit

### DIFF
--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -29,6 +29,7 @@ export const formErrors = {
   reference: '',
   versionTag: '',
   workflow_path: '',
+  service_path: '',
   workflowName: '',
   amazonDockerRegistryPath: '',
   sevenBridgesDockerRegistryPath: ''
@@ -53,6 +54,7 @@ export const validationDescriptorPatterns = {
   versionTag: '^[a-zA-Z0-9]+([-_.]*[a-zA-Z0-9]+)*$',
   reference: '[\\w-]+((/|.)[\\w-]+)*',
   workflowDescriptorPath: '^/([^\\/?:*|<>]+/)*[^\\/?:*|<>]+.(cwl|wdl|yaml|yml|config)',
+  serviceDescriptorPath: '^.([^\\/?:*|<>]+/)*[^\\/?:*|<>]+.(yml)',
   workflowName: '[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*',
   cwlTestParameterFilePath: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(json|yml|yaml)$',
   wdlTestParameterFilePath: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(json|yml|yaml)$',
@@ -141,6 +143,12 @@ export const validationMessages = {
     minlength: 'Workflow Path is too short. (Min. 3 characters.)',
     maxlength: 'Workflow Path is too long. (Max 256 characters.)',
     pattern: `Must begin with '/' and end with '*.cwl', '*.yml', '*.yaml', '*.config', or'*.wdl' ` + 'depending on the descriptor type.'
+  },
+  service_path: {
+    required: 'This field cannot be empty.',
+    minlength: 'Workflow Path is too short. (Min. 3 characters.)',
+    maxlength: 'Workflow Path is too long. (Max 256 characters.)',
+    pattern: `Must begin with '.' and end with '*.yml' `
   },
   repository: {
     maxlength: 'Repository Name is too long. (Max 256 characters.)',

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -13,7 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<h4 mat-dialog-title>{{ isPublic || !canWrite ? 'View' : 'Edit' }} Version Tag</h4>
+<h4 mat-dialog-title>{{ isPublic || !canWrite ? 'View' : 'Edit' }} {{ (isService$ | async) ? 'Service Version' : 'Version Tag' }}</h4>
 <div mat-dialog-content>
   <app-alert></app-alert>
   <fieldset [disabled]="!canWrite || isPublic">

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -35,17 +35,17 @@
         </div>
         <div class="form-group form-group-sm">
           <label class="col-sm-3 col-md-3 col-lg-3 control-label">
-            Workflow Path:
+            {{ (isService$ | async) ? 'Service Path:' : 'Workflow Path:' }}
           </label>
           <div class="col-sm-9 col-md-9 col-lg-9">
             <input
               type="text"
               class="form-control"
-              name="workflow_path"
+              name="{{ (isService$ | async) ? 'service_path' : 'workflow_path' }}"
               [(ngModel)]="version.workflow_path"
               minlength="3"
               maxlength="128"
-              [pattern]="validationPatterns.workflowDescriptorPath"
+              [pattern]="(isService$ | async) ? validationPatterns.serviceDescriptorPath : validationPatterns.workflowDescriptorPath"
               required
               [matTooltip]="tooltip.workflowPath"
               placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"
@@ -56,7 +56,11 @@
             </mat-card>
           </div>
         </div>
-        <div class="form-group form-group-sm" *ngIf="(descriptorType$ | async) !== ToolDescriptor.TypeEnum.NFL">
+        <div
+          class="form-group form-group-sm"
+          [hidden]="isService$ | async"
+          *ngIf="(descriptorType$ | async) !== ToolDescriptor.TypeEnum.NFL"
+        >
           <label class="col-sm-3 col-md-3 col-lg-3 control-label">
             Test Parameter File(s):
           </label>
@@ -155,13 +159,7 @@
           <div class="col-sm-9 col-md-9 col-lg-9">
             <div>
               <label>
-                <input
-                  type="checkbox"
-                  name="checkbox"
-                  [(ngModel)]="version.hidden"
-                  matTooltip="Hide tag from public view."
-                  [disabled]="isService$ | async"
-                />
+                <input type="checkbox" name="checkbox" [(ngModel)]="version.hidden" matTooltip="Hide tag from public view." />
               </label>
             </div>
           </div>

--- a/src/app/workflow/view/view.component.html
+++ b/src/app/workflow/view/view.component.html
@@ -15,7 +15,7 @@
   -->
 
 <button type="button" mat-button color="accent" class="btn-block" (click)="showVersionModal()">
-  {{ isPublic || !canWrite || (entryType$ | async) === EntryType.Service ? 'View' : 'Edit' }}
+  {{ isPublic || !canWrite ? 'View' : 'Edit' }}
 </button>
 <ng-container *ngIf="!isPublic">
   <button


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2755

Requested changes from #2755
1. Changed card title from 'Edit Version Tag' to 'Edit/View Service Version'
2. Make non-editable fields into normal text (remove textbox)
3. Change 'Workflow Path' to 'Service Path'
4. Remove 'test parameter file(s)' field entirely.
5. Make hidden box editable (and work like it does in entries)
6. Change action link text from 'View' to 'Edit'

Added service_path to form validations so now you can make changes and save them (currently only hidden checkbox)

![image](https://user-images.githubusercontent.com/23464754/63475946-d7898180-c433-11e9-9703-2297c45a7970.png)

For now just made changes in existing components (largely grouped with workflows), but we should move services related things to their own places in the future.
