### PR TITLE
Feature/2996/circle ci test metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,11 @@ jobs:
       - setup_integration_test
       - run:
           name: Test
-          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --spec cypress/integration/group1/**/*'
+          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/integration/group1/**/*'
+          environment:
+            MOCHA_FILE: integration-tests/test-results/junit/test-results-[hash].xml
+          when: always
+      - upload_artifacts
   integration_test_2:
     executor: integration_test_exec
     working_directory: ~/repo
@@ -77,7 +81,11 @@ jobs:
       - setup_integration_test
       - run:
           name: Test
-          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --spec cypress/integration/group2/**/*'
+          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/integration/group2/**/*'
+          environment:
+            MOCHA_FILE: integration-tests/test-results/junit/test-results-[hash].xml
+          when: always
+      - upload_artifacts
   integration_test_3:
     executor: integration_test_exec
     working_directory: ~/repo
@@ -85,7 +93,11 @@ jobs:
       - setup_integration_test
       - run:
           name: Test
-          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --spec cypress/integration/immutableDatabaseTests/**/*'
+          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/integration/immutableDatabaseTests/**/*'
+          environment:
+            MOCHA_FILE: integration-tests/test-results/junit/test-results-[hash].xml
+          when: always
+      - upload_artifacts
   upload_to_s3:
     working_directory: ~/repo
     docker:
@@ -176,6 +188,16 @@ commands:
     steps:
       - attach_workspace:
           at: .
+  upload_artifacts:
+    steps:
+      - store_test_results:
+          path: integration-tests/test-results
+      - store_artifacts:
+          path: integration-tests/test-results
+      - store_artifacts:
+          path: cypress/videos
+      - store_artifacts:
+          path: cypress/screenshots
   setup_integration_test:
     steps:
       - get_workspace
@@ -206,6 +228,7 @@ commands:
           name: Run webservice
           command: java -jar dockstore-webservice.jar server travisci/web.yml 1>/dev/null
           background: true
+      - run: mkdir -p integration-tests/test-results/junit
       - run:
           name: Wait for services
           command: bash scripts/wait-for.sh

