### PR TITLE
Logged off homepage changes

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -47,7 +47,7 @@
       </div>
 
       <div fxLayout="column wrap" fxLayoutAlign="center center" fxLayoutGap="5px" class="pb-3">
-        <h4 class="title caption text-center" style="max-width: 700px;">
+        <h4 class="title caption text-center landing-message">
           Dockstore, developed by the
           <a class="white-link" href="https://www.cancercollaboratory.org/" target="_blank">Cancer Genome Collaboratory</a>, is an open
           platform used by the <a class="white-link" href="https://genomicsandhealth.org/" target="_blank">GA4GH</a> for sharing

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -46,20 +46,24 @@
         </div>
       </div>
 
-      <div fxLayout="column wrap" fxLayoutAlign="center center" fxLayoutGap="5px">
-        <h3 class="search-title">New to Dockstore?</h3>
-        <div fxLayout="row wrap" fxLayoutAlign="center center" fxLayoutGap="20px" class="pb-5">
-          <a mat-raised-button href="#overview" class="button-link">Start here</a>
-        </div>
-
-        <!-- Left the boat and truck here in case we want them back -->
-        <!-- <div fxLayout="row wrap" fxLayoutAlign="center" fxLayoutGap="20px">
-          <img fxFlexAlign="end" src="../assets/images/dockstore/ship.png">
-          <img fxFlexAlign="end" src="../assets/images/dockstore/truck.png">
-        </div> -->
+      <div fxLayout="column wrap" fxLayoutAlign="center center" fxLayoutGap="5px" class="pb-3">
+        <h4 class="title caption text-center" style="max-width: 700px;">
+          Dockstore, developed by the
+          <a class="white-link" href="https://www.cancercollaboratory.org/" target="_blank">Cancer Genome Collaboratory</a>, is an open
+          platform used by the <a class="white-link" href="https://genomicsandhealth.org/" target="_blank">GA4GH</a> for sharing
+          Docker-based tools described with either the
+          <a class="white-link" href="http://www.commonwl.org/" target="_blank">Common Workflow Language (CWL)</a>, the
+          <a class="white-link" href="https://software.broadinstitute.org/wdl/" target="_blank">Workflow Description Language (WDL)</a>, or
+          <a class="white-link" href="https://www.nextflow.io/" target="_blank">Nextflow</a>
+        </h4>
       </div>
     </div>
   </div>
+</div>
+
+<div class="header-lower boat-header" fxLayout="row wrap" fxLayoutAlign="end" fxLayoutGap="20px" fxShow fxHide.lt-md>
+  <img fxFlexAlign="end" src="../assets/images/dockstore/ship.png" />
+  <img fxFlexAlign="end" src="../assets/images/dockstore/truck.png" class="pr-2" />
 </div>
 
 <div class="header-lower" id="overview">

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -113,15 +113,15 @@ span {
 }
 
 .top-section {
-  min-height: 800px;
-}
-
-.search-holder {
-  margin-top: 40px;
+  min-height: 500px;
 }
 
 .header-lower {
   min-height: 200px;
+}
+
+.boat-header {
+  background-color: #21335b;
 }
 
 .content-holder {

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -129,6 +129,10 @@ span {
   min-height: 300px;
 }
 
+.landing-message {
+  max-width: 700px;
+}
+
 .stripe-holder {
   min-height: 175px;
   width: 100%;


### PR DESCRIPTION
Made another PR since the other one came from develop. This updates the logged off homepage to include the truck/ship, the landing message, and removal of the start here button.

<img width="1440" alt="Screen Shot 2020-02-14 at 9 50 26 AM" src="https://user-images.githubusercontent.com/6331159/74541354-77215b80-4f0f-11ea-887e-fa3ed307c419.png">

https://github.com/dockstore/dockstore/issues/3183