### PR TITLE
Detect http(s) imports in CWL

### DIFF
--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -20,10 +20,12 @@ import {
   cwlSourceFileWithIncludeImport,
   cwlSourceFileWithMixinImport,
   cwlSourceFileWithNoImport,
+  cwlSourceFileWithSomeHttpLinks,
   emptyWdlSourceFile,
   sampleSourceFile,
   sampleTag,
   wdlSourceFile,
+  wdlSourceFileWithCommentedHttpImport,
   wdlSourceFileWithHttpImport
 } from '../test/mocked-objects';
 import { ga4ghPath } from './constants';
@@ -62,6 +64,7 @@ describe('FileService', () => {
 
   it('should detect http import in WDL', inject([FileService], (fileService: FileService) => {
     expect(fileService.hasHttpImport(wdlSourceFileWithHttpImport)).toBeTruthy();
+    expect(fileService.hasHttpImport(wdlSourceFileWithCommentedHttpImport)).toBeFalsy();
     expect(fileService.hasHttpImport(emptyWdlSourceFile)).toBeFalsy();
     expect(fileService.hasHttpImport(wdlSourceFile)).toBeFalsy();
   }));
@@ -72,5 +75,6 @@ describe('FileService', () => {
     expect(fileService.hasHttpImport(cwlSourceFileWithMixinImport)).toBeTruthy();
     expect(fileService.hasHttpImport(cwlSourceFileWithCommentedMixinImport)).toBeFalsy();
     expect(fileService.hasHttpImport(cwlSourceFileWithIncludeImport)).toBeTruthy();
+    expect(fileService.hasHttpImport(cwlSourceFileWithSomeHttpLinks)).toBeFalsy();
   }));
 });

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -14,7 +14,18 @@
  *    limitations under the License.
  */
 import { inject, TestBed } from '@angular/core/testing';
-import { sampleSourceFile, sampleTag } from '../test/mocked-objects';
+import {
+  cwlSourceFileWithCommentedMixinImport,
+  cwlSourceFileWithHttpsImport,
+  cwlSourceFileWithIncludeImport,
+  cwlSourceFileWithMixinImport,
+  cwlSourceFileWithNoImport,
+  emptyWdlSourceFile,
+  sampleSourceFile,
+  sampleTag,
+  wdlSourceFile,
+  wdlSourceFileWithHttpImport
+} from '../test/mocked-objects';
 import { ga4ghPath } from './constants';
 import { Dockstore } from './dockstore.model';
 import { FileService } from './file.service';
@@ -47,5 +58,19 @@ describe('FileService', () => {
         // tslint:disable-next-line: max-line-length
         '/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN-WDL/descriptor/HISAT2.wdl'
     );
+  }));
+
+  it('should detect http import in WDL', inject([FileService], (fileService: FileService) => {
+    expect(fileService.hasHttpImport(wdlSourceFileWithHttpImport)).toBeTruthy();
+    expect(fileService.hasHttpImport(emptyWdlSourceFile)).toBeFalsy();
+    expect(fileService.hasHttpImport(wdlSourceFile)).toBeFalsy();
+  }));
+
+  it('should detect http import in CWL', inject([FileService], (fileService: FileService) => {
+    expect(fileService.hasHttpImport(cwlSourceFileWithNoImport)).toBeFalsy();
+    expect(fileService.hasHttpImport(cwlSourceFileWithHttpsImport)).toBeTruthy();
+    expect(fileService.hasHttpImport(cwlSourceFileWithMixinImport)).toBeTruthy();
+    expect(fileService.hasHttpImport(cwlSourceFileWithCommentedMixinImport)).toBeFalsy();
+    expect(fileService.hasHttpImport(cwlSourceFileWithIncludeImport)).toBeTruthy();
   }));
 });

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -20,6 +20,9 @@ import { DescriptorTypeCompatService } from './descriptor-type-compat.service';
 import { Dockstore } from './dockstore.model';
 import { SourceFile, Tag, ToolDescriptor, WorkflowVersion } from './swagger';
 
