### PR TITLE
getting started widget for logged-in homepage

### DIFF
--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -41,7 +41,8 @@
         <featured-content></featured-content>
       </div>
       <div class="widget-section">
-        <h3>Recent Activity</h3>
+        <h3>Getting Started?</h3>
+        <app-getting-started></app-getting-started>
       </div>
     </div>
 

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -19,6 +19,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { NewsUpdatesComponent } from './widget/news-updates/news-updates.component';
 import { MarkdownModule } from 'ngx-markdown';
+import { GettingStartedComponent } from './widget/getting-started/getting-started.component';
 
 @NgModule({
   imports: [
@@ -44,7 +45,8 @@ import { MarkdownModule } from 'ngx-markdown';
     EntriesComponent,
     OrganizationsComponent,
     FeaturedContentComponent,
-    NewsUpdatesComponent
+    NewsUpdatesComponent,
+    GettingStartedComponent
   ],
   entryComponents: [],
   exports: [NgxJsonLdModule]

--- a/src/app/home-page/widget/getting-started/getting-started.component.html
+++ b/src/app/home-page/widget/getting-started/getting-started.component.html
@@ -1,0 +1,66 @@
+<div class="tutorial-container">
+  <div class="tutorial-section-card">
+    <h4 class="tutorial-title">Search for tools and workflows to launch</h4>
+    <p>
+      Use our search page to find tools and workflows to launch locally or in a cloud environment. Use advanced search to help you narrow
+      down your search.
+    </p>
+    <div class="button-row">
+      <a class="button-link" mat-button color="accent" [routerLink]="['/search']">Search for tools and workflows</a>
+      <a
+        class="button-link"
+        mat-button
+        color="accent"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+        >Learn how to launch tools and workflows <mat-icon>open_in_new</mat-icon>
+      </a>
+    </div>
+  </div>
+  <div class="tutorial-section-card">
+    <h4 class="tutorial-title">Register and publish your own tools and workflows</h4>
+    <p>
+      Dockstore uses the combination of containers and descriptor languages to make analysis portable and reproducible. Users can register
+      their tools and workflows from a variety of third-party sites like Quay.io, DockerHub, GitHub, Bitbucket, and GitLab.
+    </p>
+    <div class="button-row">
+      <a
+        class="button-link"
+        mat-button
+        color="accent"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+        >Learn more about containers and descriptors <mat-icon>open_in_new</mat-icon>
+      </a>
+      <a
+        class="button-link"
+        mat-button
+        color="accent"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/register-on-dockstore.html#linking-with-external-services"
+        >Learn how to register content <mat-icon>open_in_new</mat-icon>
+      </a>
+    </div>
+  </div>
+  <div class="tutorial-section-card">
+    <h4 class="tutorial-title">Create an organization and add some collections</h4>
+    <p>
+      Users can create organizations for labs, institutions, companies, etc. that let them showcase tools and workflows. Collections can be
+      added to organizations to further group together related tools and workflows.
+    </p>
+    <div class="button-row">
+      <a
+        class="button-link"
+        mat-button
+        color="accent"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
+        >Read about organizations and collections <mat-icon>open_in_new</mat-icon>
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/home-page/widget/getting-started/getting-started.component.scss
+++ b/src/app/home-page/widget/getting-started/getting-started.component.scss
@@ -1,0 +1,15 @@
+.tutorial-section-card {
+  border-radius: 0.5rem;
+  min-width: 20rem;
+  border: 0.1rem solid #c1c2c3;
+  padding: 1rem 1.5rem;
+  margin: 2rem;
+  flex: 1;
+}
+.tutorial-section-card p {
+  margin-bottom: 0;
+}
+
+.tutorial-title {
+  color: #21335b;
+}

--- a/src/app/home-page/widget/getting-started/getting-started.component.spec.ts
+++ b/src/app/home-page/widget/getting-started/getting-started.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GettingStartedComponent } from './getting-started.component';
+import { RouterLinkStubDirective } from '../../../test';
+import { MatButtonModule, MatIconModule } from '@angular/material';
+
+describe('GettingStartedComponent', () => {
+  let component: GettingStartedComponent;
+  let fixture: ComponentFixture<GettingStartedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [GettingStartedComponent, RouterLinkStubDirective],
+      imports: [MatIconModule, MatButtonModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GettingStartedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/home-page/widget/getting-started/getting-started.component.ts
+++ b/src/app/home-page/widget/getting-started/getting-started.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { Dockstore } from '../../../shared/dockstore.model';
+
+@Component({
+  selector: 'app-getting-started',
+  templateUrl: './getting-started.component.html',
+  styleUrls: ['./getting-started.component.scss']
+})
+export class GettingStartedComponent {
+  Dockstore = Dockstore;
+}

--- a/src/featured-content.scss
+++ b/src/featured-content.scss
@@ -9,7 +9,8 @@ The following classes are used style the featured content external html
 }
 
 .feat-content-card {
-  box-shadow: 0 0.4rem 0.8rem 0 rgba(0, 0, 0, 0.2); /* this adds the "card" effect */
+  border-radius: 0.5rem;
+  box-shadow: 0 0.4rem 0.5rem 0 rgba(0, 0, 0, 0.2); /* this adds the "card" effect */
   text-align: center;
   justify-content: center;
   min-width: 20rem;
@@ -30,9 +31,12 @@ a.cardClick:hover {
   text-decoration: none;
 }
 
-h3.feat-content-title {
+.feat-content-title {
   color: #487980;
   margin-top: 1rem;
+}
+.feat-content-card:hover {
+  box-shadow: 0 0.4rem 0.5rem 0 rgba(0, 0, 0, 0.5);
 }
 
 @media (max-width: 50rem) {


### PR DESCRIPTION
Filling up logged-in homepage with content from on-boarding until events widget is ready. 
* added getting started widget to logged-in homepage
* added minor styling changes for featured content widget

screenshot:
![image](https://user-images.githubusercontent.com/23464754/72845475-8d5f3300-3c53-11ea-92f3-bf0f2dd9a9ce.png)

