### PR TITLE
Feature/3277/small search columns on mobile

### DIFF
--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -38,8 +38,8 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">
-      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-sm *matCellDef="let tool">
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
         <a *ngIf="getVerified(tool)" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">check</mat-icon>
         </a>
@@ -50,8 +50,8 @@
       <mat-cell fxShow fxHide.lt-sm class="duration-cell" *matCellDef="let tool">{{ tool?.author || 'n/a' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">{{
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let tool">{{
         tool?.descriptorType ? (tool?.descriptorType.toString() | uppercase) : ''
       }}</mat-cell>
     </ng-container>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -38,24 +38,26 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">
-      <mat-header-cell *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell *matCellDef="let tool">
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef>Verified</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let tool">
         <a *ngIf="getVerified(tool)" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">check</mat-icon>
         </a>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
-      <mat-cell class="duration-cell" *matCellDef="let tool">{{ tool?.author || 'n/a' }}</mat-cell>
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm class="duration-cell" *matCellDef="let tool">{{ tool?.author || 'n/a' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
-      <mat-cell *matCellDef="let tool">{{ tool?.descriptorType ? (tool?.descriptorType.toString() | uppercase) : '' }}</mat-cell>
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">{{
+        tool?.descriptorType ? (tool?.descriptorType.toString() | uppercase) : ''
+      }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell *matHeaderCellDef>Project Links</mat-header-cell>
-      <mat-cell *matCellDef="let tool">
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
         <a [href]="tool?.providerUrl" *ngIf="tool?.providerUrl">
           <fa-icon class="fa-lg" [icon]="tool.providerIcon" [matTooltip]="tool?.provider"></fa-icon>
         </a>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -21,24 +21,24 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">
-      <mat-header-cell *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell *matCellDef="let workflow">
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef>Verified</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let workflow">
         <a *ngIf="getVerified(workflow)" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
-      <mat-cell class="duration-cell" *matCellDef="let workflow">{{ workflow?.author || 'n/a' }}</mat-cell>
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm class="duration-cell" *matCellDef="let workflow">{{ workflow?.author || 'n/a' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
-      <mat-cell *matCellDef="let workflow">{{ workflow?.descriptorType | uppercase }}</mat-cell>
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">{{ workflow?.descriptorType | uppercase }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell *matHeaderCellDef>Project Links</mat-header-cell>
-      <mat-cell *matCellDef="let entry">
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let entry">
         <a [href]="entry?.providerUrl" *ngIf="entry?.providerUrl">
           <fa-icon class="fa-lg" [icon]="entry.providerIcon" [matTooltip]="entry?.provider"></fa-icon>
         </a>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -21,8 +21,8 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">
-      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-sm *matCellDef="let workflow">
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">
         <a *ngIf="getVerified(workflow)" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>
@@ -33,8 +33,8 @@
       <mat-cell fxShow fxHide.lt-sm class="duration-cell" *matCellDef="let workflow">{{ workflow?.author || 'n/a' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">{{ workflow?.descriptorType | uppercase }}</mat-cell>
+      <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let workflow">{{ workflow?.descriptorType | uppercase }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Project Links</mat-header-cell>


### PR DESCRIPTION
For dockstore/dockstore#3277

When screen is md or smaller, remove project links and verified (these ones cannot be sorted in the table)
When screen is sm or smaller, remove author and descriptor types (these ones can be sorted and is slightly awkward when browser is shrunk after sorting by these)

![responsiveSearchTable](https://user-images.githubusercontent.com/24548904/75470890-5f11f900-595f-11ea-894b-182240314ef9.gif)


