### PR TITLE
Feature/2786/publish tool tips

### DIFF
--- a/src/app/shared/entry-actions/entry-actions.service.spec.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.spec.ts
@@ -125,5 +125,10 @@ describe('Service: EntryActionsService', () => {
     expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, null)).toBe('');
+    const entry2 = null;
+    expect(service.getPublishMessage(entry2, EntryType.Tool)).toBe('');
+    expect(service.getPublishMessage(entry2, EntryType.BioWorkflow)).toBe('');
+    expect(service.getPublishMessage(entry2, EntryType.Service)).toBe('');
+    expect(service.getPublishMessage(entry2, null)).toBe('');
   }));
 });

--- a/src/app/shared/entry-actions/entry-actions.service.spec.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.spec.ts
@@ -120,5 +120,10 @@ describe('Service: EntryActionsService', () => {
     expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, null)).toBe('');
+    const nullEntry = null;
+    expect(service.getPublishMessage(nullEntry, EntryType.Tool)).toBe('');
+    expect(service.getPublishMessage(nullEntry, EntryType.BioWorkflow)).toBe('');
+    expect(service.getPublishMessage(nullEntry, EntryType.Service)).toBe('');
+    expect(service.getPublishMessage(nullEntry, null)).toBe('');
   }));
 });

--- a/src/app/shared/entry-actions/entry-actions.service.spec.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.spec.ts
@@ -4,8 +4,17 @@ import { ContainerService } from '../container.service';
 import { EntryType } from '../enum/entry-type';
 import { CustomMaterialModule } from '../modules/material.module';
 import { WorkflowService } from '../state/workflow.service';
-import { ContainersService, DockstoreTool, Entry, Tag, Workflow, WorkflowsService } from '../swagger';
+import {
+  BaseClassForVersionsOfEntriesInTheDockstore,
+  ContainersService,
+  DockstoreTool,
+  Entry,
+  Tag,
+  Workflow,
+  WorkflowsService
+} from '../swagger';
 import { EntryActionsService } from './entry-actions.service';
+import { exampleEntry } from '../../test/mocked-objects';
 
 describe('Service: EntryActionsService', () => {
   beforeEach(() => {
@@ -51,6 +60,8 @@ describe('Service: EntryActionsService', () => {
   }));
   it('should get publish message', inject([EntryActionsService], (service: EntryActionsService) => {
     const entry = <Entry>{};
+    entry.workflowVersions = [exampleEntry];
+    entry.workflowVersions[0].valid = true;
     expect(service.getPublishMessage(null, EntryType.Tool)).toBe('');
     entry.is_published = true;
     expect(service.getPublishMessage(entry, EntryType.Tool)).toBe('Unpublish the tool to remove it from the public');
@@ -95,5 +106,19 @@ describe('Service: EntryActionsService', () => {
     expect(service.getViewPublicButtonTooltip(EntryType.Tool)).toBe('Go to the public page for this tool');
     expect(service.getViewPublicButtonTooltip(EntryType.BioWorkflow)).toBe('Go to the public page for this workflow');
     expect(service.getViewPublicButtonTooltip(EntryType.Service)).toBe('Go to the public page for this service');
+  }));
+  it('should display message for disabled tooltip', inject([EntryActionsService], (service: EntryActionsService) => {
+    const entry = <Entry>{};
+    entry.workflowVersions = [];
+    expect(service.getPublishMessage(entry, EntryType.Tool)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, null)).toBe('');
+    entry.workflowVersions = [exampleEntry];
+    entry.workflowVersions[0].valid = false;
+    expect(service.getPublishMessage(entry, EntryType.Tool)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, null)).toBe('');
   }));
 });

--- a/src/app/shared/entry-actions/entry-actions.service.spec.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.spec.ts
@@ -120,10 +120,10 @@ describe('Service: EntryActionsService', () => {
     expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
     expect(service.getPublishMessage(entry, null)).toBe('');
-    const nullEntry = null;
-    expect(service.getPublishMessage(nullEntry, EntryType.Tool)).toBe('');
-    expect(service.getPublishMessage(nullEntry, EntryType.BioWorkflow)).toBe('');
-    expect(service.getPublishMessage(nullEntry, EntryType.Service)).toBe('');
-    expect(service.getPublishMessage(nullEntry, null)).toBe('');
+    entry.workflowVersions = null;
+    expect(service.getPublishMessage(entry, EntryType.Tool)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.BioWorkflow)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, EntryType.Service)).toBe('Unable to publish: No valid versions found');
+    expect(service.getPublishMessage(entry, null)).toBe('');
   }));
 });

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -76,10 +76,10 @@ export class EntryActionsService {
       console.error('Null entryType, entryType should be present');
       return '';
     }
