### PR TITLE
Recent entries does not show the registry

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -25,10 +25,10 @@ describe('Dockstore my workflows', () => {
   const nextflowDescriptorType = 'Nextflow';
   it('have entries shown on the homepage', () => {
     cy.visit('/');
-    cy.contains('github.com/A/l');
+    cy.contains('A/l');
     cy.contains('Filter entries');
     cy.get('#mat-input-0').type('bit');
-    cy.contains('bitbucket.org/a/a');
+    cy.contains('a/a');
     cy.get('#mat-input-0').type('r');
     cy.contains('No matching entries');
   });

--- a/src/app/home-page/widget/entries/entries.component.html
+++ b/src/app/home-page/widget/entries/entries.component.html
@@ -11,19 +11,19 @@
 
     <div *ngFor="let entry of myItems" class="w-100">
       <a *ngIf="entry.entryType === entryTypeEnum.TOOL" [routerLink]="'/my-tools/' + entry.path" routerLinkActive="router-link-active">{{
-        entry.path
+        entry.prettyPath
       }}</a>
       <a
         *ngIf="entry.entryType === entryTypeEnum.WORKFLOW"
         [routerLink]="'/my-workflows/' + entry.path"
         routerLinkActive="router-link-active"
-        >{{ entry.path }}</a
+        >{{ entry.prettyPath }}</a
       >
       <a
         *ngIf="entry.entryType === entryTypeEnum.SERVICE"
         [routerLink]="'/my-services/' + entry.path"
         routerLinkActive="router-link-active"
-        >{{ entry.path }}</a
+        >{{ entry.prettyPath }}</a
       >
     </div>
     <p *ngIf="!myItems || myItems.length === 0">No matching entries</p>


### PR DESCRIPTION
Will now show b/c/d instead of a/b/c/d. I think the registry usually doesn't matter, so it makes sense to hide it. This is how search currently works.

Depends on https://github.com/dockstore/dockstore/pull/3061