### PR TITLE
Use JSON highlighter for .ga files

### DIFF
--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -79,7 +79,7 @@ export class CodeEditorComponent implements AfterViewInit {
         this.mode = 'wdl';
       } else if (filepath.includes('Dockerfile')) {
         this.mode = 'dockerfile';
-      } else if (filepath.endsWith('.json')) {
+      } else if (filepath.endsWith('.json') || filepath.endsWith('.ga')) {
         this.mode = 'json';
       } else if (filepath.endsWith('.yml') || filepath.endsWith('.yaml')) {
         this.mode = 'yaml';


### PR DESCRIPTION
For dockstore/dockstore#3268

.yaml and .yml is already using the yaml highlighter
Using json highlighting for .ga