### PR TITLE
Fix for version dialog being in wrong mode

### DIFF
--- a/src/app/shared/view.ts
+++ b/src/app/shared/view.ts
@@ -15,11 +15,11 @@
  */
 import { Input, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs';
-
 import { DateService } from './date.service';
+import { Tag, WorkflowVersion } from './swagger';
 
 export abstract class View implements OnDestroy {
-  @Input() version;
+  @Input() version: WorkflowVersion | Tag;
 
   protected ngUnsubscribe: Subject<{}> = new Subject();
 

--- a/src/app/workflow/view/view.component.ts
+++ b/src/app/workflow/view/view.component.ts
@@ -99,7 +99,7 @@ export class ViewWorkflowComponent extends View implements OnInit {
   private openVersionModal(): void {
     const dialogRef = this.matDialog.open(VersionModalComponent, {
       width: '600px',
-      data: { canRead: this.canRead, canWrite: this.canWrite, isOwner: this.isOwner }
+      data: { canRead: this.canRead, canWrite: this.canWrite && !this.version.frozen, isOwner: this.isOwner }
     });
   }
 


### PR DESCRIPTION
The text of the button was set, but the mode of the dialog was not.

This fixes it

dockstore/dockstore#3067