### PR TITLE
Features/2828/tools project links

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -384,7 +384,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     })
       .then(hits => {
         this.hits = hits.hits.hits;
-        const filteredHits: [Array<any>, Array<any>] = this.searchService.filterEntry(this.hits, this.query_size);
+        const filteredHits: [Array<Hit>, Array<Hit>] = this.searchService.filterEntry(this.hits, this.query_size);
         this.searchService.setHits(filteredHits[0], filteredHits[1]);
         if (this.values.length > 0 && hits) {
           this.searchTerm = true;

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -27,6 +27,7 @@ import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
+import { Hit } from './state/search.service';
 
 /**
  * There are a total of 5 calls per search.
@@ -61,7 +62,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    */
   /*TODO: Bad coding...change this up later (init)..*/
   private setFilter = false;
-  public hits: Object[];
+  public hits: Hit[];
 
   // Possibly 100 workflows and 100 tools (extra +1 is used to see if there are > 200 results)
   public readonly query_size = 201;

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -383,7 +383,8 @@ export class SearchComponent implements OnInit, OnDestroy {
     })
       .then(hits => {
         this.hits = hits.hits.hits;
-        this.searchService.filterEntry(this.hits, this.query_size);
+        const filteredHits: [Array<any>, Array<any>] = this.searchService.filterEntry(this.hits, this.query_size);
+        this.searchService.setHits(filteredHits[0], filteredHits[1]);
         if (this.values.length > 0 && hits) {
           this.searchTerm = true;
         }

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -26,8 +26,7 @@ import { AdvancedSearchService } from './advancedsearch/advanced-search.service'
 import { ELASTIC_SEARCH_CLIENT } from './elastic-search-client';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchQuery } from './state/search.query';
-import { SearchService } from './state/search.service';
-import { Hit } from './state/search.service';
+import { Hit, SearchService } from './state/search.service';
 
 /**
  * There are a total of 5 calls per search.

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -14,20 +14,22 @@
  *    limitations under the License.
  */
 import { inject, TestBed } from '@angular/core/testing';
+import { elasticSearchResponse } from '../../test/mocked-objects';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { ProviderService } from '../../shared/provider.service';
 import { ProviderStubService } from '../../test/service-stubs';
 import { SearchService } from './search.service';
 import { SearchStore } from './search.store';
+import { ImageProviderService } from '../../shared/image-provider.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('SearchService', () => {
   let searchStore: SearchStore;
   let searchService: SearchService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      providers: [SearchService, SearchStore, { provide: ProviderService, useClass: ProviderStubService }]
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [ImageProviderService, SearchService, SearchStore, { provide: ProviderService, useClass: ProviderStubService }]
     });
     searchService = TestBed.get(SearchService);
     searchStore = TestBed.get(SearchStore);
@@ -48,5 +50,15 @@ describe('SearchService', () => {
 
   it('should not crash on null advancedSearchObject', inject([SearchService], (service: SearchService) => {
     expect(service.hasSearchText(null, null, null)).toEqual(false);
+  }));
+
+  it('should create image provider', inject([SearchService], (service: SearchService) => {
+    const filtered: [Array<any>, Array<any>] = service.filterEntry(elasticSearchResponse, 201);
+    const tools = filtered[0];
+    expect(filtered[1].length).toBe(0);
+
+    const source = tools[0]._source;
+    expect(source.imgProvider).toBe('Docker Hub');
+    expect(source.imgProviderUrl).toBe('https://hub.docker.com/r/weischenfeldt/pcawg_delly_workflow');
   }));
 });

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -29,7 +29,15 @@ describe('SearchService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, HttpClientTestingModule],
-      providers: [ImageProviderService, SearchService, SearchStore, { provide: ProviderService, useClass: ProviderStubService }]
+      providers: [
+        ImageProviderService,
+        SearchService,
+        SearchStore,
+        {
+          provide: ProviderService,
+          useClass: ProviderStubService
+        }
+      ]
     });
     searchService = TestBed.get(SearchService);
     searchStore = TestBed.get(SearchStore);
