### PR TITLE
New error message for DAG tab

### DIFF
--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -25,7 +25,7 @@
       <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
         <mat-icon>warning</mat-icon>&nbsp;
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
-          A Descriptor associated with this workflow could not be found.
+          Please ensure that the Descriptor is a valid WDL workflow.
         </span>
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">
           Please ensure that the Descriptor is a valid CWL 1.0 workflow.

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -24,8 +24,13 @@
     <div fxFlex *ngIf="dagType === 'classic' && !(isNFL$ | async) && !(dagResult$ | async)">
       <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
         <mat-icon>warning</mat-icon>&nbsp;
-        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
-          Please ensure that the Descriptor is a valid WDL workflow.
+        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && isPublic">
+          The DAG cannot be displayed because the descriptor is either missing or not valid.
+          Click on the Files tab for more information.
+        </span>
+        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && !isPublic">
+          The DAG cannot be displayed because the descriptor missing or is not a valid WDL workflow.
+          Ensure the descriptor exists and is valid. Click on the Files tab for more information.
         </span>
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">
           Please ensure that the Descriptor is a valid CWL 1.0 workflow.

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -26,7 +26,7 @@
         <mat-icon>warning</mat-icon>&nbsp;
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
           The DAG cannot be displayed because the descriptor is either missing or not valid.
-          {{ (isPublic ? "Click on the Files tab for more information."
+          {{ ((isPublic$ | async) ? "Click on the Files tab for more information."
           :  "Ensure the descriptor exists and is valid. Click on the Files tab for more information.") }}
         </span>
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -24,13 +24,10 @@
     <div fxFlex *ngIf="dagType === 'classic' && !(isNFL$ | async) && !(dagResult$ | async)">
       <mat-card class="alert alert-warning" role="alert" *ngIf="!(dagResult$ | async) && !selectedVersion?.valid">
         <mat-icon>warning</mat-icon>&nbsp;
-        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && isPublic">
+        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL">
           The DAG cannot be displayed because the descriptor is either missing or not valid.
-          Click on the Files tab for more information.
-        </span>
-        <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && !isPublic">
-          The DAG cannot be displayed because the descriptor missing or is not a valid WDL workflow.
-          Ensure the descriptor exists and is valid. Click on the Files tab for more information.
+          {{ (isPublic ? "Click on the Files tab for more information."
+          :  "Ensure the descriptor exists and is valid. Click on the Files tab for more information.") }}
         </span>
         <span *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL">
           Please ensure that the Descriptor is a valid CWL 1.0 workflow.

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -20,6 +20,7 @@ import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Dockstore } from '../../shared/dockstore.model';
 import { EntryTab } from '../../shared/entry/entry-tab';
+import { SessionQuery } from '../../shared/session/session.query';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { ToolDescriptor } from '../../shared/swagger';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
@@ -70,6 +71,7 @@ export class DagComponent extends EntryTab implements OnInit, OnChanges, AfterVi
   public refreshCounter = 1;
   public dagLoading$: Observable<boolean>;
   public wdlViewerResult$: Observable<boolean>;
+  public isPublic: Boolean = false;
   /**
    * Listen to when the document enters or exits fullscreen.
    * Refreshes cytoscape because it is not centered.  Set styling based on whether it's fullscreen or not.
@@ -100,6 +102,7 @@ export class DagComponent extends EntryTab implements OnInit, OnChanges, AfterVi
     private workflowQuery: WorkflowQuery,
     private dagQuery: DagQuery,
     private ngZone: NgZone,
+    private sessionQuery: SessionQuery,
     private wdlViewerService: WdlViewerService
   ) {
     super();
@@ -143,6 +146,9 @@ export class DagComponent extends EntryTab implements OnInit, OnChanges, AfterVi
     this.missingTool$ = this.dagQuery.missingTool$;
     this.dagService.loadExtensions();
     this.wdlViewerResult$ = this.wdlViewerService.status$;
+
+    this.sessionQuery.isPublic$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(isPublic => (this.isPublic = isPublic));
+
   }
 
   ngAfterViewInit(): void {

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -71,7 +71,7 @@ export class DagComponent extends EntryTab implements OnInit, OnChanges, AfterVi
   public refreshCounter = 1;
   public dagLoading$: Observable<boolean>;
   public wdlViewerResult$: Observable<boolean>;
-  public isPublic: Boolean = false;
+  public isPublic$: Observable<boolean>;
   /**
    * Listen to when the document enters or exits fullscreen.
    * Refreshes cytoscape because it is not centered.  Set styling based on whether it's fullscreen or not.
@@ -146,9 +146,7 @@ export class DagComponent extends EntryTab implements OnInit, OnChanges, AfterVi
     this.missingTool$ = this.dagQuery.missingTool$;
     this.dagService.loadExtensions();
     this.wdlViewerResult$ = this.wdlViewerService.status$;
-
-    this.sessionQuery.isPublic$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(isPublic => (this.isPublic = isPublic));
-
+    this.isPublic$ = this.sessionQuery.isPublic$;
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
Instead of saying 'A valid descriptor could not be found' when the WDL file is malformed and a DAG cannot be created print the message 'Please ensure that the Descriptor is a valid WDL workflow.' 

The error message from the parser will be printed in the File tab area so the user can determine what is wrong with the WDL file. https://github.com/dockstore/dockstore/pull/3225

Addresses https://ucsc-cgl.atlassian.net/browse/DOCK-1137

For dockstore/dockstore#3118