### PR TITLE
Add logout page

### DIFF
--- a/cypress/integration/immutableDatabaseTests/dropdown.ts
+++ b/cypress/integration/immutableDatabaseTests/dropdown.ts
@@ -281,7 +281,7 @@ describe('Dropdown test', () => {
       cy.contains('Yes, delete my account')
         .should('not.be.disabled')
         .click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/login');
+      cy.url().should('eq', Cypress.config().baseUrl + '/logout');
     });
     it('Should have the change username button enabled', () => {
       cy.contains('Update Username').should('not.be.disabled');

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { DownloadCLIClientComponent } from './loginComponents/onboarding/downloa
 import { OnboardingComponent } from './loginComponents/onboarding/onboarding.component';
 import { QuickStartComponent } from './loginComponents/onboarding/quickstart.component';
 import { RequestsModule } from './loginComponents/requests.module';
+import { LogoutComponent } from './logout/logout.component';
 import { MaintenanceComponent } from './maintenance/maintenance.component';
 import { MetadataService } from './metadata/metadata.service';
 import { NavbarComponent } from './navbar/navbar.component';
@@ -150,7 +151,8 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     GithubCallbackComponent,
     ConfirmationDialogComponent,
     SessionExpiredComponent,
-    TosBannerComponent
+    TosBannerComponent,
+    LogoutComponent
   ],
   imports: [
     environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -23,6 +23,7 @@ import { AccountsComponent } from './loginComponents/accounts/accounts.component
 import { AuthComponent } from './loginComponents/auth/auth.component';
 import { OnboardingComponent } from './loginComponents/onboarding/onboarding.component';
 import { QuickStartComponent } from './loginComponents/onboarding/quickstart.component';
+import { LogoutComponent } from './logout/logout.component';
 import { MaintenanceComponent } from './maintenance/maintenance.component';
 import { SessionExpiredComponent } from './session-expired/session-expired.component';
 import { AuthGuard } from './shared/auth.guard';
@@ -100,6 +101,7 @@ const APP_ROUTES: Routes = [
     data: { title: 'Dockstore | Search' }
   },
   { path: 'login', component: LoginComponent, data: { title: 'Dockstore | Login' } },
+  { path: 'logout', component: LogoutComponent, data: { title: 'Dockstore | Logout' } },
   { path: 'session-expired', component: SessionExpiredComponent, data: { title: 'Dockstore | Session Expired' } },
   { path: 'quick-start', component: QuickStartComponent, data: { title: 'Dockstore | Quick Start' } },
   { path: 'onboarding', component: OnboardingComponent, canActivate: [AuthGuard], data: { title: 'Dockstore | Onboarding' } },

--- a/src/app/logout/logout.component.html
+++ b/src/app/logout/logout.component.html
@@ -20,8 +20,7 @@
   <div class="column">
     <p class="lead">
       You have logged out of Dockstore. Note that if you are still logged into GitHub or Google, a user may be able to log back into
-      Dockstore without being prompted for credentials. If on a public computer, we recommend also signing out of GitHub and Google. Click
-      <a routerLink="/login">here</a> to login again.
+      Dockstore without being prompted for credentials. If on a public computer, we recommend also signing out of GitHub and Google.
     </p>
   </div>
 </div>

--- a/src/app/logout/logout.component.html
+++ b/src/app/logout/logout.component.html
@@ -16,11 +16,13 @@
 <app-header>
   Logged Out
 </app-header>
-<div class="container">
-  <div class="column">
-    <p class="lead">
+<div fxLayout="column" style="padding: 2rem;">
+  <div fxLayout="row">
+    <div fxFlex="20%"></div>
+    <div fxFlex="60%" class="mat-h3">
       You have logged out of Dockstore. Note that if you are still logged into GitHub or Google, a user may be able to log back into
       Dockstore without being prompted for credentials. If on a public computer, we recommend also signing out of GitHub and Google.
-    </p>
+    </div>
+    <div fxFlex="20%"></div>
   </div>
 </div>

--- a/src/app/logout/logout.component.html
+++ b/src/app/logout/logout.component.html
@@ -1,0 +1,27 @@
+<!--
+   Copyright 2020 OICR
+ *
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ *
+       http://www.apache.org/licenses/LICENSE-2.0
+ *
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<app-header>
+  Logged Out
+</app-header>
+<div class="container">
+  <div class="column">
+    <p class="lead">
+      You have logged out of Dockstore. Note that if you are still logged into GitHub or Google, a user may be able to log back into
+      Dockstore without being prompted for credentials. If on a public computer, we recommend also signing out of GitHub and Google. Click
+      <a routerLink="/login">here</a> to login again.
+    </p>
+  </div>
+</div>

--- a/src/app/logout/logout.component.spec.ts
+++ b/src/app/logout/logout.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LogoutComponent } from './logout.component';
+
+describe('LogoutComponent', () => {
+  let component: LogoutComponent;
+  let fixture: ComponentFixture<LogoutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [LogoutComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LogoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/logout/logout.component.spec.ts
+++ b/src/app/logout/logout.component.spec.ts
@@ -1,6 +1,13 @@
+import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LogoutComponent } from './logout.component';
+
+@Component({
+  selector: 'app-header',
+  template: ''
+})
+class HeaderComponent {}
 
 describe('LogoutComponent', () => {
   let component: LogoutComponent;
@@ -8,7 +15,7 @@ describe('LogoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [LogoutComponent]
+      declarations: [LogoutComponent, HeaderComponent]
     }).compileComponents();
   }));
 

--- a/src/app/logout/logout.component.ts
+++ b/src/app/logout/logout.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-logout',
+  templateUrl: './logout.component.html',
+  styleUrls: ['./logout.component.scss']
+})
+export class LogoutComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/shared/logout.service.ts
+++ b/src/app/shared/logout.service.ts
@@ -17,7 +17,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from 'ng2-ui-auth';
 
-import { TrackLoginService } from '../shared/track-login.service';
+import { TrackLoginService } from './track-login.service';
 import { UserService } from './user/user.service';
 
 @Injectable()
@@ -34,7 +34,7 @@ export class LogoutService {
       complete: () => {
         this.userService.remove();
         this.trackLoginService.switchState(false);
-        routeChange ? this.router.navigate([routeChange]) : this.router.navigate(['/login']);
+        routeChange ? this.router.navigate([routeChange]) : this.router.navigate(['/logout']);
       }
     });
   }

--- a/src/app/shared/track-login.service.ts
+++ b/src/app/shared/track-login.service.ts
@@ -23,14 +23,8 @@ export class TrackLoginService {
   private isLoggedIn: Subject<boolean> = new BehaviorSubject(this.authService.isAuthenticated());
   isLoggedIn$ = this.isLoggedIn.asObservable();
 
-  dockstoreToken: string;
-
   constructor(private authService: AuthService) {}
   switchState(state: boolean) {
     this.isLoggedIn.next(state);
-
-    if (state) {
-      this.dockstoreToken = this.authService.getToken();
-    }
   }
 }


### PR DESCRIPTION
dockstore/dockstore#3363

Verbiage warns user that they may not be as logged out as they think.

In looking at code to understand how to do this, noticed an unused field
in track-login.service.ts, so removed it. Also took IDE recommendation
to shorten an import.

![Screen Shot 2020-04-30 at 1 13 51 PM](https://user-images.githubusercontent.com/1049340/80754788-7fd40780-8ae4-11ea-9009-27572dfcb1c3.png)

