### PR TITLE
Fix missing Add Tag

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -187,6 +187,18 @@
                 >
                 </app-versions-container>
               </div>
+
+              <button
+                id="addTagButton"
+                type="button"
+                class="pull-right mr-1 my-3"
+                *ngIf="!publicPage && isManualMode()"
+                mat-flat-button
+                color="primary"
+                (click)="showAddTagModal()"
+              >
+                Add Tag
+              </button>
             </div>
           </mat-tab>
           <mat-tab label="Files">
@@ -353,10 +365,10 @@
   <div class="p-3">
     <mat-card class="alert alert-info p-3" role="alert">
       <mat-icon>info</mat-icon>
-      <span *ngIf="tool?.mode === ModeEnum.HOSTED">
+      <span *ngIf="tool?.mode === ModeEnum.HOSTED || tool?.mode === ModeEnum.MANUALIMAGEPATH">
         To see versions, please add a new version.
       </span>
-      <span *ngIf="tool?.mode !== ModeEnum.HOSTED">
+      <span *ngIf="tool?.mode === ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS || tool?.mode === ModeEnum.AUTODETECTQUAYTAGSWITHMIXED">
         To see versions, please refresh the tool.
       </span>
     </mat-card>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -187,12 +187,11 @@
                 >
                 </app-versions-container>
               </div>
-
               <button
                 id="addTagButton"
                 type="button"
-                class="pull-right mr-1 my-3"
-                *ngIf="!publicPage && isManualMode()"
+                class="pull-right m-3"
+                *ngIf="!publicPage && (isManualMode$ | async)"
                 mat-flat-button
                 color="primary"
                 (click)="showAddTagModal()"

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -65,6 +65,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public toolCopyBtn: string;
   public sortedVersions: Array<Tag | WorkflowVersion> = [];
   public DockstoreToolType = DockstoreTool;
+  public isManualMode$: Observable<boolean>;
   validTabs = ['info', 'launch', 'versions', 'files'];
   separatorKeysCodes = [ENTER, COMMA];
   public schema;
@@ -123,7 +124,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
         }
       });
     }
-
+    this.isManualMode$ = this.toolQuery.isManualMode$;
     this.updateTabSelection();
   }
 
@@ -138,17 +139,6 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   isPublic(): boolean {
     return this.isToolPublic;
   }
-
-
-  isManualMode() {
-    console.log(this.tool);
-    if (this.tool && this.tool.mode === DockstoreTool.ModeEnum.MANUALIMAGEPATH) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
 
   showAddTagModal() {
     this.dialog.open(AddTagComponent, { width: '600px' });

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -45,6 +45,7 @@ import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool'
 import { ContainersService } from './../shared/swagger/api/containers.service';
 import { DockstoreTool } from './../shared/swagger/model/dockstoreTool';
 import { UrlResolverService } from './../shared/url-resolver.service';
+import { AddTagComponent } from './add-tag/add-tag.component';
 import { EmailService } from './email.service';
 
 @Component({
@@ -136,6 +137,21 @@ export class ContainerComponent extends Entry implements AfterViewInit {
 
   isPublic(): boolean {
     return this.isToolPublic;
+  }
+
+
+  isManualMode() {
+    console.log(this.tool);
+    if (this.tool && this.tool.mode === DockstoreTool.ModeEnum.MANUALIMAGEPATH) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+
+  showAddTagModal() {
+    this.dialog.open(AddTagComponent, { width: '600px' });
   }
 
   public resetCopyBtn(): void {

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -118,16 +118,4 @@
       *matRowDef="let row; columns: displayedColumns; let version"
     ></tr>
   </table>
-
-  <button
-    id="addTagButton"
-    type="button"
-    class="pull-right mr-1 my-3"
-    *ngIf="!publicPage && isManualMode()"
-    mat-flat-button
-    color="primary"
-    (click)="showAddTagModal()"
-  >
-    Add Tag
-  </button>
 </div>

--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -15,7 +15,6 @@
  */
 import { AfterViewInit, Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild } from '@angular/core';
 import { MatSort, MatTableDataSource } from '@angular/material';
-import { MatDialog } from '@angular/material/dialog';
 import { takeUntil } from 'rxjs/operators';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DateService } from '../../shared/date.service';
@@ -27,7 +26,6 @@ import { SessionQuery } from '../../shared/session/session.query';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Tag } from '../../shared/swagger/model/tag';
 import { Versions } from '../../shared/versions';
-import { AddTagComponent } from '../add-tag/add-tag.component';
 
 @Component({
   selector: 'app-versions-container',

--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -54,7 +54,6 @@ export class VersionsContainerComponent extends Versions implements OnInit, OnCh
     dateService: DateService,
     private alertService: AlertService,
     private extendedDockstoreToolQuery: ExtendedDockstoreToolQuery,
-    private matDialog: MatDialog,
     protected sessionQuery: SessionQuery
   ) {
     super(dockstoreService, dateService, sessionQuery);
@@ -93,14 +92,6 @@ export class VersionsContainerComponent extends Versions implements OnInit, OnCh
     this.dataSource.data = this.versions;
   }
 
-  isManualMode() {
-    if (this.tool && this.tool.mode === DockstoreTool.ModeEnum.MANUALIMAGEPATH) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
   setNoOrderCols(): Array<number> {
     return [5, 6];
   }
@@ -111,9 +102,5 @@ export class VersionsContainerComponent extends Versions implements OnInit, OnCh
     this.alertService.start('Changing version to ' + version.name);
     this.alertService.detailedSuccess();
     this.selectedVersionChange.emit(this.selectedTag);
-  }
-
-  showAddTagModal() {
-    this.matDialog.open(AddTagComponent, { width: '600px' });
   }
 }

--- a/src/app/shared/tool/tool.query.ts
+++ b/src/app/shared/tool/tool.query.ts
@@ -28,6 +28,9 @@ export class ToolQuery extends QueryEntity<ToolState, DockstoreTool> {
   public tool$: Observable<DockstoreTool> = this.selectActive();
   public toolId$: Observable<number> = this.tool$.pipe(map((tool: DockstoreTool) => (tool ? tool.id : null)));
   public toolIsPublished$: Observable<boolean> = this.tool$.pipe(map((tool: DockstoreTool) => (tool ? tool.is_published : null)));
+  public isManualMode$: Observable<boolean> = this.tool$.pipe(
+    map((tool: DockstoreTool) => tool && tool.mode === DockstoreTool.ModeEnum.MANUALIMAGEPATH)
+  );
   constructor(protected store: ToolStore) {
     super(store);
   }


### PR DESCRIPTION
Warning/error handling was moved outside of the versions.component.ts a while ago (so that the relatively large component will not be initialized.  Sadly, the add tag was inside versions.component.ts, so it disappeared alongside it.

Moving the add tag component outside.

This needs a test. I can't get Cypress to work locally 😢 