### PR TITLE
Build UI develop against webservice develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
     steps:
       - get_workspace
       - install_container_dependencies
-        # Override the webservice version in package.json to instead use develop version
+        # Override the webservice version in package.json to instead build against develop webservice
       - run:
           name: set webservice to develop
           command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
@@ -201,11 +201,8 @@ workflows:
           requires:
             - upload_to_s3
           filters:
-            # all for testing, change to develop before PR
             branches:
-              only: /.*/
-#            branches:
-#              only: /^develop/
+              only: /^develop/
 commands:
   install_container_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,19 +146,19 @@ jobs:
                   --cache-control max-age=0
   check_build_develop:
     working_directory: ~/repo
-      steps:
-        - get_workspace
-        - install_container_dependencies
+    steps:
+      - get_workspace
+      - install_container_dependencies
         # Override the webservice version in package.json to instead use develop version
-        - run:
-            name: set webservice to develop
-            command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
-        - run:
-            name: Build
-            command: bash -i -c 'npm run build'
-        - run:
-            name: Build
-            command: bash -i -c 'npm run build.prod
+      - run:
+          name: set webservice to develop
+          command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
+      - run:
+          name: Build
+          command: bash -i -c 'npm run build'
+      - run:
+          name: Build
+          command: bash -i -c 'npm run build.prod
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,21 @@ jobs:
                 to: 's3://${AWS_BUCKET}/${CIRCLE_TAG-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/index.html'
                 arguments: |
                   --cache-control max-age=0
+  check_build_develop:
+    working_directory: ~/repo
+      steps:
+        - get_workspace
+        - install_container_dependencies
+        # Override the webservice version in package.json to instead use develop version
+        - run:
+            name: set webservice to develop
+            command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
+        - run:
+            name: Build
+            command: bash -i -c 'npm run build'
+        - run:
+            name: Build
+            command: bash -i -c 'npm run build.prod
 
 workflows:
   version: 2
@@ -183,6 +198,15 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
+      - check_build_develop:
+          requires:
+            - upload_to_s3
+          filters:
+            # all for testing, change to develop before PR
+            branches:
+              only: /.*/
+#            branches:
+#              only: /^develop/
 commands:
   install_container_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,8 @@ jobs:
                   --cache-control max-age=0
   check_build_develop:
     working_directory: ~/repo
+    docker:
+      - image: circleci/python:2.7
     steps:
       - get_workspace
       - install_container_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,6 @@ jobs:
       - run:
           name: Build
           command: bash -i -c 'npm run build'
-      - run:
-          name: Build
-          command: bash -i -c 'npm run build.prod
 
 workflows:
   version: 2


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3160

Added a circleCI job that will run when a UI PR is merged to UI develop. The job will check whether UI develop can build against webservice develop and will error otherwise. The new job runs after s3 upload so UI bits will still upload. 