### PR TITLE
add help link to toolbar

### DIFF
--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -29,6 +29,9 @@
         <a mat-button class="icon" href="{{ Dockstore.DOCUMENTATION_URL }}" target="_blank" rel="noopener noreferrer">
           <img class="site-icons-small hidden-sm" src="../assets/images/dockstore/dockstore-documentation.png" alt="stacked pages" /> Docs
         </a>
+        <a mat-button class="icon" href="{{ Dockstore.DISCOURSE_URL }}" target="_blank" rel="noopener noreferrer">
+          <mat-icon class="hidden-sm">help_outline</mat-icon> Help
+        </a>
         <span class="spacer"></span>
         <a *ngIf="!isLoggedIn" mat-raised-button color="accent" routerLink="/login">Login</a>
         <template [ngTemplateOutlet]="loginButton"></template>


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3461

Adds a permanent link to the forum directly in the toolbar.
![Screen Shot 2020-05-07 at 3 34 52 PM](https://user-images.githubusercontent.com/6331159/81337488-10788d80-9079-11ea-954e-1c4bf24650b5.png)
