### PR TITLE
Add BD Catalyst launch buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.8.0-beta.9"
+    "webservice_version": "feature/3123/bdcatalyst"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "feature/3123/bdcatalyst"
+    "webservice_version": "1.8.1-rc.0"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
-import { Config, MetadataService } from './shared/swagger';
-import { Dockstore } from './shared/dockstore.model';
 import { ConfigService } from 'ng2-ui-auth';
-import { AuthConfig } from './shared/auth.model';
 import { IOauth2Options } from 'ng2-ui-auth/lib/config-interfaces';
+import { AuthConfig } from './shared/auth.model';
+import { Dockstore } from './shared/dockstore.model';
+import { Config, MetadataService } from './shared/swagger';
 
 @Injectable({
   providedIn: 'root'
@@ -35,6 +35,8 @@ export class ConfigurationService {
     Dockstore.DNASTACK_IMPORT_URL = config.dnaStackImportUrl;
     Dockstore.DNANEXUS_IMPORT_URL = config.dnaNexusImportUrl;
     Dockstore.TERRA_IMPORT_URL = config.terraImportUrl;
+    Dockstore.BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL = config.bdCatalystSevenBridgesImportUrl;
+    Dockstore.BD_CATALYST_TERRA_IMPORT_URL = config.bdCatalystTerraImportUrl;
 
     Dockstore.GITHUB_CLIENT_ID = config.githubClientId;
     Dockstore.GITHUB_AUTH_URL = config.gitHubAuthUrl;

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -34,8 +34,8 @@ export class Dockstore {
   static TERRA_IMPORT_URL = 'https://app.terra.bio/#import-tool/dockstore';
   static CGC_IMPORT_URL = 'https://cgc.sbgenomics.com/integration/trs/import';
   static ANVIL_IMPORT_URL = 'https://anvil.terra.bio/#import-tool/dockstore';
-  static BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL = 'https://terra.biodatacatalyst.nhlbi.nih.gov';
-  static BD_CATALYST_TERRA_IMPORT_URL = 'https://sb.biodatacatalyst.nhlbi.nih.gov';
+  static BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL = 'https://sb.biodatacatalyst.nhlbi.nih.gov/integration/trs/import';
+  static BD_CATALYST_TERRA_IMPORT_URL = 'https://terra.biodatacatalyst.nhlbi.nih.gov/#import-tool/dockstore';
 
   static GITHUB_CLIENT_ID = 'will be filled in by configuration.service';
   static GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -34,6 +34,8 @@ export class Dockstore {
   static TERRA_IMPORT_URL = 'https://app.terra.bio/#import-tool/dockstore';
   static CGC_IMPORT_URL = 'https://cgc.sbgenomics.com/integration/trs/import';
   static ANVIL_IMPORT_URL = 'https://anvil.terra.bio/#import-tool/dockstore';
+  static BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL = 'https://terra.biodatacatalyst.nhlbi.nih.gov';
+  static BD_CATALYST_TERRA_IMPORT_URL = 'https://sb.biodatacatalyst.nhlbi.nih.gov';
 
   static GITHUB_CLIENT_ID = 'will be filled in by configuration.service';
   static GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -37,16 +37,10 @@
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">
             <a
               mat-raised-button
-              [matTooltip]="
-                !(hasContent$ | async)
-                  ? 'The WDL has no content.  '
-                  : (hasFileImports$ | async)
-                  ? 'Terra does not support file-path imports in WDL. It only supports http(s) imports.'
-                  : ''
-              "
+              [matTooltip]="terraTooltip$ | async"
               target="_blank"
               rel="noopener"
-              [disabled]="!(hasContent$ | async) || (hasFileImports$ | async)"
+              [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
               color="primary"
               ><mat-icon svgIcon="terra"></mat-icon> Terra &raquo;</a
@@ -59,7 +53,7 @@
               target="_blank"
               rel="noopener"
               [attr.href]="config.CGC_IMPORT_URL + '?trs=' + trsUrl"
-              [disabled]="!(hasContent$ | async) || (hasHttpImports$ | async)"
+              [disabled]="disableSevenBridgesPlatform$ | async"
               color="primary"
               ><img src="../assets/images/thirdparty/cgc.png" /> CGC
             </a>
@@ -71,7 +65,7 @@
               target="_blank"
               rel="noopener"
               [attr.href]="config.BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL + '?trs=' + trsUrl"
-              [disabled]="!(hasContent$ | async) || (hasHttpImports$ | async)"
+              [disabled]="disableSevenBridgesPlatform$ | async"
               color="primary"
               >NHLBI BioData Catalyst
             </a>
@@ -79,16 +73,10 @@
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">
             <a
               mat-raised-button
-              [matTooltip]="
-                !(hasContent$ | async)
-                  ? 'The WDL has no content.  '
-                  : (hasFileImports$ | async)
-                  ? 'AnVIL does not support file-path imports in WDL. It only supports http(s) imports.'
-                  : ''
-              "
+              [matTooltip]="anvilTooltip$ | async"
               target="_blank"
               rel="noopener"
-              [disabled]="!(hasContent$ | async) || (hasFileImports$ | async)"
+              [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.ANVIL_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
               color="primary"
               ><mat-icon class="anvil-icon" svgIcon="anvil"></mat-icon> AnVIL &raquo;</a
@@ -97,16 +85,10 @@
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">
             <a
               mat-raised-button
-              [matTooltip]="
-                !(hasContent$ | async)
-                  ? 'The WDL has no content.  '
-                  : (hasFileImports$ | async)
-                  ? 'BioData Catalyst powered by Terra does not support file-path imports in WDL. It only supports http(s) imports.'
-                  : 'NHLBI BioData Catalyst powered by Terra'
-              "
+              [matTooltip]="bdCatalystTerraTooltip$ | async"
               target="_blank"
               rel="noopener"
-              [disabled]="!(hasContent$ | async) || (hasFileImports$ | async)"
+              [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.BD_CATALYST_TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
               color="primary"
               >NHLBI BioData Catalyst</a

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -64,6 +64,18 @@
               ><img src="../assets/images/thirdparty/cgc.png" /> CGC
             </a>
           </div>
+          <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'CWL'">
+            <a
+              mat-raised-button
+              [matTooltip]="bdCatalystSevenBridgesTooltip$ | async"
+              target="_blank"
+              rel="noopener"
+              [attr.href]="config.BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL + '?trs=' + trsUrl"
+              [disabled]="!(hasContent$ | async) || (hasHttpImports$ | async)"
+              color="primary"
+              >NHLBI BioData Catalyst
+            </a>
+          </div>
           <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">
             <a
               mat-raised-button
@@ -80,6 +92,24 @@
               [attr.href]="config.ANVIL_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
               color="primary"
               ><mat-icon class="anvil-icon" svgIcon="anvil"></mat-icon> AnVIL &raquo;</a
+            >
+          </div>
+          <div fxFlex="100%" *ngIf="workflow?.descriptorType === 'WDL'">
+            <a
+              mat-raised-button
+              [matTooltip]="
+                !(hasContent$ | async)
+                  ? 'The WDL has no content.  '
+                  : (hasFileImports$ | async)
+                  ? 'BioData Catalyst powered by Terra does not support file-path imports in WDL. It only supports http(s) imports.'
+                  : 'NHLBI BioData Catalyst powered by Terra'
+              "
+              target="_blank"
+              rel="noopener"
+              [disabled]="!(hasContent$ | async) || (hasFileImports$ | async)"
+              [attr.href]="config.BD_CATALYST_TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
+              color="primary"
+              >NHLBI BioData Catalyst</a
             >
           </div>
         </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -1,6 +1,6 @@
 a {
-  margin-bottom: 10px;
-  width: 150px;
+  margin-bottom: 0.625rem;
+  width: 18.5rem;
   max-width: 98%;
   img {
     width: 24px;

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -2,6 +2,7 @@ import { HttpUrlEncodingCodec } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
+import { combineLatest, Observable } from 'rxjs';
 import { map, share, takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
 import { DescriptorTypeCompatService } from '../../shared/descriptor-type-compat.service';
@@ -13,7 +14,6 @@ import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { DescriptorsQuery } from './state/descriptors-query';
 import { DescriptorsStore } from './state/descriptors-store';
 import { DescriptorsService } from './state/descriptors.service';
-import { combineLatest, Observable } from 'rxjs';
 import FileTypeEnum = ToolFile.FileTypeEnum;
 
 // tslint:disable:max-line-length
@@ -148,17 +148,11 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
 
   // Note: intentionally not using this.hasContent$ in the next line, as that does not work
   cgcTooltip$: Observable<string> = combineLatest(this.descriptorsQuery.hasContent$, this.hasHttpImports$).pipe(
-    map(([hasContent, hasHttpImports]) => {
-      if (!hasContent) {
-        return 'The CWL has no content.';
-      }
-      if (hasHttpImports) {
-        return (
-          'This version of the CWL has http(s) imports, which are not supported by the CGC. ' + 'Select a version without http(s) imports.'
-        );
-      }
-      return 'Export this workflow version to the CGC.';
-    })
+    map(([hasContent, hasHttpImports]) => this.sevenBridgesTooltip(hasContent, hasHttpImports, 'the CGC'))
+  );
+
+  bdCatalystSevenBridgesTooltip$: Observable<string> = combineLatest(this.descriptorsQuery.hasContent$, this.hasHttpImports$).pipe(
+    map(([hasContent, hasHttpImports]) => this.sevenBridgesTooltip(hasContent, hasHttpImports, 'BioData Catalyst powered by Seven Bridges'))
   );
 
   constructor(
@@ -174,6 +168,11 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     iconRegistry.addSvgIcon('dnanexus', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/DX_Logo_white_alpha.svg'));
     iconRegistry.addSvgIcon('terra', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/terra.svg'));
     iconRegistry.addSvgIcon('anvil', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/anvil.svg'));
+    iconRegistry.addSvgIcon('bdc_terra', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/bdc_terra.svg'));
+    iconRegistry.addSvgIcon(
+      'bdc_seven_bridges',
+      sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/bdc_seven_bridges.svg')
+    );
   }
 
   ngOnInit(): void {
@@ -209,5 +208,15 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
       this.trsUrlAsQueryValue = new HttpUrlEncodingCodec().encodeValue(this.trsUrl);
       this.workflowPathAsQueryValue = new HttpUrlEncodingCodec().encodeValue(this.workflow.full_workflow_path);
     }
+  }
+
+  private sevenBridgesTooltip(hasContent: boolean, hasHttpImports, platform: string): string {
+    if (!hasContent) {
+      return 'The CWL has no content.';
+    }
+    if (hasHttpImports) {
+      return `This version of the CWL has http(s) imports, which are not supported by ${platform}. Select a version without http(s) imports.`;
+    }
+    return `Export this workflow version to ${platform}.`;
   }
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -147,12 +147,34 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   workflowPathAsQueryValue: string;
 
   // Note: intentionally not using this.hasContent$ in the next line, as that does not work
-  cgcTooltip$: Observable<string> = combineLatest(this.descriptorsQuery.hasContent$, this.hasHttpImports$).pipe(
+  cgcTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasHttpImports$).pipe(
     map(([hasContent, hasHttpImports]) => this.sevenBridgesTooltip(hasContent, hasHttpImports, 'the CGC'))
   );
 
-  bdCatalystSevenBridgesTooltip$: Observable<string> = combineLatest(this.descriptorsQuery.hasContent$, this.hasHttpImports$).pipe(
-    map(([hasContent, hasHttpImports]) => this.sevenBridgesTooltip(hasContent, hasHttpImports, 'BioData Catalyst powered by Seven Bridges'))
+  disableSevenBridgesPlatform$: Observable<boolean> = combineLatest(this.hasContent$, this.hasHttpImports$).pipe(
+    map(([hasContent, hasHttpImports]) => !hasContent || hasHttpImports)
+  );
+
+  bdCatalystSevenBridgesTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasHttpImports$).pipe(
+    map(([hasContent, hasHttpImports]) =>
+      this.sevenBridgesTooltip(hasContent, hasHttpImports, 'NHLBI BioData Catalyst powered by Seven Bridges')
+    )
+  );
+
+  terraTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
+    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'Terra'))
+  );
+
+  anvilTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
+    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'AnVIL'))
+  );
+
+  bdCatalystTerraTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
+    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'NHLBI BioData Catalyst powered by Terra'))
+  );
+
+  disableTerraPlatform$: Observable<boolean> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
+    map(([hasContent, hasFileImports]) => !hasContent || hasFileImports)
   );
 
   constructor(
@@ -168,11 +190,6 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     iconRegistry.addSvgIcon('dnanexus', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/DX_Logo_white_alpha.svg'));
     iconRegistry.addSvgIcon('terra', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/terra.svg'));
     iconRegistry.addSvgIcon('anvil', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/anvil.svg'));
-    iconRegistry.addSvgIcon('bdc_terra', sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/bdc_terra.svg'));
-    iconRegistry.addSvgIcon(
-      'bdc_seven_bridges',
-      sanitizer.bypassSecurityTrustResourceUrl('../assets/images/thirdparty/bdc_seven_bridges.svg')
-    );
   }
 
   ngOnInit(): void {
@@ -216,6 +233,16 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     }
     if (hasHttpImports) {
       return `This version of the CWL has http(s) imports, which are not supported by ${platform}. Select a version without http(s) imports.`;
+    }
+    return `Export this workflow version to ${platform}.`;
+  }
+
+  private terraTooltip(hasContent: boolean, hasFileImports, platform: string): string {
+    if (!hasContent) {
+      return 'The WDL has no content.';
+    }
+    if (hasFileImports) {
+      return `${platform} does not support file-path imports in WDL. It only supports http(s) imports.`;
     }
     return `Export this workflow version to ${platform}.`;
   }


### PR DESCRIPTION

dockstore/dockstore#3123

As we don't have appropriately sized logos and we don't have room to say "powered by <platform>", the button labels are text-only "NHLBI BioData Catalyst", with a tooltip mentioning the platform.

We will revisit the launch UI in the future to better handle this and other upcoming use cases, but for now this approach will suffice.

For now, go with a
![Screen Shot 2020-02-12 at 3 52 28 PM](https://user-images.githubusercontent.com/1049340/74388218-b769c800-4daf-11ea-926b-0d948d4cfbc5.png)
![Screen Shot 2020-02-12 at 3 51 51 PM](https://user-images.githubusercontent.com/1049340/74388219-b8025e80-4daf-11ea-947a-9fe43bdb827a.png)



