### PR TITLE
Feature/3173/galaxy validation

### DIFF
--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.spec.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.spec.ts
@@ -1,0 +1,28 @@
+import { ToolFile, WorkflowVersion } from 'app/shared/swagger';
+import { EntryFileTabService } from './entry-file-tab.service';
+
+describe('Service: EntryFileTabService', () => {
+  it('should be able to get the validation message object from a ToolFile', () => {
+    const toolFile: ToolFile = {
+      file_type: ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR
+    };
+    const unsupportedToolFile: ToolFile = {
+      file_type: ToolFile.FileTypeEnum.CONTAINERFILE
+    };
+    const version: WorkflowVersion = {
+      name: 'do not care',
+      reference: 'do not care',
+      validations: [
+        { id: 51918, message: `{"fakeFilePath":"fakeErrorMessage"}`, type: 'DOCKSTORE_GXFORMAT2', valid: true },
+        { id: 51919, message: '{}', type: 'GXFORMAT2_TEST_FILE', valid: true }
+      ]
+    };
+    expect(EntryFileTabService.getValidationMessageObject(null, null)).toEqual(null);
+    expect(EntryFileTabService.getValidationMessageObject(toolFile, null)).toEqual(null);
+    expect(EntryFileTabService.getValidationMessageObject(null, version)).toEqual(null);
+    expect(EntryFileTabService.getValidationMessageObject(toolFile, version)).toEqual(JSON.parse(`{"fakeFilePath":"fakeErrorMessage"}`));
+    expect(EntryFileTabService.getValidationMessageObject(unsupportedToolFile, version)).toEqual(null);
+    version.validations = null;
+    expect(EntryFileTabService.getValidationMessageObject(toolFile, version)).toEqual(null);
+  });
+});

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.spec.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.spec.ts
@@ -22,6 +22,8 @@ describe('Service: EntryFileTabService', () => {
     expect(EntryFileTabService.getValidationMessageObject(null, version)).toEqual(null);
     expect(EntryFileTabService.getValidationMessageObject(toolFile, version)).toEqual(JSON.parse(`{"fakeFilePath":"fakeErrorMessage"}`));
     expect(EntryFileTabService.getValidationMessageObject(unsupportedToolFile, version)).toEqual(null);
+    version.validations[0].message = 'notJson';
+    expect(EntryFileTabService.getValidationMessageObject(toolFile, version)).toEqual(null);
     version.validations = null;
     expect(EntryFileTabService.getValidationMessageObject(toolFile, version)).toEqual(null);
   });

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -48,11 +48,16 @@ export class EntryFileTabService extends Base {
       const supportedValidationTypeEnum: Validation.TypeEnum[] = EntryFileTabService.toolFileToValdationTypeEnums(toolFile.file_type);
       const foundValidation: Validation = validations.find(validation => supportedValidationTypeEnum.includes(validation.type));
       if (foundValidation) {
-        const validationObject = JSON.parse(foundValidation.message);
-        if (validationObject && Object.keys(validationObject).length === 0 && validationObject.constructor === Object) {
+        try {
+          const validationObject = JSON.parse(foundValidation.message);
+          if (validationObject && Object.keys(validationObject).length === 0 && validationObject.constructor === Object) {
+            return null;
+          } else {
+            return validationObject;
+          }
+        } catch (e) {
+          console.error(e);
           return null;
-        } else {
-          return validationObject;
         }
       } else {
         return null;

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -10,7 +10,7 @@ import { GA4GHFilesQuery } from 'app/shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from 'app/shared/ga4gh-files/ga4gh-files.service';
 import { SessionQuery } from 'app/shared/session/session.query';
 import { WorkflowQuery } from 'app/shared/state/workflow.query';
-import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile } from 'app/shared/swagger';
+import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile, WorkflowVersion } from 'app/shared/swagger';
 import { takeUntil } from 'rxjs/operators';
 import { Validation } from '../../../shared/swagger/model/validation';
 import { EntryFileTabQuery } from './entry-file-tab.query';
@@ -30,6 +30,48 @@ export class EntryFileTabService extends Base {
     private sessionQuery: SessionQuery
   ) {
     super();
+  }
+
+  /**
+   * This is going to be problematic in the future because we need to match the Dockstore Validation.TypeEnum with
+   * TRS ToolFile.FileTypeEnum for plugins that can have anything. Right now it's matching only a select few.
+   *
+   * @static
+   * @param {(ToolFile | null)} toolFile  The file that's currently being viewed by the user (from TRS)
+   * @param {(WorkflowVersion | null)} version  The version that's currently being viewed (from Dockstore proprietary endpoint)
+   * @returns {(Object | null)}
+   * @memberof EntryFileTabService
+   */
+  public static getValidationMessageObject(toolFile: ToolFile | null, version: WorkflowVersion | null): Object | null {
+    if (version && version.validations && toolFile) {
+      const validations = version.validations;
+      const supportedValidationTypeEnum: Validation.TypeEnum[] = EntryFileTabService.toolFileToValdationTypeEnums(toolFile.file_type);
+      const foundValidation: Validation = validations.find(validation => supportedValidationTypeEnum.includes(validation.type));
+      if (foundValidation) {
+        const validationObject = JSON.parse(foundValidation.message);
+        if (validationObject && Object.keys(validationObject).length === 0 && validationObject.constructor === Object) {
+          return null;
+        } else {
+          return validationObject;
+        }
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Currently only map PRIMARYDESCRIPTOR and OTHER to DOCKSTORESERVICEYML and DOCKSTOREGXFORMAT2
+   */
+  private static toolFileToValdationTypeEnums(typeEnum: ToolFile.FileTypeEnum | null): Validation.TypeEnum[] {
+    const supportedToolFileFileTypeEnum: ToolFile.FileTypeEnum[] = [ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR, ToolFile.FileTypeEnum.OTHER];
+    if (supportedToolFileFileTypeEnum.includes(typeEnum)) {
+      return [Validation.TypeEnum.DOCKSTORESERVICEYML, Validation.TypeEnum.DOCKSTOREGXFORMAT2];
+    } else {
+      return [];
+    }
   }
 
   private setSelectedFileType(fileType: ToolFile.FileTypeEnum) {
@@ -137,34 +179,17 @@ export class EntryFileTabService extends Base {
   private getValidations() {
     const version = this.workflowQuery.getValue().version;
     const file = this.entryFileTabQuery.getValue().selectedFile;
-    if (
-      version &&
-      version.validations &&
-      file &&
-      (file.file_type === ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR || file.file_type === ToolFile.FileTypeEnum.OTHER)
-    ) {
-      for (const validation of version.validations) {
-        if (validation.type === Validation.TypeEnum.DOCKSTORESERVICEYML) {
-          const validationObject = JSON.parse(validation.message);
-          if (validationObject && Object.keys(validationObject).length === 0 && validationObject.constructor === Object) {
-            this.entryFileTabStore.update(state => {
-              return {
-                ...state,
-                validationMessage: null
-              };
-            });
-          } else {
-            this.entryFileTabStore.update(state => {
-              return {
-                ...state,
-                validationMessage: validationObject
-              };
-            });
-          }
-          break;
-        }
-      }
-    }
+    const validationMessageObject = EntryFileTabService.getValidationMessageObject(file, version);
+    this.setValidationMessage(validationMessageObject);
+  }
+
+  private setValidationMessage(message: Object | null) {
+    this.entryFileTabStore.update(state => {
+      return {
+        ...state,
+        validationMessage: message
+      };
+    });
   }
 
   /**

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -152,6 +152,7 @@ export class CodeEditorListComponent {
   }
 
   /**
+   * TODO: Fix this execution of this function.  This function is being executed a bajillion times
    * Determines whether to show the current sourcefile based on the descriptor type and tab
    * @param  type sourcefile type
    * @return {boolean}      whether or not to show file


### PR DESCRIPTION
For dockstore/dockstore#3173

Surfacing the validations on the frontend.  Webservice currently only has the descriptor validation but not the test parameter file