### PR TITLE
checker workflow instructions

### DIFF
--- a/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.html
+++ b/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.html
@@ -19,11 +19,11 @@
   class="m-2"
   matTooltip="Commands for running the checker workflow of this tool/workflow through Dockstore CLI"
 >
-  Run a checker workflow with:
-  <pre>{{ command }}</pre>
-  Make a runtime JSON template and fill in desired inputs, outputs, and other parameters from the checker workflow with:
+  To run a checker workflow for this entry, first make a runtime JSON template and fill in desired inputs, outputs, and other parameters:
   <pre>
 dockstore workflow convert entry2json --entry {{ checkerWorkflowPath$ | async
-    }}{{ versionName ? ':' + versionName : '' }} > Dockstore.json</pre
+    }}{{ versionName ? ':' + versionName : '' }} > checkparam.json</pre
   >
+  Run the checker workflow with:
+  <pre>{{ command }}</pre>
 </mat-card>


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2856

Fixed the order of launch instructions to first show creating a template json and then explain how to run a checker workflow. Changed name of test file from Dockstore.json to checkparam.json to prevent overwriting the parent workflow json. 

I only changed how launch tab instructions are displayed on a parent entry. Did not change the way the instructions for a checker's stand alone entry since the functionality isn't impacted. Could do so in this PR if others feels strongly about it, but would rather coordinate changes in the scope of a larger usability update. 