--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -193,7 +193,7 @@ describe('Dockstore my tools', () => {
         .wait(1000);
 
       cy
-        .get('#imageRegistrySpinner')
+        .get('[data-cy=imageRegistryProviderSelect]')
         .click();
       cy
         .contains('Amazon ECR')
@@ -247,10 +247,7 @@ describe('Dockstore my tools', () => {
       //     .click()
 
       // This is deactivated because:
-      // Registering a tool also refreshes it.
-      // Refresh results in an error so it is mocked.
-      // The mocked results has an id that is not correct
-      // The deregister uses this mocked id to deregister but since the id is incorrect, it can't deregister
+      // onlyThe deregister uses this mocked id to deregister but since the id is incorrect, it can't deregister
       // cy
       // .get('#tool-path')
       // .should('not.contain', 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname')
@@ -283,6 +280,7 @@ describe('Dockstore my tools', () => {
           url: /cwl/,
           response: { 'content': '#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  \'@id\': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: \'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows\'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n', 'path': '/Dockstore.cwl' }
         });
+      cy.get('#tool-path').should('be.visible');
       cy
         .get('#register_tool_button')
         .click();
@@ -299,13 +297,8 @@ describe('Dockstore my tools', () => {
         .type('testnamespace/testname')
         .wait(1000);
 
-      cy
-        .get('#imageRegistrySpinner')
-        .click();
-      cy
-        .contains('Seven Bridges')
-        .click();
-
+      cy.get('[data-cy=imageRegistryProviderSelect]').click();
+      cy.contains('mat-option', 'Seven Bridges').click();
       cy
         .get('#dockerRegistryPathInput')
         .type('images.sbgenomics.com');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -13,8 +13,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { goToTab, isActiveTab, resetDB, setTokenUserViewPort } from '../../support/commands';
 import { Repository } from '../../../src/app/shared/openapi/model/repository';
+import { goToTab, isActiveTab, resetDB, setTokenUserViewPort } from '../../support/commands';
 
 describe('Dockstore my workflows', () => {
   resetDB();
@@ -178,7 +178,7 @@ describe('Dockstore my workflows', () => {
             cannotDeleteMe,
             doesNotExist
           ]
-        })
+        });
 
       cy.visit('/my-workflows');
       cy.get('#registerWorkflowButton')
@@ -197,21 +197,21 @@ describe('Dockstore my workflows', () => {
       // Select github.com in git registry
       cy.get('entry-wizard').within(() => {
         cy
-          .get('mat-select').eq(0).click().type('{enter}')
+          .get('mat-select').eq(0).click().type('{enter}');
         cy
-          .get('mat-select').eq(1).click().type('{enter}')
+          .get('mat-select').eq(1).click().type('{enter}');
 
         // foobar/canDeleteMe should be on and not disabled
         cy
-          .get('mat-slide-toggle').eq(0).should('not.have.class', 'mat-disabled').should('have.class', 'mat-checked')
+          .get('mat-slide-toggle').eq(0).should('not.have.class', 'mat-disabled').should('have.class', 'mat-checked');
         // foobar/cannotDeleteMe should be on and disabled
         cy
-          .get('mat-slide-toggle').eq(1).should('have.class', 'mat-disabled').should('have.class', 'mat-checked')
+          .get('mat-slide-toggle').eq(1).should('have.class', 'mat-disabled').should('have.class', 'mat-checked');
 
         // foobar/doesNotExist should be off and not disabled
         cy
-          .get('mat-slide-toggle').eq(2).should('not.have.class', 'mat-disabled').should('not.have.class', 'mat-checked')
-      })
+          .get('mat-slide-toggle').eq(2).should('not.have.class', 'mat-disabled').should('not.have.class', 'mat-checked');
+      });
     });
   });
 
@@ -226,7 +226,7 @@ describe('Dockstore my workflows', () => {
       cy.wait(1000);
       cy
         .get('#1-register-workflow-option')
-        .click()
+        .click();
       cy
         .contains('button', 'Next')
         .click();
@@ -277,7 +277,7 @@ describe('Dockstore my workflows', () => {
   });
 
   describe('Look at a published workflow', () => {
-    it('Look at each tab', () => {
+    it.only('Look at each tab', () => {
       const tabs = ['Info', 'Launch', 'Versions', 'Files', 'Tools', 'DAG'];
       cy.visit('/my-workflows/github.com/A/l');
       isActiveTab('Info');
@@ -300,8 +300,8 @@ describe('Dockstore my workflows', () => {
         .get('#viewPublicWorkflowButton')
         .should('not.be.visible');
 
-      cy
-        .get('#publishButton')
+      cy.get('#publishButton')
+        .should('be.visible')
         .should('contain', 'Publish')
         .click();
 

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -130,9 +130,9 @@ describe('Dockstore Organizations', () => {
       cy.visit('/');
       cy.contains('Potatoe');
       cy.contains('Filter organizations');
-      cy.get('#mat-input-0').type('Po');
+      cy.get('[data-cy=filterOrganizationsInput]').type('Po');
       cy.contains('Potatoe');
-      cy.get('#mat-input-0').type('r');
+      cy.get('[data-cy=filterOrganizationsInput]').type('r');
       cy.contains('No matching organizations');
     });
   });

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -194,41 +194,39 @@
           </div>
           <div class="form-group form-group-sm">
             <label class="col-sm-3 control-label">
+              Image Registry Provider:
+            </label>
+            <div class="col-sm-9">
+              <mat-form-field class="w-100">
+                <mat-select [(value)]="tool.irProvider" data-cy="imageRegistryProviderSelect">
+                  <mat-option
+                    *ngFor="let registry of friendlyRegistryKeys()"
+                    value="{{ registry }}"
+                    (click)="tool.irProvider = registry; checkForSpecialDockerRegistry()"
+                    >{{ registry }}</mat-option
+                  >
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </div>
+          <div class="form-group form-group-sm">
+            <label class="col-sm-3 control-label">
               Image Registry:
             </label>
             <div class="col-sm-9">
-              <div class="input-group">
-                <div class="input-group-btn">
-                  <button id="imageRegistrySpinner" type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                    {{ tool.irProvider }}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li *ngFor="let registry of friendlyRegistryKeys()">
-                      <a
-                        [attr.id]="'imageRegistrySpinner' + registry"
-                        class="dropdown-item"
-                        (click)="tool.irProvider = registry; checkForSpecialDockerRegistry()"
-                      >
-                        {{ registry }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-                <input
-                  id="imageRegistryInput"
-                  type="text"
-                  class="form-control"
-                  name="imagePath"
-                  [(ngModel)]="tool.imagePath"
-                  minlength="3"
-                  maxlength="128"
-                  [pattern]="validationPatterns.imagePath"
-                  required
-                  matTooltip="Docker Image Registry path."
-                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
-                />
-              </div>
+              <input
+                id="imageRegistryInput"
+                type="text"
+                class="form-control"
+                name="imagePath"
+                [(ngModel)]="tool.imagePath"
+                minlength="3"
+                maxlength="128"
+                [pattern]="validationPatterns.imagePath"
+                required
+                matTooltip="Docker Image Registry path."
+                placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
+              />
               <div *ngIf="formErrors.imagePath" class="alert alert-danger">{{ formErrors.imagePath }}</div>
             </div>
           </div>

--- a/src/app/home-page/widget/organizations/organizations.component.html
+++ b/src/app/home-page/widget/organizations/organizations.component.html
@@ -6,7 +6,13 @@
 
   <ng-template #userHasOrganizations>
     <mat-form-field class="w-100">
-      <input matInput [(ngModel)]="filterText" (keyup)="onTextChange($event)" placeholder="Filter organizations..." />
+      <input
+        data-cy="filterOrganizationsInput"
+        matInput
+        [(ngModel)]="filterText"
+        (keyup)="onTextChange($event)"
+        placeholder="Filter organizations..."
+      />
     </mat-form-field>
 
     <div *ngFor="let organization of myItems" class="w-100">


### PR DESCRIPTION
For dockstore/dockstore#2996

Adds test metadata for circleCI in .circle/config.yml

The rest is just to fix group 2 from failing

Passed 9/11 
The remaining 2 times failed because of drop db timeout

A notable change is switching the image registry provider dropdown into Material and having its own row because I could not get it to select Seven Bridges reliably without it for some reason.

See https://circleci.com/gh/dockstore/dockstore-ui2/5806 as well as the artefacts tab to see how it looks