### PR TITLE
Use backend verification status

### DIFF
--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -40,7 +40,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
-        <a *ngIf="getVerified(tool)" href="{{ verifiedLink }}">
+        <a *ngIf="tool.verified" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">check</mat-icon>
         </a>
       </mat-cell>

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -31,8 +31,4 @@ export class SearchToolTableComponent extends SearchEntryTable implements OnInit
   privateNgOnInit(): Observable<Array<DockstoreTool>> {
     return this.searchQuery.tools$;
   }
-
-  getVerified(tool: DockstoreTool): boolean {
-    return this.dockstoreService.getVersionVerified(tool.workflowVersions);
-  }
 }

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { Observable } from 'rxjs';
 import { DateService } from '../../shared/date.service';
-import { DockstoreService } from '../../shared/dockstore.service';
 import { DockstoreTool } from '../../shared/swagger';
 import { SearchEntryTable } from '../search-entry-table';
 import { SearchQuery } from '../state/search.query';
@@ -19,12 +18,7 @@ import { SearchService } from '../state/search.service';
 })
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<DockstoreTool>;
-  constructor(
-    private dockstoreService: DockstoreService,
-    dateService: DateService,
-    searchQuery: SearchQuery,
-    searchService: SearchService
-  ) {
+  constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
     super(dateService, searchQuery, searchService);
   }
 

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -23,7 +23,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">
-        <a *ngIf="getVerified(workflow)" href="{{ verifiedLink }}">
+        <a *ngIf="workflow.verified" href="{{ verifiedLink }}">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -46,8 +46,4 @@ export class SearchWorkflowTableComponent extends SearchEntryTable implements On
   privateNgOnInit(): Observable<Array<Workflow>> {
     return this.searchQuery.workflows$;
   }
-
-  getVerified(workflow: Workflow): boolean {
-    return this.dockstoreService.getVersionVerified(workflow.workflowVersions);
-  }
 }

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -17,7 +17,6 @@ import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { Observable } from 'rxjs';
 import { DateService } from '../../shared/date.service';
-import { DockstoreService } from '../../shared/dockstore.service';
 import { Workflow } from '../../shared/swagger';
 import { SearchEntryTable } from '../search-entry-table';
 import { SearchQuery } from '../state/search.query';
@@ -34,12 +33,7 @@ import { SearchService } from '../state/search.service';
 })
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<Workflow>;
-  constructor(
-    private dockstoreService: DockstoreService,
-    dateService: DateService,
-    searchQuery: SearchQuery,
-    searchService: SearchService
-  ) {
+  constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
     super(dateService, searchQuery, searchService);
   }
 


### PR DESCRIPTION
Elasticsearch actually returns an object type that is NOT DockstoreTool or Workflow.  This object actually has verification status of the entry.  Simply using that instead.

For https://ucsc-cgl.atlassian.net/browse/SEAB-440

