### PR TITLE
Feature/2376/verified facet

### DIFF
--- a/src/app/search/basic-search/basic-search.component.scss
+++ b/src/app/search/basic-search/basic-search.component.scss
@@ -1,0 +1,5 @@
+// Overriding the border added in the style.scss because we're using material now
+input[type='text']:focus,
+textarea:focus {
+  border: none;
+}

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -26,7 +26,6 @@ export class MapFriendlyValuesPipe implements PipeTransform {
    * @memberof MapFriendlyValuesPipe
    */
   readonly friendlyValueNames = new Map([
-    ['workflowVersions.verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
     ['has_checker', new Map([['1', 'has a checker workflow'], ['0', 'unchecked workflow']])],
     ['verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
     ['private_access', new Map([['1', 'private'], ['0', 'public']])],
@@ -60,7 +59,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         [ToolFile.FileTypeEnum.CONTAINERFILE, 'Dockerfile'],
         [ToolFile.FileTypeEnum.OTHER, 'Files']
       ])
-    ]
+    ],
+    ['workflowVersions.verifiedSource.keyword', new Map([['[]', 'None']])]
   ]);
 
   /**

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -28,7 +28,7 @@ export class MapFriendlyValuesPipe implements PipeTransform {
   readonly friendlyValueNames = new Map([
     ['workflowVersions.verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
     ['has_checker', new Map([['1', 'has a checker workflow'], ['0', 'unchecked workflow']])],
-    ['tags.verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
+    ['verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
     ['private_access', new Map([['1', 'private'], ['0', 'public']])],
     ['descriptorType', new Map([['cwl', 'CWL'], ['wdl', 'WDL'], ['nfl', 'Nextflow'], ['NFL', 'Nextflow']])],
     [

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -16,7 +16,6 @@
 
 import { Injectable } from '@angular/core';
 import * as bodybuilder from 'bodybuilder';
-
 import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
 import { SearchService } from './state/search.service';
 
@@ -111,46 +110,6 @@ export class QueryBuilderService {
     return tableQuery;
   }
 
-  getNonVerifiedQuery(
-    query_size: number,
-    values: string,
-    advancedSearchObject: AdvancedSearchObject,
-    searchTerm: boolean,
-    filters: any
-  ): string {
-    let bodyNotVerified = bodybuilder().size(query_size);
-    bodyNotVerified = this.excludeContent(bodyNotVerified);
-    bodyNotVerified = this.appendQuery(bodyNotVerified, values, advancedSearchObject, searchTerm);
-    let key = 'tags.verified';
-    bodyNotVerified = bodyNotVerified.notFilter('term', key, true);
-    key = 'workflowVersions.verified';
-    bodyNotVerified = bodyNotVerified.notFilter('term', key, true);
-    bodyNotVerified = this.appendFilter(bodyNotVerified, null, filters);
-    const builtBodyNotVerified = bodyNotVerified.build();
-    const queryBodyNotVerified = JSON.stringify(builtBodyNotVerified);
-    return queryBodyNotVerified;
-  }
-
-  getVerifiedQuery(
-    query_size: number,
-    values: string,
-    advancedSearchObject: AdvancedSearchObject,
-    searchTerm: boolean,
-    filters: any
-  ): string {
-    let bodyNotVerified = bodybuilder().size(query_size);
-    bodyNotVerified = this.excludeContent(bodyNotVerified);
-    bodyNotVerified = this.appendQuery(bodyNotVerified, values, advancedSearchObject, searchTerm);
-    let key = 'tags.verified';
-    bodyNotVerified = bodyNotVerified.orFilter('term', key, true);
-    key = 'workflowVersions.verified';
-    bodyNotVerified = bodyNotVerified.orFilter('term', key, true);
-    bodyNotVerified = this.appendFilter(bodyNotVerified, null, filters);
-    const builtBodyNotVerified = bodyNotVerified.build();
-    const queryBodyNotVerified = JSON.stringify(builtBodyNotVerified);
-    return queryBodyNotVerified;
-  }
-
   /**===============================================
    *                Append Functions
    * ==============================================
@@ -174,11 +133,11 @@ export class QueryBuilderService {
             body = body.orFilter('term', key, insideFilter);
           } else {
             // A non-verified tool means a tool that isn't verified and a workflow that is not verified a
-            if (key === 'tags.verified' && insideFilter === '0') {
-              body = body.notFilter('term', 'tags.verified', '1');
+            if (key === 'verified' && insideFilter === '0') {
+              body = body.notFilter('term', 'verified', '1');
               body = body.notFilter('term', 'workflowVersions.verified', '1');
-            } else if (key === 'tags.verified' && insideFilter === '1') {
-              body = body.orFilter('term', 'tags.verified', insideFilter);
+            } else if (key === 'verified' && insideFilter === '1') {
+              body = body.orFilter('term', 'verified', insideFilter);
               body = body.orFilter('term', 'workflowVersions.verified', insideFilter);
             } else {
               body = body.filter('term', key, insideFilter);

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -29,9 +29,9 @@ import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
 
 /**
- * There are a total of 6 calls per search.
+ * There are a total of 5 calls per search.
  * 2 calls are from the tag cloud (1 for tool, 1 for workflow)
- * 2 calls are for the sidebar bucket count (1 for all non-verified bucket count, 1 specifically for verified)
+ * 1 calls are for the sidebar bucket count
  * 1 call for the autocomplete
  * 1 call for the actual results
  *
@@ -93,8 +93,6 @@ export class SearchComponent implements OnInit, OnDestroy {
   private bucketStubs: Map<string, string>;
   public friendlyNames: Map<string, string>;
   private entryOrder: Map<string, SubBucket>;
-  private nonVerifiedCount: number;
-  private verifiedCount: number;
 
   private advancedSearchOptions = ['ANDSplitFilter', 'ANDNoSplitFilter', 'ORFilter', 'NOTFilter', 'searchMode', 'toAdvanceSearch'];
 

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -363,7 +363,6 @@ export class SearchService {
       ['Author', 'author'],
       ['Namespace', 'namespace'],
       ['Labels', 'labels.value.keyword'],
-      ['VerifiedSourceTool', 'tags.verifiedSource'],
       ['VerifiedSourceWorkflow', 'workflowVersions.verifiedSource.keyword'],
       ['HasCheckerWorkflow', 'has_checker'],
       ['Organization', 'organization']
@@ -381,10 +380,9 @@ export class SearchService {
       ['author', 'Author'],
       ['namespace', 'Tool: Namespace'],
       ['labels.value.keyword', 'Labels'],
-      ['tags.verifiedSource', 'Tool: Verified Source'],
       ['input_file_formats.value.keyword', 'Input File Formats'],
       ['output_file_formats.value.keyword', 'Output File Formats'],
-      ['workflowVersions.verifiedSource.keyword', 'Workflow: Verified Source'],
+      ['workflowVersions.verifiedSource.keyword', 'Verified Source'],
       ['has_checker', 'Has Checker Workflows'],
       ['organization', 'Workflow: Organization']
     ]);
@@ -402,7 +400,6 @@ export class SearchService {
       ['labels.value.keyword', new SubBucket()],
       ['private_access', new SubBucket()],
       ['verified', new SubBucket()],
-      ['tags.verifiedSource', new SubBucket()],
       ['workflowVersions.verifiedSource.keyword', new SubBucket()],
       ['input_file_formats.value.keyword', new SubBucket()],
       ['output_file_formats.value.keyword', new SubBucket()],

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -15,14 +15,14 @@
  */
 import { Injectable } from '@angular/core';
 import { URLSearchParams } from '@angular/http';
