### PR TITLE
Feature/newsUpdatesWidget

### DIFF
--- a/cypress/fixtures/newsUpdates.json
+++ b/cypress/fixtures/newsUpdates.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 1,
+    "message": "Middle Newsbody Item",
+    "expiration": "2030-06-25T18:45:10.210Z",
+    "type": "NEWSBODY",
+    "priority": "CRITICAL",
+    "dbCreateDate": "2020-01-11T18:45:47.182Z",
+    "dbUpdateDate": "2020-01-11T18:45:47.182Z"
+  },
+  {
+    "id": 2,
+    "message": "Last Newsbody Item",
+    "expiration": "2030-01-25T18:45:10.210Z",
+    "type": "NEWSBODY",
+    "priority": "CRITICAL",
+    "dbCreateDate": "2020-01-12T18:45:47.182Z",
+    "dbUpdateDate": "2020-01-12T18:45:47.182Z"
+  },
+  {
+    "id": 3,
+    "message": "First Newsbody Item",
+    "expiration": "2030-12-25T18:45:10.210Z",
+    "type": "NEWSBODY",
+    "priority": "CRITICAL",
+    "dbCreateDate": "2020-01-13T18:45:47.182Z",
+    "dbUpdateDate": "2020-01-13T18:45:47.182Z"
+  }
+]

--- a/cypress/integration/immutableDatabaseTests/newsUpdates.ts
+++ b/cypress/integration/immutableDatabaseTests/newsUpdates.ts
@@ -1,0 +1,41 @@
+/*
+*    Copyright 2020 OICR
+*
+*    Licensed under the Apache License, Version 2.0 (the "License");
+*    you may not use this file except in compliance with the License.
+*    You may obtain a copy of the License at
+*
+*        http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software
+*    distributed under the License is distributed on an "AS IS" BASIS,
+*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*    See the License for the specific language governing permissions and
+*    limitations under the License.
+* */
+
+import { resetDB, setTokenUserViewPort } from '../../support/commands';
+
+describe('News and Updates Widget', () => {
+  resetDB();
+  setTokenUserViewPort();
+
+  it('News and updates widget appears on logged-in homepage', () => {
+    cy.server();
+    cy.fixture('newsUpdates.json').then(json => {
+      cy.route({
+        method: 'GET',
+        url: '*/curation/notifications',
+        response: json
+      });
+    });
+    cy.visit('/');
+    //make sure items are in proper sort order
+    cy.get('[data-cy=news-updates-container] > [data-cy=news-updates-item]')
+      .eq(0).contains('First Newsbody Item');
+    cy.get('[data-cy=news-updates-container] > [data-cy=news-updates-item]')
+      .eq(1).contains('Middle Newsbody Item');
+    cy.get('[data-cy=news-updates-container] > [data-cy=news-updates-item]')
+      .eq(2).contains('Last Newsbody Item');
+  });
+});

--- a/cypress/integration/immutableDatabaseTests/newsUpdates.ts
+++ b/cypress/integration/immutableDatabaseTests/newsUpdates.ts
@@ -14,7 +14,7 @@
 *    limitations under the License.
 * */
 
-import { resetDB, setTokenUserViewPort } from '../../support/commands';
+import { setTokenUserViewPort } from '../../support/commands';
 
 describe('News and Updates Widget', () => {
   setTokenUserViewPort();
@@ -29,7 +29,7 @@ describe('News and Updates Widget', () => {
       });
     });
     cy.visit('/');
-    //make sure items are in proper sort order
+    // make sure items are in proper sort order
     cy.get('[data-cy=news-updates-container] > [data-cy=news-updates-item]')
       .eq(0).contains('First Newsbody Item');
     cy.get('[data-cy=news-updates-container] > [data-cy=news-updates-item]')

