### PR TITLE
facet buttons

### DIFF
--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -87,8 +87,8 @@
   font-size: 12px;
   background-color: #ffffff;
   &.active {
-    background-color: #f4f4f4;
-    color: #3b769a;
+    background-color: #487980;
+    color: #ffffff;
     font-weight: bold;
   }
   &:not(.active) {

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -89,10 +89,14 @@
   &.active {
     background-color: #f4f4f4;
     color: #3b769a;
+    font-weight: bold;
   }
   &:not(.active) {
     &:hover {
       background-color: #f8f8f8;
+    }
+    .ng-fa-icon {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
dockstore/dockstore#2963
Current. Button defaults to count. 
<img width="287" alt="Screen Shot 2020-01-09 at 9 05 45 AM" src="https://user-images.githubusercontent.com/16004905/72088912-f6dc5a80-32bf-11ea-870e-ae8bff7ba2b6.png">
Option 1
<img width="288" alt="Screen Shot 2020-01-09 at 9 08 11 AM" src="https://user-images.githubusercontent.com/16004905/72088962-0bb8ee00-32c0-11ea-906a-9ac8c3da90be.png">
Option 2
<img width="285" alt="Screen Shot 2020-01-09 at 9 08 58 AM" src="https://user-images.githubusercontent.com/16004905/72088975-0fe50b80-32c0-11ea-8b12-b65283d35c73.png">
Option 3
<img width="279" alt="Screen Shot 2020-01-09 at 1 02 16 PM" src="https://user-images.githubusercontent.com/16004905/72110185-68320280-32ec-11ea-8e74-c2596c1db0d9.png">
Option 4
<img width="287" alt="Screen Shot 2020-01-09 at 2 01 09 PM" src="https://user-images.githubusercontent.com/16004905/72110194-6e27e380-32ec-11ea-85ca-284a53e32a6b.png">
Option 5
<img width="286" alt="Screen Shot 2020-01-09 at 1 33 44 PM" src="https://user-images.githubusercontent.com/16004905/72110205-72ec9780-32ec-11ea-8977-d62b36dc5fe8.png">