-    if (!entry.workflowVersions.some(version => version.valid)) {
-      return 'Unable to publish: No valid versions found';
-    } else if (entry.is_published) {
+    if (entry.is_published) {
       return `Unpublish the ${entryType} to remove it from the public`;
+    } else if (!entry.workflowVersions || !entry.workflowVersions.some(version => version.valid)) {
+      return 'Unable to publish: No valid versions found';
     } else {
       return `Publish the ${entryType} to make it visible to the public`;
     }

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -76,7 +76,9 @@ export class EntryActionsService {
       console.error('Null entryType, entryType should be present');
       return '';
     }
-    if (entry.is_published) {
+    if (!entry.workflowVersions.some(version => version.valid)) {
+      return 'Unable to publish: No valid versions found';
+    } else if (entry.is_published) {
       return `Unpublish the ${entryType} to remove it from the public`;
     } else {
       return `Publish the ${entryType} to make it visible to the public`;

--- a/src/app/shared/entry-actions/tool-actions.component.html
+++ b/src/app/shared/entry-actions/tool-actions.component.html
@@ -10,16 +10,17 @@
   >
     View Public
   </a>
-  <button
-    id="publishToolButton"
-    mat-flat-button
-    color="accent"
-    (click)="publishToggle()"
-    [disabled]="(isRefreshing$ | async) || publishDisabled"
-    [matTooltip]="pubUnpubMessage"
-  >
-    {{ tool?.is_published ? 'Unpublish' : 'Publish' }}
-  </button>
+  <div [matTooltip]="pubUnpubMessage">
+    <button
+      id="publishToolButton"
+      mat-flat-button
+      color="accent"
+      (click)="publishToggle()"
+      [disabled]="(isRefreshing$ | async) || publishDisabled"
+    >
+      {{ tool?.is_published ? 'Unpublish' : 'Publish' }}
+    </button>
+  </div>
   <ng-container *ngIf="tool?.is_published; then disabledDeleteButton; else enabledDeleteButton"></ng-container>
   <ng-template #disabledDeleteButton>
     <button *ngIf="tool?.is_published" mat-flat-button color="warn" disabled matTooltip="Delete the tool">

--- a/src/app/shared/entry-actions/workflow-actions.component.html
+++ b/src/app/shared/entry-actions/workflow-actions.component.html
@@ -10,16 +10,17 @@
   >
     View Public
   </a>
-  <button
-    mat-flat-button
-    id="publishButton"
-    color="accent"
-    (click)="publishToggle()"
-    [disabled]="(isRefreshing$ | async) || publishDisabled"
-    [matTooltip]="pubUnpubMessage"
-  >
-    {{ workflow?.is_published ? 'Unpublish' : 'Publish' }}
-  </button>
+  <div [matTooltip]="pubUnpubMessage">
+    <button
+      mat-flat-button
+      id="publishButton"
+      color="accent"
+      (click)="publishToggle()"
+      [disabled]="(isRefreshing$ | async) || publishDisabled"
+    >
+      {{ workflow?.is_published ? 'Unpublish' : 'Publish' }}
+    </button>
+  </div>
   <button
     mat-flat-button
     color="primary"

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -24,6 +24,7 @@ import { OrgToolObject } from '../mytools/my-tool/my-tool.component';
 import { WebserviceDescriptorTypeEnum } from '../shared/descriptor-type-compat.service';
 import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
 import { Hit } from '../search/state/search.service';
+import { BaseClassForVersionsOfEntriesInTheDockstore } from '../shared/swagger/model/baseClassForVersionsOfEntriesInTheDockstore';
 
 export const updatedWorkflow: Workflow = {
   descriptorType: DescriptorTypeEnum.CWL,
@@ -636,3 +637,57 @@ export const elasticSearchResponse: Hit[] = [
     }
   }
 ];
+
+export const exampleEntry: BaseClassForVersionsOfEntriesInTheDockstore = {
+  commitID: null,
+  dbUpdateDate: new Date(1568664818354),
+  dirtyBit: true,
+  doiStatus: 'NOT_REQUESTED',
+  doiURL: null,
+  frozen: false,
+  hidden: false,
+  id: 25247,
+  input_file_formats: [],
+  name: 'develop',
+  output_file_formats: [],
+  reference: 'develop',
+  referenceType: 'UNSET',
+  sourceFiles: [],
+  valid: false,
+  validations: [
+    {
+      id: 21835,
+      message: '{"/Dockstore.cwl":"Primary CWL descriptor is not present."}',
+      type: 'DOCKSTORE_CWL',
+      valid: false
+    },
+    {
+      id: 21836,
+      message: '{"/Dockstore.wdl":"Primary WDL descriptor is not present."}',
+      type: 'DOCKSTORE_WDL',
+      valid: false
+    },
+    {
+      id: 21837,
+      message: '{"/Dockerfile":"Missing a Dockerfile."}',
+      type: 'DOCKERFILE',
+      valid: false
+    },
+    {
+      id: 21838,
+      message: '{}',
+      type: 'CWL_TEST_JSON',
+      valid: true
+    },
+    {
+      id: 21839,
+      message: '{}',
+      type: 'WDL_TEST_JSON',
+      valid: true
+    }
+  ],
+  verified: false,
+  verifiedSource: null,
+  versionEditor: null,
+  workingDirectory: ''
+};


### PR DESCRIPTION
Displayed tooltip for disabled publish button

dockstore/dockstore#2786

Displayed a tooltip detailing why the Publish button is grayed out for
any tools or workflows that does not have a valid version.

Wrapped the publish button element in a div that contains the matToolTip
as this is a workaround to the fact that disabled elements do not fire
events