### PR TITLE
Feature/3154/disable language

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -94,9 +94,7 @@
       <mat-card fxLayout="column">
         <h3 class="text-center">Workflow descriptions</h3>
         <p>
-          Workflows are described with <a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>,
-          <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a> or
-          <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a> and stored on
+          Workflows are described with <span [innerHTML]="homepageInnerHTML$ | async"></span> and stored on
           <a href="https://github.com/" target="_blank" rel="noopener noreferrer">GitHub</a>,
           <a href="https://bitbucket.org/" target="_blank" rel="noopener noreferrer">Bitbucket</a>,
           <a href="https://www.gitlab.com" target="_blank" rel="noopener noreferrer">GitLab</a>, or directly on Dockstore.

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -94,7 +94,7 @@
       <mat-card fxLayout="column">
         <h3 class="text-center">Workflow descriptions</h3>
         <p>
-          Workflows are described with <span [innerHTML]="homepageInnerHTML$ | async"></span> and stored on
+          Workflows are described with <span [innerHTML]="descriptorLanguagesInnerHTML$ | async"></span> and stored on
           <a href="https://github.com/" target="_blank" rel="noopener noreferrer">GitHub</a>,
           <a href="https://bitbucket.org/" target="_blank" rel="noopener noreferrer">Bitbucket</a>,
           <a href="https://www.gitlab.com" target="_blank" rel="noopener noreferrer">GitLab</a>, or directly on Dockstore.

--- a/src/app/home-page/home-logged-out/home.component.spec.ts
+++ b/src/app/home-page/home-logged-out/home.component.spec.ts
@@ -13,14 +13,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatIconModule } from '@angular/material/icon';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-
 import { RouterTestingModule } from '@angular/router/testing';
+import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
+import { CustomMaterialModule } from 'app/shared/modules/material.module';
+import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TwitterService } from '../../shared/twitter.service';
 import { HomeComponent } from './home.component';
 
@@ -32,8 +31,8 @@ describe('HomeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [TabsModule.forRoot(), RouterTestingModule, MatButtonModule, MatIconModule, MatDialogModule],
-      providers: [TwitterService]
+      imports: [TabsModule.forRoot(), CustomMaterialModule, RouterTestingModule, HttpClientTestingModule],
+      providers: [TwitterService, DescriptorLanguageService]
     }).compileComponents();
   }));
 

--- a/src/app/home-page/home-logged-out/home.component.ts
+++ b/src/app/home-page/home-logged-out/home.component.ts
@@ -50,7 +50,7 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
   public user$: Observable<User>;
   public selectedTab = 'toolTab';
   Dockstore = Dockstore;
-  homepageInnerHTML$: Observable<string>;
+  descriptorLanguagesInnerHTML$: Observable<string>;
 
   @ViewChild('twitter', { static: false }) twitterElement: ElementRef;
 
@@ -67,7 +67,7 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-    this.homepageInnerHTML$ = this.descriptorLanguageService.homepageInnerHTML$;
+    this.descriptorLanguagesInnerHTML$ = this.descriptorLanguageService.descriptorLanguagesInnerHTML$;
     this.user$ = this.userQuery.user$;
   }
   ngAfterViewInit() {

--- a/src/app/home-page/home-logged-out/home.component.ts
+++ b/src/app/home-page/home-logged-out/home.component.ts
@@ -17,6 +17,7 @@ import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angula
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HomePageService } from 'app/home-page/home-page.service';
 import { Base } from 'app/shared/base';
+import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { TabDirective } from 'ngx-bootstrap/tabs';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -49,6 +50,8 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
   public user$: Observable<User>;
   public selectedTab = 'toolTab';
   Dockstore = Dockstore;
+  homepageInnerHTML$: Observable<string>;
+
   @ViewChild('twitter', { static: false }) twitterElement: ElementRef;
 
   @ViewChild('youtube', { static: false }) youtube: ElementRef;
@@ -57,12 +60,14 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
     private dialog: MatDialog,
     private twitterService: TwitterService,
     private userQuery: UserQuery,
-    private homePageService: HomePageService
+    private homePageService: HomePageService,
+    private descriptorLanguageService: DescriptorLanguageService
   ) {
     super();
   }
 
   ngOnInit() {
+    this.homepageInnerHTML$ = this.descriptorLanguageService.homepageInnerHTML$;
     this.user$ = this.userQuery.user$;
   }
   ngAfterViewInit() {

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -15,7 +15,7 @@
  */
 import { of as observableOf } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { ToolDescriptor, Workflow } from '../swagger';
+import { ToolDescriptor } from '../swagger';
 import { DescriptorLanguageBean } from './../swagger/model/descriptorLanguageBean';
 import { DescriptorLanguageService } from './descriptor-language.service';
 
@@ -76,17 +76,15 @@ describe('Service: DescriptorLanguage', () => {
     const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
-    let placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.CWL);
+    let placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(ToolDescriptor.TypeEnum.CWL);
     expect(placeholder).toEqual('e.g. /Dockstore.cwl');
-    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.WDL);
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(ToolDescriptor.TypeEnum.WDL);
     expect(placeholder).toEqual('e.g. /Dockstore.wdl');
-    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.NFL);
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(ToolDescriptor.TypeEnum.NFL);
     expect(placeholder).toEqual('e.g. /nextflow.config');
-    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.Service);
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(ToolDescriptor.TypeEnum.SERVICE);
     expect(placeholder).toEqual('');
