### PR TITLE
Use cloudflare

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,12 +19,7 @@
             "assets": [
               "src/assets",
               "src/favicon.ico",
-              "src/manifest.json",
-              {
-                "glob": "worker-json.js",
-                "input": "./node_modules/ace-builds/src-min-noconflict",
-                "output": "/"
-              }
+              "src/manifest.json"
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",

--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -47,6 +47,7 @@ export class CodeEditorComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     const aceMode = 'ace/mode/' + this.mode;
+    ace.config.set('workerPath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.4/');
     this.editor = ace.edit(this.aceId, {
       mode: aceMode,
       readOnly: this.readOnly,


### PR DESCRIPTION
For dockstore/dockstore#2759

Staging is directing to https://staging.dockstore.org/worker-json.js instead of https://gui.dockstore.org/2.4.0-rc.0-4930df6/worker-json.js  .  Too much of a pain to direct it to the right location.  Using the publicly available cloudflare CDN version of it instead.  

Our build is smaller and I actually trust the cloudflare one more.

Our ace version is 1.4.4, so using 1.4.4.  If we update ace-editor, we will need to update the URL too sadly.