### PR TITLE
Merge base on CircleCI before tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           name: Check dependencies
           command: bash -i -c 'npm ls'
       - run:
+          name: Check Angular Version
+          command: bash -i -c 'npx ng version'
+      - run:
           name: Lint
           command: bash -i -c 'npm run lint'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ jobs:
           name: Check dependencies
           command: bash -i -c 'npm ls'
       - run:
-          name: Check Angular Version
-          command: bash -i -c 'npx ng version'
-      - run:
           name: Lint
           command: bash -i -c 'npm run lint'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,15 @@ jobs:
       - image: circleci/buildpack-deps:18.04-browsers
     steps:
       - checkout
+      - run:
+          name: Checkout merge commit (PRs only)
+          command: |
+            set -ex
+            if [[ -n "${CIRCLE_PULL_REQUEST}" ]]
+            then
+              git fetch origin pull/${CIRCLE_PULL_REQUEST##*/}/head:mergedBranch
+              git checkout mergedBranch
+            fi
       - install_container_dependencies
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,10 @@ jobs:
       - run:
           name: Checkout merge commit (PRs only)
           command: |
-            set -ex
             if [[ -n "${CIRCLE_PULL_REQUEST}" ]]
             then
-              git fetch origin pull/${CIRCLE_PULL_REQUEST##*/}/head:mergedBranch
-              git checkout mergedBranch
+              git fetch origin +refs/pull/${CIRCLE_PULL_REQUEST##*/}/merge:
+              git checkout -qf FETCH_HEAD
             fi
       - install_container_dependencies
       - run:


### PR DESCRIPTION
For dockstore/dockstore#2475

I created this branch kind of off develop but a few commits short (before all the Angular updates).

If you go to https://github.com/dockstore/dockstore-ui2/tree/feature/2475/testMergeCircleCI, you'll see that it's 7 commits behind.

You can tell this PR works because if you go into CircleCI, the Angular version is printed out and it correctly shows version 8.x.x .

Printing the Angular version is for testing purposes only, I'll be reverting it after approval.