### PR TITLE
Feature/python dependency

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -35,7 +35,7 @@ export class DownloadCLIClientComponent implements OnInit {
       (resultFromApi: Metadata) => {
         apiVersion = resultFromApi.version;
         this.dockstoreVersion = `${apiVersion}`;
-        this.downloadCli = `https://github.com/dockstore/dockstore-cli/releases/download/${apiVersion}/dockstore`;
+        this.downloadCli = `https://github.com/dockstore/dockstore/releases/download/${apiVersion}/dockstore`;
         this.metadataService
           .getRunnerDependencies(apiVersion, '3', 'cwltool', 'json')
           .pipe(finalize(() => this.generateMarkdown()))

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -37,7 +37,7 @@ export class DownloadCLIClientComponent implements OnInit {
         this.dockstoreVersion = `${apiVersion}`;
         this.downloadCli = `https://github.com/dockstore/dockstore-cli/releases/download/${apiVersion}/dockstore`;
         this.metadataService
-          .getRunnerDependencies(apiVersion, '2', 'cwltool', 'json')
+          .getRunnerDependencies(apiVersion, '3', 'cwltool', 'json')
           .pipe(finalize(() => this.generateMarkdown()))
           .subscribe(
             (json: any) => {

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -35,7 +35,7 @@ export class DownloadCLIClientComponent implements OnInit {
       (resultFromApi: Metadata) => {
         apiVersion = resultFromApi.version;
         this.dockstoreVersion = `${apiVersion}`;
-        this.downloadCli = `https://github.com/ga4gh/dockstore/releases/download/${apiVersion}/dockstore`;
+        this.downloadCli = `https://github.com/dockstore/dockstore-cli/releases/download/${apiVersion}/dockstore`;
         this.metadataService
           .getRunnerDependencies(apiVersion, '2', 'cwltool', 'json')
           .pipe(finalize(() => this.generateMarkdown()))


### PR DESCRIPTION
* update download CLI link so that ga4gh redirect isn't used
* update python version to 3 for python dependency

https://github.com/dockstore/dockstore/issues/2897