### PR TITLE
add snack bar error alerts to link accounts page

### DIFF
--- a/src/app/loginComponents/auth/auth.component.spec.ts
+++ b/src/app/loginComponents/auth/auth.component.spec.ts
@@ -5,6 +5,7 @@ import { UserService } from '../../shared/user/user.service';
 import { TokenStubService, UserStubService } from '../../test/service-stubs';
 import { AuthComponent } from './auth.component';
 import { TokenService } from '../../shared/state/token.service';
+import { MatSnackBarModule } from '@angular/material';
 
 describe('AuthComponent', () => {
   let component: AuthComponent;
@@ -13,7 +14,7 @@ describe('AuthComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AuthComponent],
-      imports: [RouterTestingModule.withRoutes([{ path: '**', component: AuthComponent }])],
+      imports: [RouterTestingModule.withRoutes([{ path: '**', component: AuthComponent }]), MatSnackBarModule],
       providers: [{ provide: UserService, useClass: UserStubService }, { provide: TokenService, useClass: TokenStubService }]
     }).compileComponents();
   }));

--- a/src/app/loginComponents/auth/auth.component.ts
+++ b/src/app/loginComponents/auth/auth.component.ts
@@ -7,6 +7,7 @@ import { Base } from '../../shared/base';
 import { Provider } from '../../shared/enum/provider.enum';
 import { TokenService } from '../../shared/state/token.service';
 import { UserService } from '../../shared/user/user.service';
+import { AlertService } from '../../shared/alert/state/alert.service';
 
 @Component({
   selector: 'app-auth',
@@ -17,7 +18,8 @@ export class AuthComponent extends Base implements OnInit {
     private tokenService: TokenService,
     private userService: UserService,
     private activatedRoute: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private alertService: AlertService
   ) {
     super();
   }
@@ -82,6 +84,7 @@ export class AuthComponent extends Base implements OnInit {
         },
         error => {
           this.router.navigate([`${prevPage}`]);
+          this.alertService.detailedSnackBarError(error);
         }
       );
   }


### PR DESCRIPTION
dockstore/dockstore#1747
It ended up being that the errors were being suppressed because other functions in `requests.service.ts`, like `updateMyMemberships()`, were setting the state to info/clearing the errors and we only store one thing at a time.
Using the detailed matsnackbar as a workaround, but does disappear after a couple of secs.
![image](https://user-images.githubusercontent.com/16004905/63899465-d87d5e80-c9b1-11e9-8cf6-29b0482fad7e.png)
