### PR TITLE
Fix broken DNAstack icon

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -19,7 +19,7 @@
               [attr.href]="config.DNASTACK_IMPORT_URL + '?descriptorType=wdl&path=' + workflowPathAsQueryValue"
               [disabled]="!(hasContent$ | async)"
               color="primary"
-              ><img src="../../assets/images/thirdparty/dnastack.png" /> DNAstack &raquo;</a
+              ><img src="../assets/images/thirdparty/dnastack.png" /> DNAstack &raquo;</a
             >
           </div>
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">


### PR DESCRIPTION
dockstore/dockstore#2802

For staging/CDN, image paths must start with "../assets" as they
are updated with the CDN absolute url. See .circleci/config.yml.