### PR TITLE
Feature/support hosted galaxy

### DIFF
--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -1,4 +1,4 @@
-import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Validation, Workflow } from 'app/shared/swagger';
+import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
 
 /**
  * TODO: Use the value property to map the DescriptorLanguageBean to this
@@ -38,7 +38,7 @@ const extendedCWL: ExtendedDescriptorLanguageBean = {
     workflowStepHeader: 'Tool Excerpt'
   },
   workflowLaunchSupport: true,
-  testParameterFileType: Validation.TypeEnum.CWLTESTJSON
+  testParameterFileType: SourceFile.TypeEnum.CWLTESTJSON
 };
 
 const extendedWDL: ExtendedDescriptorLanguageBean = {

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -1,4 +1,4 @@
-import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
+import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Validation, Workflow } from 'app/shared/swagger';
 
 /**
  * TODO: Use the value property to map the DescriptorLanguageBean to this
@@ -19,6 +19,7 @@ export interface ExtendedDescriptorLanguageBean extends DescriptorLanguageBean {
     workflowStepHeader: string;
   };
   workflowLaunchSupport: boolean;
+  testParameterFileType: string;
 }
 
 const extendedCWL: ExtendedDescriptorLanguageBean = {
@@ -36,7 +37,8 @@ const extendedCWL: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'
   },
-  workflowLaunchSupport: true
+  workflowLaunchSupport: true,
+  testParameterFileType: Validation.TypeEnum.CWLTESTJSON
 };
 
 const extendedWDL: ExtendedDescriptorLanguageBean = {
@@ -54,7 +56,8 @@ const extendedWDL: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'task\xa0ID',
     workflowStepHeader: 'Task Excerpt'
   },
-  workflowLaunchSupport: true
+  workflowLaunchSupport: true,
+  testParameterFileType: Validation.TypeEnum.WDLTESTJSON
 };
 
 const extendedNFL: ExtendedDescriptorLanguageBean = {
@@ -72,7 +75,8 @@ const extendedNFL: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'process\xa0name',
     workflowStepHeader: 'Process Excerpt'
   },
-  workflowLaunchSupport: true
+  workflowLaunchSupport: true,
+  testParameterFileType: Validation.TypeEnum.NEXTFLOWTESTPARAMS
 };
 
 const extendedService: ExtendedDescriptorLanguageBean = {
@@ -91,7 +95,8 @@ const extendedService: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Service'
   },
-  workflowLaunchSupport: true
+  workflowLaunchSupport: true,
+  testParameterFileType: Validation.TypeEnum.DOCKSTORESERVICETESTJSON
 };
 
 const extendedGalaxy: ExtendedDescriptorLanguageBean = {
@@ -109,7 +114,8 @@ const extendedGalaxy: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'
   },
-  workflowLaunchSupport: false
+  workflowLaunchSupport: false,
+  testParameterFileType: Validation.TypeEnum.GXFORMAT2TESTFILE
 };
 
 export const extendedUnknownDescriptor: ExtendedDescriptorLanguageBean = {
@@ -127,7 +133,8 @@ export const extendedUnknownDescriptor: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'
   },
-  workflowLaunchSupport: false
+  workflowLaunchSupport: false,
+  testParameterFileType: null
 };
 export const extendedDescriptorLanguages: ExtendedDescriptorLanguageBean[] = [
   extendedCWL,

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -11,7 +11,7 @@ export interface ExtendedDescriptorLanguageBean extends DescriptorLanguageBean {
   toolDescriptorEnum: ToolDescriptor.TypeEnum;
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum;
   plainTRS: string;
-  sourceFileTypeEnum: SourceFile.TypeEnum[];
+  descriptorFileTypes: SourceFile.TypeEnum[];
   toolTab: {
     // Example: If rowIdentifier is "tool ID", then the the first column of each row will say something like "tool ID: hello-world"
     rowIdentifier: string;
@@ -19,7 +19,7 @@ export interface ExtendedDescriptorLanguageBean extends DescriptorLanguageBean {
     workflowStepHeader: string;
   };
   workflowLaunchSupport: boolean;
-  testParameterFileType: string;
+  testParameterFileType: SourceFile.TypeEnum;
 }
 
 const extendedCWL: ExtendedDescriptorLanguageBean = {
@@ -32,7 +32,7 @@ const extendedCWL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.CWL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.CWL,
   plainTRS: 'PLAIN-CWL',
-  sourceFileTypeEnum: [SourceFile.TypeEnum.DOCKSTORECWL],
+  descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTORECWL],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'
@@ -51,13 +51,13 @@ const extendedWDL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.WDL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.WDL,
   plainTRS: 'PLAIN-WDL',
-  sourceFileTypeEnum: [SourceFile.TypeEnum.DOCKSTOREWDL],
+  descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTOREWDL],
   toolTab: {
     rowIdentifier: 'task\xa0ID',
     workflowStepHeader: 'Task Excerpt'
   },
   workflowLaunchSupport: true,
-  testParameterFileType: Validation.TypeEnum.WDLTESTJSON
+  testParameterFileType: SourceFile.TypeEnum.WDLTESTJSON
 };
 
 const extendedNFL: ExtendedDescriptorLanguageBean = {
@@ -70,13 +70,13 @@ const extendedNFL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.NFL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.NFL,
   plainTRS: 'PLAIN-NFL',
-  sourceFileTypeEnum: [SourceFile.TypeEnum.NEXTFLOW, SourceFile.TypeEnum.NEXTFLOWCONFIG],
+  descriptorFileTypes: [SourceFile.TypeEnum.NEXTFLOW, SourceFile.TypeEnum.NEXTFLOWCONFIG],
   toolTab: {
     rowIdentifier: 'process\xa0name',
     workflowStepHeader: 'Process Excerpt'
   },
   workflowLaunchSupport: true,
-  testParameterFileType: Validation.TypeEnum.NEXTFLOWTESTPARAMS
+  testParameterFileType: SourceFile.TypeEnum.NEXTFLOWTESTPARAMS
 };
 
 const extendedService: ExtendedDescriptorLanguageBean = {
@@ -90,13 +90,13 @@ const extendedService: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.SERVICE,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.Service,
   plainTRS: 'PLAIN-SERVICE',
-  sourceFileTypeEnum: [],
+  descriptorFileTypes: [],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Service'
   },
   workflowLaunchSupport: true,
-  testParameterFileType: Validation.TypeEnum.DOCKSTORESERVICETESTJSON
+  testParameterFileType: SourceFile.TypeEnum.DOCKSTORESERVICETESTJSON
 };
 
 const extendedGalaxy: ExtendedDescriptorLanguageBean = {
@@ -109,13 +109,13 @@ const extendedGalaxy: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.GXFORMAT2,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.Gxformat2,
   plainTRS: '<FILL-IN>',
-  sourceFileTypeEnum: [SourceFile.TypeEnum.DOCKSTOREGXFORMAT2],
+  descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTOREGXFORMAT2],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'
   },
   workflowLaunchSupport: false,
-  testParameterFileType: Validation.TypeEnum.GXFORMAT2TESTFILE
+  testParameterFileType: SourceFile.TypeEnum.GXFORMAT2TESTFILE
 };
 
 export const extendedUnknownDescriptor: ExtendedDescriptorLanguageBean = {
@@ -128,7 +128,7 @@ export const extendedUnknownDescriptor: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: null,
   workflowDescriptorEnum: null,
   plainTRS: null,
-  sourceFileTypeEnum: [],
+  descriptorFileTypes: [],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt'

--- a/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
@@ -10,6 +10,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 import { WorkflowService } from '../state/workflow.service';
+import { ToolDescriptor } from '../swagger';
 import { PrivateFileDownloadPipe } from './../../shared/entry/private-file-download.pipe';
 import { PrivateFilePathPipe } from './../../shared/entry/private-file-path.pipe';
 import { PublicFileDownloadPipe } from './../../shared/entry/public-file-download.pipe';

--- a/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.spec.ts
@@ -10,7 +10,6 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 import { WorkflowService } from '../state/workflow.service';
-import { ToolDescriptor } from '../swagger';
 import { PrivateFileDownloadPipe } from './../../shared/entry/private-file-download.pipe';
 import { PrivateFilePathPipe } from './../../shared/entry/private-file-path.pipe';
 import { PublicFileDownloadPipe } from './../../shared/entry/public-file-download.pipe';

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -69,7 +69,7 @@ export class CodeEditorListComponent {
    * @memberof CodeEditorListComponent
    */
   isPrimaryDescriptor(path: string): boolean {
-    return CodeEditorListService.isPrimaryDescriptor(path);
+    return this.fileType === 'descriptor' && CodeEditorListService.isPrimaryDescriptor(path);
   }
 
   /**
@@ -79,7 +79,7 @@ export class CodeEditorListComponent {
    * @return {boolean}      Is path for dockerfile
    */
   isDockerFile(path: string): boolean {
-    return path === '/Dockerfile';
+    return this.fileType === 'dockerfile' && path === '/Dockerfile';
   }
 
   /**

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -64,7 +64,6 @@ export class CodeEditorListComponent {
    * TODO: Fix the execution of this function.  This function is being executed a bajillion times.
    * Returns true if path is the primary descriptor, false otherwise
    *
-   * @static
    * @param {string} path Path to check
    * @returns {boolean} Is path for primary descriptor
    * @memberof CodeEditorListComponent

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -15,7 +15,7 @@ export type FileCategory = 'descriptor' | 'dockerfile' | 'testParam';
   styleUrls: ['./code-editor-list.component.scss']
 })
 export class CodeEditorListComponent {
-  @Input() sourcefiles: Array<any>;
+  @Input() sourcefiles: SourceFile[];
   @Input() editing: boolean;
   @Input() fileType: FileCategory;
   @Input() descriptorType: ToolDescriptor.TypeEnum;

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -34,29 +34,33 @@ export class CodeEditorListComponent {
    * Adds a new file editor
    */
   addFile() {
+    const descriptorType = this.descriptorType;
     const filesToAdd = [];
     const newFilePath = this.getDefaultPath();
     if (!this.hasPrimaryDescriptor() && this.fileType === 'descriptor') {
-      switch (this.descriptorType) {
+      switch (descriptorType) {
         case ToolDescriptor.TypeEnum.NFL: {
           filesToAdd.push(this.createFileObject(this.NEXTFLOW_PATH));
           filesToAdd.push(this.createFileObject(this.NEXTFLOW_CONFIG_PATH));
           break;
         }
+        case ToolDescriptor.TypeEnum.CWL:
+        case ToolDescriptor.TypeEnum.WDL:
         case ToolDescriptor.TypeEnum.GXFORMAT2: {
-          // TODO: Switch this to defaultDescriptorPath. DO NOT LET MERGED if https://github.com/dockstore/dockstore-ui2/pull/962 is merged
-          filesToAdd.push(this.createFileObject('/Dockstore.yml'));
+          const defaultDescriptorPath = DescriptorLanguageService.toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType);
+          filesToAdd.push(this.createFileObject(defaultDescriptorPath));
           break;
         }
         default: {
+          console.log('Possibly unsupported hosted workflow language: ' + descriptorType);
           filesToAdd.push(this.createFileObject('/Dockstore' + newFilePath));
         }
       }
     } else if (!this.hasPrimaryTestParam() && this.fileType === 'testParam') {
-      if (this.descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
+      if (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
         filesToAdd.push(this.createFileObject('/test.galaxy.json'));
       } else {
-        filesToAdd.push(this.createFileObject('/test.' + this.descriptorType.toLowerCase() + newFilePath));
+        filesToAdd.push(this.createFileObject('/test.' + descriptorType.toLowerCase() + newFilePath));
       }
     } else {
       filesToAdd.push(this.createFileObject('/' + newFilePath));

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -34,7 +34,12 @@ export class CodeEditorListComponent {
    * Adds a new file editor
    */
   addFile() {
-    const filesToAdd = CodeEditorListService.determineFilesToAdd(this.descriptorType, this.fileType, this.sourcefiles);
+    let descriptorType = this.descriptorType;
+    // determineFilesToAdd gets really confusing when it needs to handle a falsey descriptorType, setting it here (no end effect)
+    if (this.fileType === 'dockerfile') {
+      descriptorType = ToolDescriptor.TypeEnum.CWL;
+    }
+    const filesToAdd = CodeEditorListService.determineFilesToAdd(descriptorType, this.fileType, this.sourcefiles);
     if (this.sourcefiles === undefined) {
       this.sourcefiles = [];
     }

--- a/src/app/shared/code-editor-list/code-editor-list.component.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.component.ts
@@ -1,11 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DescriptorLanguageService } from '../entry/descriptor-language.service';
 import { WorkflowQuery } from '../state/workflow.query';
-import { Validation } from '../swagger';
+import { SourceFile } from '../swagger';
 import { ToolDescriptor } from './../../shared/swagger/model/toolDescriptor';
 import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
+import { CodeEditorListService } from './code-editor-list.service';
+
+export type FileCategory = 'descriptor' | 'dockerfile' | 'testParam';
 
 @Component({
   selector: 'app-code-editor-list',
@@ -15,15 +17,13 @@ import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
 export class CodeEditorListComponent {
   @Input() sourcefiles: Array<any>;
   @Input() editing: boolean;
-  @Input() fileType: string;
+  @Input() fileType: FileCategory;
   @Input() descriptorType: ToolDescriptor.TypeEnum;
   @Input() entryType: string;
   @Input() entrypath: string;
   @Input() selectedVersion: WorkflowVersion;
   protected published$: Observable<boolean>;
   public downloadFilePath: string;
-  NEXTFLOW_CONFIG_PATH = '/nextflow.config';
-  NEXTFLOW_PATH = '/main.nf';
   public DescriptorType = ToolDescriptor.TypeEnum;
 
   constructor(private workflowQuery: WorkflowQuery) {
@@ -34,52 +34,13 @@ export class CodeEditorListComponent {
    * Adds a new file editor
    */
   addFile() {
-    const descriptorType = this.descriptorType;
-    const filesToAdd = [];
-    const newFilePath = this.getDefaultPath();
-    if (!this.hasPrimaryDescriptor() && this.fileType === 'descriptor') {
-      switch (descriptorType) {
-        case ToolDescriptor.TypeEnum.NFL: {
-          filesToAdd.push(this.createFileObject(this.NEXTFLOW_PATH));
-          filesToAdd.push(this.createFileObject(this.NEXTFLOW_CONFIG_PATH));
-          break;
-        }
-        case ToolDescriptor.TypeEnum.CWL:
-        case ToolDescriptor.TypeEnum.WDL:
-        case ToolDescriptor.TypeEnum.GXFORMAT2: {
-          const defaultDescriptorPath = DescriptorLanguageService.toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType);
-          filesToAdd.push(this.createFileObject(defaultDescriptorPath));
-          break;
-        }
-        default: {
-          console.log('Possibly unsupported hosted workflow language: ' + descriptorType);
-          filesToAdd.push(this.createFileObject('/Dockstore' + newFilePath));
-        }
-      }
-    } else if (!this.hasPrimaryTestParam() && this.fileType === 'testParam') {
-      if (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
-        filesToAdd.push(this.createFileObject('/test.galaxy.json'));
-      } else {
-        filesToAdd.push(this.createFileObject('/test.' + descriptorType.toLowerCase() + newFilePath));
-      }
-    } else {
-      filesToAdd.push(this.createFileObject('/' + newFilePath));
-    }
-
+    const filesToAdd = CodeEditorListService.determineFilesToAdd(this.descriptorType, this.fileType, this.sourcefiles);
     if (this.sourcefiles === undefined) {
       this.sourcefiles = [];
     }
     filesToAdd.forEach(file => {
       this.sourcefiles.push(file);
     });
-  }
-
-  createFileObject(newFilePath) {
-    return {
-      content: '',
-      path: newFilePath,
-      type: this.getFileType(newFilePath)
-    };
   }
 
   /**
@@ -95,69 +56,20 @@ export class CodeEditorListComponent {
   }
 
   /**
-   * Get the file type enum
-   * @return {string} The file type enum
-   */
-  getFileType(filepath) {
-    if (this.fileType === 'descriptor') {
-      if (this.descriptorType) {
-        if (this.descriptorType === ToolDescriptor.TypeEnum.NFL) {
-          if (filepath === this.NEXTFLOW_CONFIG_PATH) {
-            return 'NEXTFLOW_CONFIG';
-          } else {
-            return 'NEXTFLOW';
-          }
-        } else {
-          return 'DOCKSTORE_' + this.descriptorType;
-        }
-      } else {
-        return 'DOCKSTORE_CWL';
-      }
-    } else if (this.fileType === 'testParam') {
-      if (this.descriptorType) {
-        return DescriptorLanguageService.toolDescriptorTypeEnumTotestParameterFileType(this.descriptorType);
-      } else {
-        return 'CWL_TEST_JSON';
-      }
-    } else if (this.fileType === 'dockerfile') {
-      return 'DOCKERFILE';
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * Get the default path extension
-   * @return {string}the default path extension
-   */
-  getDefaultPath() {
-    if (this.fileType === 'descriptor') {
-      if (this.descriptorType) {
-        if (this.descriptorType === this.DescriptorType.NFL) {
-          return '.nf';
-        } else {
-          return '.' + this.descriptorType.toLowerCase();
-        }
-      } else {
-        return '.cwl';
-      }
-    } else if (this.fileType === 'testParam') {
-      return '.json';
-    } else if (this.fileType === 'dockerfile') {
-      return 'Dockerfile';
-    }
-  }
-
-  /**
+   * TODO: Fix the execution of this function.  This function is being executed a bajillion times.
    * Returns true if path is the primary descriptor, false otherwise
-   * @param  path Path to check
-   * @return {boolean}      Is path for primary descriptor
+   *
+   * @static
+   * @param {string} path Path to check
+   * @returns {boolean} Is path for primary descriptor
+   * @memberof CodeEditorListComponent
    */
   isPrimaryDescriptor(path: string): boolean {
-    return path === '/Dockstore.cwl' || path === '/Dockstore.wdl' || path === this.NEXTFLOW_CONFIG_PATH || path === this.NEXTFLOW_PATH;
+    return CodeEditorListService.isPrimaryDescriptor(path);
   }
 
   /**
+   * TODO: Fix the execution of this function.  This function is being executed a bajillion times.
    * Returns true if path is the dockerfile, false otherwise
    * @param  path Path to check
    * @return {boolean}      Is path for dockerfile
@@ -167,74 +79,14 @@ export class CodeEditorListComponent {
   }
 
   /**
-   * TODO: Fix this execution of this function.  This function is being executed a bajillion times
+   * TODO: Fix the execution of this function.  This function is being executed a bajillion times.
    * Determines whether to show the current sourcefile based on the descriptor type and tab
    * @param  type sourcefile type
    * @return {boolean}      whether or not to show file
    */
-  showSourcefile(type: string): boolean {
-    if (type === null || type === undefined) {
-      return true;
-    } else if (this.fileType === 'dockerfile') {
-      return true;
-    } else if (this.fileType === 'descriptor') {
-      return (
-        (this.descriptorType === ToolDescriptor.TypeEnum.CWL && type === 'DOCKSTORE_CWL') ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.WDL && type === 'DOCKSTORE_WDL') ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.NFL && (type === 'NEXTFLOW' || type === 'NEXTFLOW_CONFIG')) ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2 && type === Validation.TypeEnum.DOCKSTOREGXFORMAT2)
-      );
-    } else if (this.fileType === 'testParam') {
-      return (
-        (this.descriptorType === ToolDescriptor.TypeEnum.CWL && type === 'CWL_TEST_JSON') ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.WDL && type === 'WDL_TEST_JSON') ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.NFL && type === 'NEXTFLOW_TEST_PARAMS') ||
-        (this.descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2 && type === Validation.TypeEnum.GXFORMAT2TESTFILE)
-      );
-    } else {
-      return true;
-    }
-  }
-
-  /**
-   * Checks for the given descriptor type, does there already exist a primary descriptor
-   * @return {boolean} whether or not version has a primary descriptor
-   */
-  hasPrimaryDescriptor(): boolean {
-    if (this.descriptorType === null || this.descriptorType === undefined) {
-      return false;
-    }
-
-    const pathToFind = '/Dockstore.' + this.descriptorType.toLowerCase();
-    if (this.descriptorType === ToolDescriptor.TypeEnum.NFL) {
-      return this.hasFilePath(this.NEXTFLOW_PATH) && this.hasFilePath(this.NEXTFLOW_CONFIG_PATH);
-    }
-    return this.hasFilePath(pathToFind);
-  }
-
-  /**
-   * Checks for the given descriptor type, does there already exist a primary test json
-   * @return {boolean} whether or not version has a primary test json
-   */
-  hasPrimaryTestParam(): boolean {
-    if (this.descriptorType === null || this.descriptorType === undefined) {
-      return false;
-    }
-    const pathToFind = 'test.' + this.descriptorType.toLowerCase() + '.json';
-    return this.hasFilePath(pathToFind);
-  }
-
-  /**
-   * Determines if there exists a sourcefile with the given file path
-   * @param  path File path to look for
-   * @return {boolean}      Whether a sourcefile with the path exists
-   */
-  hasFilePath(path: string): boolean {
-    for (const sourcefile of this.sourcefiles) {
-      if (sourcefile.path === path) {
-        return true;
-      }
-    }
-    return false;
+  showSourcefile(type: SourceFile.TypeEnum): boolean {
+    const fileType = this.fileType;
+    const descriptorType = this.descriptorType;
+    return CodeEditorListService.showSourcefile(type, fileType, descriptorType);
   }
 }

--- a/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SourceFile, ToolDescriptor } from '../swagger';
+import { CodeEditorListService } from './code-editor-list.service';
+
+describe('CodeEditorListService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: CodeEditorListService = TestBed.get(CodeEditorListService);
+    expect(service).toBeTruthy();
+  });
+  it('should be able to know if path is a primary descriptor', () => {
+    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.cwl')).toBe(true);
+    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.wdl')).toBe(true);
+    expect(CodeEditorListService.isPrimaryDescriptor('/nextflow.config')).toBe(true);
+    expect(CodeEditorListService.isPrimaryDescriptor('/main.nf')).toBe(true);
+    // This seems wrong
+    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.yml')).toBe(false);
+    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.potato')).toBe(false);
+  });
+
+  it('should be able to know if path is a primary descriptor', () => {
+    // Brand new hosted workflow with no descriptors
+    const primaryCWLFile = { content: '', path: '/Dockstore.cwl', type: SourceFile.TypeEnum.DOCKSTORECWL };
+    const secondaryCWLFile = { content: '', path: '/.cwl', type: SourceFile.TypeEnum.DOCKSTORECWL };
+    const primaryWDLFile = { content: '', path: '/Dockstore.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
+    const secondaryWDLFile = { content: '', path: '/.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
+    const firstPrimaryNFLFile = { content: '', path: '/main.nf', type: SourceFile.TypeEnum.NEXTFLOW };
+    const secondPrimaryNFLFile = { content: '', path: '/nextflow.config', type: SourceFile.TypeEnum.NEXTFLOWCONFIG };
+    const secondaryNFLFile = { content: '', path: '/.nf', type: SourceFile.TypeEnum.NEXTFLOW };
+    const primaryNFLFiles = [firstPrimaryNFLFile, secondPrimaryNFLFile];
+    const primaryGalaxyFile = { content: '', path: '/Dockstore.yml', type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2 };
+    const secondaryGalaxyFile = { content: '', path: '/Dockstore.yml', type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2 };
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'descriptor', [])).toEqual([primaryCWLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'descriptor', [])).toEqual([primaryWDLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.NFL, 'descriptor', [])).toEqual(primaryNFLFiles);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'descriptor', [])).toEqual([primaryGalaxyFile]);
+
+    const testCWLFile = { content: '', path: '/test.cwl.json', type: SourceFile.TypeEnum.CWLTESTJSON };
+    const testWDLFile = { content: '', path: '/test.wdl.json', type: SourceFile.TypeEnum.WDLTESTJSON };
+    // Weird because NFL doesn't have test parameter files
+    const testNFLFile = { content: '', path: '/test.nfl.json', type: SourceFile.TypeEnum.NEXTFLOWTESTPARAMS };
+    const testGalaxyFile = { content: '', path: '/test.galaxy.json', type: SourceFile.TypeEnum.GXFORMAT2TESTFILE };
+    // Brand new hosted workflow with no test parameter file
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'testParam', [])).toEqual([testCWLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'testParam', [])).toEqual([testWDLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.NFL, 'testParam', [])).toEqual([testNFLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'testParam', [])).toEqual([testGalaxyFile]);
+
+    // When there's already the primary descriptor
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'descriptor', [primaryCWLFile])).toEqual([
+      secondaryCWLFile
+    ]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'descriptor', [primaryWDLFile])).toEqual([
+      secondaryWDLFile
+    ]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.NFL, 'descriptor', primaryNFLFiles)).toEqual([
+      secondaryNFLFile
+    ]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'descriptor', [primaryGalaxyFile])).toEqual([
+      secondaryGalaxyFile
+    ]);
+
+    // When there's already a test parameter file
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'testParam', [testCWLFile])).toEqual([testCWLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'testParam', [testWDLFile])).toEqual([testWDLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.NFL, 'testParam', [testNFLFile])).toEqual([testNFLFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'testParam', [testGalaxyFile])).toEqual([
+      testGalaxyFile
+    ]);
+  });
+  it('should be able to determine whether to show the sourcefile in the current tab or not', () => {
+    // Descriptor tab
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTORECWL, 'descriptor', ToolDescriptor.TypeEnum.CWL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.CWLTESTJSON, 'descriptor', ToolDescriptor.TypeEnum.CWL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREWDL, 'descriptor', ToolDescriptor.TypeEnum.WDL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.WDLTESTJSON, 'descriptor', ToolDescriptor.TypeEnum.WDL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOW, 'descriptor', ToolDescriptor.TypeEnum.NFL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWCONFIG, 'descriptor', ToolDescriptor.TypeEnum.NFL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, 'descriptor', ToolDescriptor.TypeEnum.NFL)).toBe(
+      false
+    );
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREGXFORMAT2, 'descriptor', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(true);
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.GXFORMAT2TESTFILE, 'descriptor', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(false);
+
+    // Test file tab
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTORECWL, 'testParam', ToolDescriptor.TypeEnum.CWL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.CWLTESTJSON, 'testParam', ToolDescriptor.TypeEnum.CWL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREWDL, 'testParam', ToolDescriptor.TypeEnum.WDL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.WDLTESTJSON, 'testParam', ToolDescriptor.TypeEnum.WDL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOW, 'testParam', ToolDescriptor.TypeEnum.NFL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWCONFIG, 'testParam', ToolDescriptor.TypeEnum.NFL)).toBe(false);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, 'testParam', ToolDescriptor.TypeEnum.NFL)).toBe(
+      true
+    );
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREGXFORMAT2, 'testParam', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(false);
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.GXFORMAT2TESTFILE, 'testParam', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(true);
+
+    // Dockerfile tab, everything is true because something else handles it...?
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTORECWL, 'dockerfile', ToolDescriptor.TypeEnum.CWL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.CWLTESTJSON, 'dockerfile', ToolDescriptor.TypeEnum.CWL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREWDL, 'dockerfile', ToolDescriptor.TypeEnum.WDL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.WDLTESTJSON, 'dockerfile', ToolDescriptor.TypeEnum.WDL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOW, 'dockerfile', ToolDescriptor.TypeEnum.NFL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWCONFIG, 'dockerfile', ToolDescriptor.TypeEnum.NFL)).toBe(true);
+    expect(CodeEditorListService.showSourcefile(SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, 'dockerfile', ToolDescriptor.TypeEnum.NFL)).toBe(
+      true
+    );
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.DOCKSTOREGXFORMAT2, 'dockerfile', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(true);
+    expect(
+      CodeEditorListService.showSourcefile(SourceFile.TypeEnum.GXFORMAT2TESTFILE, 'dockerfile', ToolDescriptor.TypeEnum.GXFORMAT2)
+    ).toBe(true);
+  });
+});

