### PR TITLE
Add custom X-Dockstore-UI header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,6 +1526,12 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -13571,6 +13577,11 @@
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -14329,6 +14340,14 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -15438,6 +15457,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -15608,9 +15633,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -16041,6 +16066,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pipeline-builder": "^0.3.10-dev.313",
     "rxjs": "^6.5.3",
     "ts-md5": "^1.2.6",
+    "uuid": "^7.0.3",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { FundingComponent } from './funding/funding.component';
 import { GithubCallbackComponent } from './github-callback/github-callback.component';
 import { YoutubeComponent } from './home-page/home-logged-out/home.component';
 import { HomePageModule } from './home-page/home-page.module';
+import { CustomHeaderInterceptor } from './interceptors/custom-header.interceptor';
 import { WorkflowVersionsInterceptor } from './interceptors/workflow-versions.interceptor';
 import { LoginComponent } from './login/login.component';
 import { LoginService } from './login/login.service';
@@ -221,7 +222,8 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     },
     { provide: MAT_TOOLTIP_DEFAULT_OPTIONS, useValue: myCustomTooltipDefaults },
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: myCustomSnackbarDefaults },
-    { provide: HTTP_INTERCEPTORS, useClass: WorkflowVersionsInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: WorkflowVersionsInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: CustomHeaderInterceptor, multi: true }
   ],
   entryComponents: [DeleteAccountDialogComponent, YoutubeComponent, ConfirmationDialogComponent],
   bootstrap: [AppComponent]

--- a/src/app/interceptors/custom-header.interceptor.spec.ts
+++ b/src/app/interceptors/custom-header.interceptor.spec.ts
@@ -18,12 +18,18 @@ describe('CustomHeaderInterceptor', () => {
     });
   });
 