+const wdlImportHttpRegEx: RegExp = new RegExp(/^\s*import\s+"?https?/, 'm');
+const cwlImportHttpRegEx: RegExp = new RegExp(/^[^#]+\$((import)|(include)|(mixin))\s*:\s+\"?https?/, 'm');
+
 @Injectable({ providedIn: 'root' })
 export class FileService {
   constructor(private sanitizer: DomSanitizer, private descriptorTypeCompatService: DescriptorTypeCompatService) {}
@@ -115,5 +118,16 @@ export class FileService {
     } else {
       return null;
     }
+  }
+
+  hasHttpImport(sourceFile: SourceFile): boolean {
+    if (sourceFile) {
+      if (sourceFile.type === SourceFile.TypeEnum.DOCKSTOREWDL) {
+        return wdlImportHttpRegEx.test(sourceFile.content);
+      } else if (sourceFile.type === SourceFile.TypeEnum.DOCKSTORECWL) {
+        return cwlImportHttpRegEx.test(sourceFile.content);
+      }
+    }
+    return false;
   }
 }

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -280,6 +280,99 @@ export const wdlSourceFileWithHttpImport: SourceFile = {
   type: 'DOCKSTORE_WDL'
 };
 
+const cwlWithNoImport = `#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+      type: string
+          inputBinding:
+                position: 1
+                outputs: []
+`;
+
+// Modified from https://www.commonwl.org/user_guide/19-custom-types/
+const cwlWithHttpsImport = `#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+  InlineJavascriptRequirement: {}
+  ResourceRequirement:
+    coresMax: 1
+    ramMin: 100  # just a default, could be lowered
+  SchemaDefRequirement:
+    types:
+      - $import: https://example.com/biom-convert-table.yaml
+`;
+
+// Modified from https://www.biostars.org/p/221902/
+const cwlWithHttpsMixin = `#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  $mixin: https://example.com/input.yaml
+`;
+
+const cwlWithCommentedHttpsMixin = `#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  # $mixin: https://example.com/input.yaml
+`;
+
+// Based on https://github.com/common-workflow-language/common-workflow-language/issues/850#issuecomment-483698263
+const cwlWithHttpsInclude = `#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+content:
+  literal: {$include: "https://example.com/something}
+`;
+
+export const cwlSourceFileWithNoImport: SourceFile = {
+  content: cwlWithNoImport,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
+export const cwlSourceFileWithHttpsImport: SourceFile = {
+  content: cwlWithHttpsImport,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
+export const cwlSourceFileWithMixinImport: SourceFile = {
+  content: cwlWithHttpsMixin,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
+export const cwlSourceFileWithCommentedMixinImport: SourceFile = {
+  content: cwlWithCommentedHttpsMixin,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
+export const cwlSourceFileWithIncludeImport: SourceFile = {
+  content: cwlWithHttpsInclude,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
 export const sampleSourceFile: SourceFile = {
   content: 'potato',
   id: 1,

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -280,6 +280,14 @@ export const wdlSourceFileWithHttpImport: SourceFile = {
   type: 'DOCKSTORE_WDL'
 };
 
+export const wdlSourceFileWithCommentedHttpImport: SourceFile = {
+  content: '#import http://example.com/foo',
+  id: 2,
+  path: '/goo.wdl',
+  absolutePath: '',
+  type: 'DOCKSTORE_WDL'
+};
+
 const cwlWithNoImport = `#!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
@@ -333,6 +341,19 @@ content:
   literal: {$include: "https://example.com/something}
 `;
 
+const cwlWithSomeHttpLinks = `class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  sbg: 'https://sevenbridges.com'
+doc: >-
+  The DELLY workflow from the ICGC PanCancer Analysis of Whole Genomes (PCAWG)
+  project.
+
+  ![pcawg
+  logo](https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/2.0.0/img/PCAWG-final-small.png
+  "pcawg logo")
+`;
+
 export const cwlSourceFileWithNoImport: SourceFile = {
   content: cwlWithNoImport,
   id: 3,
@@ -367,6 +388,14 @@ export const cwlSourceFileWithCommentedMixinImport: SourceFile = {
 
 export const cwlSourceFileWithIncludeImport: SourceFile = {
   content: cwlWithHttpsInclude,
+  id: 3,
+  path: '/fubar.cwl',
+  absolutePath: '',
+  type: 'DOCKSTORE_CWL'
+};
+
+export const cwlSourceFileWithSomeHttpLinks: SourceFile = {
+  content: cwlWithSomeHttpLinks,
   id: 3,
   path: '/fubar.cwl',
   absolutePath: '',

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -53,19 +53,22 @@
             >
           </div>
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'CWL'">
-            <div *ngIf="hasHttpImports$ | async" class="import-warning">
-              Warning: this version of the CWL has http imports, which are not supported by the CGC. Make sure to select a version without http
-              imports in the CGC.
-            </div>
             <a
               mat-raised-button
-              [matTooltip]="!(hasContent$ | async) ? 'The CWL has no content.' : ''"
+              [matTooltip]="
+                !(hasContent$ | async)
+                  ? 'The CWL has no content.'
+                  : (hasHttpImports$ | async)
+                  ? 'This version of the CWL has http imports, which are not supported by the CGC. Select a version without http imports.'
+                  : 'Export this workflow version to the CGC.'
+              "
               target="_blank"
               rel="noopener"
               [attr.href]="config.CGC_IMPORT_URL + '?trs=' + trsUrl"
-              [disabled]="!(hasContent$ | async)"
+              [disabled]="!(hasContent$ | async) || (hasHttpImports$ | async)"
               color="primary"
-              ><img src="../assets/images/thirdparty/cgc.png" /> CGC </a>
+              ><img src="../assets/images/thirdparty/cgc.png" /> CGC
+            </a>
           </div>
         </div>
       </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -55,13 +55,7 @@
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'CWL'">
             <a
               mat-raised-button
-              [matTooltip]="
-                !(hasContent$ | async)
-                  ? 'The CWL has no content.'
-                  : (hasHttpImports$ | async)
-                  ? 'This version of the CWL has http imports, which are not supported by the CGC. Select a version without http imports.'
-                  : 'Export this workflow version to the CGC.'
-              "
+              [matTooltip]="cgcTooltip$ | async"
               target="_blank"
               rel="noopener"
               [attr.href]="config.CGC_IMPORT_URL + '?trs=' + trsUrl"

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -2,18 +2,18 @@ import { HttpUrlEncodingCodec } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { MatIconRegistry } from '@angular/material';
 import { DomSanitizer } from '@angular/platform-browser';
-import { share, takeUntil } from 'rxjs/operators';
+import { map, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
 import { DescriptorTypeCompatService } from '../../shared/descriptor-type-compat.service';
 import { Dockstore } from '../../shared/dockstore.model';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
-import { ToolDescriptor, ToolFile, Workflow, WorkflowVersion } from '../../shared/swagger';
+import { ToolFile, Workflow, WorkflowVersion } from '../../shared/swagger';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { DescriptorsQuery } from './state/descriptors-query';
 import { DescriptorsStore } from './state/descriptors-store.';
 import { DescriptorsService } from './state/descriptors.service';
-
+import { Observable, of as observableOf } from 'rxjs';
 import FileTypeEnum = ToolFile.FileTypeEnum;
 
 // tslint:disable:max-line-length
@@ -145,6 +145,22 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
    * The workflow path encoded for use as a query parameter value.
    */
   workflowPathAsQueryValue: string;
+
+  cgcTooltip$: Observable<string> = this.descriptorsQuery.hasContent$.pipe(
+    map(hasContent => (hasContent ? null : 'The CWL has no content')),
+    mergeMap(msg => {
+      if (msg) {
+        return observableOf(msg);
+      }
+      return this.hasHttpImports$.pipe(
+        map(hasHttpImports =>
+          hasHttpImports
+            ? 'This version of the CWL has http(s) imports, which are not supported by the CGC. Select a version without http(s) imports.'
+            : 'Export this workflow version to the CGC.'
+        )
+      );
+    })
+  );
 
   constructor(
     private workflowsService: WorkflowsService,

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -146,6 +146,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
    */
   workflowPathAsQueryValue: string;
 
+  // Note: intentionally not using this.hasContent$ in the next line, as that does not work
   cgcTooltip$: Observable<string> = this.descriptorsQuery.hasContent$.pipe(
     map(hasContent => (hasContent ? null : 'The CWL has no content')),
     mergeMap(msg => {


### PR DESCRIPTION
dockstore/dockstore#2819

Use regexes to test for CWL http(s) imports, and disable
the CGC button if any are detected.

This is an admittedly crude test, but until dockstore/dockstore#2834,
it should do.

I couldn't find any examples of CWL http imports/mixins/includes, so I deduced them from non-https examples, hopefully correctly.