--- a/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
@@ -22,26 +22,56 @@ describe('CodeEditorListService', () => {
 
   it('should be able to know if path is a primary descriptor', () => {
     // Brand new hosted workflow with no descriptors
-    const primaryCWLFile = { content: '', path: '/Dockstore.cwl', type: SourceFile.TypeEnum.DOCKSTORECWL };
-    const secondaryCWLFile = { content: '', path: '/.cwl', type: SourceFile.TypeEnum.DOCKSTORECWL };
-    const primaryWDLFile = { content: '', path: '/Dockstore.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
-    const secondaryWDLFile = { content: '', path: '/.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
-    const firstPrimaryNFLFile = { content: '', path: '/main.nf', type: SourceFile.TypeEnum.NEXTFLOW };
-    const secondPrimaryNFLFile = { content: '', path: '/nextflow.config', type: SourceFile.TypeEnum.NEXTFLOWCONFIG };
-    const secondaryNFLFile = { content: '', path: '/.nf', type: SourceFile.TypeEnum.NEXTFLOW };
+    const primaryCWLFile: SourceFile = {
+      content: '',
+      absolutePath: '/Dockstore.cwl',
+      path: '/Dockstore.cwl',
+      type: SourceFile.TypeEnum.DOCKSTORECWL
+    };
+    const secondaryCWLFile = { content: '', absolutePath: '/.cwl', path: '/.cwl', type: SourceFile.TypeEnum.DOCKSTORECWL };
+    const primaryWDLFile = { content: '', absolutePath: '/Dockstore.wdl', path: '/Dockstore.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
+    const secondaryWDLFile = { content: '', absolutePath: '/.wdl', path: '/.wdl', type: SourceFile.TypeEnum.DOCKSTOREWDL };
+    const firstPrimaryNFLFile = { content: '', absolutePath: '/main.nf', path: '/main.nf', type: SourceFile.TypeEnum.NEXTFLOW };
+    const secondPrimaryNFLFile = {
+      content: '',
+      absolutePath: '/nextflow.config',
+      path: '/nextflow.config',
+      type: SourceFile.TypeEnum.NEXTFLOWCONFIG
+    };
+    const secondaryNFLFile = { content: '', absolutePath: '/.nf', path: '/.nf', type: SourceFile.TypeEnum.NEXTFLOW };
     const primaryNFLFiles = [firstPrimaryNFLFile, secondPrimaryNFLFile];
-    const primaryGalaxyFile = { content: '', path: '/Dockstore.yml', type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2 };
-    const secondaryGalaxyFile = { content: '', path: '/Dockstore.yml', type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2 };
+    const primaryGalaxyFile = {
+      content: '',
+      absolutePath: '/Dockstore.yml',
+      path: '/Dockstore.yml',
+      type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2
+    };
+    const secondaryGalaxyFile = {
+      content: '',
+      absolutePath: '/.yml',
+      path: '/.yml',
+      type: SourceFile.TypeEnum.DOCKSTOREGXFORMAT2
+    };
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'descriptor', [])).toEqual([primaryCWLFile]);
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'descriptor', [])).toEqual([primaryWDLFile]);
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.NFL, 'descriptor', [])).toEqual(primaryNFLFiles);
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'descriptor', [])).toEqual([primaryGalaxyFile]);
 
