### PR TITLE
Files visible after direct navigation to workflow

### DIFF
--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -184,6 +184,14 @@ describe('Dockstore hosted workflows', () => {
       cy.get('table')
         .find('a')
         .should('not.contain', '3');
+
+      // Reload the hosted workflow to test https://github.com/dockstore/dockstore/issues/2854
+      cy.reload();
+
+      goToTab('Files');
+      cy.contains('/Dockstore.wdl')
+        .should('be.visible');
+
     });
   });
 

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -171,13 +171,16 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
             // If a user navigates directly to an unpublished workflow on their my-workflows page (via bookmark, refresh),
             // the url needs to be used to set the workflow onInit.
             // Otherwise, the select - tab.pipe results in really strange behaviour. Not entirely sure why.
-            // Changed this to invoke this.selectEntry to fix https://github.com/dockstore/dockstore/issues/2854
-            this.selectEntry(
-              this.findEntryFromPath(
-                this.urlResolverService.getEntryPathFromUrl(),
-                this.groupEntriesObject.concat(this.groupSharedEntriesObject)
-              )
+            const entry = this.findEntryFromPath(
+              this.urlResolverService.getEntryPathFromUrl(),
+              this.groupEntriesObject.concat(this.groupSharedEntriesObject)
             );
+            if (entry) {
+              // Url could have non-existent entry
+              this.workflowService.setWorkflow(entry);
+              // Call this.selectEntry to fix https://github.com/dockstore/dockstore/issues/2854
+              this.selectEntry(entry);
+            }
             // Only select initial entry if there current is no selected entry.  Otherwise, leave as is.
             if (!this.workflow) {
               if (this.workflows.length > 0) {

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -171,7 +171,8 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
             // If a user navigates directly to an unpublished workflow on their my-workflows page (via bookmark, refresh),
             // the url needs to be used to set the workflow onInit.
             // Otherwise, the select - tab.pipe results in really strange behaviour. Not entirely sure why.
-            this.workflowService.setWorkflow(
+            // Changed this to invoke this.selectEntry to fix https://github.com/dockstore/dockstore/issues/2854
+            this.selectEntry(
               this.findEntryFromPath(
                 this.urlResolverService.getEntryPathFromUrl(),
                 this.groupEntriesObject.concat(this.groupSharedEntriesObject)

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -176,17 +176,16 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
               this.groupEntriesObject.concat(this.groupSharedEntriesObject)
             );
             if (entry) {
-              // Url could have non-existent entry
-              this.workflowService.setWorkflow(entry);
               // Call this.selectEntry to fix https://github.com/dockstore/dockstore/issues/2854
               this.selectEntry(entry);
-            }
-            // Only select initial entry if there current is no selected entry.  Otherwise, leave as is.
-            if (!this.workflow) {
-              if (this.workflows.length > 0) {
-                this.selectInitialEntry(sortedWorkflows);
-              } else if (this.sharedWorkflows.length > 0) {
-                this.selectInitialEntry(sortedSharedWorkflows);
+            } else {
+              // Only select initial entry if there current is no selected entry.  Otherwise, leave as is.
+              if (!this.workflow) {
+                if (this.workflows.length > 0) {
+                  this.selectInitialEntry(sortedWorkflows);
+                } else if (this.sharedWorkflows.length > 0) {
+                  this.selectInitialEntry(sortedSharedWorkflows);
+                }
               }
             }
           }


### PR DESCRIPTION
dockstore/dockstore#2854

When you navigate within the app, e.g., from home page to My Workflows, the `NavigationEnd` event fires (line 132), which leads to `selectEntry` being called.

If you navigate directly to a workflow, by reloading, bookmark, etc., there is no NavigationEnd event, so `selectEntry` is never called.

Changed the code that was calling `setWorkflow` to instead call `selectEntry` (selectEntry does call setWorkflow, as well as do other stuff), which leads to a validations Ajax call, which both gets the file contents and should also fix Natalie's issue with validation messages.

@NatalieEO would you be able to test the issue you were running into with this branch?

This could probably use a test, but discovered it at the end of my day, so opening for initial review and thoughts.