### PR TITLE
Use flexbox for stacked buttons

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -20,14 +20,23 @@
 </app-header>
 <div class="container search-container">
   <div class="row">
-    <div class="col-md-3 containers-rsb">
-      <div class="mb-3 expand-collapse-holder">
-        <button mat-raised-button color="accent" (click)="accordion.openAll()">Expand All<mat-icon>unfold_more</mat-icon></button>
-        <button mat-raised-button color="accent" (click)="accordion.closeAll()">Collapse All<mat-icon>unfold_less</mat-icon></button>
+    <div class="col-md-3">
+      <div class="pb-3">
+        <div fxLayout="row wrap" fxLayoutAlign="space-between center">
+          <button fxFlex="1 0 12rem" class="m-1" mat-raised-button color="accent" (click)="accordion.openAll()">
+            Expand All<mat-icon>unfold_more</mat-icon>
+          </button>
+          <button fxFlex="1 0 12rem" class="m-1" mat-raised-button color="accent" (click)="accordion.closeAll()">
+            Collapse All<mat-icon>unfold_less</mat-icon>
+          </button>
+        </div>
+        <div>
+          <!-- For some reason w-100 doesn't work exactly, using fxFlex instead -->
+          <button fxFlex="1 1 auto" mat-raised-button color="accent" (click)="resetFilters()" type="button" class="mx-1">
+            Reset Filters
+          </button>
+        </div>
       </div>
-      <button mat-raised-button color="accent" (click)="resetFilters()" type="button" class="w-100 my-3">
-        Reset Filters
-      </button>
       <mat-accordion multi>
         <app-basic-search></app-basic-search>
         <mat-expansion-panel *ngFor="let key of getKeys(orderedBuckets)" #bucket expanded>


### PR DESCRIPTION
dockstore/dockstore#3249

Changes: 
- randomly set the width to 12rem (seems to fit both buttons), buttons are now the same size
- when wrapped, buttons are full width
- slight horizontal margin defect compared to the accordions because fxLayoutGap doesn't seem to work well with flex wrap
- less vertical margin for the reset filters button

![stackedButtons](https://user-images.githubusercontent.com/24548904/75464311-03db0900-5955-11ea-95a1-2b6cd29bc1ef.gif)

Cannot seem to make the text break out of the button (aside from making the button incredibly small)