-    const testCWLFile = { content: '', path: '/test.cwl.json', type: SourceFile.TypeEnum.CWLTESTJSON };
-    const testWDLFile = { content: '', path: '/test.wdl.json', type: SourceFile.TypeEnum.WDLTESTJSON };
+    const testCWLFile = { content: '', absolutePath: '/test.cwl.json', path: '/test.cwl.json', type: SourceFile.TypeEnum.CWLTESTJSON };
+    const testWDLFile = { content: '', absolutePath: '/test.wdl.json', path: '/test.wdl.json', type: SourceFile.TypeEnum.WDLTESTJSON };
     // Weird because NFL doesn't have test parameter files
-    const testNFLFile = { content: '', path: '/test.nfl.json', type: SourceFile.TypeEnum.NEXTFLOWTESTPARAMS };
-    const testGalaxyFile = { content: '', path: '/test.galaxy.json', type: SourceFile.TypeEnum.GXFORMAT2TESTFILE };
+    const testNFLFile = {
+      content: '',
+      absolutePath: '/test.nfl.json',
+      path: '/test.nfl.json',
+      type: SourceFile.TypeEnum.NEXTFLOWTESTPARAMS
+    };
+    const testGalaxyFile = {
+      content: '',
+      absolutePath: '/test.galaxy.json',
+      path: '/test.galaxy.json',
+      type: SourceFile.TypeEnum.GXFORMAT2TESTFILE
+    };
     // Brand new hosted workflow with no test parameter file
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'testParam', [])).toEqual([testCWLFile]);
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'testParam', [])).toEqual([testWDLFile]);

