### PR TITLE
Redirect to maintenance page if web service down

### DIFF
--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -34,6 +34,12 @@ export class FooterComponent extends Base implements OnInit {
   public prod = true;
   public dsServerURI: any;
   Dockstore = Dockstore;
+  private WEBSERVICE_DOWN_STATUS_CODES = [
+    0, // Was like this, don't know when it happens
+    404, // Web service container is down. Obviously only test with a specific, known, endpoint
+    502, // Stack is down
+    504 // Angular proxy returns 504 -- for local dev environment
+  ];
 
   constructor(private metadataService: MetadataService) {
     super();
@@ -55,8 +61,8 @@ export class FooterComponent extends Base implements OnInit {
         },
         (error: HttpErrorResponse) => {
           console.log(error);
-          // Angular proxy returns 504
-          if ((error.status === 0 || error.status === 504) && window.location.pathname !== '/maintenance') {
+          const webserviceDown = this.WEBSERVICE_DOWN_STATUS_CODES.some(code => code === error.status);
+          if (webserviceDown && window.location.pathname !== '/maintenance') {
             window.location.href = '/maintenance';
           }
         }

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -34,12 +34,17 @@ export class FooterComponent extends Base implements OnInit {
   public prod = true;
   public dsServerURI: any;
   Dockstore = Dockstore;
-  private WEBSERVICE_DOWN_STATUS_CODES = [
-    0, // Was like this, don't know when it happens
-    404, // Web service container is down. Obviously only test with a specific, known, endpoint
-    502, // Stack is down
-    504 // Angular proxy returns 504 -- for local dev environment
-  ];
+
+  /**
+   * API Status codes that can indicate the web service is down
+   *
+   * * 0 This may have only happened without the load balancer, but it was already in the code, so leaving it.
+   * * 404 The web service container is down or restarting. While most 404s don't mean the web service is down,
+   * going to assume that a 404 on the TRS metadata endpoint means something is wrong
+   * * 502 The whole compose_setup backend stack is down.
+   * * 504 In a local dev environment, the Angular proxy returns 504 if it can't connect to the web service.
+   */
+  private readonly WEBSERVICE_DOWN_STATUS_CODES = [0, 404, 502, 504];
 
   constructor(private metadataService: MetadataService) {
     super();

--- a/src/app/shared/refresh.service.ts
+++ b/src/app/shared/refresh.service.ts
@@ -91,7 +91,7 @@ export class RefreshService {
    * @memberof RefreshService
    */
   refreshWorkflowVersion(prefix: string, workflow: Workflow, versionName: string): void {
-    const message = 'Refreshing ' + this.workflow.full_workflow_path + ' version ' + versionName;
+    const message = 'Refreshing ' + workflow.full_workflow_path + ' version ' + versionName;
     const ga4ghId = prefix + workflow.full_workflow_path;
     this.alertService.start(message);
     this.workflowsService.refreshVersion(workflow.id, versionName).subscribe(


### PR DESCRIPTION

dockstore/dockstore#3319

This tackles the scenario the case where the webservice Docker container is down/constantly restarting, but the rest of the Dockstore stack is up. What happens is that the nginx container redirects to the webservice container, but because the container has not finished initializing (or maybe because it's down -- not 100% sure), nginx returns a 404.

Comments are in code, but I think it's safe to assume for this endpoint that a 404 means the webservice is down.

See dockstore/dockstore#3319 for a more detailed discussion, and dockstore/dockstore#3387 as an issue for how the UI could check more frequently.