### PR TITLE
Feature/3410/change dockstore yml file tab

### DIFF
--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -67,7 +67,7 @@
     </div>
     <mat-card class="alert alert-warning" role="alert" *ngIf="!content">
       <mat-icon>warning</mat-icon>
-      &nbsp;A Descriptor File associated with this workflow could not be found.
+      &nbsp;A {{ !otherFiles ? 'Descriptor File' : 'Configuration File' }} associated with this workflow could not be found.
     </mat-card>
   </ng-template>
 </div>

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -35,6 +35,7 @@ import { FilesService } from '../files/state/files.service';
 export class DescriptorsWorkflowComponent extends EntryFileSelector {
   @Input() id: number;
   @Input() entrypath: string;
+  @Input() otherFiles: boolean;
   @Input() set selectedVersion(value: WorkflowVersion) {
     this.onVersionChange(value);
     this.checkIfValid(true, value);
@@ -72,9 +73,13 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
    * @memberof DescriptorsWorkflowComponent
    */
   getFiles(descriptorType: ToolDescriptor.TypeEnum): Observable<Array<ToolFile>> {
-    return this.gA4GHFilesQuery.getToolFiles(descriptorType, [
-      ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR,
-      ToolFile.FileTypeEnum.SECONDARYDESCRIPTOR
-    ]);
+    if (this.otherFiles) {
+      return this.gA4GHFilesQuery.getToolFiles(descriptorType, [ToolFile.FileTypeEnum.OTHER]);
+    } else {
+      return this.gA4GHFilesQuery.getToolFiles(descriptorType, [
+        ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR,
+        ToolFile.FileTypeEnum.SECONDARYDESCRIPTOR
+      ]);
+    }
   }
 }

--- a/src/app/workflow/files/files.component.html
+++ b/src/app/workflow/files/files.component.html
@@ -18,12 +18,19 @@
   <!-- Keep this as lazy loaded -->
   <mat-tab label="Descriptor Files">
     <ng-template matTabContent>
-      <app-descriptors-workflow [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion"> </app-descriptors-workflow>
+      <app-descriptors-workflow [entrypath]="entrypath" [id]="id" [otherFiles]="false" [selectedVersion]="selectedVersion">
+      </app-descriptors-workflow>
     </ng-template>
   </mat-tab>
   <mat-tab label="Test Parameter Files">
     <ng-template matTabContent>
       <app-paramfiles-workflow [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion"> </app-paramfiles-workflow>
+    </ng-template>
+  </mat-tab>
+  <mat-tab label="Configuration">
+    <ng-template matTabContent>
+      <app-descriptors-workflow [entrypath]="entrypath" [id]="id" [otherFiles]="true" [selectedVersion]="selectedVersion">
+      </app-descriptors-workflow>
     </ng-template>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/workflow/files/files.component.ts
+++ b/src/app/workflow/files/files.component.ts
@@ -31,6 +31,7 @@ export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
   versionsWithParamfiles: Array<any>;
   previousEntryPath: string;
   previousVersionName: string;
+
   constructor(private paramfilesService: ParamfilesService) {
     super();
   }

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -248,7 +248,12 @@
                     <ng-container *ngTemplateOutlet="hostedComponent"></ng-container>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML">
-                    <ng-container *ngTemplateOutlet="oldComponent"></ng-container>
+                    <div *ngIf="workflow.descriptorType === WorkflowModel.DescriptorTypeEnum.Service">
+                      <ng-container *ngTemplateOutlet="newComponent"></ng-container>
+                    </div>
+                    <div *ngIf="workflow.descriptorType !== WorkflowModel.DescriptorTypeEnum.Service">
+                      <ng-container *ngTemplateOutlet="oldComponent"></ng-container>
+                    </div>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.FULL">
                     <!-- For old languages, we use the old files component because it's well tested, for new unknown languages, use the new component -->

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -248,7 +248,7 @@
                     <ng-container *ngTemplateOutlet="hostedComponent"></ng-container>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML">
-                    <ng-container *ngTemplateOutlet="newComponent"></ng-container>
+                    <ng-container *ngTemplateOutlet="oldComponent"></ng-container>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.FULL">
                     <!-- For old languages, we use the old files component because it's well tested, for new unknown languages, use the new component -->


### PR DESCRIPTION
Services use the new TRS component (matches prod) and Workflows with a dockstore.yml use the existing component. Modified the descriptor component to also work with OTHER files. In this case, OTHER is the dockstore.yml.

https://github.com/dockstore/dockstore/issues/3410