--- a/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
@@ -17,6 +17,7 @@ describe('CodeEditorListService', () => {
     expect(CodeEditorListService.isPrimaryDescriptor('/main.nf')).toBe(true);
     // This seems wrong
     expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.yml')).toBe(false);
+    expect(CodeEditorListService.isPrimaryDescriptor(null)).toBe(false);
     expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.potato')).toBe(false);
   });
 
@@ -72,6 +73,12 @@ describe('CodeEditorListService', () => {
       path: '/test.galaxy.json',
       type: SourceFile.TypeEnum.GXFORMAT2TESTFILE
     };
+    const testDockerFile = {
+      content: '',
+      absolutePath: '/Dockerfile',
+      path: '/Dockerfile',
+      type: SourceFile.TypeEnum.DOCKERFILE
+    };
     // Brand new hosted workflow with no test parameter file
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'testParam', [])).toEqual([testCWLFile]);
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'testParam', [])).toEqual([testWDLFile]);
@@ -99,6 +106,22 @@ describe('CodeEditorListService', () => {
     expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.GXFORMAT2, 'testParam', [testGalaxyFile])).toEqual([
       testGalaxyFile
     ]);
+
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'dockerfile', [])).toEqual([testDockerFile]);
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.WDL, 'dockerfile', [])).toEqual([testDockerFile]);
+
+    expect(CodeEditorListService.determineFilesToAdd(null, null, null)).toEqual([]);
+
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.CWL, 'dockerfile', [])).toEqual([testDockerFile]);
+
+    // Unhandled hosted workflow descriptor type
+    const weirdServiceFile = {
+      content: '',
+      absolutePath: '/Dockstore.service',
+      path: '/Dockstore.service',
+      type: SourceFile.TypeEnum.DOCKSTORECWL
+    };
+    expect(CodeEditorListService.determineFilesToAdd(ToolDescriptor.TypeEnum.SERVICE, 'descriptor', [])).toEqual([weirdServiceFile]);
   });
   it('should be able to determine whether to show the sourcefile in the current tab or not', () => {
     // Descriptor tab
@@ -151,5 +174,6 @@ describe('CodeEditorListService', () => {
     expect(
       CodeEditorListService.showSourcefile(SourceFile.TypeEnum.GXFORMAT2TESTFILE, 'dockerfile', ToolDescriptor.TypeEnum.GXFORMAT2)
     ).toBe(true);
+    expect(CodeEditorListService.showSourcefile(null, null, null)).toBe(true);
   });
 });

