### PR TITLE
footer is column on small screens and below

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -16,7 +16,7 @@
 
 <div class="container-fluid">
   <div class="container">
-    <div fxLayout="row" fxLayoutAlign="center">
+    <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutAlign="center">
       <div fxFlex="25%">
         <ul class="footer-list m-0">
           <li class="m-0">Dockstore</li>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -16,7 +16,7 @@
 
 <div class="container-fluid">
   <div class="container">
-    <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutAlign="center">
+    <div fxLayout="row" fxLayoutAlign="center">
       <div fxFlex="25%">
         <ul class="footer-list m-0">
           <li class="m-0">Dockstore</li>
@@ -142,7 +142,7 @@
     </div>
   </div>
   <div class="row" fxLayoutAlign="center center">
-    <a [routerLink]="['/funding']" class="footer-link">
+    <a [routerLink]="['/funding']" class="footer-link p-4">
       <small
         >Support for Dockstore is provided by grants from Genome Canada, the National Institutes of Health, and the Province of
         Ontario.</small


### PR DESCRIPTION
On small screens (phones) the footer content switches from rows to column.
Previously
![row-footer](https://user-images.githubusercontent.com/6331159/72284779-cd993280-360f-11ea-87b8-63acfbe70c17.png)

Now
![column-footer](https://user-images.githubusercontent.com/6331159/72284787-d0942300-360f-11ea-928c-e8241b335b22.png)
