### PR TITLE
added next steps to onboarding

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -59,6 +59,8 @@ export class DownloadCLIClientComponent implements OnInit {
     this.textData1 = `
 ### Setup Command Line Interface (Ubuntu)
 ------------------------------
+Setup our Dockstore CLI application to start launching workflows from the command line.
+
 #### Requirements
 1. Linux/Ubuntu (Recommended - Tested on 18.04.3 LTS) or Mac OS X machine
 2. Java 11 (Tested with OpenJDK 11, Oracle JDK may work but is untested)

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -88,8 +88,13 @@
         down your search.
       </p>
       <div class="button-row">
-        <a mat-raised-button [routerLink]="['/search']">Search for tools and workflows</a>
-        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+        <a mat-button color="accent" [routerLink]="['/search']">Search for tools and workflows</a>
+        <a
+          mat-button
+          color="accent"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
           >Learn how to launch tools and workflows <mat-icon>open_in_new</mat-icon></a
         >
       </div>
@@ -102,14 +107,13 @@
       </p>
       <div class="button-row">
         <a
-          mat-raised-button
+          mat-button
+          color="accent"
           target="_blank"
           rel="noopener noreferrer"
           href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
           >Learn how to register content <mat-icon>open_in_new</mat-icon></a
         >
-        <a mat-raised-button [routerLink]="['/my-tools']">My tools</a>
-        <a mat-raised-button [routerLink]="['/my-workflows']">My workflows</a>
       </div>
       <mat-divider></mat-divider>
 
@@ -120,18 +124,12 @@
       </p>
       <div class="button-row">
         <a
-          mat-raised-button
+          mat-button
+          color="accent"
           target="_blank"
           rel="noopener noreferrer"
           href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
-          >Learn about organizations <mat-icon>open_in_new</mat-icon></a
-        >
-        <a
-          mat-raised-button
-          target="_blank"
-          rel="noopener noreferrer"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html#collections"
-          >Learn about collections <mat-icon>open_in_new</mat-icon></a
+          >Read about organizations and collections <mat-icon>open_in_new</mat-icon></a
         >
       </div>
       <mat-divider></mat-divider>
@@ -142,10 +140,10 @@
         Dockstore developers and the general Dockstore audience.
       </p>
       <div class="button-row">
-        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
+        <a mat-button color="accent" target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
           >Documentation <mat-icon> open_in_new</mat-icon></a
         >
-        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"
+        <a mat-button color="accent" target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"
           >Forum <mat-icon>open_in_new </mat-icon></a
         >
       </div>

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -14,7 +14,7 @@
     <hr />
 
     <app-change-username showText="true"></app-change-username>
-    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2">Next<mat-icon>navigate_next </mat-icon></button>
+    <button mat-raised-button matStepperNext class="pull-right mt-2">Next<mat-icon>navigate_next </mat-icon></button>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Link External Accounts</ng-template>
@@ -59,111 +59,98 @@
       prototype workflows in private or with team-members in the near future.
     </p>
     <app-accounts-external></app-accounts-external>
-    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
-    <button mat-raised-button color="primary" matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
+    <button mat-raised-button matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
+    <button mat-raised-button matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Setup Dockstore CLI</ng-template>
     <app-downloadcliclient></app-downloadcliclient>
-    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
-    <button mat-raised-button color="primary" matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
+    <button mat-raised-button matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
+    <button mat-raised-button matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Next Steps</ng-template>
-    <div fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="10px">
+    <div fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="20px">
       <h3>
         Where To Go Next
         <hr />
       </h3>
-      <h4>You Have Completed The Onboarding Process</h4>
+      <h4>You have completed the onboarding process</h4>
       <p>
         Now that you have created an account and have the Dockstore CLI running locally, you can start exploring Dockstore. Below are some
         ideas to get you started!
       </p>
 
       <h4>Next Steps</h4>
-      <mat-card>
-        <h4>Search For Tools and Workflows To Launch</h4>
-        <p>
-          Use our search page to find tools and workflows to launch locally or in a cloud environment. Use advanced search to help you
-          narrow down your search.
-        </p>
-        <div class="button-row">
-          <a mat-raised-button color="primary" [routerLink]="['/search']">Search for Tools and Workflows</a>
-          <a
-            mat-raised-button
-            color="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
-            >Learn How To Launch Tools and Workflows <mat-icon>open_in_new</mat-icon></a
-          >
-        </div>
-      </mat-card>
+      <h5>Search for tools and workflows to launch</h5>
+      <p>
+        Use our search page to find tools and workflows to launch locally or in a cloud environment. Use advanced search to help you narrow
+        down your search.
+      </p>
+      <div class="button-row">
+        <a mat-raised-button [routerLink]="['/search']">Search for tools and workflows</a>
+        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+          >Learn how to launch tools and workflows <mat-icon>open_in_new</mat-icon></a
+        >
+      </div>
+      <mat-divider></mat-divider>
 
-      <mat-card>
-        <h4>Register and Publish Your Own Tools and Workflows</h4>
-        <p>
-          Dockstore supports the registering of tools and workflows from a variety of third-party sites. This includes sites like Quay.io,
-          DockerHub, GitHub, Bitbucket, and GitLab.
-        </p>
-        <div class="button-row">
-          <a
-            mat-raised-button
-            color="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
-            >Learn How To Register Content <mat-icon>open_in_new</mat-icon></a
-          >
-          <a mat-raised-button color="primary" [routerLink]="['/my-tools']">My Tools</a>
-          <a mat-raised-button color="primary" [routerLink]="['/my-workflows']">My Workflows</a>
-        </div>
-      </mat-card>
+      <h5>Register and publish your own tools and workflows</h5>
+      <p>
+        Dockstore supports the registering of tools and workflows from a variety of third-party sites. This includes sites like Quay.io,
+        DockerHub, GitHub, Bitbucket, and GitLab.
+      </p>
+      <div class="button-row">
+        <a
+          mat-raised-button
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+          >Learn how to register content <mat-icon>open_in_new</mat-icon></a
+        >
+        <a mat-raised-button [routerLink]="['/my-tools']">My tools</a>
+        <a mat-raised-button [routerLink]="['/my-workflows']">My workflows</a>
+      </div>
+      <mat-divider></mat-divider>
 
-      <mat-card>
-        <h4>Create An Organization and Add Some Collections</h4>
-        <p>
-          Users can create organizations for labs, institutions, companies, etc. that let them showcase tools and workflows. Collections can
-          be added to organizations to further group together related tools and workflows.
-        </p>
-        <div class="button-row">
-          <a
-            mat-raised-button
-            color="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
-            >Learn About Organizations <mat-icon>open_in_new</mat-icon></a
-          >
-          <a
-            mat-raised-button
-            color="primary"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html#collections"
-            >Learn About Collections <mat-icon>open_in_new</mat-icon></a
-          >
-        </div>
-      </mat-card>
+      <h5>Create an organization and add some collections</h5>
+      <p>
+        Users can create organizations for labs, institutions, companies, etc. that let them showcase tools and workflows. Collections can
+        be added to organizations to further group together related tools and workflows.
+      </p>
+      <div class="button-row">
+        <a
+          mat-raised-button
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
+          >Learn about organizations <mat-icon>open_in_new</mat-icon></a
+        >
+        <a
+          mat-raised-button
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html#collections"
+          >Learn about collections <mat-icon>open_in_new</mat-icon></a
+        >
+      </div>
+      <mat-divider></mat-divider>
 
-      <mat-card>
-        <h4>Check Out Our Extensive Documentation and Our Discussion Forum</h4>
-        <p>
-          We have lots of helpful documentation to help you get the most out of Dockstore. We also have a forum where you can ask questions
-          to Dockstore developers and the general Dockstore audience.
-        </p>
-        <div class="button-row">
-          <a mat-raised-button color="primary" target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
-            >Documentation <mat-icon> open_in_new</mat-icon></a
-          >
-          <a mat-raised-button color="primary" target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"
-            >Forum <mat-icon>open_in_new </mat-icon></a
-          >
-        </div>
-      </mat-card>
+      <h5>Check out our documentation and our discussion forum</h5>
+      <p>
+        We have lots of helpful documentation to help you get the most out of Dockstore. We also have a forum where you can ask questions to
+        Dockstore developers and the general Dockstore audience.
+      </p>
+      <div class="button-row">
+        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
+          >Documentation <mat-icon> open_in_new</mat-icon></a
+        >
+        <a mat-raised-button target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"
+          >Forum <mat-icon>open_in_new </mat-icon></a
+        >
+      </div>
       <span class="mt-2">
-        <button mat-raised-button color="primary" matStepperPrevious class="pull-right"><mat-icon>navigate_before</mat-icon>Back</button>
+        <button mat-raised-button matStepperPrevious class="pull-right"><mat-icon>navigate_before</mat-icon>Back</button>
       </span>
     </div>
   </mat-step>

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -14,7 +14,7 @@
     <hr />
 
     <app-change-username showText="true"></app-change-username>
-    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2">Next<mat-icon>navigate_next</mat-icon></button>
+    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2">Next<mat-icon>navigate_next </mat-icon></button>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Link External Accounts</ng-template>
@@ -59,23 +59,112 @@
       prototype workflows in private or with team-members in the near future.
     </p>
     <app-accounts-external></app-accounts-external>
-    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next</mat-icon></button>
+    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
     <button mat-raised-button color="primary" matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Setup Dockstore CLI</ng-template>
     <app-downloadcliclient></app-downloadcliclient>
-    <span class="mt-2">
-      <a
-        mat-raised-button
-        color="primary"
-        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started-with-docker.html"
-        class="pull-right ml-1"
-        target="_blank"
-        rel="noopener noreferrer"
-        >Go to Docs<mat-icon>navigate_next</mat-icon></a
-      >
-      <button mat-raised-button color="primary" matStepperPrevious class="pull-right"><mat-icon>navigate_before</mat-icon>Back</button>
-    </span>
+    <button mat-raised-button color="primary" matStepperNext class="pull-right mt-2 ml-1">Next<mat-icon>navigate_next </mat-icon></button>
+    <button mat-raised-button color="primary" matStepperPrevious class="pull-right mt-2"><mat-icon>navigate_before</mat-icon>Back</button>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Next Steps</ng-template>
+    <div fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="10px">
+      <h3>
+        Where To Go Next
+        <hr />
+      </h3>
+      <h4>You Have Completed The Onboarding Process</h4>
+      <p>
+        Now that you have created an account and have the Dockstore CLI running locally, you can start exploring Dockstore. Below are some
+        ideas to get you started!
+      </p>
+
+      <h4>Next Steps</h4>
+      <mat-card>
+        <h4>Search For Tools and Workflows To Launch</h4>
+        <p>
+          Use our search page to find tools and workflows to launch locally or in a cloud environment. Use advanced search to help you
+          narrow down your search.
+        </p>
+        <div class="button-row">
+          <a mat-raised-button color="primary" [routerLink]="['/search']">Search for Tools and Workflows</a>
+          <a
+            mat-raised-button
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+            >Learn How To Launch Tools and Workflows <mat-icon>open_in_new</mat-icon></a
+          >
+        </div>
+      </mat-card>
+
+      <mat-card>
+        <h4>Register and Publish Your Own Tools and Workflows</h4>
+        <p>
+          Dockstore supports the registering of tools and workflows from a variety of third-party sites. This includes sites like Quay.io,
+          DockerHub, GitHub, Bitbucket, and GitLab.
+        </p>
+        <div class="button-row">
+          <a
+            mat-raised-button
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+            >Learn How To Register Content <mat-icon>open_in_new</mat-icon></a
+          >
+          <a mat-raised-button color="primary" [routerLink]="['/my-tools']">My Tools</a>
+          <a mat-raised-button color="primary" [routerLink]="['/my-workflows']">My Workflows</a>
+        </div>
+      </mat-card>
+
+      <mat-card>
+        <h4>Create An Organization and Add Some Collections</h4>
+        <p>
+          Users can create organizations for labs, institutions, companies, etc. that let them showcase tools and workflows. Collections can
+          be added to organizations to further group together related tools and workflows.
+        </p>
+        <div class="button-row">
+          <a
+            mat-raised-button
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
+            >Learn About Organizations <mat-icon>open_in_new</mat-icon></a
+          >
+          <a
+            mat-raised-button
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html#collections"
+            >Learn About Collections <mat-icon>open_in_new</mat-icon></a
+          >
+        </div>
+      </mat-card>
+
+      <mat-card>
+        <h4>Check Out Our Extensive Documentation and Our Discussion Forum</h4>
+        <p>
+          We have lots of helpful documentation to help you get the most out of Dockstore. We also have a forum where you can ask questions
+          to Dockstore developers and the general Dockstore audience.
+        </p>
+        <div class="button-row">
+          <a mat-raised-button color="primary" target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
+            >Documentation <mat-icon> open_in_new</mat-icon></a
+          >
+          <a mat-raised-button color="primary" target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"
+            >Forum <mat-icon>open_in_new </mat-icon></a
+          >
+        </div>
+      </mat-card>
+      <span class="mt-2">
+        <button mat-raised-button color="primary" matStepperPrevious class="pull-right"><mat-icon>navigate_before</mat-icon>Back</button>
+      </span>
+    </div>
   </mat-step>
 </mat-horizontal-stepper>

--- a/src/app/loginComponents/onboarding/onboarding.component.scss
+++ b/src/app/loginComponents/onboarding/onboarding.component.scss
@@ -1,0 +1,4 @@
+.button-row button,
+.button-row a {
+  margin-right: 8px;
+}

--- a/src/app/loginComponents/onboarding/onboarding.component.ts
+++ b/src/app/loginComponents/onboarding/onboarding.component.ts
@@ -9,7 +9,8 @@ import { Dockstore } from '../../shared/dockstore.model';
 
 @Component({
   selector: 'app-onboarding',
-  templateUrl: './onboarding.component.html'
+  templateUrl: './onboarding.component.html',
+  styleUrls: ['./onboarding.component.scss']
 })
 export class OnboardingComponent implements OnInit, OnDestroy {
   public tokenSetComplete;


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3114

Onboarding wizard was good for setting up your third party accounts and installing Dockstore, but then doesn't really tell you where to go next. I've added another stepper option that helps new users figure out where to go next.

EDIT: see comment for newer version
Open to more ideas.
![onboarding-next-steps](https://user-images.githubusercontent.com/6331159/72177062-e6a2a900-33ad-11ea-80ca-8883451c096d.png)