--- a/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.spec.ts
@@ -15,8 +15,7 @@ describe('CodeEditorListService', () => {
     expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.wdl')).toBe(true);
     expect(CodeEditorListService.isPrimaryDescriptor('/nextflow.config')).toBe(true);
     expect(CodeEditorListService.isPrimaryDescriptor('/main.nf')).toBe(true);
-    // This seems wrong
-    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.yml')).toBe(false);
+    expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.yml')).toBe(true);
     expect(CodeEditorListService.isPrimaryDescriptor(null)).toBe(false);
     expect(CodeEditorListService.isPrimaryDescriptor('/Dockstore.potato')).toBe(false);
   });

--- a/src/app/shared/code-editor-list/code-editor-list.service.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.ts
@@ -66,6 +66,42 @@ export class CodeEditorListService {
     return primaryDescriptors.includes(path);
   }
 
+  static determineFilesToAdd(descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory, sourcefiles: SourceFile[]): SourceFile[] {
+    const filesToAdd = [];
+    const newFilePath = CodeEditorListService.getDefaultPath(fileType, descriptorType);
+    if (!CodeEditorListService.hasPrimaryDescriptor(descriptorType, sourcefiles) && fileType === 'descriptor') {
+      switch (descriptorType) {
+        case ToolDescriptor.TypeEnum.NFL: {
+          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_PATH, descriptorType, fileType));
+          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_CONFIG_PATH, descriptorType, fileType));
+          break;
+        }
+        case ToolDescriptor.TypeEnum.CWL:
+        case ToolDescriptor.TypeEnum.WDL:
+        case ToolDescriptor.TypeEnum.GXFORMAT2: {
+          const defaultDescriptorPath = DescriptorLanguageService.toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType);
+          filesToAdd.push(CodeEditorListService.createFileObject(defaultDescriptorPath, descriptorType, fileType));
+          break;
+        }
+        default: {
+          console.log('Possibly unsupported hosted workflow language: ' + descriptorType);
+          filesToAdd.push(CodeEditorListService.createFileObject('/Dockstore' + newFilePath, descriptorType, fileType));
+        }
+      }
+    } else if (!CodeEditorListService.hasPrimaryTestParam(descriptorType, sourcefiles) && fileType === 'testParam') {
+      if (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
+        filesToAdd.push(CodeEditorListService.createFileObject('/test.galaxy.json', descriptorType, fileType));
+      } else {
+        filesToAdd.push(
+          CodeEditorListService.createFileObject('/test.' + descriptorType.toLowerCase() + newFilePath, descriptorType, fileType)
+        );
+      }
+    } else {
+      filesToAdd.push(CodeEditorListService.createFileObject('/' + newFilePath, descriptorType, fileType));
+    }
+    return filesToAdd;
+  }
+
   /**
    * Get the file type enum
    * TODO: Actually return an enum
@@ -75,37 +111,55 @@ export class CodeEditorListService {
    * @returns
    * @memberof CodeEditorListComponent
    */
