### PR TITLE
Feature/2813/tooltip workflow mode

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -51,6 +51,11 @@ describe('Dockstore my workflows', () => {
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore.cwl');
     });
+    it('should have mode tooltip', () => {
+      // .trigger('mouseover') doesn't work for some reason
+      cy.contains('Mode').trigger('mouseenter');
+      cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
+    });
     it('add and remove test parameter file', () => {
       cy.visit('/my-workflows/github.com/A/l');
       cy.contains('Versions').click();

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -120,10 +120,7 @@
             <strong matTooltip="Currently disabled for Hosted Workflows and Nextflow Workflows">Checker Workflow</strong>: n/a
           </div>
           <li *ngIf="!isPublic">
-            <ng-template #modeTooltip>
-              <div [innerHtml]="modeTooltipContent"></div>
-            </ng-template>
-            <strong [matTooltip]="modeTooltip">Mode</strong>: {{ workflow?.mode }}
+            <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ workflow?.mode }}
             <button
               class="btn btn-link push-right"
               type="button"

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -64,9 +64,9 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   ToolDescriptor = ToolDescriptor;
   public entryType$: Observable<EntryType>;
   public isRefreshing$: Observable<boolean>;
-  modeTooltipContent = `<b>STUB:</b> Basic metadata pulled from source control.<br />
-  <b>FULL:</b> Full content synced from source control.<br />
-  <b>HOSTED:</b> Workflow metadata and files hosted on Dockstore.`;
+  modeTooltipContent = `STUB: Basic metadata pulled from source control.
+  FULL: Full content synced from source control.
+  HOSTED: Workflow metadata and files hosted on Dockstore.`;
   constructor(
     private workflowService: WorkflowService,
     private workflowsService: ExtendedWorkflowsService,


### PR DESCRIPTION
For dockstore/dockstore#2813

Fixes the tooltip for the build mode.  Removed the bolding because tooltips are supposed to be plain.

Side note: Material recommends short tooltips