--- a/cypress/integration/immutableDatabaseTests/newsUpdates.ts
+++ b/cypress/integration/immutableDatabaseTests/newsUpdates.ts
@@ -17,7 +17,6 @@
 import { resetDB, setTokenUserViewPort } from '../../support/commands';
 
 describe('News and Updates Widget', () => {
-  resetDB();
   setTokenUserViewPort();
 
   it('News and updates widget appears on logged-in homepage', () => {

--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -30,6 +30,12 @@
   <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutAlign="start start" fxLayoutGap="10px" class="w-100" fxFlex="1 1 100%">
     <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="20px" class="px-4 w-100" fxFlex="1 1 100%" fxFlexAlign="stretch">
       <div class="widget-section">
+        <h3>News and Updates</h3>
+        <div class="news-container">
+          <app-news-updates data-cy="news-updates-container"></app-news-updates>
+        </div>
+      </div>
+      <div class="widget-section">
         <h3>Explore Featured Content</h3>
         <app-alert></app-alert>
         <featured-content></featured-content>
@@ -40,9 +46,6 @@
     </div>
 
     <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="20px" fxFlex="1 2 100%" class="px-4 side-column" fxFlexAlign="stretch">
-      <div class="w-100">
-        <h3>News and Updates</h3>
-      </div>
       <app-requests *ngIf="user$ | async" class="w-100"></app-requests>
       <div class="w-100">
         <h3>Links</h3>

--- a/src/app/home-page/home-logged-in/home-logged-in.component.scss
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.scss
@@ -1,5 +1,4 @@
 .widget-section {
-  min-height: 300px;
   width: 100%;
 }
 
@@ -30,4 +29,7 @@ mat-sidenav-container {
 ul {
   list-style: none;
   padding-left: 0;
+}
+.news-container {
+  border-top: 0.1rem solid #e0e1e2;
 }

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -17,6 +17,8 @@ import { OrganizationsComponent } from './widget/organizations/organizations.com
 import { FeaturedContentComponent } from './widget/featured-content/featured-content.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
+import { NewsUpdatesComponent } from './widget/news-updates/news-updates.component';
+import { MarkdownModule } from 'ngx-markdown';
 
 @NgModule({
   imports: [
@@ -31,7 +33,8 @@ import { RefreshAlertModule } from '../shared/alert/alert.module';
     FormsModule,
     TabsModule,
     HttpClientModule,
-    RefreshAlertModule
+    RefreshAlertModule,
+    MarkdownModule
   ],
   declarations: [
     HomePageComponent,
@@ -40,7 +43,8 @@ import { RefreshAlertModule } from '../shared/alert/alert.module';
     RequestsComponent,
     EntriesComponent,
     OrganizationsComponent,
-    FeaturedContentComponent
+    FeaturedContentComponent,
+    NewsUpdatesComponent
   ],
   entryComponents: [],
   exports: [NgxJsonLdModule]

--- a/src/app/home-page/widget/news-updates/news-updates.component.html
+++ b/src/app/home-page/widget/news-updates/news-updates.component.html
@@ -1,0 +1,7 @@
+<div data-cy="news-updates-item" *ngFor="let notification of allNotifications$ | async">
+  <div class="news-card" *ngIf="notification.type === notificationTypeEnum.NEWSBODY">
+    <markdown class="markdown-remove-pmargin">
+      {{ notification.message }}
+    </markdown>
+  </div>
+</div>

--- a/src/app/home-page/widget/news-updates/news-updates.component.scss
+++ b/src/app/home-page/widget/news-updates/news-updates.component.scss
@@ -1,0 +1,4 @@
+.news-card {
+  padding: 1rem;
+  border-bottom: 0.1rem solid #e0e1e2;
+}

--- a/src/app/home-page/widget/news-updates/news-updates.component.spec.ts
+++ b/src/app/home-page/widget/news-updates/news-updates.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NewsUpdatesComponent } from './news-updates.component';
+import { MarkdownModule } from 'ngx-markdown';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('NewsUpdatesComponent', () => {
   let component: NewsUpdatesComponent;
@@ -8,7 +10,8 @@ describe('NewsUpdatesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [NewsUpdatesComponent]
+      declarations: [NewsUpdatesComponent],
+      imports: [MarkdownModule, HttpClientTestingModule]
     }).compileComponents();
   }));
 

--- a/src/app/home-page/widget/news-updates/news-updates.component.spec.ts
+++ b/src/app/home-page/widget/news-updates/news-updates.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewsUpdatesComponent } from './news-updates.component';
+
+describe('NewsUpdatesComponent', () => {
+  let component: NewsUpdatesComponent;
+  let fixture: ComponentFixture<NewsUpdatesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [NewsUpdatesComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewsUpdatesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/home-page/widget/news-updates/news-updates.component.ts
+++ b/src/app/home-page/widget/news-updates/news-updates.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { NotificationsQuery } from '../../../notifications/state/notifications.query';
+import { NotificationsService } from '../../../notifications/state/notifications.service';
+import { Notification } from '../../../shared/swagger';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-news-updates',
+  templateUrl: './news-updates.component.html',
+  styleUrls: ['./news-updates.component.scss']
+})
+export class NewsUpdatesComponent implements OnInit {
+  constructor(private notificationsQuery: NotificationsQuery, private notificationsService: NotificationsService) {}
+  public message: string;
+  public allNotifications$: Observable<Array<Notification>>;
+  public notificationTypeEnum = Notification.TypeEnum;
+
+  ngOnInit() {
+    this.notificationsService.getNotifications();
+    this.allNotifications$ = this.notificationsQuery.allNotifications$;
+  }
+}

--- a/src/app/home-page/widget/news-updates/news-updates.component.ts
+++ b/src/app/home-page/widget/news-updates/news-updates.component.ts
@@ -11,7 +11,6 @@ import { Observable } from 'rxjs';
 })
 export class NewsUpdatesComponent implements OnInit {
   constructor(private notificationsQuery: NotificationsQuery, private notificationsService: NotificationsService) {}
-  public message: string;
   public allNotifications$: Observable<Array<Notification>>;
   public notificationTypeEnum = Notification.TypeEnum;
 

--- a/src/app/notifications/state/notifications.query.ts
+++ b/src/app/notifications/state/notifications.query.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@angular/core';
-import { QueryEntity } from '@datorama/akita';
+import { Order, QueryEntity } from '@datorama/akita';
 import { NotificationsStore, NotificationsState } from './notifications.store';
 import { Notification } from '../../shared/swagger/model/notification';
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class NotificationsQuery extends QueryEntity<NotificationsState> {
-  allNotifications$: Observable<Array<Notification>> = this.selectAll();
+  allNotifications$: Observable<Array<Notification>> = this.selectAll({
+    // sort notifications, those expiring the soonest last
+    sortBy: 'expiration',
+    sortByOrder: Order.DESC
+  });
 
   constructor(protected store: NotificationsStore) {
     super(store);


### PR DESCRIPTION
UI for the news and updates widget on logged-in homepage
* Uses same endpoints as notifications, but items for widget are of type newsbody
* Changed notifications query to sort notifications by expiration date (doesn't affect notifications ui, it uses a separate query)
* added a separate cypress tests file, can transition this file for homepage tests in general, probably will refactor in a future homepage clean up ticket

Screenshot: 
![image](https://user-images.githubusercontent.com/23464754/72309796-d6502f80-3634-11ea-8a24-3d49e5796dcb.png)
