### PR TITLE
Add short friendly name to extended descriptor languages

### DIFF
--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -91,7 +91,7 @@ const superService: ExtendedDescriptorLanguage = {
 
 const superGalaxy: ExtendedDescriptorLanguage = {
   value: 'gxformat2',
-  shortFriendlyName: 'Galaxyv2',
+  shortFriendlyName: 'GalaxyV2',
   friendlyName: 'Galaxy Workflow Format 2',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(ga|yaml|yml)',
   descriptorPathPlaceholder: 'e.g. /Dockstore.yml',

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -1,9 +1,10 @@
 import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
 
 /**
- * Use the value property to map the DescriptorLanguageBean to this
+ * TODO: Use the value property to map the DescriptorLanguageBean to this
  */
 export interface ExtendedDescriptorLanguage extends DescriptorLanguageBean {
+  shortFriendlyName: string;
   descriptorPathPattern: string;
   descriptorPathPlaceholder: string;
   toolDescriptorEnum: ToolDescriptor.TypeEnum;
@@ -21,7 +22,8 @@ export interface ExtendedDescriptorLanguage extends DescriptorLanguageBean {
 
 const superCWL: ExtendedDescriptorLanguage = {
   value: 'CWL',
-  friendlyName: 'Workflow Descriptor ',
+  shortFriendlyName: 'CWL',
+  friendlyName: 'Common Workflow Language',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(cwl|yaml|yml)',
   descriptorPathPlaceholder: 'e.g. /Dockstore.cwl',
   toolDescriptorEnum: ToolDescriptor.TypeEnum.CWL,
@@ -37,6 +39,7 @@ const superCWL: ExtendedDescriptorLanguage = {
 
 const superWDL: ExtendedDescriptorLanguage = {
   value: 'WDL',
+  shortFriendlyName: 'WDL',
   friendlyName: 'Workflow Description Language',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.wdl$',
   descriptorPathPlaceholder: 'e.g. /Dockstore.wdl',
@@ -53,6 +56,7 @@ const superWDL: ExtendedDescriptorLanguage = {
 
 const superNFL: ExtendedDescriptorLanguage = {
   value: 'NFL',
+  shortFriendlyName: 'Nextflow',
   friendlyName: 'Nextflow',
   descriptorPathPattern: '^^/([^/?:*|<>]+/)*[^/?:*|<>]+.(config)',
   descriptorPathPlaceholder: 'e.g. /nextflow.config',
@@ -69,6 +73,7 @@ const superNFL: ExtendedDescriptorLanguage = {
 
 const superService: ExtendedDescriptorLanguage = {
   value: 'service',
+  shortFriendlyName: 'Service',
   friendlyName: 'generic placeholder for services',
   // This is not really applicable
   descriptorPathPattern: '.*',
@@ -86,6 +91,7 @@ const superService: ExtendedDescriptorLanguage = {
 
 const superGalaxy: ExtendedDescriptorLanguage = {
   value: 'gxformat2',
+  shortFriendlyName: 'Galaxyv2',
   friendlyName: 'Galaxy Workflow Format 2',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(ga|yaml|yml)',
   descriptorPathPlaceholder: 'e.g. /Dockstore.yml',
@@ -102,6 +108,7 @@ const superGalaxy: ExtendedDescriptorLanguage = {
 
 export const extendedUnknownDescriptor: ExtendedDescriptorLanguage = {
   value: null,
+  shortFriendlyName: null,
   friendlyName: null,
   descriptorPathPattern: '.*',
   descriptorPathPlaceholder: '',

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -91,8 +91,8 @@ const superService: ExtendedDescriptorLanguage = {
 
 const superGalaxy: ExtendedDescriptorLanguage = {
   value: 'gxformat2',
-  shortFriendlyName: 'GalaxyV2',
-  friendlyName: 'Galaxy Workflow Format 2',
+  shortFriendlyName: 'Galaxy',
+  friendlyName: 'Galaxy Workflow Format',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(ga|yaml|yml)',
   descriptorPathPlaceholder: 'e.g. /Dockstore.yml',
   toolDescriptorEnum: ToolDescriptor.TypeEnum.GXFORMAT2,

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -14,12 +14,20 @@
  *    limitations under the License.
  */
 import { Pipe, PipeTransform } from '@angular/core';
-import { ToolFile } from 'app/shared/swagger';
+import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
+import { ToolFile, Workflow } from 'app/shared/swagger';
 
 @Pipe({
   name: 'mapFriendlyValue'
 })
 export class MapFriendlyValuesPipe implements PipeTransform {
+  readonly shortFriendlyCWLName = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.CWL);
+  readonly shortFriendlyWDLName = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.WDL);
+  readonly shortFriendlyNFLName = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.NFL);
+  readonly shortFriendlyGalaxyName = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(
+    Workflow.DescriptorTypeEnum.Gxformat2
+  );
+
   /**
    * Map containing what the friendly names should be mapped to
    *
@@ -29,10 +37,27 @@ export class MapFriendlyValuesPipe implements PipeTransform {
     ['has_checker', new Map([['1', 'has a checker workflow'], ['0', 'unchecked workflow']])],
     ['verified', new Map([['1', 'verified'], ['0', 'non-verified']])],
     ['private_access', new Map([['1', 'private'], ['0', 'public']])],
-    ['descriptorType', new Map([['cwl', 'CWL'], ['wdl', 'WDL'], ['nfl', 'Nextflow'], ['NFL', 'Nextflow']])],
+    [
+      'descriptorType',
+      new Map([
+        ['cwl', this.shortFriendlyCWLName],
+        ['wdl', this.shortFriendlyWDLName],
+        ['nfl', this.shortFriendlyNFLName],
+        ['NFL', this.shortFriendlyNFLName],
+        [Workflow.DescriptorTypeEnum.Gxformat2, this.shortFriendlyGalaxyName]
+      ])
+    ],
     [
       'descriptor_type',
-      new Map([['CWL', 'CWL'], ['WDL', 'WDL'], ['cwl', 'CWL'], ['wdl', 'WDL'], ['nfl', 'Nextflow'], ['NFL', 'Nextflow']])
+      new Map([
+        ['CWL', this.shortFriendlyCWLName],
+        ['WDL', this.shortFriendlyWDLName],
+        ['cwl', this.shortFriendlyCWLName],
+        ['wdl', this.shortFriendlyWDLName],
+        ['nfl', this.shortFriendlyNFLName],
+        ['NFL', this.shortFriendlyNFLName],
+        [Workflow.DescriptorTypeEnum.Gxformat2, this.shortFriendlyGalaxyName]
+      ])
     ],
     [
       'registry',

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -50,10 +50,10 @@ export class MapFriendlyValuesPipe implements PipeTransform {
     [
       'descriptor_type',
       new Map([
-        ['CWL', this.shortFriendlyCWLName],
-        ['WDL', this.shortFriendlyWDLName],
         ['cwl', this.shortFriendlyCWLName],
+        ['CWL', this.shortFriendlyCWLName],
         ['wdl', this.shortFriendlyWDLName],
+        ['WDL', this.shortFriendlyWDLName],
         ['nfl', this.shortFriendlyNFLName],
         ['NFL', this.shortFriendlyNFLName],
         [Workflow.DescriptorTypeEnum.Gxformat2, this.shortFriendlyGalaxyName]

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -129,7 +129,7 @@ describe('Service: DescriptorLanguage', () => {
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Service);
     expect(placeholder).toEqual('Service');
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Gxformat2);
-    expect(placeholder).toEqual('GalaxyV2');
+    expect(placeholder).toEqual('Galaxy');
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(null);
     expect(placeholder).toEqual(null);
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(<Workflow.DescriptorTypeEnum>'UnrecognizedType');

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -129,7 +129,7 @@ describe('Service: DescriptorLanguage', () => {
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Service);
     expect(placeholder).toEqual('Service');
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Gxformat2);
-    expect(placeholder).toEqual('Galaxyv2');
+    expect(placeholder).toEqual('GalaxyV2');
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(null);
     expect(placeholder).toEqual(null);
     placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(<Workflow.DescriptorTypeEnum>'UnrecognizedType');

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -15,7 +15,7 @@
  */
 import { of as observableOf } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { ToolDescriptor } from '../swagger';
+import { ToolDescriptor, Workflow } from '../swagger';
 import { DescriptorLanguageBean } from './../swagger/model/descriptorLanguageBean';
 import { DescriptorLanguageService } from './descriptor-language.service';
 
@@ -117,6 +117,22 @@ describe('Service: DescriptorLanguage', () => {
     placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(ToolDescriptor.TypeEnum.SERVICE);
     expect(placeholder).toEqual(null);
     placeholder = descriptorLanguageService.toolDescriptorTypeEnumToWeirdCheckerRegisterString(<ToolDescriptor.TypeEnum>'UnrecognizedType');
+    expect(placeholder).toEqual(null);
+  });
+  it('should be able to get shortFriendlyName from Worfklow.DescriptorTypeEnum for workflow registration', () => {
+    let placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.CWL);
+    expect(placeholder).toEqual('CWL');
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.WDL);
+    expect(placeholder).toEqual('WDL');
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.NFL);
+    expect(placeholder).toEqual('Nextflow');
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Service);
+    expect(placeholder).toEqual('Service');
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(Workflow.DescriptorTypeEnum.Gxformat2);
+    expect(placeholder).toEqual('Galaxyv2');
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(null);
+    expect(placeholder).toEqual(null);
+    placeholder = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(<Workflow.DescriptorTypeEnum>'UnrecognizedType');
     expect(placeholder).toEqual(null);
   });
 });

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -54,6 +54,17 @@ export class DescriptorLanguageService {
     const combined$ = combineLatest([this.descriptorLanguages$, this.sessionQuery.entryType$]);
     this.filteredDescriptorLanguages$ = combined$.pipe(map(combined => this.filterLanguages(combined[0], combined[1])));
   }
+
+  static workflowDescriptorTypeEnumToShortFriendlyName(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum | null): string | null {
+    const foundExtendedDescriptorLanguageFromValue = extendedDescriptorLanguages.find(
+      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === workflowDescriptorTypeEnum
+    );
+    if (foundExtendedDescriptorLanguageFromValue) {
+      return foundExtendedDescriptorLanguageFromValue.shortFriendlyName;
+    }
+    return extendedUnknownDescriptor.shortFriendlyName;
+  }
+
   update() {
     this.metadataService.getDescriptorLanguages().subscribe((languageBeans: Array<DescriptorLanguageBean>) => {
       this.descriptorLanguagesBean$.next(languageBeans);


### PR DESCRIPTION
For dockstore/dockstore#3292

Originally going to use a short friendly name from the webservice. but realized merging the frontend descriptor language with the backend descriptor language bean is required first

Just making a frontend-only shortFriendlyName field for now.