### PR TITLE
Feature/unsubscribe refresh service

### DIFF
--- a/src/app/container/info-tab/info-tab.service.ts
+++ b/src/app/container/info-tab/info-tab.service.ts
@@ -96,7 +96,7 @@ export class InfoTabService extends Base {
         this.alertService.start('Refreshing ' + message);
         this.containersService.refresh(this.tool.id).subscribe(
           refreshResponse => {
-            this.containerService.replaceTool(this.tools, refreshResponse);
+            this.containerService.replaceTool(refreshResponse);
             this.containerService.setTool(refreshResponse);
             this.alertService.detailedSuccess();
           },

--- a/src/app/container/view/view.service.ts
+++ b/src/app/container/view/view.service.ts
@@ -21,7 +21,7 @@ export class ViewService {
     this.containersService.updateToolDefaultVersion(toolId, newDefaultVersion).subscribe(
       response => {
         this.alertService.detailedSuccess();
-        this.containerService.replaceTool(null, response);
+        this.containerService.replaceTool(response);
         this.containerService.setTool(response);
       },
       error => this.alertService.detailedError(error)

--- a/src/app/shared/container.service.spec.ts
+++ b/src/app/shared/container.service.spec.ts
@@ -62,6 +62,7 @@ describe('ContainerService', () => {
 
   it('should replace tool', inject([ContainerService], (service: ContainerService) => {
     const tools: DockstoreTool[] = [sampleTool1, sampleTool2, sampleTool3];
+    service.setTools(tools);
     const newSampleTool1: DockstoreTool = {
       id: 1,
       default_cwl_path: 'sampleDefaultCWLPath',
@@ -78,7 +79,7 @@ describe('ContainerService', () => {
       defaultCWLTestParameterFile: 'sampleDefaultCWLTestParameterFile',
       defaultWDLTestParameterFile: 'sampleDefaultWDLTestParameterFile'
     };
-    service.replaceTool(tools, newSampleTool1);
+    service.replaceTool(newSampleTool1);
     expect(service.tools$.getValue()).toEqual([newSampleTool1, sampleTool2, sampleTool3]);
   }));
 

--- a/src/app/shared/container.service.ts
+++ b/src/app/shared/container.service.ts
@@ -58,15 +58,21 @@ export class ContainerService {
   }
 
   /**
-   * This function replaces the tool inside of tools with an updated tool
+   * This function replaces the tool inside of tools with an updated tool.
+   * This should eventually use an entity store instead
    *
-   * @param {*} tools the current set of tools
-   * @param {*} newTool the new tool we are replacing
+   * @param {DockstoreTool} newTool the new tool we are replacing
+   * @returns
    * @memberof ContainerService
    */
-  replaceTool(tools: any, newTool) {
-    if (this.tools$.getValue()) {
-      tools = this.tools$.getValue();
+  replaceTool(newTool: DockstoreTool | null) {
+    const tools = this.tools$.getValue();
+    if (!tools) {
+      console.error('tools in state is falsey');
+      return;
+    }
+    if (!newTool) {
+      return;
     }
     const oldTool = tools.find(x => x.id === newTool.id);
     const index = tools.indexOf(oldTool);

--- a/src/app/shared/refresh.service.spec.ts
+++ b/src/app/shared/refresh.service.spec.ts
@@ -70,32 +70,6 @@ describe('RefreshService', () => {
   it('should be created', inject([RefreshService], (service: RefreshService) => {
     expect(service).toBeTruthy();
   }));
-
-  it('should refresh tool', inject(
-    [RefreshService, AlertQuery, ContainerService],
-    (service: RefreshService, alertQuery: AlertQuery, containerService: ContainerService) => {
-      const refreshedTool: DockstoreTool = {
-        default_cwl_path: 'refreshedDefaultCWLPath',
-        default_dockerfile_path: 'refreshedDefaultDockerfilePath',
-        default_wdl_path: 'refreshedDefaultWDLPath',
-        gitUrl: 'refreshedGitUrl',
-        mode: DockstoreTool.ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS,
-        name: 'refreshedName',
-        namespace: 'refreshedNamespace',
-        private_access: false,
-        registry_string: 'quay.io',
-        registry: DockstoreTool.RegistryEnum.QUAYIO,
-        toolname: 'refreshedToolname',
-        defaultCWLTestParameterFile: 'refreshedDefaultCWLTestParameterFile',
-        defaultWDLTestParameterFile: 'refreshedDefaultWDLTestParameterFile'
-      };
-      service.tool = sampleTool1;
-      service.refreshTool();
-      alertQuery.showInfo$.subscribe(refreshing => {
-        expect(refreshing).toBeFalsy();
-      });
-    }
-  ));
   it('should refresh workflow', inject(
     [RefreshService, AlertQuery, WorkflowService, WorkflowQuery],
     (service: RefreshService, alertQuery: AlertQuery, workflowService: WorkflowService, workflowQuery: WorkflowQuery) => {

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -51,7 +51,7 @@ export class RefreshService {
     this.alertService.start(message);
     this.containersService.refresh(tool.id).subscribe(
       (response: DockstoreTool) => {
-        this.containerService.replaceTool(null, response);
+        this.containerService.replaceTool(response);
         this.containerService.setTool(response);
         this.alertService.detailedSuccess();
       },


### PR DESCRIPTION
Random issue I noticed.

In general services shouldn't subscribe to other services since they're unlikely to ever be destroyed. This removes it.

Simplified replaceTool function

Removed a useless test