### PR TITLE
my org tooltip is now the display name

### DIFF
--- a/src/app/home-page/widget/organizations/organizations.component.html
+++ b/src/app/home-page/widget/organizations/organizations.component.html
@@ -16,7 +16,7 @@
     </mat-form-field>
 
     <div *ngFor="let organization of myItems" class="w-100 ellipsis-overflow">
-      <span [matTooltip]="organization.name">
+      <span [matTooltip]="organization.displayName">
         <a [routerLink]="'/organizations/' + organization.name" routerLinkActive="router-link-active">{{ organization.displayName }}</a>
       </span>
     </div>


### PR DESCRIPTION
My org tooltip is now the same as the text shown.