@@ -55,10 +63,12 @@ describe('SearchService', () => {
   it('should create image provider', inject([SearchService], (service: SearchService) => {
     const filtered: [Array<any>, Array<any>] = service.filterEntry(elasticSearchResponse, 201);
     const tools = filtered[0];
-    expect(filtered[1].length).toBe(0);
-
-    const source = tools[0]._source;
-    expect(source.imgProvider).toBe('Docker Hub');
-    expect(source.imgProviderUrl).toBe('https://hub.docker.com/r/weischenfeldt/pcawg_delly_workflow');
+    const workflows = filtered[1];
+    const toolsSource = tools[0]._source;
+    const workflowSource = workflows[0]._source;
+    expect(toolsSource.imgProvider).toBe('Docker Hub');
+    expect(toolsSource.imgProviderUrl).toBe('https://hub.docker.com/r/weischenfeldt/pcawg_delly_workflow');
+    expect(workflowSource.imgProvider).toBe(undefined);
+    expect(workflowSource.imgProviderUrl).toBe(undefined);
   }));
 });

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -18,7 +18,7 @@ import { elasticSearchResponse } from '../../test/mocked-objects';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ProviderService } from '../../shared/provider.service';
 import { ProviderStubService } from '../../test/service-stubs';
-import { SearchService } from './search.service';
+import { Hit, SearchService } from './search.service';
 import { SearchStore } from './search.store';
 import { ImageProviderService } from '../../shared/image-provider.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -61,7 +61,7 @@ describe('SearchService', () => {
   }));
 
   it('should create image provider', inject([SearchService], (service: SearchService) => {
-    const filtered: [Array<any>, Array<any>] = service.filterEntry(elasticSearchResponse, 201);
+    const filtered: [Array<Hit>, Array<Hit>] = service.filterEntry(elasticSearchResponse, 201);
     const tools = filtered[0];
     const workflows = filtered[1];
     const toolsSource = tools[0]._source;

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -142,7 +142,7 @@ export class SearchService {
     return [toolHits, workflowHits];
   }
 
-  setHits(toolHit: any, workflowHit: any) {
+  setHits(toolHit: Array<Hit>, workflowHit: Array<Hit>) {
     this.searchStore.setState(state => {
       return {
         ...state,

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -24,6 +24,21 @@ import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
 import { SearchQuery } from './search.query';
 import { SearchStore } from './search.store';
 import { ImageProviderService } from '../../shared/image-provider.service';
+import { Explanation } from 'elasticsearch';
+
+export interface Hit {
+  _index: string;
+  _type: string;
+  _id: string;
+  _score: number;
+  _source: any;
+  _version?: number;
+  _explanation?: Explanation;
+  fields?: any;
+  highlight?: any;
+  inner_hits?: any;
+  sort?: string[];
+}
 
 @Injectable()
 export class SearchService {
@@ -110,13 +125,14 @@ export class SearchService {
    * @param {number} query_size
    * @memberof SearchService
    */
-  filterEntry(hits: Array<any>, query_size: number): [Array<any>, Array<any>] {
+  filterEntry(hits: Array<Hit>, query_size: number): [Array<Hit>, Array<Hit>] {
     const workflowHits = [];
     const toolHits = [];
     hits.forEach(hit => {
-      hit['_source'] = this.providerService.setUpProvider(this.imageProviderService.setUpImageProvider(hit['_source']));
+      hit['_source'] = this.providerService.setUpProvider(hit['_source']);
       if (workflowHits.length + toolHits.length < query_size - 1) {
         if (hit['_type'] === 'tool') {
+          hit['_source'] = this.imageProviderService.setUpImageProvider(hit['_source']);
           toolHits.push(hit);
         } else if (hit['_type'] === 'workflow') {
           workflowHits.push(hit);

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -23,6 +23,7 @@ import { ProviderService } from '../../shared/provider.service';
 import { ELASTIC_SEARCH_CLIENT } from '../elastic-search-client';
 import { SearchQuery } from './search.query';
 import { SearchStore } from './search.store';
+import { ImageProviderService } from '../../shared/image-provider.service';
 
 @Injectable()
 export class SearchService {
@@ -44,7 +45,8 @@ export class SearchService {
     private searchStore: SearchStore,
     private searchQuery: SearchQuery,
     private providerService: ProviderService,
-    private router: Router
+    private router: Router,
+    private imageProviderService: ImageProviderService
   ) {}
 
   // Given a URL, will attempt to shorten it
@@ -108,11 +110,11 @@ export class SearchService {
    * @param {number} query_size
    * @memberof SearchService
    */
-  filterEntry(hits: Array<any>, query_size: number) {
+  filterEntry(hits: Array<any>, query_size: number): [Array<any>, Array<any>] {
     const workflowHits = [];
     const toolHits = [];
     hits.forEach(hit => {
-      hit['_source'] = this.providerService.setUpProvider(hit['_source']);
+      hit['_source'] = this.providerService.setUpProvider(this.imageProviderService.setUpImageProvider(hit['_source']));
       if (workflowHits.length + toolHits.length < query_size - 1) {
         if (hit['_type'] === 'tool') {
           toolHits.push(hit);
@@ -121,7 +123,8 @@ export class SearchService {
         }
       }
     });
-    this.setHits(toolHits, workflowHits);
+    return [toolHits, workflowHits];
+    //this.setHits(toolHits, workflowHits);
   }
 
   setHits(toolHit: any, workflowHit: any) {

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -124,7 +124,6 @@ export class SearchService {
       }
     });
     return [toolHits, workflowHits];
-    //this.setHits(toolHits, workflowHits);
   }
 
   setHits(toolHit: any, workflowHit: any) {

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -142,12 +142,12 @@ export class SearchService {
     return [toolHits, workflowHits];
   }
 
-  setHits(toolHit: Array<Hit>, workflowHit: Array<Hit>) {
+  setHits(toolHits: Array<Hit>, workflowHits: Array<Hit>) {
     this.searchStore.setState(state => {
       return {
         ...state,
-        toolhit: toolHit,
-        workflowhit: workflowHit
+        toolhit: toolHits,
+        workflowhit: workflowHits
       };
     });
   }

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -456,3 +456,88 @@ export const testSourceFiles: Array<SourceFile> = [
     }
   }
 ];
+
+export const elasticSearchResponse = [
+  {
+    _index: 'entry',
+    _type: 'tool',
+    _id: '2313',
+    _score: 1,
+    _source: {
+      tool_maintainer_email: '',
+      aliases: {},
+      default_dockerfile_path: '/delly_docker/Dockerfile',
+      is_published: true,
+      toolname: null,
+      last_modified_date: null,
+      checker_id: null,
+      private_access: false,
+      descriptorType: ['CWL'],
+      mode: 'MANUAL_IMAGE_PATH',
+      lastBuild: null,
+      lastUpdated: 1513149095843,
+      path: 'registry.hub.docker.com/weischenfeldt/pcawg_delly_workflow',
+      defaultCWLTestParameterFile: '/test.json',
+      workflowVersions: [
+        {
+          doiURL: null,
+          dbUpdateDate: null,
+          versionEditor: null,
+          verifiedSource: null,
+          verified: false,
+          referenceType: 'UNSET',
+          frozen: false,
+          commitID: null,
+          dockerfile_path: '/delly_docker/Dockerfile',
+          last_built: null,
+          doiStatus: 'NOT_REQUESTED',
+          wdl_path: '/delly_docker/Dockstore.wdl',
+          automated: false,
+          size: 0,
+          cwl_path: '/delly_docker/Dockstore.cwl',
+          id: 8459,
+          image_id: ''
+        },
+        {
+          doiURL: null,
+          dbUpdateDate: null,
+          versionEditor: null,
+          verifiedSource: null,
+          verified: false,
+          referenceType: 'UNSET',
+          frozen: false,
+          commitID: null,
+          dockerfile_path: '/delly_docker/Dockerfile',
+          last_built: null,
+          doiStatus: 'NOT_REQUESTED',
+          wdl_path: '/delly_docker/Dockstore.wdl',
+          automated: false,
+          size: 0,
+          cwl_path: '/delly_docker/Dockstore.cwl',
+          id: 8458,
+          image_id: ''
+        }
+      ],
+      has_checker: false,
+      id: 2313,
+      last_modified: null,
+      email: 'briandoconnor@gmail.com',
+      default_wdl_path: '/delly_docker/Dockstore.wdl',
+      tool_path: 'registry.hub.docker.com/weischenfeldt/pcawg_delly_workflow',
+      registry: 'DOCKER_HUB',
+      dbUpdateDate: null,
+      author: "Brian O'Connor",
+      registry_string: 'registry.hub.docker.com',
+      tags: null,
+      dbCreateDate: null,
+      topicId: null,
+      custom_docker_registry_path: 'registry.hub.docker.com',
+      default_cwl_path: '/delly_docker/Dockstore.cwl',
+      name: 'pcawg_delly_workflow',
+      namespace: 'weischenfeldt',
+      gitUrl: 'git@bitbucket.org:weischenfeldt/pcawg_delly_workflow.git',
+      defaultWDLTestParameterFile: '/test.json',
+      defaultVersion: 'DELLYlegacy'
+    }
+  }
+];

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -23,6 +23,7 @@ import { WorkflowVersion } from '../shared/swagger';
 import { OrgToolObject } from '../mytools/my-tool/my-tool.component';
 import { WebserviceDescriptorTypeEnum } from '../shared/descriptor-type-compat.service';
 import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
+import { Hit } from '../search/state/search.service';
 
 export const updatedWorkflow: Workflow = {
   descriptorType: DescriptorTypeEnum.CWL,
@@ -457,7 +458,7 @@ export const testSourceFiles: Array<SourceFile> = [
   }
 ];
 
-export const elasticSearchResponse = [
+export const elasticSearchResponse: Hit[] = [
   {
     _index: 'entry',
     _type: 'tool',
@@ -537,6 +538,58 @@ export const elasticSearchResponse = [
       gitUrl: 'git@bitbucket.org:weischenfeldt/pcawg_delly_workflow.git',
       defaultWDLTestParameterFile: '/test.json',
       defaultVersion: 'DELLYlegacy'
+    }
+  },
+  {
+    _index: 'entry',
+    _type: 'workflow',
+    _id: '2210',
+    _score: 1,
+    _source: {
+      aliases: {},
+      is_published: true,
+      last_modified_date: null,
+      is_checker: false,
+      checker_id: null,
+      type: 'BioWorkflow',
+      repository: 'Ginny-9609498',
+      source_control_provider: 'GITHUB',
+      descriptorType: 'CWL',
+      full_workflow_path: 'github.com/smc-rna-challenge/Ginny-9609498/Ginny-9609498',
+      mode: 'FULL',
+      lastUpdated: 1496192152500,
+      path: 'github.com/smc-rna-challenge/Ginny-9609498',
+      workflowVersions: [
+        {
+          doiURL: null,
+          dbUpdateDate: null,
+          subClass: null,
+          versionEditor: null,
+          verifiedSource: null,
+          verified: false,
+          frozen: false,
+          referenceType: 'UNSET',
+          commitID: null,
+          id: 8288,
+          doiStatus: 'NOT_REQUESTED'
+        }
+      ],
+      sourceControl: 'github.com',
+      has_checker: false,
+      id: 2210,
+      last_modified: null,
+      email: 'Ginny@synapse.org',
+      dbUpdateDate: null,
+      author: 'Ginny',
+      defaultTestParameterFilePath: '/test.json',
+      workflowName: 'Ginny-9609498',
+      workflow_path: '/main.cwl',
+      dbCreateDate: null,
+      topicId: null,
+      parent_id: null,
+      organization: 'smc-rna-challenge',
+      gitUrl: 'git@github.com:smc-rna-challenge/Ginny-9609498.git',
+      defaultVersion: null
     }
   }
 ];

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -526,7 +526,6 @@ export const elasticSearchResponse = [
       tool_path: 'registry.hub.docker.com/weischenfeldt/pcawg_delly_workflow',
       registry: 'DOCKER_HUB',
       dbUpdateDate: null,
-      author: "Brian O'Connor",
       registry_string: 'registry.hub.docker.com',
       tags: null,
       dbCreateDate: null,


### PR DESCRIPTION
Displayed Quay.io link and other links

dockstore/dockstore#2828

Set up the ImageProviderService for search.service.ts allowing the
tools data to merge with the images (quay.io and other links) before
pushing the data into the Akita 'store' state.

Modified the filterEntry method in search.service.ts to return a tuple
in order to unit test without side effects.