### PR TITLE
Turn back on tests for snapshotting

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -75,7 +75,7 @@ describe('Dockstore my workflows', () => {
       cy.visit('/my-workflows/github.com/A/l');
       cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
       goToTab('Versions');
-      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+      //cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
 
       cy.get('[data-cy=dockstore-snapshot-unlocked]')
         .its('length')
@@ -84,6 +84,8 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=dockstore-snapshot]')
         .first()
         .click();
+
+      cy.get('[data-cy=confirm-dialog-button]').click();
 
       cy.wait(250);
       cy.get('[data-cy=dockstore-snapshot-locked').should('have.length', 1);

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -70,24 +70,24 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=save-version').click();
       cy.get('[data-cy=save-version').should('not.be.visible');
     });
-    // TODO turn back on
-    // it('Should be able to snapshot', () => {
-    //   cy.visit('/my-workflows/github.com/A/l');
-    //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-    //   goToTab('Versions');
-    //   cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
-    //
-    //   cy.get('[data-cy=dockstore-snapshot-unlocked]')
-    //     .its('length')
-    //     .should('be.gt', 0);
-    //
-    //   cy.get('[data-cy=dockstore-snapshot]')
-    //     .first()
-    //     .click();
-    //
-    //   cy.wait(250);
-    //   cy.get('[data-cy=dockstore-snapshot-locked').should('have.length', 1);
-    // });
+
+    it('Should be able to snapshot', () => {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+      goToTab('Versions');
+      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+
+      cy.get('[data-cy=dockstore-snapshot-unlocked]')
+        .its('length')
+        .should('be.gt', 0);
+
+      cy.get('[data-cy=dockstore-snapshot]')
+        .first()
+        .click();
+
+      cy.wait(250);
+      cy.get('[data-cy=dockstore-snapshot-locked').should('have.length', 1);
+    });
   });
 
   describe('Look at an invalid workflow', () => {

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -75,7 +75,7 @@ describe('Dockstore my workflows', () => {
       cy.visit('/my-workflows/github.com/A/l');
       cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
       goToTab('Versions');
-      //cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
 
       cy.get('[data-cy=dockstore-snapshot-unlocked]')
         .its('length')

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -72,8 +72,7 @@ describe('Dockstore Workflow Details', () => {
     cy.get('[data-cy=dockstore-snapshot-unlocked]')
       .its('length')
       .should('be.gt', 0);
-        cy.get('[data-cy=dockstore-snapshot]')
-          .should('not.be.visible');
+
    });
 
   describe('Change tab to files', () => {

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -67,8 +67,8 @@ describe('Dockstore Workflow Details', () => {
       .get('tbody>tr')
       .should('have.length', 1); // 1 Version and no warning line
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=versions');
-    // Buttons to create snapshots are visible
-    cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
+    // Buttons to create snapshots are hidden on public
+    cy.get('[data-cy=dockstore-snapshot]').should('not.be.visible');
     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
 
     cy.get('[data-cy=dockstore-snapshot-unlocked]')

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -61,12 +61,14 @@ describe('Dockstore Workflow Details', () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=launch');
   });
 
-  it('Change tab to versions and not see snapshot', () => {
+  it('Change tab to versions and not see snapshotted version', () => {
     goToTab('Versions');
     cy
       .get('tbody>tr')
       .should('have.length', 1); // 1 Version and no warning line
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=versions');
+    // Buttons to create snapshots are visible
+    cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
 
     cy.get('[data-cy=dockstore-snapshot-unlocked]')

--- a/src/app/workflow/view/view.component.ts
+++ b/src/app/workflow/view/view.component.ts
@@ -18,7 +18,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { EntryType } from 'app/shared/enum/entry-type';
 import { BioWorkflow } from 'app/shared/swagger/model/bioWorkflow';
-import { WorkflowVersion } from 'app/shared/swagger/model/workflowVersion';
 import { Service } from 'app/shared/swagger/model/service';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -95,34 +94,6 @@ export class ViewWorkflowComponent extends View implements OnInit {
       width: '600px',
       data: { canRead: this.canRead, canWrite: this.canWrite, isOwner: this.isOwner }
     });
-  }
-
-  /**
-   * Updates the workflow version and alerts the Dockstore User with success
-   * or failure.
-   *
-   * @private
-   * @memberof ViewWorkflowComponent
-   */
-  private updateWorkflowToSnapshot(version): void {
-    // Clear sourcefiles to shrink version
-    version.sourceFiles = [];
-
-    this.workflowsService.updateWorkflowVersion(this.workflow.id, [version]).subscribe(
-      workflowVersions => {
-        this.alertService.detailedSuccess('Snapshot successfully created!');
-        const workflow = { ...this.workflowQuery.getActive() };
-        workflow.workflowVersions = workflowVersions;
-        this.workflowService.setWorkflow(workflow);
-      },
-      error => {
-        if (error) {
-          this.alertService.detailedError(error);
-        } else {
-          this.alertService.simpleError();
-        }
-      }
-    );
   }
 
   /**

--- a/src/app/workflow/view/view.service.ts
+++ b/src/app/workflow/view/view.service.ts
@@ -17,12 +17,10 @@ import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatDialog } from '@angular/material';
 import { BehaviorSubject, Observable, of as observableOf, Subject } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { RefreshService } from '../../shared/refresh.service';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
-import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { Workflow, WorkflowVersion } from '../../shared/swagger';
 import { ConfirmationDialogService } from '../../confirmation-dialog/confirmation-dialog.service';
@@ -37,9 +35,7 @@ export class ViewService {
     private confirmationDialogService: ConfirmationDialogService,
     private workflowQuery: WorkflowQuery,
     private workflowService: WorkflowService,
-    private workflowsService: WorkflowsService,
-    private refreshService: RefreshService,
-    private matDialog: MatDialog
+    private workflowsService: WorkflowsService
   ) {}
 
   /**

--- a/src/app/workflow/view/view.service.ts
+++ b/src/app/workflow/view/view.service.ts
@@ -49,7 +49,7 @@ export class ViewService {
     const snapshot: WorkflowVersion = { ...version, frozen: true };
     this.workflowsService.updateWorkflowVersion(workflow.id, [snapshot]).subscribe(
       (workflowVersions: Array<WorkflowVersion>) => {
-        this.alertService.detailedSuccess(`A Snapshot was successfully requested for workflow
+        this.alertService.detailedSuccess(`A snapshot was created for workflow
                                        "${workflow.workflowName}" version "${version.name}"!`);
         const selectedWorkflow = { ...this.workflowQuery.getActive() };
         if (selectedWorkflow.id === workflow.id) {
@@ -134,7 +134,7 @@ export class ViewService {
     if (selectedWorkflow.id === workflow.id) {
       this.workflowService.setWorkflow(workflow);
     }
-    this.alertService.detailedSuccess(`A Digital Object Identifier (DOI) was successfully requested for workflow
+    this.alertService.detailedSuccess(`A Digital Object Identifier (DOI) was created for workflow
                                        "${workflow.workflowName}" version "${version.name}"!`);
   }
 
@@ -156,10 +156,10 @@ export class ViewService {
       confirmationButtonText: 'Snapshot Version',
       cancelButtonText: 'Cancel'
     };
-    this.confirmationDialogService.openDialog(dialogData, bootstrap4mediumModalSize).subscribe((confirmationResult: Boolean) => {
+    this.confirmationDialogService.openDialog(dialogData, bootstrap4mediumModalSize).subscribe((confirmationResult: boolean) => {
       if (confirmationResult) {
         this.updateWorkflowToSnapshot(workflow, version, () => {
-          this.alertService.detailedSuccess(`A Snapshot was successfully requested for workflow
+          this.alertService.detailedSuccess(`A snapshot was created for workflow
                                        "${workflow.workflowName}" version "${version.name}"!`);
         });
       } else {

--- a/src/app/workflow/view/view.service.ts
+++ b/src/app/workflow/view/view.service.ts
@@ -53,10 +53,10 @@ export class ViewService {
     const snapshot: WorkflowVersion = { ...version, frozen: true };
     this.workflowsService.updateWorkflowVersion(workflow.id, [snapshot]).subscribe(
       workflowVersions => {
+        const selectedWorkflow = { ...this.workflowQuery.getActive() };
+        selectedWorkflow.workflowVersions = workflowVersions;
+        this.workflowService.setWorkflow(selectedWorkflow);
         cb(workflowVersions);
-        const activeWorkflow = { ...this.workflowQuery.getActive() };
-        workflow.workflowVersions = workflowVersions;
-        this.workflowService.setWorkflow(activeWorkflow);
       },
       error => {
         if (error) {
@@ -130,8 +130,9 @@ export class ViewService {
    * @memberof ViewService
    */
   private requestDOISuccess(version: WorkflowVersion, workflowVersions: Array<WorkflowVersion>): void {
-    const newSelectedVersion = workflowVersions.find(v => v.id === version.id);
-    this.workflowService.setWorkflowVersion(newSelectedVersion);
+    const workflow = { ...this.workflowQuery.getActive() };
+    workflow.workflowVersions = workflowVersions;
+    this.workflowService.setWorkflow(workflow);
     this.alertService.simpleSuccess();
   }
 

--- a/src/app/workflow/view/view.service.ts
+++ b/src/app/workflow/view/view.service.ts
@@ -53,6 +53,8 @@ export class ViewService {
     const snapshot: WorkflowVersion = { ...version, frozen: true };
     this.workflowsService.updateWorkflowVersion(workflow.id, [snapshot]).subscribe(
       (workflowVersions: Array<WorkflowVersion>) => {
+        this.alertService.detailedSuccess(`A Snapshot was successfully requested for workflow
+                                       "${workflow.workflowName}" version "${version.name}"!`);
         const selectedWorkflow = { ...this.workflowQuery.getActive() };
         if (selectedWorkflow.id === workflow.id) {
           this.workflowService.setWorkflow({ ...selectedWorkflow, workflowVersions: workflowVersions });
@@ -160,7 +162,10 @@ export class ViewService {
     };
     this.confirmationDialogService.openDialog(dialogData, bootstrap4mediumModalSize).subscribe((confirmationResult: Boolean) => {
       if (confirmationResult) {
-        this.updateWorkflowToSnapshot(workflow, version, () => this.alertService.detailedSuccess('Snapshot successfully created!'));
+        this.updateWorkflowToSnapshot(workflow, version, () => {
+          this.alertService.detailedSuccess(`A Snapshot was successfully requested for workflow
+                                       "${workflow.workflowName}" version "${version.name}"!`);
+        });
       } else {
         this.alertService.detailedSuccess('You cancelled creating a snapshot.');
       }


### PR DESCRIPTION
This PR is meant to bring the snapshot/doi UI features into a working state by changing the logic of refresh and turning the tests back on.

Address SEAB-430