### PR TITLE
Feature/2793/double click modal

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -118,10 +118,13 @@ describe('Dockstore my workflows', () => {
   describe('Test register workflow form validation', () => {
     it('It should have 3 seperate descriptor path validation patterns', () => {
       cy.visit('/my-workflows');
-      cy
-        .get('#registerWorkflowButton')
+      cy.get('#registerWorkflowButton')
         .should('be.visible')
         .should('be.enabled')
+        .click()
+        .click()
+        .click()
+        .click()
         .click();
       // TODO: Fix this.  When 'Next' is clicked too fast, the next step is empty
       cy.wait(1000);
@@ -170,6 +173,7 @@ describe('Dockstore my workflows', () => {
         .should('be.visible')
         .should('be.enabled')
         .click();
+      cy.get('#closeRegisterWorkflowModalButton').should('not.be.visible');
     });
   });
 

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -121,11 +121,9 @@ describe('Dockstore my workflows', () => {
       cy.get('#registerWorkflowButton')
         .should('be.visible')
         .should('be.enabled')
-        .click()
-        .click()
-        .click()
-        .click()
         .click();
+      cy.get('#registerWorkflowButton')
+        .should('not.be.visible');
       // TODO: Fix this.  When 'Next' is clicked too fast, the next step is empty
       cy.wait(1000);
       cy

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -795,7 +795,8 @@ mat-panel-title.org-accordion-header {
   position: fixed !important;
   bottom: 30px;
   right: 30px;
-  z-index: 99999;
+  // Material dialog is observed to be z-index 1000. This goes underneath it
+  z-index: 980;
 }
 
 .spacer {


### PR DESCRIPTION
For dockstore/dockstore#2793

Original PR prevented opening modal again when clicked multiple times. That solution worked but the main issue is that the button was visible and clickable even when the modal was opened. 

The current solution is to fix the z-index so that the modal will always be on top of it.  The resulting functionality is that trying to click the button again (not really visible) will close the original modal.

Bootstrap uses the following z-index:
```
$zindex-dropdown:          1000 !default;
$zindex-sticky:            1020 !default;
$zindex-fixed:             1030 !default;
$zindex-modal-backdrop:    1040 !default;
$zindex-modal:             1050 !default;
$zindex-popover:           1060 !default;
$zindex-tooltip:           1070 !default;
```
But because we use material, the modal's z-index appears to be 1000 instead of 1050. The button should've been `$zindex-fixed:             1030 !default;` if using bootstrap. So in our case, I am merely reducing it by 20 instead (which is why it's 980).
