### PR TITLE
Don't refresh entry

### DIFF
--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -15,21 +15,20 @@
  */
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { ContainerService } from 'app/shared/container.service';
 import { takeUntil } from 'rxjs/operators';
-
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DateService } from '../../shared/date.service';
+import { Dockstore } from '../../shared/dockstore.model';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedDockstoreToolQuery } from '../../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
-import { RefreshService } from '../../shared/refresh.service';
 import { SessionQuery } from '../../shared/session/session.query';
 import { ContainersService } from '../../shared/swagger/api/containers.service';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Tag } from '../../shared/swagger/model/tag';
 import { Versions } from '../../shared/versions';
 import { AddTagComponent } from '../add-tag/add-tag.component';
-import { Dockstore } from '../../shared/dockstore.model';
 
 @Component({
   selector: 'app-versions-container',
@@ -53,11 +52,11 @@ export class VersionsContainerComponent extends Versions implements OnInit {
     dockstoreService: DockstoreService,
     private containersService: ContainersService,
     dateService: DateService,
-    private refreshService: RefreshService,
     private alertService: AlertService,
     private extendedDockstoreToolQuery: ExtendedDockstoreToolQuery,
     private matDialog: MatDialog,
-    protected sessionQuery: SessionQuery
+    protected sessionQuery: SessionQuery,
+    private containerService: ContainerService
   ) {
     super(dockstoreService, dateService, sessionQuery);
     this.sortColumn = 'last_built';
@@ -94,9 +93,8 @@ export class VersionsContainerComponent extends Versions implements OnInit {
     this.containersService.updateToolDefaultVersion(this.tool.id, newDefaultVersion).subscribe(
       response => {
         this.alertService.detailedSuccess();
-        if (this.tool.mode !== this.DockstoreToolType.ModeEnum.HOSTED) {
-          this.refreshService.refreshTool();
-        }
+        this.containerService.replaceTool(null, response);
+        this.containerService.setTool(response);
       },
       error => this.alertService.detailedError(error)
     );

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -15,20 +15,19 @@
  */
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { WorkflowService } from 'app/shared/state/workflow.service';
 import { takeUntil } from 'rxjs/operators';
-
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DateService } from '../../shared/date.service';
+import { Dockstore } from '../../shared/dockstore.model';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedWorkflow } from '../../shared/models/ExtendedWorkflow';
-import { RefreshService } from '../../shared/refresh.service';
 import { SessionQuery } from '../../shared/session/session.query';
 import { ExtendedWorkflowQuery } from '../../shared/state/extended-workflow.query';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { Versions } from '../../shared/versions';
-import { Dockstore } from '../../shared/dockstore.model';
 
 @Component({
   selector: 'app-versions-workflow',
@@ -59,7 +58,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit {
     private alertService: AlertService,
     private extendedWorkflowQuery: ExtendedWorkflowQuery,
     private workflowsService: WorkflowsService,
-    private refreshService: RefreshService,
+    private workflowService: WorkflowService,
     protected sessionQuery: SessionQuery
   ) {
     super(dockstoreService, dateService, sessionQuery);
@@ -94,11 +93,10 @@ export class VersionsWorkflowComponent extends Versions implements OnInit {
     const message = 'Updating default workflow version';
     this.alertService.start(message);
     this.workflowsService.updateWorkflowDefaultVersion(this.workflowId, newDefaultVersion).subscribe(
-      response => {
+      updatedWorkflow => {
         this.alertService.detailedSuccess();
-        if (this.workflow.mode !== Workflow.ModeEnum.HOSTED) {
-          this.refreshService.refreshWorkflow();
-        }
+        this.workflowService.upsertWorkflowToWorkflow(updatedWorkflow);
+        this.workflowService.setWorkflow(updatedWorkflow);
       },
       (error: HttpErrorResponse) => this.alertService.detailedError(error)
     );


### PR DESCRIPTION
For SEAB-636

The webservice should now automatically update the metadata and refreshing is no longer needed.

Can't be merged until https://github.com/dockstore/dockstore/pull/3024