### PR TITLE
add fullscreen overlay so the tooltips for the 2 dag toggles show

### DIFF
--- a/src/app/workflow/dag/dag.module.ts
+++ b/src/app/workflow/dag/dag.module.ts
@@ -22,8 +22,10 @@ import { CustomMaterialModule } from './../../shared/modules/material.module';
 import { CwlViewerComponent } from './cwl-viewer/cwl-viewer.component';
 import { DagComponent } from './dag.component';
 import { WdlViewerComponent } from './wdl-viewer/wdl-viewer.component';
+import { FullscreenOverlayContainer, OverlayContainer } from '@angular/cdk/overlay';
 
 @NgModule({
+  providers: [{ provide: OverlayContainer, useClass: FullscreenOverlayContainer }],
   imports: [CommonModule, FlexLayoutModule, FormsModule, MatIconModule, MatProgressBarModule, MatTooltipModule, CustomMaterialModule],
   declarations: [DagComponent, CwlViewerComponent, WdlViewerComponent],
   exports: [DagComponent]


### PR DESCRIPTION
dockstore/dockstore#1993
I don't think this was being covered by the sidebar anymore? Anyway, fixed the two tooltips not showing in fullscreen mode by adding the overlaycontainer.