-    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(<Workflow.DescriptorTypeEnum>(
-      'UnrecognizedType'
-    ));
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(<ToolDescriptor.TypeEnum>'UnrecognizedType');
     expect(placeholder).toEqual('');
   });
   it('should be able to get descriptor path pattern', () => {

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -14,19 +14,109 @@
  *     limitations under the License.
  */
 import { of as observableOf } from 'rxjs';
-
+import { first } from 'rxjs/operators';
+import { ToolDescriptor, Workflow } from '../swagger';
 import { DescriptorLanguageBean } from './../swagger/model/descriptorLanguageBean';
 import { DescriptorLanguageService } from './descriptor-language.service';
 
 describe('Service: DescriptorLanguage', () => {
+  let metadataServiceSpy;
+  let workflowQuerySpy;
+  beforeAll(() => {
+    metadataServiceSpy = jasmine.createSpyObj('MetadataService', ['getDescriptorLanguages']);
+    workflowQuerySpy = jasmine.createSpyObj('WorkflowQuery', ['getDescriptorLanguages']);
+  });
   it('should return the descriptor languages in an string array', () => {
-    const metadataServiceSpy = jasmine.createSpyObj('MetadataService', ['getDescriptorLanguages']);
-    const workflowQuerySpy = jasmine.createSpyObj('WorkflowQuery', ['getDescriptorLanguages']);
     const stubValue: Array<DescriptorLanguageBean> = [{ value: 'cwl' }, { value: 'wdl' }, { value: 'nextflow' }];
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(stubValue));
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
-    descriptorLanguageService.filteredDescriptorLanguages$.subscribe((languages: Array<string>) => {
+    descriptorLanguageService.filteredDescriptorLanguages$.pipe(first()).subscribe((languages: Array<string>) => {
       expect(languages).toEqual(['cwl', 'wdl', 'nextflow'], 'service returned stub value');
     });
+  });
+  it('should be able to filter service out', () => {
+    const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
+    descriptorLanguageBeans.push({ friendlyName: 'potato', value: 'potato' });
+    descriptorLanguageBeans.push({ friendlyName: 'beef', value: 'beef' });
+    descriptorLanguageBeans.push({ friendlyName: 'stew', value: 'stew' });
+    descriptorLanguageBeans.push({ friendlyName: 'generic placeholder for services', value: 'service' });
+    metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
+    const filteredDescriptorLanguageBeans = descriptorLanguageService.filterService(descriptorLanguageBeans);
+    expect(filteredDescriptorLanguageBeans.length).toEqual(3);
+    filteredDescriptorLanguageBeans.forEach(descriptorLanguageBean => {
+      expect(descriptorLanguageBean.value).not.toEqual(descriptorLanguageService.knownServiceValue);
+    });
+  });
+  it('should be able to get home page inner HTML', () => {
+    const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
+    descriptorLanguageBeans.push({ friendlyName: 'potato', value: 'CWL' });
+
+    metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
+    let innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    expect(innerHTML).toEqual(`<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>`);
+    descriptorLanguageBeans.push({ friendlyName: 'beef', value: 'WDL' });
+    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    expect(innerHTML).toEqual(
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a> or <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>`
+    );
+    descriptorLanguageBeans.push({ friendlyName: 'stew', value: 'NFL' });
+    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    expect(innerHTML).toEqual(
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
+    );
+    descriptorLanguageBeans.push({ friendlyName: 'hmm', value: 'service' });
+    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    expect(innerHTML).toEqual(
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
+    );
+  });
+  it('should be able to get descriptor path placeholder', () => {
+    const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
+    metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
+    let placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.CWL);
+    expect(placeholder).toEqual('e.g. /Dockstore.cwl');
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.WDL);
+    expect(placeholder).toEqual('e.g. /Dockstore.wdl');
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.NFL);
+    expect(placeholder).toEqual('e.g. /nextflow.config');
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(Workflow.DescriptorTypeEnum.Service);
+    expect(placeholder).toEqual('');
+    placeholder = descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(<Workflow.DescriptorTypeEnum>(
+      'UnrecognizedType'
+    ));
+    expect(placeholder).toEqual('');
+  });
+  it('should be able to get descriptor path pattern', () => {
+    const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
+    metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
+    let placeholder = descriptorLanguageService.getDescriptorPattern(ToolDescriptor.TypeEnum.CWL);
+    expect(placeholder).toEqual('^/([^/?:*|<>]+/)*[^/?:*|<>]+.(cwl|yaml|yml)');
+    placeholder = descriptorLanguageService.getDescriptorPattern(ToolDescriptor.TypeEnum.WDL);
+    expect(placeholder).toEqual('^/([^/?:*|<>]+/)*[^/?:*|<>]+.wdl$');
+    placeholder = descriptorLanguageService.getDescriptorPattern(ToolDescriptor.TypeEnum.NFL);
+    expect(placeholder).toEqual('^/([^/?:*|<>]+/)*[^/?:*|<>]+.(config)');
+    placeholder = descriptorLanguageService.getDescriptorPattern(ToolDescriptor.TypeEnum.SERVICE);
+    expect(placeholder).toEqual('.*');
+    placeholder = descriptorLanguageService.getDescriptorPattern(<ToolDescriptor.TypeEnum>'UnrecognizedType');
+    expect(placeholder).toEqual('.*');
+  });
+  it('should be able to get weird descriptor type for checker workflow registration', () => {
+    const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
+    metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
+    let placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(ToolDescriptor.TypeEnum.CWL);
+    expect(placeholder).toEqual('cwl');
+    placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(ToolDescriptor.TypeEnum.WDL);
+    expect(placeholder).toEqual('wdl');
+    placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(ToolDescriptor.TypeEnum.NFL);
+    expect(placeholder).toEqual(null);
+    placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(ToolDescriptor.TypeEnum.SERVICE);
+    expect(placeholder).toEqual(null);
+    placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(<ToolDescriptor.TypeEnum>'UnrecognizedType');
+    expect(placeholder).toEqual(null);
   });
 });

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -59,17 +59,17 @@ describe('Service: DescriptorLanguage', () => {
     descriptorLanguageBeans.push({ friendlyName: 'beef', value: 'WDL' });
     innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
-      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a> or <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>`
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a> or <a href="https://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>`
     );
     descriptorLanguageBeans.push({ friendlyName: 'stew', value: 'NFL' });
     innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
-      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="https://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
     );
     descriptorLanguageBeans.push({ friendlyName: 'hmm', value: 'service' });
     innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
-      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
+      `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="https://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
     );
   });
   it('should be able to get descriptor path placeholder', () => {

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -54,20 +54,20 @@ describe('Service: DescriptorLanguage', () => {
 
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
-    let innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    let innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(`<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>`);
     descriptorLanguageBeans.push({ friendlyName: 'beef', value: 'WDL' });
-    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
       `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a> or <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>`
     );
     descriptorLanguageBeans.push({ friendlyName: 'stew', value: 'NFL' });
-    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
       `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
     );
     descriptorLanguageBeans.push({ friendlyName: 'hmm', value: 'service' });
-    innerHTML = descriptorLanguageService.getHomepageInnerHTML(descriptorLanguageBeans);
+    innerHTML = descriptorLanguageService.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans);
     expect(innerHTML).toEqual(
       `<a href="https://www.commonwl.org/" target="_blank" rel="noopener noreferrer">CWL</a>, <a href="http://openwdl.org/" target="_blank" rel="noopener noreferrer">WDL</a>, or <a href="https://www.nextflow.io/" target="_blank" rel="noopener noreferrer">Nextflow</a>`
     );

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -33,12 +33,6 @@ export class DescriptorLanguageService {
   readonly knownServiceValue = 'service';
 
   public descriptorLanguages$: Observable<Array<Workflow.DescriptorTypeEnum>>;
-  // This converts the descriptor language beans into a human readable list of short names for use in tooltips and such
-  // E.g. "CWL, WDL, and NFL"
-  public shortDescriptorLanguageString$: Observable<string>;
-  // This converts the descriptor language beans into a human readable list of friendly names for use in tooltips and such
-  // (e.g. "Common Workflow Language, Workflow Description Language, and Nextflow")
-  public friendlyDescriptorLanguageString$: Observable<string>;
   public homepageInnerHTML$: Observable<string>;
   public noService$: Observable<DescriptorLanguageBean[]>;
   private descriptorLanguagesBean$ = new BehaviorSubject<DescriptorLanguageBean[]>([]);
@@ -52,8 +46,6 @@ export class DescriptorLanguageService {
         }
       })
     );
-    this.shortDescriptorLanguageString$ = this.descriptorLanguagesBean$.pipe(map(beans => this.convertBeansToShortNames(beans)));
-    this.friendlyDescriptorLanguageString$ = this.descriptorLanguagesBean$.pipe(map(bean => this.convertBeansToFriendlyNames(bean)));
     this.noService$ = this.descriptorLanguagesBean$.pipe(map(beans => this.filterService(beans)));
     this.homepageInnerHTML$ = this.noService$.pipe(
       map((descriptorLanguageBeans: DescriptorLanguageBean[]) => this.getHomepageInnerHTML(descriptorLanguageBeans))
@@ -98,11 +90,11 @@ export class DescriptorLanguageService {
         return validationDescriptorPatterns.nflPath;
       }
       case ToolDescriptor.TypeEnum.SERVICE: {
-        return '*';
+        return '.*';
       }
       default: {
         this.genericUnhandledTypeError(descriptorType);
-        return '*';
+        return '.*';
       }
     }
   }
@@ -159,38 +151,12 @@ export class DescriptorLanguageService {
       return innerHTMLArray[0];
     }
     if (length === 2) {
-      return innerHTMLArray.join(' and ');
+      return innerHTMLArray.join(' or ');
     }
     if (length >= 3) {
       innerHTMLArray[length - 1] = 'or ' + innerHTMLArray[length - 1];
       return innerHTMLArray.join(', ');
     }
-  }
-
-  convertBeansToShortNames(descriptorLanguageBeans: DescriptorLanguageBean[]): string {
-    const numberOfLanguages = descriptorLanguageBeans.length;
-    if (numberOfLanguages === 1) {
-      return descriptorLanguageBeans[0].value;
-    }
-    if (numberOfLanguages === 2) {
-      return descriptorLanguageBeans[0].value + ' and ' + descriptorLanguageBeans[1].value;
-    }
-    const listOfShortNames: string[] = descriptorLanguageBeans.map(descriptorLanguageBean => descriptorLanguageBean.value);
-    listOfShortNames.splice(listOfShortNames.length - 1, 0, 'and');
-    return listOfShortNames.join(', ');
-  }
-
-  convertBeansToFriendlyNames(descriptorLanguageBeans: DescriptorLanguageBean[]): string {
-    const numberOfLanguages = descriptorLanguageBeans.length;
-    if (numberOfLanguages === 1) {
-      return descriptorLanguageBeans[0].friendlyName;
-    }
-    if (numberOfLanguages === 2) {
-      return descriptorLanguageBeans[0].friendlyName + ' and ' + descriptorLanguageBeans[1].friendlyName;
-    }
-    const listOfShortNames: string[] = descriptorLanguageBeans.map(descriptorLanguageBean => descriptorLanguageBean.friendlyName);
-    listOfShortNames.splice(listOfShortNames.length - 1, 0, 'and');
-    return listOfShortNames.join(', ');
   }
 
   /**

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -99,15 +99,15 @@ export class DescriptorLanguageService {
     }
   }
 
-  workflowDescriptorTypeEnumToPlaceholderDescriptor(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum): string {
+  workflowDescriptorTypeEnumToPlaceholderDescriptor(workflowDescriptorTypeEnum: ToolDescriptor.TypeEnum): string {
     switch (workflowDescriptorTypeEnum) {
-      case Workflow.DescriptorTypeEnum.CWL: {
+      case ToolDescriptor.TypeEnum.CWL: {
         return 'e.g. /Dockstore.cwl';
       }
-      case Workflow.DescriptorTypeEnum.WDL: {
+      case ToolDescriptor.TypeEnum.WDL: {
         return 'e.g. /Dockstore.wdl';
       }
-      case Workflow.DescriptorTypeEnum.NFL: {
+      case ToolDescriptor.TypeEnum.NFL: {
         return 'e.g. /nextflow.config';
       }
       default: {

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -66,6 +66,24 @@ export class DescriptorLanguageService {
     });
   }
 
+  workflowDescriptorTypeEnumToPlaceholderDescriptor(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum): string {
+    switch (workflowDescriptorTypeEnum) {
+      case Workflow.DescriptorTypeEnum.CWL: {
+        return 'e.g. /Dockstore.cwl';
+      }
+      case Workflow.DescriptorTypeEnum.WDL: {
+        return 'e.g. /Dockstore.wdl';
+      }
+      case Workflow.DescriptorTypeEnum.NFL: {
+        return 'e.g. /nextflow.config';
+      }
+      default: {
+        console.error('Unhandled descriptor type: ' + workflowDescriptorTypeEnum);
+        return '';
+      }
+    }
+  }
+
   getHomepageInnerHTML(descriptorLanguageBeans: DescriptorLanguageBean[]): string {
     const innerHTMLArray = [];
     descriptorLanguageBeans.forEach(descriptorLanguageBean => {
@@ -139,7 +157,7 @@ export class DescriptorLanguageService {
    * @memberof DescriptorLanguageService
    */
   convertDescriptorLanguageBeanToToolDescriptorTypeEnum(descriptorLanguageBean: DescriptorLanguageBean): ToolDescriptor.TypeEnum {
-    if (descriptorLanguageBean.value === this.serviceValue) {
+    if (descriptorLanguageBean.value === this.knownServiceValue) {
       return ToolDescriptor.TypeEnum.SERVICE;
     } else {
       return <ToolDescriptor.TypeEnum>descriptorLanguageBean.value.toString();
@@ -147,7 +165,7 @@ export class DescriptorLanguageService {
   }
 
   filterService(beans: DescriptorLanguageBean[]): DescriptorLanguageBean[] {
-    return beans.filter(bean => bean.value !== this.serviceValue);
+    return beans.filter(bean => bean.value !== this.knownServiceValue);
   }
 
   /**

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -20,6 +20,7 @@ import { EntryType } from '../enum/entry-type';
 import { SessionQuery } from '../session/session.query';
 import { ToolDescriptor } from '../swagger';
 import { Workflow } from '../swagger/model/workflow';
+import { validationDescriptorPatterns } from '../validationMessages.model';
 import { MetadataService } from './../swagger/api/metadata.service';
 import { DescriptorLanguageBean } from './../swagger/model/descriptorLanguageBean';
 
@@ -66,6 +67,27 @@ export class DescriptorLanguageService {
     });
   }
 
+  getDescriptorPattern(descriptorType: ToolDescriptor.TypeEnum): string {
+    switch (descriptorType) {
+      case ToolDescriptor.TypeEnum.CWL: {
+        return validationDescriptorPatterns.cwlPath;
+      }
+      case ToolDescriptor.TypeEnum.WDL: {
+        return validationDescriptorPatterns.wdlPath;
+      }
+      case ToolDescriptor.TypeEnum.NFL: {
+        return validationDescriptorPatterns.nflPath;
+      }
+      case ToolDescriptor.TypeEnum.SERVICE: {
+        return '*';
+      }
+      default: {
+        this.genericUnhandledTypeError(descriptorType);
+        return '*';
+      }
+    }
+  }
+
   workflowDescriptorTypeEnumToPlaceholderDescriptor(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum): string {
     switch (workflowDescriptorTypeEnum) {
       case Workflow.DescriptorTypeEnum.CWL: {
@@ -78,10 +100,14 @@ export class DescriptorLanguageService {
         return 'e.g. /nextflow.config';
       }
       default: {
-        console.error('Unhandled descriptor type: ' + workflowDescriptorTypeEnum);
+        this.genericUnhandledTypeError(workflowDescriptorTypeEnum);
         return '';
       }
     }
+  }
+
+  genericUnhandledTypeError(type: any): void {
+    console.error('Unhandled descriptor type: ' + type);
   }
 
   getHomepageInnerHTML(descriptorLanguageBeans: DescriptorLanguageBean[]): string {
@@ -101,7 +127,7 @@ export class DescriptorLanguageService {
           break;
         }
         default: {
-          console.error('Unrecognized descriptor language bean value');
+          this.genericUnhandledTypeError(descriptorLanguageBean.value);
         }
       }
     });

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -67,6 +67,25 @@ export class DescriptorLanguageService {
     });
   }
 
+  toolDescriptorTypeEnumToWeirdCheckerRegisterString(descriptorType: ToolDescriptor.TypeEnum): 'cwl' | 'wdl' | null {
+    let descriptorTypeNoNFL: 'cwl' | 'wdl';
+    switch (descriptorType) {
+      case ToolDescriptor.TypeEnum.CWL: {
+        descriptorTypeNoNFL = 'cwl';
+        break;
+      }
+      case ToolDescriptor.TypeEnum.WDL: {
+        descriptorTypeNoNFL = 'wdl';
+        break;
+      }
+      default: {
+        this.genericUnhandledTypeError(descriptorType);
+        return null;
+      }
+    }
+    return descriptorTypeNoNFL;
+  }
+
   getDescriptorPattern(descriptorType: ToolDescriptor.TypeEnum): string {
     switch (descriptorType) {
       case ToolDescriptor.TypeEnum.CWL: {

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
@@ -24,8 +24,8 @@
             maxlength="256"
             [pattern]="validationDescriptorPatterns.workflowDescriptorPath"
             required
-            matTooltip="Default relative path to the CWL Descriptor in the Git repository."
-            placeholder="e.g. /Dockstore.cwl"
+            matTooltip="Default relative path to the descriptor in the Git repository."
+            [placeholder]="placeholderDescriptorPath$ | async"
           />
           <mat-card *ngIf="formErrors.workflow_path" class="alert alert-danger"> {{ formErrors.workflow_path }} </mat-card>
         </div>
@@ -45,7 +45,7 @@
             maxlength="256"
             [pattern]="validationDescriptorPatterns.testParameterFilePath"
             required
-            matTooltip="Default relative path to the WDL Descriptor in the Git repository."
+            matTooltip="Default relative path to the test parameter file in the Git repository."
             placeholder="e.g. /test.json"
           />
           <mat-card *ngIf="formErrors.testParameterFilePath" class="alert alert-danger"> {{ formErrors.testParameterFilePath }} </mat-card>

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
@@ -12,7 +12,7 @@
         [(ngModel)]="workflowPath"
         minlength="3"
         maxlength="256"
-        [pattern]="validationDescriptorPatterns.workflowDescriptorPath"
+        [pattern]="descriptorPattern"
         required
         matTooltip="Default relative path to the descriptor in the Git repository."
         [placeholder]="placeholderDescriptorPath$ | async"

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
@@ -15,7 +15,7 @@
         [pattern]="descriptorPattern"
         required
         matTooltip="Default relative path to the descriptor in the Git repository."
-        [placeholder]="placeholderDescriptorPath$ | async"
+        [placeholder]="descriptorPathPlaceholder"
       />
       <mat-error *ngIf="formErrors.workflow_path"> {{ formErrors.workflow_path }} </mat-error>
     </mat-form-field>

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
@@ -1,72 +1,49 @@
 <h4 mat-dialog-title>Register Checker Workflow</h4>
 <div mat-dialog-content>
   <app-alert></app-alert>
-  <form
-    #registerCheckerWorkflowForm="ngForm"
-    name="registerCheckerWorkflowForm"
-    class="form-horizontal"
-    (submit)="registerCheckerWorkflow()"
-    novalidate
-  >
-    <div class="modal-body">
-      <div class="form-group form-group-sm">
-        <label class="col-sm-3 control-label">
-          Default Descriptor Path:
-        </label>
-        <div class="col-sm-9">
-          <input
-            type="text"
-            id="checkerWorkflowPath"
-            class="form-control"
-            name="workflow_path"
-            [(ngModel)]="workflowPath"
-            minlength="3"
-            maxlength="256"
-            [pattern]="validationDescriptorPatterns.workflowDescriptorPath"
-            required
-            matTooltip="Default relative path to the descriptor in the Git repository."
-            [placeholder]="placeholderDescriptorPath$ | async"
-          />
-          <mat-card *ngIf="formErrors.workflow_path" class="alert alert-danger"> {{ formErrors.workflow_path }} </mat-card>
-        </div>
-      </div>
-      <div class="form-group form-group-sm">
-        <label class="col-sm-3 control-label">
-          Default Test Parameter File Path:
-        </label>
-        <div class="col-sm-9">
-          <input
-            type="text"
-            id="checkerWorkflowTestParameterFilePath"
-            class="form-control"
-            name="testParameterFilePath"
-            [(ngModel)]="testParameterFilePath"
-            minlength="3"
-            maxlength="256"
-            [pattern]="validationDescriptorPatterns.testParameterFilePath"
-            required
-            matTooltip="Default relative path to the test parameter file in the Git repository."
-            placeholder="e.g. /test.json"
-          />
-          <mat-card *ngIf="formErrors.testParameterFilePath" class="alert alert-danger"> {{ formErrors.testParameterFilePath }} </mat-card>
-        </div>
-      </div>
-      <div class="form-group form-group-sm" *ngIf="!isWorkflow">
-        <label class="col-sm-3 control-label" matTooltip="Type of descriptor language used">Descriptor Type: </label>
-        <div class="col-sm-9">
-          <select
-            class="form-control input-sm"
-            [(ngModel)]="descriptorType"
-            (ngModelChange)="onDescriptorTypeChange($event)"
-            name="descriptorType"
-          >
-            <option *ngFor="let descriptorLanguage of descriptorLanguages" value="{{ descriptorLanguage }}">{{
-              descriptorLanguage
-            }}</option>
-          </select>
-        </div>
-      </div>
-    </div>
+  <form #registerCheckerWorkflowForm="ngForm" name="registerCheckerWorkflowForm" (submit)="registerCheckerWorkflow()" novalidate>
+    <mat-form-field class="w-100">
+      <mat-label>Default Descriptor Path</mat-label>
+      <input
+        matInput
+        type="text"
+        id="checkerWorkflowPath"
+        name="workflow_path"
+        [(ngModel)]="workflowPath"
+        minlength="3"
+        maxlength="256"
+        [pattern]="validationDescriptorPatterns.workflowDescriptorPath"
+        required
+        matTooltip="Default relative path to the descriptor in the Git repository."
+        [placeholder]="placeholderDescriptorPath$ | async"
+      />
+      <mat-error *ngIf="formErrors.workflow_path"> {{ formErrors.workflow_path }} </mat-error>
+    </mat-form-field>
+    <mat-form-field class="w-100">
+      <mat-label>Default Test Parameter File Path:</mat-label>
+      <input
+        matInput
+        type="text"
+        id="checkerWorkflowTestParameterFilePath"
+        name="testParameterFilePath"
+        [(ngModel)]="testParameterFilePath"
+        minlength="3"
+        maxlength="256"
+        [pattern]="validationDescriptorPatterns.testParameterFilePath"
+        required
+        matTooltip="Default relative path to the test parameter file in the Git repository."
+        placeholder="e.g. /test.json"
+      />
+      <mat-error *ngIf="formErrors.testParameterFilePath"> {{ formErrors.testParameterFilePath }} </mat-error>
+    </mat-form-field>
+    <mat-form-field *ngIf="!isWorkflow" class="w-100">
+      <mat-label>Descriptor Type</mat-label>
+      <mat-select [(ngModel)]="descriptorType" (ngModelChange)="onDescriptorTypeChange($event)" name="descriptorType">
+        <mat-option *ngFor="let descriptorLanguage of descriptorLanguages" value="{{ descriptorLanguage }}">{{
+          descriptorLanguage
+        }}</mat-option>
+      </mat-select>
+    </mat-form-field>
     <div class="modal-footer">
       <button type="button" mat-button color="secondary" data-dismiss="modal" mat-dialog-close>
         Close

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.scss
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.scss
@@ -1,0 +1,5 @@
+// Overriding the border added in the style.scss because we're using material now
+input[type='text']:focus,
+textarea:focus {
+  border: none;
+}

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.spec.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.spec.ts
@@ -18,7 +18,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CustomMaterialModule } from 'app/shared/modules/material.module';
 import { CheckerWorkflowStubService, DescriptorLanguageStubService, RegisterCheckerWorkflowStubService } from '../../../test/service-stubs';
 import { DescriptorTypeCompatService } from '../../descriptor-type-compat.service';
 import { CheckerWorkflowService } from '../../state/checker-workflow.service';
@@ -34,7 +35,7 @@ describe('RegisterCheckerWorkflowComponent', () => {
     TestBed.configureTestingModule({
       declarations: [RegisterCheckerWorkflowComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [FormsModule, MatSnackBarModule, MatDialogModule],
+      imports: [FormsModule, MatSnackBarModule, MatDialogModule, BrowserAnimationsModule, CustomMaterialModule],
       providers: [
         { provide: RegisterCheckerWorkflowService, useClass: RegisterCheckerWorkflowStubService },
         { provide: CheckerWorkflowService, useClass: CheckerWorkflowStubService },

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -57,6 +57,7 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
   public descriptorType: ToolDescriptor.TypeEnum;
   public descriptorLanguages: Array<string>;
   public placeholderDescriptorPath$: Observable<string>;
+  public descriptorPattern = validationDescriptorPatterns.workflowDescriptorPath;
   private entry: Entry;
   registerCheckerWorkflowForm: NgForm;
   isWorkflow = false;
@@ -72,9 +73,11 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
           const workflowDescriptorTypeEnum = (<Workflow>this.entry).descriptorType;
           // Set checker workflow descriptor type to the same as the current workflow
           this.descriptorType = this.descriptorTypeCompatService.stringToDescriptorType(workflowDescriptorTypeEnum);
+          this.updateDescriptorPattern(this.descriptorType);
         } else {
           // Set checker workflow descriptor type to CWL for now. TODO: Solve this once webservice changes are known.
           this.descriptorType = ToolDescriptor.TypeEnum.CWL;
+          this.updateDescriptorPattern(this.descriptorType);
         }
       } else {
         this.testParameterFilePath = null;
@@ -105,6 +108,10 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
         }
       })
     );
+  }
+
+  updateDescriptorPattern(descriptorType: ToolDescriptor.TypeEnum): void {
+    this.descriptorPattern = this.descriptorLanguageService.getDescriptorPattern(descriptorType);
   }
 
   /**
@@ -159,6 +166,7 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
    */
   public onDescriptorTypeChange(descriptorType: ToolDescriptor.TypeEnum): void {
     this.testParameterFilePath = this.getTestParameterFileDefault(this.entry, descriptorType);
+    this.updateDescriptorPattern(descriptorType);
   }
 
   // Validation starts here, should move most of these to a service somehow

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -142,22 +142,10 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
   }
 
   registerCheckerWorkflow(): void {
-    let descriptorTypeNoNFL: 'cwl' | 'wdl';
-    switch (this.descriptorType) {
-      case ToolDescriptor.TypeEnum.CWL: {
-        descriptorTypeNoNFL = 'cwl';
-        break;
-      }
-      case ToolDescriptor.TypeEnum.WDL: {
-        descriptorTypeNoNFL = 'wdl';
-        break;
-      }
-      default: {
-        console.error('Unrecognized descriptor type: ' + this.descriptorType);
-        return;
-      }
+    const weirdDescriptorType = this.descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(this.descriptorType);
+    if (weirdDescriptorType) {
+      this.registerCheckerWorkflowService.registerCheckerWorkflow(this.workflowPath, this.testParameterFilePath, weirdDescriptorType);
     }
-    this.registerCheckerWorkflowService.registerCheckerWorkflow(this.workflowPath, this.testParameterFilePath, descriptorTypeNoNFL);
   }
 
   /**

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -17,7 +17,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewChecked, Component, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { Observable } from 'rxjs';
-import { debounceTime, map, takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 import { AlertQuery } from '../../alert/state/alert.query';
 import { Base } from '../../base';
 import { formInputDebounceTime } from '../../constants';
@@ -56,7 +56,7 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
   public mode$: Observable<'add' | 'edit'>;
   public descriptorType: ToolDescriptor.TypeEnum;
   public descriptorLanguages: Array<string>;
-  public placeholderDescriptorPath$: Observable<string>;
+  public descriptorPathPlaceholder: string;
   public descriptorPattern = validationDescriptorPatterns.workflowDescriptorPath;
   private entry: Entry;
   registerCheckerWorkflowForm: NgForm;
@@ -95,24 +95,10 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
         );
       });
     this.isRefreshing$ = this.alertQuery.showInfo$;
-    this.placeholderDescriptorPath$ = this.checkerWorkflowQuery.entry$.pipe(
-      map(entry => {
-        if (entry) {
-          const isWorkflow = this.checkerWorkflowQuery.isEntryAWorkflow(entry);
-          if (isWorkflow) {
-            const workflowDescriptorTypeEnum = (<Workflow>this.entry).descriptorType;
-            return this.descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(workflowDescriptorTypeEnum);
-          } else {
-            return '';
-          }
-        } else {
-          return '';
-        }
-      })
-    );
   }
 
   updateDescriptorPattern(descriptorType: ToolDescriptor.TypeEnum): void {
+    this.descriptorPathPlaceholder = this.descriptorLanguageService.workflowDescriptorTypeEnumToPlaceholderDescriptor(descriptorType);
     this.descriptorPattern = this.descriptorLanguageService.getDescriptorPattern(descriptorType);
   }
 

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -81,8 +81,10 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
     });
     this.mode$ = this.registerCheckerWorkflowService.mode$;
     this.syncTestJson = false;
-    this.descriptorLanguageService.filteredDescriptorLanguages$.subscribe((descriptorLanguages: Array<string>) => {
-      this.descriptorLanguages = descriptorLanguages.filter((language: string) => language !== ToolDescriptor.TypeEnum.NFL);
+    this.descriptorLanguageService.filteredDescriptorLanguages$.subscribe((descriptorLanguages: Array<Workflow.DescriptorTypeEnum>) => {
+      this.descriptorLanguages = descriptorLanguages.filter(
+        (language: Workflow.DescriptorTypeEnum) => language !== ToolDescriptor.TypeEnum.NFL
+      );
     });
     this.isRefreshing$ = this.alertQuery.showInfo$;
     this.placeholderDescriptorPath$ = this.checkerWorkflowQuery.entry$.pipe(

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -17,7 +17,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewChecked, Component, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { Observable } from 'rxjs';
-import { debounceTime, takeUntil, map } from 'rxjs/operators';
+import { debounceTime, map, takeUntil } from 'rxjs/operators';
 import { AlertQuery } from '../../alert/state/alert.query';
 import { Base } from '../../base';
 import { formInputDebounceTime } from '../../constants';
@@ -46,8 +46,8 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
     super();
   }
   public registerError: HttpErrorResponse;
-  public workflowPath: string;
-  public testParameterFilePath: string;
+  public workflowPath = '';
+  public testParameterFilePath = '';
   public syncTestJson: boolean;
   public formErrors = formErrors;
   public validationDescriptorPatterns = validationDescriptorPatterns;
@@ -63,7 +63,6 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
   @ViewChild('registerCheckerWorkflowForm', { static: true }) currentForm: NgForm;
 
   ngOnInit() {
-    this.clearForm();
     this.checkerWorkflowQuery.entry$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((entry: Entry) => {
       this.entry = entry;
       if (entry) {
@@ -71,7 +70,11 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
         this.testParameterFilePath = this.getTestParameterFileDefault(entry, this.descriptorType);
         if (this.isWorkflow) {
           const workflowDescriptorTypeEnum = (<Workflow>this.entry).descriptorType;
+          // Set checker workflow descriptor type to the same as the current workflow
           this.descriptorType = this.descriptorTypeCompatService.stringToDescriptorType(workflowDescriptorTypeEnum);
+        } else {
+          // Set checker workflow descriptor type to CWL for now. TODO: Solve this once webservice changes are known.
+          this.descriptorType = ToolDescriptor.TypeEnum.CWL;
         }
       } else {
         this.testParameterFilePath = null;
@@ -102,12 +105,6 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
         }
       })
     );
-  }
-
-  private clearForm(): void {
-    this.workflowPath = '';
-    this.testParameterFilePath = '';
-    this.descriptorType = ToolDescriptor.TypeEnum.CWL;
   }
 
   /**

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -87,11 +87,13 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
     });
     this.mode$ = this.registerCheckerWorkflowService.mode$;
     this.syncTestJson = false;
-    this.descriptorLanguageService.filteredDescriptorLanguages$.subscribe((descriptorLanguages: Array<Workflow.DescriptorTypeEnum>) => {
-      this.descriptorLanguages = descriptorLanguages.filter(
-        (language: Workflow.DescriptorTypeEnum) => language !== ToolDescriptor.TypeEnum.NFL
-      );
-    });
+    this.descriptorLanguageService.filteredDescriptorLanguages$
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((descriptorLanguages: Array<Workflow.DescriptorTypeEnum>) => {
+        this.descriptorLanguages = descriptorLanguages.filter(
+          (language: Workflow.DescriptorTypeEnum) => language !== ToolDescriptor.TypeEnum.NFL
+        );
+      });
     this.isRefreshing$ = this.alertQuery.showInfo$;
     this.placeholderDescriptorPath$ = this.checkerWorkflowQuery.entry$.pipe(
       map(entry => {

--- a/src/app/shared/state/checker-workflow.query.ts
+++ b/src/app/shared/state/checker-workflow.query.ts
@@ -18,7 +18,6 @@ import { Query } from '@datorama/akita';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ga4ghWorkflowIdPrefix } from '../constants';
-import { SessionQuery } from '../session/session.query';
 import { BioWorkflow, DockstoreTool, Entry, Workflow } from '../swagger';
 import { CheckerWorkflowState, CheckerWorkflowStore } from './checker-workflow.store';
 
@@ -35,7 +34,7 @@ export class CheckerWorkflowQuery extends Query<CheckerWorkflowState> {
   checkerId$: Observable<number> = this.entry$.pipe(map((entry: Entry) => (entry ? entry.checker_id : null)));
   entryIsWorkflow$: Observable<boolean> = this.entry$.pipe(map((entry: Entry) => (entry ? this.isEntryAWorkflow(entry) : null)));
   trsId$: Observable<string | null> = this.entry$.pipe(map((entry: Entry | null) => this.getTRSId(entry)));
-  constructor(protected store: CheckerWorkflowStore, private query: SessionQuery) {
+  constructor(protected store: CheckerWorkflowStore) {
     super(store);
   }
 

--- a/src/app/shared/tooltip.ts
+++ b/src/app/shared/tooltip.ts
@@ -1,6 +1,6 @@
 import { TooltipConfig } from 'ngx-bootstrap/tooltip';
 export const Tooltip = {
-  testParameterFile: 'Relative path to a WDL/CWL Test Parameter File in the Git repository',
+  testParameterFile: 'Relative path to a Test Parameter File in the Git repository',
   workflowPath: 'Path in Git repository to main descriptor file',
   defaultVersionUser: 'The branch that the tool/workflow author intends others to use',
   defaultVersionAuthor:

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -123,12 +123,12 @@
                   type="text"
                   #model1="ngModel"
                   class="form-control"
-                  name="cwlTestParameterFilePath"
+                  name="testParameterFilePath"
                   [(ngModel)]="testParameterFilePath"
                   minlength="3"
                   maxlength="128"
                   [pattern]="validationPatterns.testFilePath"
-                  placeholder="e.g. /test.cwl.json"
+                  placeholder="e.g. /test.json"
                   [disabled]="workflow?.mode === WorkflowType.ModeEnum.HOSTED"
                   [matTooltip]="tooltip.testParameterFile"
                 />
@@ -154,8 +154,8 @@
                   </button>
                 </span>
               </div>
-              <div *ngIf="formErrors.cwlTestParameterFilePath" class="form-error-messages alert alert-danger">
-                {{ formErrors.cwlTestParameterFilePath }}
+              <div *ngIf="formErrors.testParameterFilePath" class="form-error-messages alert alert-danger">
+                {{ formErrors.testParameterFilePath }}
               </div>
               <mat-card *ngIf="hasDuplicateTestJson()" class="alert alert-danger">
                 Duplicate test json files are not allowed.


### PR DESCRIPTION
For dockstore/dockstore#3154

Missing the entirety of tool handling because there's uncertainty on how tool registration happens (look at the DockstoreTool model in swagger-ui to see that it's hardcoded to certain languages)

These are relatively small changes because in previous issues, we've already moved workflow registration to be dependant on the endpoint already.

Also converted checker workflow registration modal to material