### PR TITLE
Display missing file validation for services

### DIFF
--- a/src/app/entry/entry-file-tab/entry-file-tab.component.html
+++ b/src/app/entry/entry-file-tab/entry-file-tab.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="version" class="p-3">
   <mat-card *ngIf="validationMessage$ | async as validation" class="alert alert-warning">
     <mat-icon>warning</mat-icon>
+    &nbsp;
     <span *ngFor="let item of validation | keyvalue">
       <strong>{{ item.key }}</strong
       >: {{ item.value }}

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -187,7 +187,8 @@ export class EntryFileTabService extends Base {
    */
   private setAlmostEverything(unfilteredFiles: ToolFile[]) {
     const fileTypes = this.getFileTypes(unfilteredFiles);
-    const selectedFileType: ToolFile.FileTypeEnum = fileTypes[0];
+    const previousFileType = this.entryFileTabQuery.getValue().selectedFileType;
+    const selectedFileType: ToolFile.FileTypeEnum = previousFileType ? previousFileType : fileTypes[0];
     const files = this.filterFiles(selectedFileType, unfilteredFiles);
     const file = files[0];
     this.entryFileTabStore.update(state => {

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -137,8 +137,12 @@ export class EntryFileTabService extends Base {
   private getValidations() {
     const version = this.workflowQuery.getValue().version;
     const file = this.entryFileTabQuery.getValue().selectedFile;
-    if (version && version.validations && file &&
-      (file.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR || file.file_type === ToolFile.FileTypeEnum.OTHER)) {
+    if (
+      version &&
+      version.validations &&
+      file &&
+      (file.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR || file.file_type === ToolFile.FileTypeEnum.OTHER)
+    ) {
       for (const validation of version.validations) {
         if (validation.type === Validation.TypeEnum.DOCKSTORESERVICEYML) {
           const validationObject = JSON.parse(validation.message);
@@ -188,7 +192,8 @@ export class EntryFileTabService extends Base {
   private setAlmostEverything(unfilteredFiles: ToolFile[]) {
     const fileTypes = this.getFileTypes(unfilteredFiles);
     const previousFileType = this.entryFileTabQuery.getValue().selectedFileType;
-    const selectedFileType: ToolFile.FileTypeEnum = previousFileType ? previousFileType : fileTypes[0];
+    const validPreviousFileType = fileTypes.filter(fileType => fileType === previousFileType).length === 1;
+    const selectedFileType: ToolFile.FileTypeEnum = validPreviousFileType ? previousFileType : fileTypes[0];
     const files = this.filterFiles(selectedFileType, unfilteredFiles);
     const file = files[0];
     this.entryFileTabStore.update(state => {

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -192,8 +192,7 @@ export class EntryFileTabService extends Base {
   private setAlmostEverything(unfilteredFiles: ToolFile[]) {
     const fileTypes = this.getFileTypes(unfilteredFiles);
     const previousFileType = this.entryFileTabQuery.getValue().selectedFileType;
-    const validPreviousFileType = fileTypes.filter(fileType => fileType === previousFileType).length === 1;
-    const selectedFileType: ToolFile.FileTypeEnum = validPreviousFileType ? previousFileType : fileTypes[0];
+    const selectedFileType: ToolFile.FileTypeEnum = fileTypes.includes(previousFileType) ? previousFileType : fileTypes[0];
     const files = this.filterFiles(selectedFileType, unfilteredFiles);
     const file = files[0];
     this.entryFileTabStore.update(state => {

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -137,7 +137,8 @@ export class EntryFileTabService extends Base {
   private getValidations() {
     const version = this.workflowQuery.getValue().version;
     const file = this.entryFileTabQuery.getValue().selectedFile;
-    if (version && version.validations && file && file.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR) {
+    if (version && version.validations && file &&
+      (file.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR || file.file_type === ToolFile.FileTypeEnum.OTHER)) {
       for (const validation of version.validations) {
         if (validation.type === Validation.TypeEnum.DOCKSTORESERVICEYML) {
           const validationObject = JSON.parse(validation.message);


### PR DESCRIPTION
If a file is missing in the .dockstore.yml, the validation message appears when viewing the Files > Files tab and the Files > Primary Descriptor tab.

In Files > Files tab:
![Screenshot from 2020-03-12 11-03-30](https://user-images.githubusercontent.com/25287123/76535453-4589aa80-6451-11ea-9f02-401ef31b2303.png)

In Files > Primary Descriptor tab:
![Screenshot from 2020-03-12 11-05-09](https://user-images.githubusercontent.com/25287123/76535517-6520d300-6451-11ea-9b94-a1e947daa0c3.png)

While I was testing the validation for services, I noticed that when I selected a new version from the drop down menu at the top, the previous version's validation message still remained. This was fixed in my [second commit](https://github.com/dockstore/dockstore-ui2/commit/6909076c3cc79327438021f7ff358b881e0f468e). The problem was that previous validation message wasn't being cleared if you changed the version when you were in the Files > Files tab.

I also noticed that if you were in the Files > Primary Descriptor tab and you selected a new version from the drop down, it would load the file contents for Files > Files. This was fixed in my [third commit](https://github.com/dockstore/dockstore-ui2/commit/09145a3c1f02c89e48cc65091a17cead2c65aa2b). The problem was that the Files > Files content was loaded for the new version selected no matter what your current selectedFileType was.