-  private static getFileType(filepath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory) {
+  private static getFileType(filepath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory): SourceFile.TypeEnum {
     switch (fileType) {
       case 'descriptor': {
         if (descriptorType) {
-          if (descriptorType === ToolDescriptor.TypeEnum.NFL) {
-            if (filepath === CodeEditorListService.NEXTFLOW_CONFIG_PATH) {
-              return 'NEXTFLOW_CONFIG';
-            } else {
-              return 'NEXTFLOW';
+          switch (descriptorType) {
+            case ToolDescriptor.TypeEnum.NFL: {
+              if (filepath === CodeEditorListService.NEXTFLOW_CONFIG_PATH) {
+                return SourceFile.TypeEnum.NEXTFLOWCONFIG;
+              } else {
+                return SourceFile.TypeEnum.NEXTFLOW;
+              }
             }
-          } else {
-            return 'DOCKSTORE_' + descriptorType;
+            case ToolDescriptor.TypeEnum.CWL:
+            case ToolDescriptor.TypeEnum.WDL:
+            case ToolDescriptor.TypeEnum.GXFORMAT2: {
+              const descriptorFileTypes = DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType)
+                .descriptorFileTypes;
+              if (descriptorFileTypes && descriptorFileTypes.length > 0) {
+                return descriptorFileTypes[0];
+              } else {
+                // Defaulting to CWL for some reason
+                return SourceFile.TypeEnum.DOCKSTORECWL;
+              }
+            }
+            default: {
+              // Defaulting to CWL for some reason
+              return SourceFile.TypeEnum.DOCKSTORECWL;
+            }
           }
         } else {
-          return 'DOCKSTORE_CWL';
+          return SourceFile.TypeEnum.DOCKSTORECWL;
         }
       }
       case 'testParam': {
         if (descriptorType) {
           return DescriptorLanguageService.toolDescriptorTypeEnumTotestParameterFileType(descriptorType);
         } else {
-          return 'CWL_TEST_JSON';
+          // Defaulting to CWL for some reason
+          return SourceFile.TypeEnum.DOCKSTORECWL;
         }
       }
       case 'dockerfile': {
-        return 'DOCKERFILE';
+        return SourceFile.TypeEnum.DOCKERFILE;
       }
     }
   }
-  private static createFileObject(newFilePath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory): any {
+  private static createFileObject(newFilePath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory): SourceFile {
     return {
+      absolutePath: newFilePath,
       content: '',
       path: newFilePath,
       type: CodeEditorListService.getFileType(newFilePath, descriptorType, fileType)
@@ -113,7 +167,6 @@ export class CodeEditorListService {
   }
 
   /**
-   * TODO: Move this to a service
    * Get the default path extension
    *
    * @static
@@ -151,48 +204,12 @@ export class CodeEditorListService {
     }
   }
 
-  static determineFilesToAdd(descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory, sourcefiles: any[]): any[] {
-    const filesToAdd = [];
-    const newFilePath = CodeEditorListService.getDefaultPath(fileType, descriptorType);
-    if (!CodeEditorListService.hasPrimaryDescriptor(descriptorType, sourcefiles) && fileType === 'descriptor') {
-      switch (descriptorType) {
-        case ToolDescriptor.TypeEnum.NFL: {
-          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_PATH, descriptorType, fileType));
-          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_CONFIG_PATH, descriptorType, fileType));
-          break;
-        }
-        case ToolDescriptor.TypeEnum.CWL:
-        case ToolDescriptor.TypeEnum.WDL:
-        case ToolDescriptor.TypeEnum.GXFORMAT2: {
-          const defaultDescriptorPath = DescriptorLanguageService.toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType);
-          filesToAdd.push(CodeEditorListService.createFileObject(defaultDescriptorPath, descriptorType, fileType));
-          break;
-        }
-        default: {
-          console.log('Possibly unsupported hosted workflow language: ' + descriptorType);
-          filesToAdd.push(CodeEditorListService.createFileObject('/Dockstore' + newFilePath, descriptorType, fileType));
-        }
-      }
-    } else if (!CodeEditorListService.hasPrimaryTestParam(descriptorType, sourcefiles) && fileType === 'testParam') {
-      if (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
-        filesToAdd.push(CodeEditorListService.createFileObject('/test.galaxy.json', descriptorType, fileType));
-      } else {
-        filesToAdd.push(
-          CodeEditorListService.createFileObject('/test.' + descriptorType.toLowerCase() + newFilePath, descriptorType, fileType)
-        );
-      }
-    } else {
-      filesToAdd.push(CodeEditorListService.createFileObject('/' + newFilePath, descriptorType, fileType));
-    }
-    return filesToAdd;
-  }
-
   /**
    * Determines if there exists a sourcefile with the given file path
    * @param  path File path to look for
    * @return {boolean}      Whether a sourcefile with the path exists
    */
-  private static hasFilePath(path: string, sourcefiles: any): boolean {
+  private static hasFilePath(path: string, sourcefiles: Array<SourceFile>): boolean {
     for (const sourcefile of sourcefiles) {
       if (sourcefile.path === path) {
         return true;
@@ -205,7 +222,7 @@ export class CodeEditorListService {
    * Checks for the given descriptor type, does there already exist a primary test json
    * @return {boolean} whether or not version has a primary test json
    */
-  private static hasPrimaryTestParam(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: any[]): boolean {
+  private static hasPrimaryTestParam(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: SourceFile[]): boolean {
     if (descriptorType === null || descriptorType === undefined) {
       return false;
     }
@@ -217,7 +234,7 @@ export class CodeEditorListService {
    * Checks for the given descriptor type, does there already exist a primary descriptor
    * @return {boolean} whether or not version has a primary descriptor
    */
-  private static hasPrimaryDescriptor(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: any[]): boolean {
+  private static hasPrimaryDescriptor(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: SourceFile[]): boolean {
     if (descriptorType === null || descriptorType === undefined) {
       return false;
     }

--- a/src/app/shared/code-editor-list/code-editor-list.service.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.ts
@@ -1,0 +1,234 @@
+import { Injectable } from '@angular/core';
+import { DescriptorLanguageService } from '../entry/descriptor-language.service';
+import { SourceFile, ToolDescriptor, Validation } from '../swagger';
+import { FileCategory } from './code-editor-list.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CodeEditorListService {
+  static readonly NEXTFLOW_CONFIG_PATH = '/nextflow.config';
+  static readonly NEXTFLOW_PATH = '/main.nf';
+  constructor() {}
+  /**
+   * Determines whether to show the current sourcefile based on the descriptor type and tab
+   *
+   * @static
+   * @param {(SourceFile.TypeEnum | null | undefined)} sourcefileType
+   * @param {FileCategory} fileCategory
+   * @param {ToolDescriptor.TypeEnum} descriptorType
+   * @returns {boolean} Whether to show sourcefile or not
+   * @memberof CodeEditorListService
+   */
+  static showSourcefile(
+    sourcefileType: SourceFile.TypeEnum | null | undefined,
+    fileCategory: FileCategory,
+    descriptorType: ToolDescriptor.TypeEnum
+  ): boolean {
+    if (sourcefileType === null || sourcefileType === undefined) {
+      return true;
+    }
+    switch (fileCategory) {
+      case 'dockerfile': {
+        return true;
+      }
+      case 'descriptor': {
+        return (
+          (descriptorType === ToolDescriptor.TypeEnum.CWL && sourcefileType === SourceFile.TypeEnum.DOCKSTORECWL) ||
+          (descriptorType === ToolDescriptor.TypeEnum.WDL && sourcefileType === SourceFile.TypeEnum.DOCKSTOREWDL) ||
+          (descriptorType === ToolDescriptor.TypeEnum.NFL &&
+            (sourcefileType === SourceFile.TypeEnum.NEXTFLOW || sourcefileType === SourceFile.TypeEnum.NEXTFLOWCONFIG)) ||
+          (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2 && sourcefileType === Validation.TypeEnum.DOCKSTOREGXFORMAT2)
+        );
+      }
+      case 'testParam': {
+        return (
+          (descriptorType === ToolDescriptor.TypeEnum.CWL && sourcefileType === SourceFile.TypeEnum.CWLTESTJSON) ||
+          (descriptorType === ToolDescriptor.TypeEnum.WDL && sourcefileType === SourceFile.TypeEnum.WDLTESTJSON) ||
+          (descriptorType === ToolDescriptor.TypeEnum.NFL && sourcefileType === SourceFile.TypeEnum.NEXTFLOWTESTPARAMS) ||
+          (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2 && sourcefileType === Validation.TypeEnum.GXFORMAT2TESTFILE)
+        );
+      }
+      default: {
+        console.error('Unrecognized fileCategory: ' + fileCategory);
+        return true;
+      }
+    }
+  }
+
+  static isPrimaryDescriptor(path: string): boolean {
+    const primaryDescriptors = [
+      '/Dockstore.cwl',
+      '/Dockstore.wdl',
+      CodeEditorListService.NEXTFLOW_CONFIG_PATH,
+      CodeEditorListService.NEXTFLOW_PATH
+    ];
+    return primaryDescriptors.includes(path);
+  }
+
+  /**
+   * Get the file type enum
+   * TODO: Actually return an enum
+   * @param {string} filepath Path of the file
+   * @param {ToolDescriptor.TypeEnum} descriptorType Descriptor Type
+   * @param {string} fileType Weird string denoting the type of file it is
+   * @returns
+   * @memberof CodeEditorListComponent
+   */
+  private static getFileType(filepath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory) {
+    switch (fileType) {
+      case 'descriptor': {
+        if (descriptorType) {
+          if (descriptorType === ToolDescriptor.TypeEnum.NFL) {
+            if (filepath === CodeEditorListService.NEXTFLOW_CONFIG_PATH) {
+              return 'NEXTFLOW_CONFIG';
+            } else {
+              return 'NEXTFLOW';
+            }
+          } else {
+            return 'DOCKSTORE_' + descriptorType;
+          }
+        } else {
+          return 'DOCKSTORE_CWL';
+        }
+      }
+      case 'testParam': {
+        if (descriptorType) {
+          return DescriptorLanguageService.toolDescriptorTypeEnumTotestParameterFileType(descriptorType);
+        } else {
+          return 'CWL_TEST_JSON';
+        }
+      }
+      case 'dockerfile': {
+        return 'DOCKERFILE';
+      }
+    }
+  }
+  private static createFileObject(newFilePath: string, descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory): any {
+    return {
+      content: '',
+      path: newFilePath,
+      type: CodeEditorListService.getFileType(newFilePath, descriptorType, fileType)
+    };
+  }
+
+  /**
+   * TODO: Move this to a service
+   * Get the default path extension
+   *
+   * @static
+   * @param {FileCategory} fileType Weird string denoting the type of file it is
+   * @param {ToolDescriptor.TypeEnum} descriptorType  The descriptor type (used when fileType is descriptor)
+   * @returns The default path extension
+   * @memberof CodeEditorListComponent
+   */
+  private static getDefaultPath(fileType: FileCategory, descriptorType: ToolDescriptor.TypeEnum): string {
+    switch (fileType) {
+      case 'descriptor': {
+        if (descriptorType) {
+          switch (descriptorType) {
+            case ToolDescriptor.TypeEnum.NFL: {
+              return '.nf';
+            }
+            case ToolDescriptor.TypeEnum.GXFORMAT2: {
+              return '.yml';
+            }
+            default: {
+              return '.' + descriptorType.toLowerCase();
+            }
+          }
+        } else {
+          console.error('No descriptor type. How odd');
+          return '.cwl';
+        }
+      }
+      case 'testParam': {
+        return '.json';
+      }
+      case 'dockerfile': {
+        return 'Dockerfile';
+      }
+    }
+  }
+
+  static determineFilesToAdd(descriptorType: ToolDescriptor.TypeEnum, fileType: FileCategory, sourcefiles: any[]): any[] {
+    const filesToAdd = [];
+    const newFilePath = CodeEditorListService.getDefaultPath(fileType, descriptorType);
+    if (!CodeEditorListService.hasPrimaryDescriptor(descriptorType, sourcefiles) && fileType === 'descriptor') {
+      switch (descriptorType) {
+        case ToolDescriptor.TypeEnum.NFL: {
+          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_PATH, descriptorType, fileType));
+          filesToAdd.push(CodeEditorListService.createFileObject(CodeEditorListService.NEXTFLOW_CONFIG_PATH, descriptorType, fileType));
+          break;
+        }
+        case ToolDescriptor.TypeEnum.CWL:
+        case ToolDescriptor.TypeEnum.WDL:
+        case ToolDescriptor.TypeEnum.GXFORMAT2: {
+          const defaultDescriptorPath = DescriptorLanguageService.toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType);
+          filesToAdd.push(CodeEditorListService.createFileObject(defaultDescriptorPath, descriptorType, fileType));
+          break;
+        }
+        default: {
+          console.log('Possibly unsupported hosted workflow language: ' + descriptorType);
+          filesToAdd.push(CodeEditorListService.createFileObject('/Dockstore' + newFilePath, descriptorType, fileType));
+        }
+      }
+    } else if (!CodeEditorListService.hasPrimaryTestParam(descriptorType, sourcefiles) && fileType === 'testParam') {
+      if (descriptorType === ToolDescriptor.TypeEnum.GXFORMAT2) {
+        filesToAdd.push(CodeEditorListService.createFileObject('/test.galaxy.json', descriptorType, fileType));
+      } else {
+        filesToAdd.push(
+          CodeEditorListService.createFileObject('/test.' + descriptorType.toLowerCase() + newFilePath, descriptorType, fileType)
+        );
+      }
+    } else {
+      filesToAdd.push(CodeEditorListService.createFileObject('/' + newFilePath, descriptorType, fileType));
+    }
+    return filesToAdd;
+  }
+
+  /**
+   * Determines if there exists a sourcefile with the given file path
+   * @param  path File path to look for
+   * @return {boolean}      Whether a sourcefile with the path exists
+   */
+  private static hasFilePath(path: string, sourcefiles: any): boolean {
+    for (const sourcefile of sourcefiles) {
+      if (sourcefile.path === path) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Checks for the given descriptor type, does there already exist a primary test json
+   * @return {boolean} whether or not version has a primary test json
+   */
+  private static hasPrimaryTestParam(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: any[]): boolean {
+    if (descriptorType === null || descriptorType === undefined) {
+      return false;
+    }
+    const pathToFind = 'test.' + descriptorType.toLowerCase() + '.json';
+    return CodeEditorListService.hasFilePath(pathToFind, sourcefiles);
+  }
+
+  /**
+   * Checks for the given descriptor type, does there already exist a primary descriptor
+   * @return {boolean} whether or not version has a primary descriptor
+   */
+  private static hasPrimaryDescriptor(descriptorType: ToolDescriptor.TypeEnum, sourcefiles: any[]): boolean {
+    if (descriptorType === null || descriptorType === undefined) {
+      return false;
+    }
+
+    const pathToFind = '/Dockstore.' + descriptorType.toLowerCase();
+    if (descriptorType === ToolDescriptor.TypeEnum.NFL) {
+      return (
+        CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_PATH, sourcefiles) &&
+        CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_CONFIG_PATH, sourcefiles)
+      );
+    }
+    return CodeEditorListService.hasFilePath(pathToFind, sourcefiles);
+  }
+}

--- a/src/app/shared/code-editor-list/code-editor-list.service.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.ts
@@ -276,12 +276,19 @@ export class CodeEditorListService {
     }
 
     const pathToFind = '/Dockstore.' + descriptorType.toLowerCase();
-    if (descriptorType === ToolDescriptor.TypeEnum.NFL) {
-      return (
-        CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_PATH, sourcefiles) &&
-        CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_CONFIG_PATH, sourcefiles)
-      );
+    switch (descriptorType) {
+      case ToolDescriptor.TypeEnum.NFL: {
+        return (
+          CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_PATH, sourcefiles) &&
+          CodeEditorListService.hasFilePath(CodeEditorListService.NEXTFLOW_CONFIG_PATH, sourcefiles)
+        );
+      }
+      case ToolDescriptor.TypeEnum.GXFORMAT2: {
+        return CodeEditorListService.hasFilePath('/Dockstore.yml', sourcefiles);
+      }
+      default: {
+        return CodeEditorListService.hasFilePath(pathToFind, sourcefiles);
+      }
     }
-    return CodeEditorListService.hasFilePath(pathToFind, sourcefiles);
   }
 }

--- a/src/app/shared/code-editor-list/code-editor-list.service.ts
+++ b/src/app/shared/code-editor-list/code-editor-list.service.ts
@@ -59,8 +59,8 @@ export class CodeEditorListService {
   }
 
   /**
-   * Determines whether the path is a primary descriptor
-   *
+   * Determines whether the path is a primary descriptor.
+   * This is kind of easy to break.
    * @static
    * @param {(string | null)} path
    * @returns {boolean}
@@ -71,10 +71,15 @@ export class CodeEditorListService {
       return false;
     }
     const primaryDescriptors = [
+      // CWL
       '/Dockstore.cwl',
+      // WDL
       '/Dockstore.wdl',
+      // NFL
       CodeEditorListService.NEXTFLOW_CONFIG_PATH,
-      CodeEditorListService.NEXTFLOW_PATH
+      CodeEditorListService.NEXTFLOW_PATH,
+      // Galaxy
+      '/Dockstore.yml'
     ];
     return primaryDescriptors.includes(path);
   }

--- a/src/app/shared/descriptor.service.ts
+++ b/src/app/shared/descriptor.service.ts
@@ -35,7 +35,7 @@ export class DescriptorService {
       const unique = new Set(version.sourceFiles.map((sourceFile: SourceFile) => sourceFile.type));
       unique.forEach((element: SourceFile.TypeEnum) => {
         extendedDescriptorLanguages.forEach(extendedDescriptorLanguage => {
-          if (extendedDescriptorLanguage.sourceFileTypeEnum.includes(element)) {
+          if (extendedDescriptorLanguage.descriptorFileTypes.includes(element)) {
             descriptorTypes.push(extendedDescriptorLanguage.toolDescriptorEnum);
           }
         });
@@ -55,7 +55,7 @@ export class DescriptorService {
     if (version && version.validations) {
       extendedDescriptorLanguages.forEach(extendedDescriptorLanguage => {
         const cwlValidation = version.validations.find(validation => {
-          return extendedDescriptorLanguage.sourceFileTypeEnum.includes(validation.type);
+          return extendedDescriptorLanguage.descriptorFileTypes.includes(validation.type);
         });
         if (cwlValidation && cwlValidation.valid) {
           descriptorTypes.push(extendedDescriptorLanguage.toolDescriptorEnum);

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -23,7 +23,7 @@ import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { EntryType } from '../enum/entry-type';
 import { SessionQuery } from '../session/session.query';
-import { ToolDescriptor } from '../swagger';
+import { SourceFile, ToolDescriptor } from '../swagger';
 import { Workflow } from '../swagger/model/workflow';
 import { validationDescriptorPatterns } from '../validationMessages.model';
 import { MetadataService } from './../swagger/api/metadata.service';
@@ -71,7 +71,7 @@ export class DescriptorLanguageService {
     return foundExtendedDescriptorLanguageFromValue || extendedUnknownDescriptor;
   }
 
-  static toolDescriptorTypeEnumTotestParameterFileType(descriptorType: ToolDescriptor.TypeEnum): string | null {
+  static toolDescriptorTypeEnumTotestParameterFileType(descriptorType: ToolDescriptor.TypeEnum): SourceFile.TypeEnum | null {
     return this.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).testParameterFileType;
   }
 

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -76,13 +76,16 @@ export class DescriptorLanguageService {
   }
 
   static workflowDescriptorTypeEnumToShortFriendlyName(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum | null): string | null {
+    return this.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(workflowDescriptorTypeEnum).shortFriendlyName;
+  }
+
+  static workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(
+    descriptorType: Workflow.DescriptorTypeEnum | null
+  ): ExtendedDescriptorLanguageBean {
     const foundExtendedDescriptorLanguageFromValue = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === workflowDescriptorTypeEnum
+      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === descriptorType
     );
-    if (foundExtendedDescriptorLanguageFromValue) {
-      return foundExtendedDescriptorLanguageFromValue.shortFriendlyName;
-    }
-    return extendedUnknownDescriptor.shortFriendlyName;
+    return foundExtendedDescriptorLanguageFromValue || extendedUnknownDescriptor;
   }
 
   update() {

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -59,16 +59,20 @@ export class DescriptorLanguageService {
     this.filteredDescriptorLanguages$ = combined$.pipe(map(combined => this.filterLanguages(combined[0], combined[1])));
   }
   static toolDescriptorTypeEnumToDefaultDescriptorPath(descriptorType: ToolDescriptor.TypeEnum | null): string | null {
-    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguage(descriptorType).defaultDescriptorPath;
+    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).defaultDescriptorPath;
   }
 
-  static toolDescriptorTypeEnumToExtendedDescriptorLanguage(
+  static toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(
     descriptorType: ToolDescriptor.TypeEnum | null
   ): ExtendedDescriptorLanguageBean {
     const foundExtendedDescriptorLanguageFromValue = extendedDescriptorLanguages.find(
       extendedDescriptorLanguage => extendedDescriptorLanguage.toolDescriptorEnum === descriptorType
     );
     return foundExtendedDescriptorLanguageFromValue || extendedUnknownDescriptor;
+  }
+
+  static toolDescriptorTypeEnumTotestParameterFileType(descriptorType: ToolDescriptor.TypeEnum): string | null {
+    return this.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).testParameterFileType;
   }
 
   static workflowDescriptorTypeEnumToShortFriendlyName(workflowDescriptorTypeEnum: Workflow.DescriptorTypeEnum | null): string | null {
@@ -151,7 +155,7 @@ export class DescriptorLanguageService {
    * @memberof DescriptorLanguageService
    */
   workflowDescriptorTypeEnumToPlaceholderDescriptor(descriptorType: ToolDescriptor.TypeEnum | null): string {
-    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguage(descriptorType).descriptorPathPlaceholder;
+    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).descriptorPathPlaceholder;
   }
 
   genericUnhandledTypeError(type: any): void {

--- a/src/app/shared/file-editing.ts
+++ b/src/app/shared/file-editing.ts
@@ -57,7 +57,8 @@ export class FileEditing extends Files {
         sourcefile.type === SourceFile.TypeEnum.NEXTFLOWCONFIG ||
         // DOCKSTORE-2428 - demo how to add new workflow language
         // sourcefile.type === SourceFile.TypeEnum.DOCKSTORESWL ||
-        sourcefile.type === SourceFile.TypeEnum.NEXTFLOW
+        sourcefile.type === SourceFile.TypeEnum.NEXTFLOW ||
+        sourcefile.type === SourceFile.TypeEnum.DOCKSTOREGXFORMAT2
     );
   }
 
@@ -73,7 +74,8 @@ export class FileEditing extends Files {
         sourcefile.type === SourceFile.TypeEnum.CWLTESTJSON ||
         // DOCKSTORE-2428 - demo how to add new workflow language
         // sourcefile.type === SourceFile.TypeEnum.SWLTESTJSON ||
-        sourcefile.type === SourceFile.TypeEnum.NEXTFLOWTESTPARAMS
+        sourcefile.type === SourceFile.TypeEnum.NEXTFLOWTESTPARAMS ||
+        sourcefile.type === SourceFile.TypeEnum.GXFORMAT2TESTFILE
     );
   }
 

--- a/src/app/shared/state/workflow.query.ts
+++ b/src/app/shared/state/workflow.query.ts
@@ -1,14 +1,11 @@
 import { Injectable } from '@angular/core';
 import { QueryEntity } from '@datorama/akita';
-import {
-  ExtendedDescriptorLanguageBean,
-  extendedDescriptorLanguages,
-  extendedUnknownDescriptor
-} from 'app/entry/extendedDescriptorLanguage';
+import { ExtendedDescriptorLanguageBean } from 'app/entry/extendedDescriptorLanguage';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DescriptorTypeCompatService } from '../descriptor-type-compat.service';
-import { ToolDescriptor, Workflow } from '../swagger';
+import { DescriptorLanguageService } from '../entry/descriptor-language.service';
+import { ToolDescriptor } from '../swagger';
 import { BioWorkflow } from '../swagger/model/bioWorkflow';
 import { Service } from '../swagger/model/service';
 import { WorkflowState, WorkflowStore } from './workflow.store';
@@ -29,7 +26,7 @@ export class WorkflowQuery extends QueryEntity<WorkflowState, Service | BioWorkf
     )
   );
   public extendedDescriptorLanguageBean$: Observable<ExtendedDescriptorLanguageBean> = this.workflow$.pipe(
-    map(workflow => this.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(workflow.descriptorType))
+    map(workflow => DescriptorLanguageService.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(workflow.descriptorType))
   );
   public launchSupport$: Observable<boolean> = this.extendedDescriptorLanguageBean$.pipe(
     map(extendedDescriptorLanguage => extendedDescriptorLanguage.workflowLaunchSupport)
@@ -42,25 +39,5 @@ export class WorkflowQuery extends QueryEntity<WorkflowState, Service | BioWorkf
   );
   constructor(protected store: WorkflowStore, private descriptorTypeCompatService: DescriptorTypeCompatService) {
     super(store);
-  }
-
-  /**
-   * Converts the Workflow.DescriptorTypeEnum to the ExtendedDescriptorLanguage that's used throughout the frontend
-   *
-   * @private
-   * @param {Workflow.DescriptorTypeEnum} descriptorType  Typically the "workflow.descriptorType"
-   * @returns {ExtendedDescriptorLanguageBean}  ExtendedDescriptorLanguage that's used throughout
-   * @memberof WorkflowQuery
-   */
-  private workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(
-    descriptorType: Workflow.DescriptorTypeEnum
-  ): ExtendedDescriptorLanguageBean {
-    const foundextendedDescriptorLanguageFromValue = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === descriptorType
-    );
-    if (foundextendedDescriptorLanguageFromValue) {
-      return foundextendedDescriptorLanguageFromValue;
-    }
-    return extendedUnknownDescriptor;
   }
 }

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
@@ -17,7 +17,6 @@ import { AfterViewChecked, Component, OnDestroy, OnInit, ViewChild } from '@angu
 import { NgForm } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatRadioChange } from '@angular/material/radio';
