### PR TITLE
Revert differential loading, keeping updated CLI though

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Differential loading is failing everything on CircleCI (not enough wam), reverting now rather than later.  Keeping the updated Angular CLI though.