### PR TITLE
link to help desk in footer

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -107,7 +107,7 @@
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small><mat-icon>live_help</mat-icon> Help Desk</small>
+              <small><mat-icon>contact_support</mat-icon> Help Desk</small>
             </a>
           </li>
         </ul>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -101,7 +101,12 @@
             </a>
           </li>
           <li class="m-0">
-            <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer" class="footer-link">
+            <a
+              href="https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="footer-link"
+            >
               <small><mat-icon>live_help</mat-icon> Help Desk</small>
             </a>
           </li>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -100,6 +100,11 @@
               >
             </a>
           </li>
+          <li class="m-0">
+            <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer" class="footer-link">
+              <small><mat-icon>live_help</mat-icon> Help Desk</small>
+            </a>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
Adds a link to Discourse (Help Desk) in the footer.

![Screenshot from 2019-12-19 10-06-23](https://user-images.githubusercontent.com/6331159/71184163-53130800-2247-11ea-8163-00a948caa718.png)

Edit:
Updated screenshot
![Screenshot from 2019-12-19 13-49-54](https://user-images.githubusercontent.com/6331159/71200663-7e591f80-2266-11ea-8ba7-cf5f6a910085.png)
