### PR TITLE
Enable Terra for workflows with file imports

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -174,7 +174,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   );
 
   disableTerraPlatform$: Observable<boolean> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
-    map(([hasContent, hasFileImports]) => !hasContent || hasFileImports)
+    map(([hasContent, hasFileImports]) => !hasContent || (hasFileImports && !this.isGitHubWorkflow()))
   );
 
   constructor(
@@ -237,12 +237,16 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     return `Export this workflow version to ${platform}.`;
   }
 
+  private isGitHubWorkflow(): boolean {
+    return this.workflow && this.workflow.gitUrl && this.workflow.gitUrl.startsWith('git@github.com');
+  }
+
   private terraTooltip(hasContent: boolean, hasFileImports, platform: string): string {
     if (!hasContent) {
       return 'The WDL has no content.';
     }
-    if (hasFileImports) {
-      return `${platform} does not support file-path imports in WDL. It only supports http(s) imports.`;
+    if (!this.isGitHubWorkflow() && hasFileImports) {
+      return `This version of the WDL has file-path imports, which are only supported by ${platform} for GitHub-based workflows.`;
     }
     return `Export this workflow version to ${platform}.`;
   }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -162,15 +162,17 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   );
 
   terraTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
-    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'Terra'))
+    map(([hasContent, hasFileImports]) => this.terraBasedPlatformTooltip(hasContent, hasFileImports, 'Terra'))
   );
 
   anvilTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
-    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'AnVIL'))
+    map(([hasContent, hasFileImports]) => this.terraBasedPlatformTooltip(hasContent, hasFileImports, 'AnVIL'))
   );
 
   bdCatalystTerraTooltip$: Observable<string> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
-    map(([hasContent, hasFileImports]) => this.terraTooltip(hasContent, hasFileImports, 'NHLBI BioData Catalyst powered by Terra'))
+    map(([hasContent, hasFileImports]) =>
+      this.terraBasedPlatformTooltip(hasContent, hasFileImports, 'NHLBI BioData Catalyst powered by Terra')
+    )
   );
 
   disableTerraPlatform$: Observable<boolean> = combineLatest(this.hasContent$, this.hasFileImports$).pipe(
@@ -241,7 +243,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     return this.workflow && this.workflow.gitUrl && this.workflow.gitUrl.startsWith('git@github.com');
   }
 
-  private terraTooltip(hasContent: boolean, hasFileImports, platform: string): string {
+  private terraBasedPlatformTooltip(hasContent: boolean, hasFileImports, platform: string): string {
     if (!hasContent) {
       return 'The WDL has no content.';
     }


### PR DESCRIPTION

dockstore/dockstore#3342

Only do it for GitHub based-workflows, as Terra is getting
the imported files directly from GitHub.