### PR TITLE
remove underline text styling when card is clicked

### DIFF
--- a/src/featured-content.scss
+++ b/src/featured-content.scss
@@ -25,9 +25,6 @@ a.cardClick {
   color: #313131;
   height: 100%;
   width: 100%;
-}
-
-a.cardClick:hover {
   text-decoration: none;
 }
 


### PR DESCRIPTION
Really minor fix, removes text underline when card is clicked, also still removes the underline on hover.