-import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router/';
+import { BehaviorSubject } from 'rxjs';
 import { Dockstore } from '../../shared/dockstore.model';
 import { SubBucket } from '../../shared/models/SubBucket';
-import { SearchStore } from './search.store';
-import { SearchQuery } from './search.query';
 import { ProviderService } from '../../shared/provider.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
+import { SearchQuery } from './search.query';
+import { SearchStore } from './search.store';
 
 @Injectable()
 export class SearchService {
@@ -38,7 +38,7 @@ export class SearchService {
    * @private
    * @memberof SearchService
    */
-  public exclusiveFilters = ['tags.verified', 'private_access', '_type', 'has_checker'];
+  public exclusiveFilters = ['verified', 'private_access', '_type', 'has_checker'];
 
   constructor(
     private searchStore: SearchStore,
@@ -359,7 +359,7 @@ export class SearchService {
       ['Input File Formats', 'input_file_formats.value.keyword'],
       ['Output File Formats', 'output_file_formats.value.keyword'],
       ['Private Access', 'private_access'],
-      ['VerifiedTool', 'tags.verified'],
+      ['VerifiedTool', 'verified'],
       ['Author', 'author'],
       ['Namespace', 'namespace'],
       ['Labels', 'labels.value.keyword'],
@@ -377,7 +377,7 @@ export class SearchService {
       ['registry', 'Tool: Registry'],
       ['source_control_provider.keyword', 'Workflow: Source Control'],
       ['private_access', 'Tool: Private Access'], // Workflow has no counterpart
-      ['tags.verified', 'Verified'],
+      ['verified', 'Verified'],
       ['author', 'Author'],
       ['namespace', 'Tool: Namespace'],
       ['labels.value.keyword', 'Labels'],
@@ -401,7 +401,7 @@ export class SearchService {
       ['organization', new SubBucket()],
       ['labels.value.keyword', new SubBucket()],
       ['private_access', new SubBucket()],
-      ['tags.verified', new SubBucket()],
+      ['verified', new SubBucket()],
       ['tags.verifiedSource', new SubBucket()],
       ['workflowVersions.verifiedSource.keyword', new SubBucket()],
       ['input_file_formats.value.keyword', new SubBucket()],

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -158,7 +158,7 @@ export class SearchStubService {
       ['Entry Type', '_type'],
       ['Registry', 'registry'],
       ['Private Access', 'private_access'],
-      ['Verified', 'tags.verified'],
+      ['Verified', 'verified'],
       ['Author', 'author'],
       ['Organization', 'namespace'],
       ['Labels', 'labels.value.keyword'],
@@ -179,7 +179,7 @@ export class SearchStubService {
       ['_type', 'Entry Type'],
       ['registry', 'Registry'],
       ['private_access', 'Private Access'],
-      ['tags.verified', 'Verified'],
+      ['verified', 'Verified'],
       ['author', 'Author'],
       ['namespace', 'Organization'],
       ['labels.value.keyword', 'Labels'],
@@ -195,14 +195,14 @@ export class SearchStubService {
       ['namespace', new SubBucket()],
       ['labels.value.keyword', new SubBucket()],
       ['private_access', new SubBucket()],
-      ['tags.verified', new SubBucket()],
+      ['verified', new SubBucket()],
       ['tags.verifiedSource', new SubBucket()]
     ]);
   }
 
   initializeFriendlyValueNames() {
     return new Map([
-      ['tags.verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
+      ['verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
       ['private_access', new Map([['1', 'private'], ['0', 'public']])],
       ['registry', new Map([['QUAY_IO', 'Quay.io'], ['DOCKER_HUB', 'Docker Hub'], ['GITLAB', 'GitLab'], ['AMAZON_ECR', 'Amazon ECR']])]
     ]);

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -162,7 +162,7 @@ export class SearchStubService {
       ['Author', 'author'],
       ['Organization', 'namespace'],
       ['Labels', 'labels.value.keyword'],
-      ['Verified Source', 'tags.verifiedSource']
+      ['Verified Source', 'verifiedSource']
     ]);
   }
 
@@ -183,7 +183,7 @@ export class SearchStubService {
       ['author', 'Author'],
       ['namespace', 'Organization'],
       ['labels.value.keyword', 'Labels'],
-      ['tags.verifiedSource', 'Verified Source']
+      ['verifiedSource', 'Verified Source']
     ]);
   }
 
@@ -196,7 +196,7 @@ export class SearchStubService {
       ['labels.value.keyword', new SubBucket()],
       ['private_access', new SubBucket()],
       ['verified', new SubBucket()],
-      ['tags.verifiedSource', new SubBucket()]
+      ['verifiedSource', new SubBucket()]
     ]);
   }
 


### PR DESCRIPTION
For dockstore/dockstore#2376

Requires a webservice counterpart.  Fixes it by making the index cleaner (as opposed to UI2 shenanigans) by appending the calculated verification property during index creation.  Ends up removing 2 elasticsearch queries per search.

Each search used to be: 
- 1 for table results
- 1 for sidebar results
- 1 for verified bucket sidebar override
- 1 for non-verified bucket sidebar override
- 1 for auto-complete. 

Now it is:
- 1 for table results
- 1 for sidebar results
- 1 for auto-complete

Also for dockstore/dockstore#2804