### PR TITLE
Fixing typos

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -104,10 +104,10 @@ printf "token: ${this.dsToken}\\nserver-url: ${this.dsServerURI}\\n" > ~/.dockst
 \`\`\`
 $ java -version
 openjdk version "11.0.4" 2019-07-16
-$ dockstore --version
-Dockstore version ${this.dockstoreVersion}
 OpenJDK Runtime Environment (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3)
 OpenJDK 64-Bit Server VM (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3, mixed mode, sharing)
+$ dockstore --version
+Dockstore version ${this.dockstoreVersion}
 $ docker run hello-world
 Hello from Docker!
 ...

--- a/src/app/workflow/view/view.service.ts
+++ b/src/app/workflow/view/view.service.ts
@@ -197,7 +197,7 @@ export class ViewService {
     }
     const dialogData: ConfirmationDialogData = {
       message: `Snapshotting a version will make it so it <b>can no longer be edited and cannot be undone</b>. <p>Are
-                you sure you would like to snapshot version <b>${version.name}</b> <p><b>Warning: This CANNOT be undone!</b></p>?`,
+                you sure you would like to snapshot version <b>${version.name}</b>? <p><b>Warning: This CANNOT be undone!</b></p>`,
       title: 'Snapshot',
       confirmationButtonText: 'Snapshot Version',
       cancelButtonText: 'Cancel'


### PR DESCRIPTION
Fixing two typos. The order of commands in the client download instructions wasn't correct and there was a floating question mark on the snapshot dialog.