### PR TITLE
on medium and smaller screens change to rows

### DIFF
--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -46,7 +46,7 @@
             </mat-card-subtitle>
           </mat-card-header>
           <mat-card-content>
-            <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
+            <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="10px" fxLayoutAlign="space-between" class="mx-4">
               <span fxLayout="row" *ngIf="org?.email">
                 <mat-icon>email</mat-icon>
                 <span
@@ -64,8 +64,8 @@
                 <span class="ellipsis-lines">{{ org.location }}</span>
               </span>
               <span fxLayout="row" *ngIf="org?.starredUsers.length !== 0" class="pull-right">
-                <span class="ellipsis-lines">{{ org.starredUsers.length }}</span>
                 <mat-icon class="orgStar">star</mat-icon>
+                <span class="ellipsis-lines">{{ org.starredUsers.length }}</span>
               </span>
             </div>
           </mat-card-content>

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -40,13 +40,18 @@
           <mat-card-header>
             <mat-card-title>
               <a [routerLink]="org.name" [matTooltip]="org?.name">{{ org.displayName }}</a>
+
+              <span fxLayout="row" *ngIf="org?.starredUsers.length !== 0" class="pull-right">
+                <mat-icon class="orgStar">star</mat-icon>
+                <span class="ellipsis-lines">{{ org.starredUsers.length }}</span>
+              </span>
             </mat-card-title>
             <mat-card-subtitle>
               {{ org.topic }}
             </mat-card-subtitle>
           </mat-card-header>
           <mat-card-content>
-            <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="10px" fxLayoutAlign="space-between" class="mx-4">
+            <div fxLayout="column" fxLayoutGap="10px" fxLayoutAlign="space-between" class="mx-4">
               <span fxLayout="row" *ngIf="org?.email">
                 <mat-icon>email</mat-icon>
                 <span
@@ -62,10 +67,6 @@
               <span fxLayout="row" *ngIf="org?.location">
                 <mat-icon>location_on</mat-icon>
                 <span class="ellipsis-lines">{{ org.location }}</span>
-              </span>
-              <span fxLayout="row" *ngIf="org?.starredUsers.length !== 0" class="pull-right">
-                <mat-icon class="orgStar">star</mat-icon>
-                <span class="ellipsis-lines">{{ org.starredUsers.length }}</span>
               </span>
             </div>
           </mat-card-content>

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -11,3 +11,7 @@
 .orgStar {
   line-height: 1.1em;
 }
+
+::ng-deep .mat-card-header-text {
+  width: 100%;
+}


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2432
![smaller-screen-orgs](https://user-images.githubusercontent.com/6331159/72103155-9d435280-32f6-11ea-9d6b-a8f6a3593100.png)

Could not figure out how to deal with overflow :cry:. I think that the current design is bad anyways (I designed it) so I moved it to using rows instead of columns (on screens below large).