### PR TITLE
do not say available Tools/Workflows/Services

### DIFF
--- a/cypress/integration/immutableDatabaseTests/services.ts
+++ b/cypress/integration/immutableDatabaseTests/services.ts
@@ -42,14 +42,14 @@ describe('Dockstore Home', () => {
     it('Have one service in /services', () => {
       cy.visit('/services');
       cy.url().should('contain', 'services');
-      cy.get('[data-cy=header]').contains('h3', 'Available Services');
+      cy.get('[data-cy=header]').contains('h3', 'Services');
       cy.contains('Search services');
       cy.contains('garyluu/another-test-service');
     });
     it('Have fake service in /services/{id}', () => {
       cy.visit('/services/github.com/garyluu/another-test-service');
       cy.url().should('contain', '/services/github.com/garyluu/another-test-service');
-      cy.get('[data-cy=header]').contains('h3', 'Available Services');
+      cy.get('[data-cy=header]').contains('h3', 'Services');
       cy.contains('github.com/garyluu/another-test-service:1.3');
       checkTabs();
       checkInfoTab();

--- a/src/app/shared/session/session.query.ts
+++ b/src/app/shared/session/session.query.ts
@@ -28,7 +28,7 @@ import { SessionState, SessionStore } from './session.store';
 export class SessionQuery extends Query<SessionState> {
   isPublic$: Observable<boolean> = this.select(session => session.isPublic);
   entryType$: Observable<EntryType> = this.select(session => session.entryType);
-  entryPageTitle$: Observable<string> = this.entryType$.pipe(map((entryType: EntryType) => 'available ' + entryType + 's'));
+  entryPageTitle$: Observable<string> = this.entryType$.pipe(map((entryType: EntryType) => entryType + 's'));
   myEntryPageTitle$: Observable<string> = this.entryType$.pipe(map((entryType: EntryType) => 'my ' + entryType + 's'));
   isService$: Observable<boolean> = this.entryType$.pipe(map(entryType => entryType === EntryType.Service));
   gitHubAppInstallationLink$: Observable<string> = this.entryType$.pipe(


### PR DESCRIPTION
Do not say `Available Tools/Workflows/Services`, for now just say `Tools/Workflows/Services`.

https://github.com/dockstore/dockstore/issues/2532