### PR TITLE
Use fixed tweet limit to avoid constant polling

### DIFF
--- a/src/app/home-page/home-logged-in/home-logged-in.component.ts
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.ts
@@ -33,7 +33,7 @@ export class HomeLoggedInComponent extends Base implements OnInit, AfterViewInit
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         () => {
-          this.twitterService.createTimeline(this.twitterElement, 800);
+          this.twitterService.createTimeline(this.twitterElement, 3);
         },
         err => console.error(err)
       );

--- a/src/app/home-page/home-logged-out/home.component.ts
+++ b/src/app/home-page/home-logged-out/home.component.ts
@@ -75,7 +75,7 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         () => {
-          this.twitterService.createTimeline(this.twitterElement, 400);
+          this.twitterService.createTimeline(this.twitterElement, 2);
         },
         err => console.error(err)
       );

--- a/src/app/shared/twitter.service.ts
+++ b/src/app/shared/twitter.service.ts
@@ -66,13 +66,13 @@ export class TwitterService {
     })(document, 'script', this.TWITTER_SCRIPT_ID, this.TWITTER_WIDGET_URL);
   }
 
-  createTimeline(element: ElementRef, height: number) {
+  createTimeline(element: ElementRef, tweetLimit: number) {
     const nativeElement = element.nativeElement;
     nativeElement.innerHTML = '';
     window['twttr'].widgets
       .createTimeline({ sourceType: 'url', url: 'https://twitter.com/dockstoreOrg' }, nativeElement, {
         theme: 'light',
-        height: height
+        tweetLimit: tweetLimit
       })
       .then(embed => {
         // console.log(embed);


### PR DESCRIPTION
For dockstore/dockstore#1630

Can't seem to stop polling on other pages, disabling polling altogether by grabbing a fixed amount of tweets.

Functionality lost:
- height is no longer fixed, no scrollbar, height auto-adjusts based on the height of the specified amount of tweets
- can no longer view more tweets when scrolling down
