### PR TITLE
Rearrange logos

### DIFF
--- a/src/app/sponsors/sponsors.component.html
+++ b/src/app/sponsors/sponsors.component.html
@@ -26,7 +26,18 @@
       </div>
     </div>
   </div>
-  <div *ngIf="showSecondRow" class="row text-center">
+  <div *ngIf="showAdditionalRows" class="row text-center">
+    <h5 style="color:#21335B">Workflow Languages</h5>
+    <br />
+    <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">
+      <div *ngFor="let partner of languages" class="pb-5 px-1">
+        <a href="{{ partner.url }}" target="_blank">
+          <img [src]="partner.current" />
+        </a>
+      </div>
+    </div>
+  </div>
+  <div *ngIf="showAdditionalRows" class="row text-center">
     <h5 style="color:#21335B">Works With</h5>
     <br />
     <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">

--- a/src/app/sponsors/sponsors.component.ts
+++ b/src/app/sponsors/sponsors.component.ts
@@ -31,7 +31,8 @@ import { SponsorsService } from './sponsors.service';
 export class SponsorsComponent extends Base implements OnInit {
   public sponsors: Sponsor[];
   public partners: Sponsor[];
-  public showSecondRow = false;
+  public languages: Sponsor[];
+  public showAdditionalRows = false;
 
   constructor(private sponsorsService: SponsorsService, private location: Location, private router: Router) {
     super();
@@ -49,15 +50,16 @@ export class SponsorsComponent extends Base implements OnInit {
     // Initialize sponsors and partners
     this.sponsors = this.sponsorsService.getSponsors();
     this.partners = this.sponsorsService.getPartners();
+    this.languages = this.sponsorsService.getLanguages();
   }
 
   hideSecondRow() {
     // Hide the second row if not on the home page
     const currentPath = this.location.prepareExternalUrl(this.location.path());
     if (currentPath === '/') {
-      this.showSecondRow = true;
+      this.showAdditionalRows = true;
     } else {
-      this.showSecondRow = false;
+      this.showAdditionalRows = false;
     }
   }
 }

--- a/src/app/sponsors/sponsors.service.ts
+++ b/src/app/sponsors/sponsors.service.ts
@@ -26,10 +26,13 @@ export class SponsorsService {
     // new Sponsor('broad.png', new URL('https://www.broadinstitute.org/'))
   ];
 
-  private partners: Sponsor[] = [
+  private languages: Sponsor[] = [
     new Sponsor('cwl.png', new URL('https://www.commonwl.org')),
     new Sponsor('wdl.png', new URL('http://openwdl.org')),
-    new Sponsor('nfl.png', new URL('https://www.nextflow.io')),
+    new Sponsor('nfl.png', new URL('https://www.nextflow.io'))
+  ];
+
+  private partners: Sponsor[] = [
     new Sponsor('dnastack.png', new URL('https://dnastack.com')),
     new Sponsor('sevenbridges.png', new URL('https://www.sevenbridges.com'))
   ];
@@ -40,5 +43,9 @@ export class SponsorsService {
 
   getPartners(): Sponsor[] {
     return this.partners;
+  }
+
+  getLanguages(): Sponsor[] {
+    return this.languages;
   }
 }


### PR DESCRIPTION

dockstore/dockstore#2911

Separate languages and partners into their own rows.

![Screen Shot 2019-09-18 at 11 50 08 AM](https://user-images.githubusercontent.com/1049340/65177122-f1a28980-da0a-11e9-8976-c402147b464e.png)
