### PR TITLE
Feature/3246/remove ngx bootstrap hosted workflows

### DIFF
--- a/cypress/integration/group1/hostedTools.ts
+++ b/cypress/integration/group1/hostedTools.ts
@@ -14,68 +14,82 @@
  *    limitations under the License.
  */
 import { Dockstore } from '../../../src/app/shared/dockstore.model';
-import { clickFirstActionsButton, goToTab, goToUnexpandedSidebarEntry, resetDB, setTokenUserViewPort } from '../../support/commands';
+import { goToTab, goToUnexpandedSidebarEntry, resetDB, setTokenUserViewPort } from '../../support/commands';
 
-describe('Dockstore hosted workflows', () => {
+describe('Dockstore hosted tools', () => {
   resetDB();
   setTokenUserViewPort();
 
   beforeEach(() => {
-    cy.visit('/my-workflows');
+    cy.visit('/my-tools');
 
     cy.server();
 
     cy.route({
       method: 'GET',
-      url: /workflows\/.+\/zip\/.+/,
+      url: /containers\/.+\/zip\/.+/,
       response: 200
     }).as('downloadZip');
   });
 
-  function getWorkflow() {
-    goToUnexpandedSidebarEntry('dockstore.org/A', /hosted/);
+  function getTool() {
+    goToUnexpandedSidebarEntry('quay.io/hosted-tool', 'ht');
   }
 
-  // Ensure tabs are correct for the hosted workflow, try adding a version
-  describe('Should be able to register a hosted workflow and add files to it', () => {
-    it('Register the workflow', () => {
-      // Select the hosted workflow
-      getWorkflow();
+  // Ensure tabs are correct for the hosted tool, try adding a version
+  describe('Should be able to register a hosted tool and add files to it', () => {
+    it('Register the tool', () => {
+      // Select the hosted tool
+      getTool();
 
       // Should not be able to publish (No valid versions)
-      cy.get('#publishButton').should('be.disabled');
-
-      // Check content of the info tab
-      cy.contains('Mode: HOSTED');
+      cy.get('#publishToolButton').should('be.disabled');
 
       // Should not be able to download zip
       cy.get('#downloadZipButton').should('not.be.visible');
 
-      // Should have alert saying there are no versions
+      // Check content of the version tab. New hosted tool, there's no versions
       goToTab('Versions');
-      cy.contains('To see versions, please add a new version.');
+      cy.contains('To see versions, please add a new version');
 
-      // Add a new version with one descriptor
+      // Add a new version with one descriptor and dockerfile
       goToTab('Files');
+
       cy.get('#editFilesButton').click();
+
       cy.contains('Add File').click();
       cy.window().then(function(window: any) {
         cy.document().then(doc => {
           const editors = doc.getElementsByClassName('ace_editor');
-          const wdlDescriptorFile = `task md5 { File inputFile command { /bin/my_md5sum \${inputFile} } output { File value = \"md5sum.txt\" } runtime { docker: \"quay.io/agduncan94/my-md5sum\" } } workflow ga4ghMd5 { File inputFile call md5 { input: inputFile=inputFile } }`;
-          window.ace.edit(editors[0]).setValue(wdlDescriptorFile, -1);
+          const dockerfile = `FROM ubuntu:latest`;
+          window.ace.edit(editors[0]).setValue(dockerfile, -1);
+        });
+      });
+
+      cy.get('#descriptorFilesTab-link').click();
+      cy.wait(500);
+
+      cy.get('#descriptorFilesTab')
+        .contains('Add File')
+        .click();
+      cy.window().then(function(window: any) {
+        cy.document().then(doc => {
+          const editors = doc.getElementsByClassName('ace_editor');
+          const cwlDescriptor = `cwlVersion: v1.0\nclass: CommandLineTool`;
+          window.ace.edit(editors[1]).setValue(cwlDescriptor, -1);
         });
       });
 
       cy.get('#saveNewVersionButton').click();
-      cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:1');
+
+      cy.get('#tool-path').contains('quay.io/hosted-tool/ht:1');
+
       // Should have a version 1
       goToTab('Versions');
       cy.get('table').contains('span', /\b1\b/);
 
       // Should be able to download zip
       goToTab('Info');
-
       cy.get('#downloadZipButton').should('be.visible');
 
       // Verify that clicking calls the correct endpoint
@@ -89,67 +103,74 @@ describe('Dockstore hosted workflows', () => {
       // Add a new version with a second descriptor and a test json
       goToTab('Files');
       cy.get('#editFilesButton').click();
-      cy.contains('Add File').click();
+      cy.get('#descriptorFilesTab-link').click();
+      cy.wait(500);
+      cy.get('#descriptorFilesTab')
+        .contains('Add File')
+        .click();
       cy.window().then(function(window: any) {
         cy.document().then(doc => {
           const editors = doc.getElementsByClassName('ace_editor');
-          const wdlDescriptorFile = `task test { File inputFile command { /bin/my_md5sum \${inputFile} } output { File value = \"md5sum.txt\" } runtime { docker: \"quay.io/agduncan94/my-md5sum\" } } workflow ga4ghMd5 { File inputFile call test { input: inputFile=inputFile } }`;
-          window.ace.edit(editors[1]).setValue(wdlDescriptorFile, -1);
+          const cwlDescriptor = `cwlVersion: v1.0\nclass: CommandLineTool`;
+          window.ace.edit(editors[2]).setValue(cwlDescriptor, -1);
         });
       });
 
-      goToTab('Test Parameter Files');
+      cy.get('#testParameterFilesTab-link').click();
       cy.wait(500);
-      cy.contains('Add File').click();
+      cy.get('#testParameterFilesTab')
+        .contains('Add File')
+        .click();
       cy.window().then(function(window: any) {
         cy.document().then(doc => {
           const editors = doc.getElementsByClassName('ace_editor');
           const testParameterFile = '{}';
-          window.ace.edit(editors[2]).setValue(testParameterFile, -1);
+          window.ace.edit(editors[3]).setValue(testParameterFile, -1);
         });
       });
 
       cy.get('#saveNewVersionButton').click();
-      cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:2');
+      cy.get('#tool-path').contains('quay.io/hosted-tool/ht:2');
       // Should have a version 2
       goToTab('Versions');
-      cy.get('table').contains('span', /\b2\b/);
+      cy.get('table')
+        .contains('span', /\b2\b/)
+        .click();
 
       // Should be able to publish
       cy.get('#publishButton').should('not.be.disabled');
 
-      // Try deleting a file (.wdl file)
+      // Try deleting a file (.cwl file)
       goToTab('Files');
       cy.get('#editFilesButton').click();
-      cy.get('.delete-editor-file')
+      cy.get('#descriptorFilesTab-link').click();
+      cy.wait(500);
+      cy.get('#descriptorFilesTab')
+        .find('.delete-editor-file')
         .first()
         .click();
       cy.get('#saveNewVersionButton').click();
-      cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:3');
+      cy.get('#tool-path').contains('quay.io/hosted-tool/ht:3');
 
-      // Testing for one ace editor as mat-tab hides the second element due to it being in a different tab
-      cy.get('.ace_editor').should('have.length', 1);
+      // Should now only have 1 visible editor
+      cy.get('.ace_editor:visible').should('have.length', 1);
 
       // New version should be added
       goToTab('Versions');
       cy.get('table').contains('span', /\b3\b/);
 
       // Delete a version
-      clickFirstActionsButton();
-      cy.contains('Delete').click();
+      cy.contains('button', 'Actions')
+        .should('be.visible')
+        .click();
+      cy.get('.deleteVersionButton').click();
       // Automatically selects the newest version that wasn't the one that was just deleted
-      cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:2');
+      cy.get('#tool-path').contains('quay.io/hosted-tool/ht:2');
       // Version 3 should no longer exist since it was just deleted
       goToTab('Versions');
       cy.get('table')
         .find('a')
         .should('not.contain', '3');
-
-      // Reload the hosted workflow to test https://github.com/dockstore/dockstore/issues/2854
-      cy.reload();
-
-      goToTab('Files');
-      cy.contains('/Dockstore.wdl').should('be.visible');
     });
   });
 });

--- a/cypress/integration/group1/hostedTools.ts
+++ b/cypress/integration/group1/hostedTools.ts
@@ -67,7 +67,7 @@ describe('Dockstore hosted tools', () => {
       });
 
       cy.get('#descriptorFilesTab-link').click();
-      cy.wait(500);
+      cy.wait(1000);
 
       cy.get('#descriptorFilesTab')
         .contains('Add File')
@@ -160,9 +160,10 @@ describe('Dockstore hosted tools', () => {
       cy.get('table').contains('span', /\b3\b/);
 
       // Delete a version
-      cy.contains('button', 'Actions').should('be.visible').click();
-      cy.get('.deleteVersionButton')
+      cy.contains('button', 'Actions')
+        .should('be.visible')
         .click();
+      cy.get('.deleteVersionButton').click();
       // Automatically selects the newest version that wasn't the one that was just deleted
       cy.get('#tool-path').contains('quay.io/hosted-tool/ht:2');
       // Version 3 should no longer exist since it was just deleted

--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -98,7 +98,7 @@ describe('Dockstore hosted workflows', () => {
         });
       });
 
-      cy.get('#testParameterFilesTab-link').click();
+      cy.get('[data-cy=testParameterFilesTab]').click();
       cy.wait(500);
       cy.get('#testParameterFilesTab')
         .contains('Add File')

--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -98,11 +98,9 @@ describe('Dockstore hosted workflows', () => {
         });
       });
 
-      cy.get('[data-cy=testParameterFilesTab]').click();
+      goToTab('Test Parameter Files');
       cy.wait(500);
-      cy.get('#testParameterFilesTab')
-        .contains('Add File')
-        .click();
+      cy.contains('Add File').click();
       cy.window().then(function(window: any) {
         cy.document().then(doc => {
           const editors = doc.getElementsByClassName('ace_editor');
@@ -112,6 +110,7 @@ describe('Dockstore hosted workflows', () => {
       });
 
       cy.get('#saveNewVersionButton').click();
+      cy.get('.ace_editor');
       cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:2');
       // Should have a version 2
       goToTab('Versions');
@@ -122,6 +121,7 @@ describe('Dockstore hosted workflows', () => {
 
       // Try deleting a file (.wdl file)
       goToTab('Files');
+      cy.get('.ace_editor');
       cy.get('#editFilesButton').click();
       cy.get('.delete-editor-file')
         .first()
@@ -129,8 +129,8 @@ describe('Dockstore hosted workflows', () => {
       cy.get('#saveNewVersionButton').click();
       cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:3');
 
-      // Should now only be two ace editors
-      cy.get('.ace_editor').should('have.length', 2);
+      // Testing for one ace editor as mat-tab hides the second element due to it being in a different tab
+      cy.get('.ace_editor').should('have.length', 1);
 
       // New version should be added
       goToTab('Versions');

--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -110,7 +110,6 @@ describe('Dockstore hosted workflows', () => {
       });
 
       cy.get('#saveNewVersionButton').click();
-      cy.get('.ace_editor');
       cy.get('#workflow-path').contains('dockstore.org/A/hosted-workflow:2');
       // Should have a version 2
       goToTab('Versions');
@@ -121,7 +120,6 @@ describe('Dockstore hosted workflows', () => {
 
       // Try deleting a file (.wdl file)
       goToTab('Files');
-      cy.get('.ace_editor');
       cy.get('#editFilesButton').click();
       cy.get('.delete-editor-file')
         .first()

--- a/src/app/home-page/home-logged-out/home.component.ts
+++ b/src/app/home-page/home-logged-out/home.component.ts
@@ -18,7 +18,6 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HomePageService } from 'app/home-page/home-page.service';
 import { Base } from 'app/shared/base';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
-import { TabDirective } from 'ngx-bootstrap/tabs';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Dockstore } from '../../shared/dockstore.model';
@@ -86,10 +85,6 @@ export class HomeComponent extends Base implements OnInit, AfterViewInit {
 
   goToSearch(searchValue: string) {
     this.homePageService.goToSearch(searchValue);
-  }
-
-  onSelect(data: TabDirective): void {
-    this.selectedTab = data.id;
   }
 
   openYoutube() {

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
@@ -15,7 +15,7 @@
   -->
 
 <mat-tab-group mat-stretch-tabs>
-  <mat-tab label="Descriptor Files" id="descriptorFilesTab" data-cy="descriptorFilesTab">
+  <mat-tab label="Descriptor Files" id="descriptorFilesTab">
     <app-code-editor-list
       [sourcefiles]="descriptorFiles"
       [editing]="editing"
@@ -26,7 +26,7 @@
       [entrypath]="entrypath"
     ></app-code-editor-list>
   </mat-tab>
-  <mat-tab label="Test Parameter Files" id="testParameterFilesTab" data-cy="testParameterFilesTab">
+  <mat-tab label="Test Parameter Files" id="testParameterFilesTab">
     <app-code-editor-list
       *ngIf="!(isNFL$ | async)"
       [sourcefiles]="testParameterFiles"

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
@@ -14,8 +14,8 @@
   ~    limitations under the License.
   -->
 
-<tabset [justified]="true">
-  <tab heading="Descriptor Files" id="descriptorFilesTab">
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Descriptor Files" id="descriptorFilesTab">
     <app-code-editor-list
       [sourcefiles]="descriptorFiles"
       [editing]="editing"
@@ -25,8 +25,8 @@
       [entryType]="'workflow'"
       [entrypath]="entrypath"
     ></app-code-editor-list>
-  </tab>
-  <tab heading="Test Parameter Files" id="testParameterFilesTab">
+  </mat-tab>
+  <mat-tab label="Test Parameter Files" id="testParameterFilesTab">
     <app-code-editor-list
       *ngIf="!(isNFL$ | async)"
       [sourcefiles]="testParameterFiles"
@@ -41,8 +41,9 @@
       <mat-icon>warning</mat-icon>
       &nbsp; Nextflow does not have the concept of a test parameter file.
     </mat-card>
-  </tab>
-</tabset>
+  </mat-tab>
+</mat-tab-group>
+
 <div class="editor-button-container p-2" *ngIf="!publicPage && canWrite && isNewestVersion">
   <span *ngIf="!editing">
     <button id="editFilesButton" mat-raised-button color="primary" (click)="toggleEdit()">

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
@@ -15,7 +15,7 @@
   -->
 
 <mat-tab-group mat-stretch-tabs>
-  <mat-tab label="Descriptor Files" id="descriptorFilesTab">
+  <mat-tab label="Descriptor Files" id="descriptorFilesTab" data-cy="descriptorFilesTab">
     <app-code-editor-list
       [sourcefiles]="descriptorFiles"
       [editing]="editing"
@@ -26,7 +26,7 @@
       [entrypath]="entrypath"
     ></app-code-editor-list>
   </mat-tab>
-  <mat-tab label="Test Parameter Files" id="testParameterFilesTab">
+  <mat-tab label="Test Parameter Files" id="testParameterFilesTab" data-cy="testParameterFilesTab">
     <app-code-editor-list
       *ngIf="!(isNFL$ | async)"
       [sourcefiles]="testParameterFiles"

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
@@ -9,6 +9,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TabsModule } from 'ngx-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
 import { WorkflowService } from '../../shared/state/workflow.service';
@@ -49,7 +50,8 @@ describe('WorkflowFileEditorComponent', () => {
         MatTooltipModule,
         ClipboardModule,
         MatSnackBarModule,
-        MatCardModule
+        MatCardModule,
+        BrowserAnimationsModule
       ],
       providers: [
         { provide: HostedService, useClass: HostedStubService },


### PR DESCRIPTION
Removed ngx-bootstrap tab from hosted workflows

dockstore/dockstore#3246

Migrated from using ngx-bootstrap tabs to Material Tabs in the
hosted workflows page.

Imported BrowserAnimationsModule to the spec file in order for tests
to pass

Removed an unused ngx-bootstrap module and method from home.component.ts

Adjusted hostedWorkflows cypress tests to work with the new Material Tabs