### PR TITLE
make my tools panel look like my workflows

### DIFF
--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -41,18 +41,26 @@
         <div id="parent">
           <div id="child">
             <div class="clearfix sidebar-header">
-              <button
-                mat-flat-button
-                color="primary"
-                [matTooltipPosition]="'after'"
-                matTooltip="Find new tools and sync all existing tools"
-                class="pull-right"
-                (click)="refreshAllEntries()"
-                [disabled]="isRefreshing$ | async"
-              >
-                Refresh All
-              </button>
-              <h3 class="sidebar-header">My tools</h3>
+              <mat-toolbar>
+                <mat-toolbar-row>
+                  <div fxLayout="row" fxLayoutAlign="space-between center" class="w-100">
+                    <span>My tools</span>
+                    <span>
+                      <button
+                        mat-button
+                        color="primary"
+                        [matTooltipPosition]="'after'"
+                        matTooltip="Find new tools and sync all existing tools"
+                        class="pull-right"
+                        (click)="refreshAllEntries()"
+                        [disabled]="isRefreshing$ | async"
+                      >
+                        Refresh All
+                      </button>
+                    </span>
+                  </div>
+                </mat-toolbar-row>
+              </mat-toolbar>
             </div>
             <p *ngIf="!groupEntriesObject || !groupEntriesObject.length">You have not registered any tools</p>
             <app-sidebar-accordion


### PR DESCRIPTION
On the My tools page accordion, we simply used a header and a flat button for the title and refresh all. I have changed this to use a mat toolbar and regular button to be consistent with the my workflows page.

![Screenshot from 2019-08-23 11-45-32](https://user-images.githubusercontent.com/6331159/63605261-90b69b80-c59b-11e9-8343-55bf06e6121c.png)
