### PR TITLE
Feature/2966/back button fix

### DIFF
--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -52,13 +52,12 @@ describe('Admin UI', () => {
       cy.get('a')
         .contains('Organizations')
         .click();
-      cy.get('a')
-        .contains('Search')
-        .click();
+      cy.go('back');
       cy.contains('21 - 40');
       cy.get('[data-cy=search-tool-table-paginator]').contains(20);
+      cy.contains('pancancer/pcawg-dkfz-workflow').should('not.exist');
     });
-    it.only('should have basic search and advanced search mutually exclusive', () => {
+    it('should have basic search and advanced search mutually exclusive', () => {
       cy.get('[data-cy=basic-search]').type('dockstore_');
       cy.contains('Open Advanced Search').click();
       cy.contains('button', /^Advanced Search$/).should('be.visible').click();

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -48,13 +48,13 @@ export abstract class SearchEntryTable extends Base implements OnInit {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(([pageSize, pageIndex, entries]) => {
         this.dataSource.paginator.pageSize = pageSize;
-        if (entries) {
-          this.dataSource.paginator.pageIndex = pageIndex;
-          this.dataSource.data = entries;
-        }
+        this.dataSource.paginator.pageIndex = pageIndex;
+        // Must set data after paginator, just a material datatables thing.
+        // See https://inneka.com/programming/angular/angular-matpaginator-not-working/ solution 14
+        this.dataSource.data = entries || [];
       });
     this.dataSource.sortData = (data: DockstoreTool[] | Workflow[], sort: MatSort) => {
-      return data.slice().sort((a, b) => {
+      return data.slice().sort((a: Workflow | DockstoreTool, b: Workflow | DockstoreTool) => {
         return this.searchService.compareAttributes(a, b, sort.active, sort.direction);
       });
     };

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -50,7 +50,6 @@ export abstract class SearchEntryTable extends Base implements OnInit {
         this.dataSource.paginator.pageSize = pageSize;
         this.dataSource.paginator.pageIndex = pageIndex;
         // Must set data after paginator, just a material datatables thing.
-        // See https://inneka.com/programming/angular/angular-matpaginator-not-working/ solution 14
         this.dataSource.data = entries || [];
       });
     this.dataSource.sortData = (data: DockstoreTool[] | Workflow[], sort: MatSort) => {

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -49,8 +49,8 @@ export abstract class SearchEntryTable extends Base implements OnInit {
       .subscribe(([pageSize, pageIndex, entries]) => {
         this.dataSource.paginator.pageSize = pageSize;
         if (entries) {
-          this.dataSource.data = entries;
           this.dataSource.paginator.pageIndex = pageIndex;
+          this.dataSource.data = entries;
         }
       });
     this.dataSource.sortData = (data: DockstoreTool[] | Workflow[], sort: MatSort) => {


### PR DESCRIPTION
Data must be set after pagination it seems.

dockstore/dockstore#2966

Quote from some other guy
"
This took me hours to finally track down and understand why my table wasn’t working. Placing some console.logs() helped me figure out the order of events and why it didn’t work consistently. My scenario was similar to the original issue above with a dynamic data source, but slightly different. For me, when I would first refresh my angular app, the paginator state would be set and then the data for my table would be set. When these events would happen in the this order the paginator worked just as expected.

Because I was using ReplaySubjects for getting the data for my tables, my paginator state would be set in ngAfterViewInit and then the table data would come in from my subscription (it depends on user ID so I don’t have an initial value and that is why I didn’t use BehaviorSubjects). My problem was that, when I would navigate to another component in my app, and return to my dynamic table data source, the table data would be set before the paginator state. This would make the paginator show page x, but the displayed data would always be the first page of data.
"