### PR TITLE
Feature/2561/cache npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,10 @@ jobs:
             fi
       - install_container_dependencies
       - restore_cache:
-          keys:
-            - dep-cache-{{ checksum "./package-lock.json" }}
+          key: dep-cache-{{ checksum "./package-lock.json" }}
       - run:
           name: Install dependencies
+          #Only run 'npm ci' if node_modules was not restored from cache
           command: |
               if [ ! -d "./node_modules" ]
               then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
       - image: circleci/buildpack-deps:18.04-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dep-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Checkout merge commit (PRs only)
           command: |
@@ -29,6 +26,9 @@ jobs:
               git checkout -qf FETCH_HEAD
             fi
       - install_container_dependencies
+      - restore_cache:
+          key:
+            - dep-cache-{{ checksum "./package-lock.json" }}
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ jobs:
                 bash -i -c 'npm ci'
               fi
       - save_cache:
-          keys:
-            - dep-cache-{{ checksum "./package-lock.json" }}
+          key: dep-cache-{{ checksum "./package-lock.json" }}
           paths:
             - ./node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
               fi
       - save_cache:
           key:
-            - dep-cache-{{ checksum "package-lock.json" }}
+            - dep-cache-{{ checksum "./package-lock.json" }}
           paths:
             - ./node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
       - image: circleci/buildpack-deps:18.04-browsers
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dep-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Checkout merge commit (PRs only)
           command: |
@@ -28,7 +31,16 @@ jobs:
       - install_container_dependencies
       - run:
           name: Install dependencies
-          command: bash -i -c 'npm ci'
+          command: |
+              if [ ! -d "./node_modules" ]
+              then
+                bash -i -c 'npm ci'
+              fi
+      - save_cache:
+          key:
+            - dep-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
       - run:
           name: Check dependencies
           command: bash -i -c 'npm ls'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,20 +26,9 @@ jobs:
               git checkout -qf FETCH_HEAD
             fi
       - install_container_dependencies
-      - restore_cache:
-          keys:
-            - dep-cache-{{ checksum "./package-lock.json" }}
       - run:
           name: Install dependencies
-          command: |
-              if [ ! -d "./node_modules" ]
-              then
-                bash -i -c 'npm ci'
-              fi
-      - save_cache:
-          key: dep-cache-{{ checksum "./package-lock.json" }}
-          paths:
-            - ./node_modules
+          command: bash -i -c 'npm ci'
       - run:
           name: Check dependencies
           command: bash -i -c 'npm ls'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,20 @@ jobs:
               git checkout -qf FETCH_HEAD
             fi
       - install_container_dependencies
+      - restore_cache:
+          keys:
+            - dep-cache-{{ checksum "./package-lock.json" }}
       - run:
           name: Install dependencies
-          command: bash -i -c 'npm ci'
+          command: |
+              if [ ! -d "./node_modules" ]
+              then
+                bash -i -c 'npm ci'
+              fi
+      - save_cache:
+          key: dep-cache-{{ checksum "./package-lock.json" }}
+          paths:
+            - ./node_modules
       - run:
           name: Check dependencies
           command: bash -i -c 'npm ls'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             fi
       - install_container_dependencies
       - restore_cache:
-          key:
+          keys:
             - dep-cache-{{ checksum "./package-lock.json" }}
       - run:
           name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
                 bash -i -c 'npm ci'
               fi
       - save_cache:
-          key:
+          keys:
             - dep-cache-{{ checksum "./package-lock.json" }}
           paths:
             - ./node_modules


### PR DESCRIPTION
Cache NPM Node_Modules

dockstore/dockstore#2561

Modified config.yml to cache dependencies from package-lock.json to
the node_modules directory.

Implemented a bash script that checks if the node_modules directory
exists. If it does not exist, it will run a npm ci. If it does exist,
it will do nothing and fetch its dependencies from node_modules.