-import { extendedDescriptorLanguages, extendedUnknownDescriptor } from 'app/entry/extendedDescriptorLanguage';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { SessionQuery } from 'app/shared/session/session.query';
 import { Observable, Subject } from 'rxjs';
@@ -168,13 +167,7 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
   }
 
   getWorkflowPathPlaceholder(descriptorType: Workflow.DescriptorTypeEnum): string {
-    const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === descriptorType
-    );
-    if (foundExtendedDescriptorLanguage) {
-      return foundExtendedDescriptorLanguage.descriptorPathPlaceholder;
-    }
-    return extendedUnknownDescriptor.descriptorPathPlaceholder;
+    return DescriptorLanguageService.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).descriptorPathPlaceholder;
   }
 
   formChanged() {
@@ -241,15 +234,9 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
    * @memberof RegisterWorkflowModalComponent
    */
   changeDescriptorType(descriptorType: Workflow.DescriptorTypeEnum): void {
-    const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.workflowDescriptorEnum === descriptorType
-    );
-    if (foundExtendedDescriptorLanguage) {
-      this.descriptorValidationPattern = foundExtendedDescriptorLanguage.descriptorPathPattern;
-    } else {
-      this.descriptorValidationPattern = '.*';
-    }
-    console.log(this.workflow.descriptorType);
+    this.descriptorValidationPattern = DescriptorLanguageService.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(
+      descriptorType
+    ).descriptorPathPattern;
     this.workflowPathPlaceholder = this.getWorkflowPathPlaceholder(this.workflow.descriptorType);
   }
 

