### PR TITLE
Feature/fix some unused locals

### DIFF
--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -15,8 +15,6 @@
  */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
-
-import { ContainerService } from '../../shared/container.service';
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
@@ -46,7 +44,6 @@ export class DescriptorsComponent extends EntryFileSelector {
   protected entryType: 'tool' | 'workflow' = 'tool';
 
   constructor(
-    private containerService: ContainerService,
     private descriptorsService: DescriptorService,
     protected gA4GHService: GA4GHService,
     private toolQuery: ToolQuery,

--- a/src/app/container/dockerfile/dockerfile.component.ts
+++ b/src/app/container/dockerfile/dockerfile.component.ts
@@ -19,7 +19,6 @@ import { Observable } from 'rxjs';
 import { finalize, first } from 'rxjs/operators';
 
 import { ga4ghPath } from '../../shared/constants';
-import { ContainerService } from '../../shared/container.service';
 import { Dockstore } from '../../shared/dockstore.model';
 import { FileService } from '../../shared/file.service';
 import { ContainersService } from '../../shared/swagger';
@@ -48,12 +47,7 @@ export class DockerfileComponent {
   public customDownloadHREF: SafeUrl;
   public customDownloadPath: string;
   public loading = true;
-  constructor(
-    public fileService: FileService,
-    private toolQuery: ToolQuery,
-    private containerService: ContainerService,
-    private containersService: ContainersService
-  ) {
+  constructor(public fileService: FileService, private toolQuery: ToolQuery, private containersService: ContainersService) {
     this.filePath = '/Dockerfile';
     this.published$ = this.toolQuery.toolIsPublished$;
   }

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -64,8 +64,7 @@ export class InfoTabComponent implements OnInit, OnChanges {
     this.tool = JSON.parse(JSON.stringify(this.extendedDockstoreTool));
     if (this.selectedVersion && this.tool) {
       this.currentVersion = this.selectedVersion;
-      const found = this.validVersions.find((version: Tag) => version.id === this.selectedVersion.id);
-      this.isValidVersion = !!found;
+      this.isValidVersion = this.validVersions.some((version: Tag) => version.id === this.selectedVersion.id);
       this.downloadZipLink = Dockstore.API_URI + '/containers/' + this.tool.id + '/zip/' + this.currentVersion.id;
       if (this.tool.descriptorType.includes(DescriptorTypeEnum.CWL)) {
         this.trsLinkCWL = this.getTRSLink(

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -15,9 +15,7 @@
  */
 import { HttpResponse } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-
 import { ga4ghPath } from '../../shared/constants';
-import { ContainerService } from '../../shared/container.service';
 import { Dockstore } from '../../shared/dockstore.model';
 import { ExtendedToolsService } from '../../shared/extended-tools.service';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
@@ -27,6 +25,7 @@ import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Tag } from '../../shared/swagger/model/tag';
 import { exampleDescriptorPatterns, validationDescriptorPatterns } from '../../shared/validationMessages.model';
 import { InfoTabService } from './info-tab.service';
+
 import DescriptorTypeEnum = ToolVersion.DescriptorTypeEnum;
 
 @Component({
@@ -56,7 +55,6 @@ export class InfoTabComponent implements OnInit, OnChanges {
   isValidVersion = false;
   Dockstore = Dockstore;
   constructor(
-    private containerService: ContainerService,
     private infoTabService: InfoTabService,
     private sessionQuery: SessionQuery,
     private containersService: ExtendedToolsService
@@ -67,7 +65,7 @@ export class InfoTabComponent implements OnInit, OnChanges {
     if (this.selectedVersion && this.tool) {
       this.currentVersion = this.selectedVersion;
       const found = this.validVersions.find((version: Tag) => version.id === this.selectedVersion.id);
-      this.isValidVersion = found ? true : false;
+      this.isValidVersion = !!found;
       this.downloadZipLink = Dockstore.API_URI + '/containers/' + this.tool.id + '/zip/' + this.currentVersion.id;
       if (this.tool.descriptorType.includes(DescriptorTypeEnum.CWL)) {
         this.trsLinkCWL = this.getTRSLink(

--- a/src/app/container/info-tab/info-tab.service.ts
+++ b/src/app/container/info-tab/info-tab.service.ts
@@ -21,7 +21,6 @@ import { Base } from '../../shared/base';
 import { ContainerService } from '../../shared/container.service';
 import { ExtendedDockstoreToolQuery } from '../../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
-import { RefreshService } from '../../shared/refresh.service';
 import { ContainersService } from '../../shared/swagger/api/containers.service';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 
@@ -55,7 +54,6 @@ export class InfoTabService extends Base {
     private containersService: ContainersService,
     private alertService: AlertService,
     private containerService: ContainerService,
-    private refreshService: RefreshService,
     private extendedDockstoreToolQuery: ExtendedDockstoreToolQuery
   ) {
     super();

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -15,13 +15,11 @@
  */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
-
-import { ContainerService } from '../../shared/container.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-import { ContainersService, GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { FilesQuery } from '../../workflow/files/state/files.query';
@@ -46,8 +44,6 @@ export class ParamfilesComponent extends EntryFileSelector {
   protected entryType: 'tool' | 'workflow' = 'tool';
   public downloadFilePath: string;
   constructor(
-    private containerService: ContainerService,
-    private containersService: ContainersService,
     protected gA4GHService: GA4GHService,
     private paramfilesService: ParamfilesService,
     protected gA4GHFilesService: GA4GHFilesService,

--- a/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
+++ b/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 import { Component } from '@angular/core';
-
 import { AlertQuery } from '../../shared/alert/state/alert.query';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { ContainerService } from '../../shared/container.service';
@@ -22,7 +21,6 @@ import { RefreshOrganizationComponent } from '../../shared/refresh-organization/
 import { UsersService } from '../../shared/swagger/api/users.service';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { UserQuery } from '../../shared/user/user.query';
-import { RefreshService } from './../../shared/refresh.service';
 
 @Component({
   selector: 'app-refresh-tool-organization',
@@ -36,7 +34,6 @@ export class RefreshToolOrganizationComponent extends RefreshOrganizationCompone
     private alertService: AlertService,
     private usersService: UsersService,
     private containerService: ContainerService,
-    private refreshService: RefreshService,
     protected alertQuery: AlertQuery
   ) {
     super(userQuery, alertQuery);

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -19,10 +19,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { finalize } from 'rxjs/operators';
-
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { ContainerService } from '../../shared/container.service';
-import { Repository } from '../../shared/enum/Repository.enum';
 import { ContainersService } from '../../shared/swagger/api/containers.service';
 import { HostedService } from '../../shared/swagger/api/hosted.service';
 import { MetadataService } from '../../shared/swagger/api/metadata.service';
@@ -34,7 +32,6 @@ import { Tool } from './tool';
 export class RegisterToolService {
   toolRegisterError: BehaviorSubject<any> = new BehaviorSubject<any>(null);
   customDockerRegistryPath: BehaviorSubject<string> = new BehaviorSubject<string>('quay.io');
-  private repositories = Repository;
   public showCustomDockerRegistryPath: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public disabledPrivateCheckbox = false;
   private dockerRegistryMap = [];

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -62,7 +62,7 @@ export class ViewContainerComponent extends View implements OnInit {
   setMode(mode: TagEditorMode) {
     this.versionModalService.setVersion(this.version);
     this.versionModalService.setCurrentMode(mode);
-    const dialogRef = this.matDialog.open(VersionModalComponent, { width: '600px' });
+    this.matDialog.open(VersionModalComponent, { width: '600px' });
   }
 
   deleteTag() {

--- a/src/app/entry/state/current-collections.service.ts
+++ b/src/app/entry/state/current-collections.service.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ID, transaction } from '@datorama/akita';
 import { CollectionOrganization, EntriesService } from '../../shared/swagger';
@@ -6,7 +5,7 @@ import { CurrentCollectionsStore } from './current-collections.store';
 
 @Injectable({ providedIn: 'root' })
 export class CurrentCollectionsService {
-  constructor(private currentCollectionsStore: CurrentCollectionsStore, private entriesService: EntriesService, private http: HttpClient) {}
+  constructor(private currentCollectionsStore: CurrentCollectionsStore, private entriesService: EntriesService) {}
 
   @transaction()
   get(id: number) {

--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatTabChangeEvent } from '@angular/material/tabs';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params } from '@angular/router';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
@@ -15,7 +15,7 @@ export class AccountsComponent extends Base implements OnInit {
   public currentTab = 'accounts'; // default to the 'accounts' tab
   selected = new FormControl();
   validTabs = ['accounts', 'profiles', 'dockstore account controls', 'requests'];
-  constructor(private location: Location, private router: Router, private activatedRoute: ActivatedRoute) {
+  constructor(private location: Location, private activatedRoute: ActivatedRoute) {
     super();
   }
 

--- a/src/app/loginComponents/accounts/controls/controls.component.ts
+++ b/src/app/loginComponents/accounts/controls/controls.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
-
 import { UsersService } from '../../../shared/swagger';
 import { UserQuery } from '../../../shared/user/user.query';
 import { UserService } from '../../../shared/user/user.service';
@@ -22,6 +21,6 @@ export class ControlsComponent implements OnInit {
   }
 
   deleteAccount() {
-    const dialogRef = this.dialog.open(DeleteAccountDialogComponent, { width: '600px' });
+    this.dialog.open(DeleteAccountDialogComponent, { width: '600px' });
   }
 }

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -15,19 +15,16 @@
  */
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { AuthService } from 'ng2-ui-auth';
 import { Subject } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
-
 import { Dockstore } from '../../../shared/dockstore.model';
 import { TokenSource } from '../../../shared/enum/token-source.enum';
 import { TokenQuery } from '../../../shared/state/token.query';
 import { TokenService } from '../../../shared/state/token.service';
 import { TrackLoginService } from '../../../shared/track-login.service';
 import { UserService } from '../../../shared/user/user.service';
-import { UsersService } from './../../../shared/swagger/api/users.service';
-import { Configuration } from './../../../shared/swagger/configuration';
 import { Token } from './../../../shared/swagger/model/token';
 import { AccountsService } from './accounts.service';
 
@@ -91,7 +88,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   ];
 
   public tokens: Token[];
-  private userId;
   private ngUnsubscribe: Subject<{}> = new Subject();
   public show: false;
   public dockstoreToken: string;
@@ -99,11 +95,8 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     private trackLoginService: TrackLoginService,
     private tokenService: TokenService,
     private userService: UserService,
-    private activatedRoute: ActivatedRoute,
     private router: Router,
-    private usersService: UsersService,
     private authService: AuthService,
-    private configuration: Configuration,
     private accountsService: AccountsService,
     private matSnackBar: MatSnackBar,
     private tokenQuery: TokenQuery

--- a/src/app/loginComponents/accounts/internal/accounts.component.ts
+++ b/src/app/loginComponents/accounts/internal/accounts.component.ts
@@ -1,12 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable } from 'rxjs';
-
 import { AlertQuery } from '../../../shared/alert/state/alert.query';
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { TokenSource } from '../../../shared/enum/token-source.enum';
 import { TokenQuery } from '../../../shared/state/token.query';
-import { Configuration, Profile, User } from '../../../shared/swagger';
+import { Profile, User } from '../../../shared/swagger';
 import { UsersService } from '../../../shared/swagger/api/users.service';
 import { UserQuery } from '../../../shared/user/user.query';
 import { UserService } from '../../../shared/user/user.service';
@@ -27,9 +25,7 @@ export class AccountsInternalComponent implements OnInit {
   constructor(
     private userService: UserService,
     private usersService: UsersService,
-    private configuration: Configuration,
     private tokenQuery: TokenQuery,
-    private matSnackBar: MatSnackBar,
     private userQuery: UserQuery,
     private alertQuery: AlertQuery,
     private alertService: AlertService

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
@@ -17,13 +17,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, finalize, takeUntil } from 'rxjs/operators';
-
 import { formInputDebounceTime } from '../../../../shared/constants';
 import { MyErrorStateMatcher } from '../../../../shared/error-state-matcher';
 import { User } from '../../../../shared/swagger/model/user';
 import { UserQuery } from '../../../../shared/user/user.query';
 import { UserService } from '../../../../shared/user/user.service';
-import { RefreshService } from './../../../../shared/refresh.service';
 import { UsersService } from './../../../../shared/swagger/api/users.service';
 
 @Component({
@@ -46,12 +44,7 @@ export class ChangeUsernameComponent implements OnInit {
     Validators.maxLength(39)
   ]);
   protected ngUnsubscribe: Subject<{}> = new Subject();
-  constructor(
-    private userService: UserService,
-    private usersService: UsersService,
-    private refreshService: RefreshService,
-    private userQuery: UserQuery
-  ) {}
+  constructor(private userService: UserService, private usersService: UsersService, private userQuery: UserQuery) {}
 
   ngOnInit() {
     this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(user => {

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -104,7 +104,7 @@ export class CollectionComponent implements OnInit {
 
   editCollection(collection: Collection) {
     const collectionMap = { key: collection.id, value: collection };
-    const dialogRef = this.dialog.open(CreateCollectionComponent, {
+    this.dialog.open(CreateCollectionComponent, {
       data: { collection: collectionMap, mode: TagEditorMode.Edit },
       width: '600px'
     });

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -2,7 +2,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AkitaNgFormsManager } from '@datorama/akita-ng-forms-manager';
 import { finalize } from 'rxjs/operators';
 import { AlertService } from '../../../shared/alert/state/alert.service';
@@ -27,7 +26,6 @@ export class CreateCollectionService {
     private organizationsService: OrganizationsService,
     private organizationQuery: OrganizationQuery,
     private matDialog: MatDialog,
-    private matSnackBar: MatSnackBar,
     private collectionsService: CollectionsService,
     private builder: FormBuilder,
     private alertService: AlertService

--- a/src/app/organizations/organization/organization-starring/organization-starring.component.ts
+++ b/src/app/organizations/organization/organization-starring/organization-starring.component.ts
@@ -19,14 +19,11 @@ import { Observable } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { Base } from '../../../shared/base';
-import { ContainerService } from '../../../shared/container.service';
 import { StarOrganizationService } from '../../../shared/star-organization.service';
-import { StarentryService } from '../../../shared/starentry.service';
 import { isStarredByUser } from '../../../shared/starring';
 import { Organization, User } from '../../../shared/swagger';
 import { TrackLoginService } from '../../../shared/track-login.service';
 import { UserQuery } from '../../../shared/user/user.query';
-import { StarringService } from '../../../starring/starring.service';
 import { OrganizationStarringService } from './organization-starring.service';
 
 @Component({
@@ -46,9 +43,6 @@ export class OrganizationStarringComponent extends Base implements OnInit, OnDes
   constructor(
     private trackLoginService: TrackLoginService,
     private userQuery: UserQuery,
-    private containerService: ContainerService,
-    private starringService: StarringService,
-    private starentryService: StarentryService,
     private starOrganizationService: StarOrganizationService,
     private organizationStarringService: OrganizationStarringService,
     private alertService: AlertService

--- a/src/app/organizations/organization/state/update-organization-description.service.ts
+++ b/src/app/organizations/organization/state/update-organization-description.service.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -13,7 +12,6 @@ import { UpdateOrganizationOrCollectionDescriptionStore } from './update-organiz
 export class UpdateOrganizationOrCollectionDescriptionService {
   constructor(
     private updateOrganizationOrCollectionDescriptionStore: UpdateOrganizationOrCollectionDescriptionStore,
-    private http: HttpClient,
     private formBuilder: FormBuilder,
     private organizationsService: OrganizationsService,
     private organizationQuery: OrganizationQuery,

--- a/src/app/organizations/state/events.service.ts
+++ b/src/app/organizations/state/events.service.ts
@@ -1,13 +1,11 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { finalize } from 'rxjs/operators';
-import { Event } from '../../shared/swagger';
-import { OrganizationsService } from '../../shared/swagger';
+import { Event, OrganizationsService } from '../../shared/swagger';
 import { EventsStore } from './events.store';
 
 @Injectable({ providedIn: 'root' })
 export class EventsService {
-  constructor(private eventsStore: EventsStore, private http: HttpClient, private organizationsService: OrganizationsService) {}
+  constructor(private eventsStore: EventsStore, private organizationsService: OrganizationsService) {}
 
   /**
    * Retrieves the events for an organization from the database and updates the entityStore

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
@@ -14,10 +14,9 @@
  *    limitations under the License.
  */
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-
 import { MatDialog } from '@angular/material/dialog';
 import { Workflow } from 'app/shared/swagger';
+import { Observable } from 'rxjs';
 import { AlertQuery } from '../../alert/state/alert.query';
 import { Base } from '../../base';
 import { SessionQuery } from '../../session/session.query';
@@ -71,7 +70,7 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
 
   add(): void {
     this.registerCheckerWorkflowService.add();
-    const dialogRef = this.matDialog.open(RegisterCheckerWorkflowComponent, { width: '600px' });
+    this.matDialog.open(RegisterCheckerWorkflowComponent, { width: '600px' });
   }
 
   delete(): void {

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.service.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.service.ts
@@ -18,7 +18,6 @@ import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { BehaviorSubject, merge as observableMerge, Observable } from 'rxjs';
 import { filter, first } from 'rxjs/operators';
-
 import { AlertService } from '../../alert/state/alert.service';
 import { ContainerService } from '../../container.service';
 import { RefreshService } from '../../refresh.service';
@@ -69,6 +68,7 @@ export class RegisterCheckerWorkflowService {
               this.containerService.upsertToolToTools(<DockstoreTool>entry);
               this.containerService.setTool(<DockstoreTool>entry);
             }
+            // TODO: Use the message or remove it
             const refreshCheckerMessage = 'Refreshing checker workflow';
             this.workflowsService
               .refresh(entry.checker_id)

--- a/src/app/shared/ga4gh-files/ga4gh-files.query.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.query.ts
@@ -17,8 +17,6 @@ import { Injectable } from '@angular/core';
 import { QueryEntity } from '@datorama/akita';
 import { Observable, of as observableOf } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-
-import { DescriptorTypeCompatService } from '../descriptor-type-compat.service';
 import { ToolDescriptor, ToolFile } from '../swagger';
 import { GA4GHFiles } from './ga4gh-files.model';
 import { GA4GHFilesState, GA4GHFilesStore } from './ga4gh-files.store';
@@ -50,7 +48,7 @@ export class GA4GHFilesQuery extends QueryEntity<GA4GHFilesState, GA4GHFiles> {
       return observableOf([]);
     }
   }
-  constructor(protected store: GA4GHFilesStore, private descriptorTypeCompatService: DescriptorTypeCompatService) {
+  constructor(protected store: GA4GHFilesStore) {
     super(store);
   }
 }

--- a/src/app/shared/pagenumber.service.ts
+++ b/src/app/shared/pagenumber.service.ts
@@ -14,9 +14,7 @@
  *    limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router/';
 import { BehaviorSubject } from 'rxjs';
-
 import { PageInfo } from './../shared/models/PageInfo';
 
 @Injectable()
@@ -28,9 +26,8 @@ export class PagenumberService {
   pgNumWorkflows$ = this.pgNumWorkflowsSource.asObservable(); // This is the selected tool
 
   private backRouteSource = new BehaviorSubject<any>(null);
-  private backRoute$ = this.backRouteSource.asObservable();
   needSetPageNumber: boolean;
-  constructor(private router: Router) {
+  constructor() {
     this.needSetPageNumber = false;
   }
   setToolsPageInfo(pginfo: PageInfo) {

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
-
 import { Observable } from 'rxjs';
 import { AlertService } from './alert/state/alert.service';
 import { ContainerService } from './container.service';
@@ -36,7 +34,6 @@ export class RefreshService {
   public tool: DockstoreTool;
   private tools;
   private workflow: Service | BioWorkflow;
-  private workflows;
   constructor(
     private workflowsService: WorkflowsService,
     private containerService: ContainerService,
@@ -44,7 +41,6 @@ export class RefreshService {
     private workflowService: WorkflowService,
     private containersService: ContainersService,
     private usersService: UsersService,
-    private snackBar: MatSnackBar,
     private toolQuery: ToolQuery,
     private gA4GHFilesService: GA4GHFilesService,
     private workflowQuery: WorkflowQuery
@@ -52,7 +48,6 @@ export class RefreshService {
     this.toolQuery.tool$.subscribe(tool => (this.tool = tool));
     this.workflowQuery.workflow$.subscribe(workflow => (this.workflow = workflow));
     this.containerService.tools$.subscribe(tools => (this.tools = tools));
-    this.workflowService.workflows$.subscribe(workflows => (this.workflows = workflows));
   }
 
   /**

--- a/src/app/shared/state/checker-workflow.query.ts
+++ b/src/app/shared/state/checker-workflow.query.ts
@@ -18,7 +18,6 @@ import { Query } from '@datorama/akita';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ga4ghWorkflowIdPrefix } from '../constants';
-import { SessionQuery } from '../session/session.query';
 import { BioWorkflow, DockstoreTool, Entry, Workflow } from '../swagger';
 import { CheckerWorkflowState, CheckerWorkflowStore } from './checker-workflow.store';
 
@@ -35,7 +34,7 @@ export class CheckerWorkflowQuery extends Query<CheckerWorkflowState> {
   checkerId$: Observable<number> = this.entry$.pipe(map((entry: Entry) => (entry ? entry.checker_id : null)));
   entryIsWorkflow$: Observable<boolean> = this.entry$.pipe(map((entry: Entry) => (entry ? this.isEntryAWorkflow(entry) : null)));
   trsId$: Observable<string | null> = this.entry$.pipe(map((entry: Entry | null) => this.getTRSId(entry)));
-  constructor(protected store: CheckerWorkflowStore, private query: SessionQuery) {
+  constructor(protected store: CheckerWorkflowStore) {
     super(store);
   }
 

--- a/src/app/shared/state/paginator.service.ts
+++ b/src/app/shared/state/paginator.service.ts
@@ -1,12 +1,11 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PaginatorInfo, PaginatorStore } from './paginator.store';
 
 @Injectable({ providedIn: 'root' })
 export class PaginatorService {
-  constructor(private paginatorStore: PaginatorStore, private http: HttpClient) {}
+  constructor(private paginatorStore: PaginatorStore) {}
 
-  setPaginator(type: 'tool' | 'workflow', pageSize: number, pageNumber): void {
+  setPaginator(type: 'tool' | 'workflow', pageSize: number, pageNumber: number): void {
     const paginatorInfo: PaginatorInfo = {
       pageSize: pageSize,
       pageIndex: pageNumber

--- a/src/app/shared/user/user.service.ts
+++ b/src/app/shared/user/user.service.ts
@@ -3,7 +3,6 @@ import { transaction } from '@datorama/akita';
 import { AuthService } from 'ng2-ui-auth';
 import { Md5 } from 'ts-md5/dist/md5';
 import { AlertService } from '../alert/state/alert.service';
-import { RefreshService } from '../refresh.service';
 import { TokenService } from '../state/token.service';
 import { Configuration, ExtendedUserData, User, UsersService } from '../swagger';
 import { UserStore } from './user.store';
@@ -15,7 +14,6 @@ export class UserService {
     private authService: AuthService,
     private usersService: UsersService,
     private configuration: Configuration,
-    private refreshService: RefreshService,
     private tokenService: TokenService,
     private alertService: AlertService
   ) {

--- a/src/app/sponsors/sponsor.model.ts
+++ b/src/app/sponsors/sponsor.model.ts
@@ -17,9 +17,9 @@
 export class Sponsor {
   private static colouredPath = '../assets/images/sponsors/coloured/';
 
-  private current: string;
-  private coloured: string;
-  private url: URL;
+  public current: string;
+  public coloured: string;
+  public url: URL;
 
   constructor(image: string, url: URL) {
     this.current = Sponsor.colouredPath + image;

--- a/src/app/stargazers/stargazers.component.ts
+++ b/src/app/stargazers/stargazers.component.ts
@@ -14,9 +14,8 @@
  *    limitations under the License.
  */
 import { Component, OnInit } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
-
 import { StarEntry } from 'app/starring/StarEntry';
+import { takeUntil } from 'rxjs/operators';
 import { Base } from '../shared/base';
 import { altAvatarImg } from '../shared/constants';
 import { StarentryService } from '../shared/starentry.service';
@@ -30,7 +29,7 @@ import { StarringService } from '../starring/starring.service';
 })
 export class StargazersComponent extends Base implements OnInit {
   starGazers: any;
-  private altAvatarImg = altAvatarImg;
+  public altAvatarImg = altAvatarImg;
 
   constructor(private starringService: StarringService, private userService: UserService, private starentryService: StarentryService) {
     super();

--- a/src/app/starring/starring.component.ts
+++ b/src/app/starring/starring.component.ts
@@ -18,7 +18,6 @@ import { EntryType } from 'app/shared/enum/entry-type';
 import { Observable, Subject } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
 import { AlertService } from '../shared/alert/state/alert.service';
-import { ContainerService } from '../shared/container.service';
 import { StarentryService } from '../shared/starentry.service';
 import { isStarredByUser } from '../shared/starring';
 import { User } from '../shared/swagger/model/user';
@@ -48,7 +47,6 @@ export class StarringComponent implements OnInit, OnDestroy, OnChanges {
   constructor(
     private trackLoginService: TrackLoginService,
     private userQuery: UserQuery,
-    private containerService: ContainerService,
     private starringService: StarringService,
     private starentryService: StarentryService,
     private alertService: AlertService

--- a/src/app/tosBanner/state/tos-banner.service.ts
+++ b/src/app/tosBanner/state/tos-banner.service.ts
@@ -14,14 +14,13 @@
  *    limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { currentPrivacyPolicyVersion, currentTOSVersion, dismissedLatestPrivacyPolicy, dismissedLatestTOS } from '../../shared/constants';
 import { TosBannerStore } from './tos-banner.store';
 
 @Injectable({ providedIn: 'root' })
 export class TosBannerService {
-  constructor(private tosBannerStore: TosBannerStore, private http: HttpClient) {}
+  constructor(private tosBannerStore: TosBannerStore) {}
 
   dismissTOS() {
     localStorage.setItem(dismissedLatestTOS, JSON.stringify(currentTOSVersion));

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -33,7 +33,6 @@ import { Workflow } from '../../shared/swagger/model/workflow';
 export class InfoTabService {
   public workflowPathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public defaultTestFilePathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  private workflows: Workflow[];
   public descriptorLanguageMap = [];
 
   /**
@@ -67,7 +66,6 @@ export class InfoTabService {
       this.cancelEditing();
     });
     this.descriptorLanguageService.filteredDescriptorLanguages$.subscribe(map => (this.descriptorLanguageMap = map));
-    this.workflowService.workflows$.subscribe(workflows => (this.workflows = workflows));
   }
   setWorkflowPathEditing(editing: boolean) {
     this.workflowPathEditing$.next(editing);

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -17,7 +17,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { DescriptorTypeCompatService } from 'app/shared/descriptor-type-compat.service';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
@@ -41,7 +40,6 @@ export class RegisterWorkflowModalService {
   workflow: BehaviorSubject<Workflow> = new BehaviorSubject<Workflow>(this.sampleWorkflow);
   constructor(
     private workflowsService: WorkflowsService,
-    private descriptorTypeCompatService: DescriptorTypeCompatService,
     private workflowService: WorkflowService,
     private router: Router,
     private alertService: AlertService,

--- a/src/app/workflow/version-modal/version-modal.service.ts
+++ b/src/app/workflow/version-modal/version-modal.service.ts
@@ -59,6 +59,7 @@ export class VersionModalService {
    */
   saveVersion(workflowVersion: WorkflowVersion, originalTestParameterFilePaths, newTestParameterFiles, workflowMode: String) {
     const message1 = 'Saving workflow version';
+    // TODO: Use or delete this second message
     const message2 = 'Modifying test parameter files';
     const workflowId = this.workflowQuery.getActive().id;
     this.alertService.start(message1);

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -15,7 +15,6 @@
  */
 import { AfterViewInit, Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild } from '@angular/core';
 import { MatSort, MatTableDataSource } from '@angular/material';
-import { WorkflowService } from 'app/shared/state/workflow.service';
 import { takeUntil } from 'rxjs/operators';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DateService } from '../../shared/date.service';
@@ -24,7 +23,6 @@ import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedWorkflow } from '../../shared/models/ExtendedWorkflow';
 import { SessionQuery } from '../../shared/session/session.query';
 import { ExtendedWorkflowQuery } from '../../shared/state/extended-workflow.query';
-import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { Versions } from '../../shared/versions';
@@ -59,8 +57,6 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
     dateService: DateService,
     private alertService: AlertService,
     private extendedWorkflowQuery: ExtendedWorkflowQuery,
-    private workflowsService: WorkflowsService,
-    private workflowService: WorkflowService,
     protected sessionQuery: SessionQuery
   ) {
     super(dockstoreService, dateService, sessionQuery);

--- a/src/app/workflow/view/view.component.ts
+++ b/src/app/workflow/view/view.component.ts
@@ -99,7 +99,7 @@ export class ViewWorkflowComponent extends View implements OnInit {
    * @memberof ViewWorkflowComponent
    */
   private openVersionModal(): void {
-    const dialogRef = this.matDialog.open(VersionModalComponent, {
+    this.matDialog.open(VersionModalComponent, {
       width: '600px',
       data: { canRead: this.canRead, canWrite: this.canWrite && !this.version.frozen, isOwner: this.isOwner }
     });


### PR DESCRIPTION
tslint `"no-use-before-declare": true` is deprecated. Turning on the tsconfig `"noUnusedLocals": true` causes A LOT of warnings.  Most of the warnings are from swagger/openapi which I can't seem to disable right now (new openapi generator helps).  This PR fixes most of our written code's problems
