### PR TITLE
Feature/2308/refresh

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.css
+++ b/src/app/loginComponents/accounts/external/accounts.component.css
@@ -12,7 +12,3 @@
 mat-card-footer {
   padding: 24px;
 }
-
-.relink {
-  margin-right: 5px;
-}

--- a/src/app/loginComponents/accounts/external/accounts.component.css
+++ b/src/app/loginComponents/accounts/external/accounts.component.css
@@ -12,3 +12,7 @@
 mat-card-footer {
   padding: 24px;
 }
+
+.relink {
+  margin-right: 5px;
+}

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -58,6 +58,7 @@
     </div>
     <div>
       {{ row.message }}
+      <span *ngIf="row.isLinked">If your token has expired, relink your account.</span>
     </div>
     <div>
       {{ row.bold }}
@@ -85,10 +86,21 @@
       <span *ngIf="row.isLinked; else notLinked" class="pull-right">
         <span class="mr-2">Username: {{ row.source | getTokenUsername: tokens }}</span>
         <button
+          class="relink"
+          mat-raised-button
+          color="primary"
+          [attr.id]="'relink-' + row.name"
+          (click)="relink(row.source)"
+          matTooltip="Relink the account"
+        >
+          <mat-icon>link</mat-icon>
+          <span>Relink Account</span>
+        </button>
+        <button
           mat-raised-button
           color="primary"
           [attr.id]="'unlink-' + row.name"
-          (click)="unlink(row.source)"
+          (click)="link(row.source)"
           matTooltip="Unlink the account"
         >
           <mat-icon>link_off</mat-icon>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -86,7 +86,7 @@
       <span *ngIf="row.isLinked; else notLinked" class="pull-right">
         <span class="mr-2">Username: {{ row.source | getTokenUsername: tokens }}</span>
         <button
-          class="relink"
+          class="mr-2"
           mat-raised-button
           color="primary"
           [attr.id]="'relink-' + row.name"

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -100,7 +100,7 @@
           mat-raised-button
           color="primary"
           [attr.id]="'unlink-' + row.name"
-          (click)="link(row.source)"
+          (click)="unlink(row.source)"
           matTooltip="Unlink the account"
         >
           <mat-icon>link_off</mat-icon>

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -130,7 +130,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
           this.matSnackBar.open('Failed to relink ' + source + ' account', 'Dismiss');
         }
       );
-    this.link(source);
   }
 
   link(source: string): void {

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -44,14 +44,14 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
       name: 'GitHub',
       source: TokenSource.GITHUB,
       bold: 'One of GitHub or Google is required.',
-      message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub',
+      message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub.',
       show: false
     },
     {
       name: 'Google',
       source: TokenSource.GOOGLE,
       bold: 'One of GitHub or Google is required.',
-      message: 'Google credentials are used for login purposes and integration with FireCloud.',
+      message: 'Google credentials are used for login purposes and integration with Terra.',
       show: false
     },
     {
@@ -117,6 +117,20 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
         return this.tokenService.deleteToken(token.id);
       }
     }
+  }
+
+  relink(source: string): void {
+    this.deleteToken(source)
+      .pipe(first())
+      .subscribe(
+        () => {
+          this.link(source);
+        },
+        error => {
+          this.matSnackBar.open('Failed to relink ' + source + ' account', 'Dismiss');
+        }
+      );
+    this.link(source);
   }
 
   link(source: string): void {

--- a/src/app/workflow/permissions/permissions.component.html
+++ b/src/app/workflow/permissions/permissions.component.html
@@ -7,7 +7,7 @@
     During the limited beta of sharing functionality, your Google account must also be registered with
     <a [href]="terraUrl" target="_blank">Terra</a>.
   </p>
-  <p>Any emails that you share the workflow with must also be registered with FireCloud.</p>
+  <p>Any emails that you share the workflow with must also be registered with Terra.</p>
 </div>
 <div *ngIf="hasGoogleAccount">
   <div *ngIf="!canViewPermissions">


### PR DESCRIPTION
Add relink buttons to accounts page, along with some text.

dockstore/dockstore#2308

Also renamed a couple of dangling references from FireCloud to Terra, and a missing period.

![Screen Shot 2019-08-28 at 3 46 54 PM](https://user-images.githubusercontent.com/1049340/63961473-bc2b0180-ca45-11e9-8be8-0c3a445d2338.png)
