### PR TITLE
Feature/1265/inform users of migration

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.css
+++ b/src/app/workflow/info-tab/info-tab.component.css
@@ -13,3 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+.link-with-underline {
+  text-decoration: underline;
+}

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -14,23 +14,22 @@
   ~    limitations under the License.
   -->
 <div class="p-3">
-  <mat-card class="alert alert-info">
-    <span
-      *ngIf="
-        workflow?.source_control_provider === 'GITHUB' &&
-        (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
-      "
+  <mat-card
+    class="alert alert-info"
+    *ngIf="
+      workflow?.source_control_provider === 'GITHUB' &&
+      (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
+    "
+  >
+    Keep your workflow automatically in sync with GitHub with our new registration process. Click
+    <a
+      href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="link-with-underline"
+      >here</a
     >
-      Keep your workflow automatically in sync with GitHub with our new registration process. Click
-      <a
-        href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="link-with-underline"
-        >here</a
-      >
-      to learn more.
-    </span>
+    to learn more.
   </mat-card>
   <mat-card>
     <mat-card-header>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -17,6 +17,7 @@
   <mat-card
     class="alert alert-info"
     *ngIf="
+      !isPublic &&
       workflow?.source_control_provider === 'GITHUB' &&
       (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
     "

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -14,6 +14,23 @@
   ~    limitations under the License.
   -->
 <div class="p-3">
+  <mat-card class="alert alert-info">
+    <span
+      *ngIf="
+        workflow?.source_control_provider === 'GITHUB' &&
+        (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
+      "
+    >
+      This workflow can be migrated to our new registration process. See our
+      <a
+        href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml"
+        target="_blank"
+        rel="noopener noreferrer"
+        >documentation</a
+      >
+      for details.
+    </span>
+  </mat-card>
   <mat-card>
     <mat-card-header>
       <mat-card-title>{{ entryType$ | async | titlecase }} Information</mat-card-title>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -21,14 +21,15 @@
         (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
       "
     >
-      This workflow can be migrated to our new registration process. See our
+      Keep your workflow automatically in sync with GitHub with our new registration process. Click
       <a
         href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml"
         target="_blank"
         rel="noopener noreferrer"
-        >documentation</a
+        class="link-with-underline"
+        >here</a
       >
-      for details.
+      to learn more.
     </span>
   </mat-card>
   <mat-card>


### PR DESCRIPTION
First part of https://github.com/dockstore/dockstore/issues/3322

I thought the discussion could continue here. Currently have an always visible bar on GitHub legacy workflows. Only shows on my workflows.


![Screen Shot 2020-04-07 at 2 39 01 PM](https://user-images.githubusercontent.com/6331159/78788140-63c3c700-7979-11ea-80f5-3df03e3b3ea9.png)