### PR TITLE
Autosize Update Organization/Collection Description Window

### DIFF
--- a/src/app/organizations/organization/update-organization-description/update-organization-description.component.html
+++ b/src/app/organizations/organization/update-organization-description/update-organization-description.component.html
@@ -5,7 +5,7 @@
     <mat-tab label="Edit Mode">
       <form class="p-1" [formGroup]="updateOrganizationOrCollectionDescriptionForm" fxLayout="column">
         <mat-form-field>
-          <textarea cdkAutosizeMinRows="3" type="text" matInput formControlName="description" placeholder="Description"></textarea>
+          <textarea matTextareaAutosize type="text" matInput formControlName="description" placeholder="Description"></textarea>
         </mat-form-field>
       </form>
     </mat-tab>


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2864

cdkAutosize is apparently deprecated, changed to matTextareaAutosize and that seems to have fixed things. Pop-up window now changes with screen size.
Normal screen:
![image](https://user-images.githubusercontent.com/23464754/70482694-0850fd80-1a9b-11ea-9707-d491544a3002.png)
Mobile (small):
![image](https://user-images.githubusercontent.com/23464754/70482766-42ba9a80-1a9b-11ea-8cd8-1587aabf5a14.png)
