### PR TITLE
add alertService to register so error messages surface on UI

### DIFF
--- a/src/app/register/register.service.ts
+++ b/src/app/register/register.service.ts
@@ -18,20 +18,24 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AuthService } from 'ng2-ui-auth';
 import { MatSnackBar } from '@angular/material';
+import { AlertService } from '../shared/alert/state/alert.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable()
 export class RegisterService {
-  constructor(private auth: AuthService, private matSnackBar: MatSnackBar) {}
+  constructor(private auth: AuthService, private matSnackBar: MatSnackBar, private alertService: AlertService) {}
 
   authenticate(provider: string): Observable<any> {
     return Observable.create(observable => {
+      this.alertService.start('Register');
       return this.auth.authenticate(provider, { register: true }).subscribe(
         user => {
+          this.alertService.simpleSuccess();
           observable.next(user);
           observable.complete();
         },
-        error => {
-          this.matSnackBar.open(error._body, 'Dismiss');
+        (error: HttpErrorResponse) => {
+          this.alertService.detailedError(error);
         }
       );
     });


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2519

We already catch the error in the webservice, it just wasn't surfacing in the UI.

Pretty much identical solution to #629. Added alertService to register.service so error message displays correctly.
![image](https://user-images.githubusercontent.com/23464754/63722177-7f71c700-c807-11e9-9802-4f7f09912619.png)