--- a/src/app/workflow/tool-tab/tool-tab.service.ts
+++ b/src/app/workflow/tool-tab/tool-tab.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { extendedDescriptorLanguages, extendedUnknownDescriptor } from 'app/entry/extendedDescriptorLanguage';
+import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { ToolDescriptor } from '../../shared/swagger';
 
 @Injectable({
@@ -16,13 +16,7 @@ export class ToolTabService {
    * @memberof ToolTabService
    */
   descriptorTypeToHeaderName(descriptorType: ToolDescriptor.TypeEnum): string {
-    const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.toolDescriptorEnum === descriptorType
-    );
-    if (foundExtendedDescriptorLanguage) {
-      return foundExtendedDescriptorLanguage.toolTab.workflowStepHeader;
-    }
-    return extendedUnknownDescriptor.toolTab.workflowStepHeader;
+    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).toolTab.workflowStepHeader;
   }
 
   /**
@@ -34,12 +28,6 @@ export class ToolTabService {
    * @memberof ToolTabService
    */
   descriptorTypeToWorkflowExcerptRowHeading(descriptorType: ToolDescriptor.TypeEnum): string {
-    const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
-      extendedDescriptorLanguage => extendedDescriptorLanguage.toolDescriptorEnum === descriptorType
-    );
-    if (foundExtendedDescriptorLanguage) {
-      return foundExtendedDescriptorLanguage.toolTab.rowIdentifier;
-    }
-    return extendedUnknownDescriptor.toolTab.rowIdentifier;
+    return DescriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).toolTab.rowIdentifier;
   }
 }


### PR DESCRIPTION
Support hosted Galaxy workflows.

Kept logic mostly the same.
Moved functions into a service.
Add tests (~92% coverage).
Ran strictNullChecks on the file (which is why it looks so complicated)
A lot of the existing logic is odd. but for better or worse, keeping it the same for now.