-  it('Should add X-Dockstore-UI and X-UUID headers',
-    inject([HttpClient, HttpTestingController], (http: HttpClient, httpMock: HttpTestingController) => {
+  it('Should add X-Dockstore-UI, X-Session-ID, and X-Request-ID headers', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
       http.get('/api').subscribe(response => expect(response).toBeTruthy());
       const uiVersion = versions.tag;
-      const request = httpMock.expectOne(req =>
-        (req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === uiVersion) && req.headers.has('X-UUID'));
+      const request = httpMock.expectOne(
+        req =>
+          req.headers.has('X-Dockstore-UI') &&
+          req.headers.get('X-Dockstore-UI') === uiVersion &&
+          req.headers.has('X-Request-ID') &&
+          req.headers.has('X-Session-ID')
+      );
 
       request.flush({ data: 'test' });
       httpMock.verify();

--- a/src/app/interceptors/custom-header.interceptor.spec.ts
+++ b/src/app/interceptors/custom-header.interceptor.spec.ts
@@ -18,12 +18,12 @@ describe('CustomHeaderInterceptor', () => {
     });
   });
 
-  it('Should add X-Dockstore-UI header', inject(
-    [HttpClient, HttpTestingController],
-    (http: HttpClient, httpMock: HttpTestingController) => {
+  it('Should add X-Dockstore-UI and X-UUID headers',
+    inject([HttpClient, HttpTestingController], (http: HttpClient, httpMock: HttpTestingController) => {
       http.get('/api').subscribe(response => expect(response).toBeTruthy());
       const uiVersion = versions.tag;
-      const request = httpMock.expectOne(req => req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === uiVersion);
+      const request = httpMock.expectOne(req =>
+        (req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === uiVersion) && req.headers.has('X-UUID'));
 
       request.flush({ data: 'test' });
       httpMock.verify();

--- a/src/app/interceptors/custom-header.interceptor.spec.ts
+++ b/src/app/interceptors/custom-header.interceptor.spec.ts
@@ -1,7 +1,7 @@
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
-import { version } from '../../../package.json';
+import { versions } from '../footer/versions';
 import { CustomHeaderInterceptor } from './custom-header.interceptor';
 
 describe('CustomHeaderInterceptor', () => {
@@ -22,7 +22,8 @@ describe('CustomHeaderInterceptor', () => {
     [HttpClient, HttpTestingController],
     (http: HttpClient, httpMock: HttpTestingController) => {
       http.get('/api').subscribe(response => expect(response).toBeTruthy());
-      const request = httpMock.expectOne(req => req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === version);
+      const uiVersion = versions.tag.match(/\d+\.\d+\.\d+/)[0];
+      const request = httpMock.expectOne(req => req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === uiVersion);
 
       request.flush({ data: 'test' });
       httpMock.verify();

--- a/src/app/interceptors/custom-header.interceptor.spec.ts
+++ b/src/app/interceptors/custom-header.interceptor.spec.ts
@@ -1,0 +1,31 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import { version } from '../../../package.json';
+import { CustomHeaderInterceptor } from './custom-header.interceptor';
+
+describe('CustomHeaderInterceptor', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: CustomHeaderInterceptor,
+          multi: true
+        }
+      ]
+    });
+  });
+
+  it('Should add X-Dockstore-UI header', inject(
+    [HttpClient, HttpTestingController],
+    (http: HttpClient, httpMock: HttpTestingController) => {
+      http.get('/api').subscribe(response => expect(response).toBeTruthy());
+      const request = httpMock.expectOne(req => req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === version);
+
+      request.flush({ data: 'test' });
+      httpMock.verify();
+    }
+  ));
+});

--- a/src/app/interceptors/custom-header.interceptor.spec.ts
+++ b/src/app/interceptors/custom-header.interceptor.spec.ts
@@ -22,7 +22,7 @@ describe('CustomHeaderInterceptor', () => {
     [HttpClient, HttpTestingController],
     (http: HttpClient, httpMock: HttpTestingController) => {
       http.get('/api').subscribe(response => expect(response).toBeTruthy());
-      const uiVersion = versions.tag.match(/\d+\.\d+\.\d+/)[0];
+      const uiVersion = versions.tag;
       const request = httpMock.expectOne(req => req.headers.has('X-Dockstore-UI') && req.headers.get('X-Dockstore-UI') === uiVersion);
 
       request.flush({ data: 'test' });

--- a/src/app/interceptors/custom-header.interceptor.ts
+++ b/src/app/interceptors/custom-header.interceptor.ts
@@ -18,7 +18,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { versions } from '../footer/versions';
 
-const uiVersion = versions.tag.match(/\d+\.\d+\.\d+/)[0];
+const uiVersion = versions.tag;
 
 /**
  * An interceptor that ensures that every request has a custom X-Dockstore-UI header with the UI version as

--- a/src/app/interceptors/custom-header.interceptor.ts
+++ b/src/app/interceptors/custom-header.interceptor.ts
@@ -1,0 +1,31 @@
+/**
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { version } from '../../../package.json';
+
+/**
+ * An interceptor that ensures that every request has a custom X-Dockstore-UI header with the UI version as
+ * the value so we can track API calls coming from the Dockstore UI.
+ */
+@Injectable()
+export class CustomHeaderInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    req = req.clone({ headers: req.headers.set('X-Dockstore-UI', version) });
+    return next.handle(req);
+  }
+}

--- a/src/app/interceptors/custom-header.interceptor.ts
+++ b/src/app/interceptors/custom-header.interceptor.ts
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2019 OICR
+ *    Copyright 2020 OICR
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { version } from '../../../package.json';
+import { versions } from '../footer/versions';
+
+const uiVersion = versions.tag.match(/\d+\.\d+\.\d+/)[0];
 
 /**
  * An interceptor that ensures that every request has a custom X-Dockstore-UI header with the UI version as
@@ -25,7 +27,7 @@ import { version } from '../../../package.json';
 @Injectable()
 export class CustomHeaderInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    req = req.clone({ headers: req.headers.set('X-Dockstore-UI', version) });
+    req = req.clone({ headers: req.headers.set('X-Dockstore-UI', uiVersion) });
     return next.handle(req);
   }
 }

--- a/src/app/interceptors/custom-header.interceptor.ts
+++ b/src/app/interceptors/custom-header.interceptor.ts
@@ -16,18 +16,25 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
 import { versions } from '../footer/versions';
 
 const uiVersion = versions.tag;
+const uuid = uuidv4().toString();
 
 /**
  * An interceptor that ensures that every request has a custom X-Dockstore-UI header with the UI version as
- * the value so we can track API calls coming from the Dockstore UI.
+ * the value and a custom UUID header so we can track API calls coming from the Dockstore UI.
  */
 @Injectable()
 export class CustomHeaderInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    req = req.clone({ headers: req.headers.set('X-Dockstore-UI', uiVersion) });
+    req = req.clone({
+      setHeaders: {
+        'X-Dockstore-UI': uiVersion,
+        'X-UUID': uuid
+      }
+    });
     return next.handle(req);
   }
 }

--- a/src/app/interceptors/custom-header.interceptor.ts
+++ b/src/app/interceptors/custom-header.interceptor.ts
@@ -20,19 +20,23 @@ import { v4 as uuidv4 } from 'uuid';
 import { versions } from '../footer/versions';
 
 const uiVersion = versions.tag;
-const uuid = uuidv4().toString();
+const sessionUUID = uuidv4().toString();
 
 /**
- * An interceptor that ensures that every request has a custom X-Dockstore-UI header with the UI version as
- * the value and a custom UUID header so we can track API calls coming from the Dockstore UI.
+ * An interceptor that ensures that every request has the following custom headers:
+ *  - X-Dockstore-UI: Dockstore UI version
+ *  - X-Session-ID: UUID for each browser session
+ *  - X-Request-ID: UUID for each request
  */
 @Injectable()
 export class CustomHeaderInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const requestUUID = uuidv4().toString();
     req = req.clone({
       setHeaders: {
         'X-Dockstore-UI': uiVersion,
-        'X-UUID': uuid
+        'X-Session-ID': sessionUUID,
+        'X-Request-ID': requestUUID
       }
     });
     return next.handle(req);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "jszip": [
         "../node_modules/jszip/dist/jszip.min.js"
       ]
-    }
+    },
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
       "jszip": [
         "../node_modules/jszip/dist/jszip.min.js"
       ]
-    },
-    "resolveJsonModule": true
+    }
   }
 }


### PR DESCRIPTION
For https://github.com/dockstore/dockstore/issues/3113

Added the following custom headers to track API calls from the Dockstore UI:
- X-Dockstore-UI: Dockstore UI version
- X-Request-ID: UUID for each request
- X-Session-ID: UUID for each browser session

Here's an example of what the headers look like:
![Screen Shot 2020-04-02 at 1 52 13 PM](https://user-images.githubusercontent.com/25287123/78282573-80c84800-74ea-11ea-9dd7-a5f31d4233f3.png)

