### PR TITLE
Feature/3454/collection page loading bar

### DIFF
--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -18,7 +18,7 @@
   Collections
 </app-header>
 <!-- Beware of double loading bar (from page and from loading component) -->
-<app-loading [loading]="(loadingCollection$ | async) && (loadingOrganization$ | async)">
+<app-loading [loading]="(loadingCollection$ | async) || (loadingOrganization$ | async)">
   <div *ngIf="organization$ | async as organization">
     <div class="container" *ngIf="collection$ | async as collection" fxLayout="column">
       <mat-card fxFlex class="my-3 alert alert-info" *ngIf="organization?.status === pendingEnum">

--- a/src/app/organizations/collection/collection.component.ts
+++ b/src/app/organizations/collection/collection.component.ts
@@ -77,7 +77,6 @@ export class CollectionComponent implements OnInit {
     this.canEdit$ = this.organizationQuery.canEdit$;
     this.organization$ = this.organizationQuery.organization$;
     this.gravatarUrl$ = this.organizationQuery.gravatarUrl$;
-    this.organizationService.updateOrganizationFromName(organizationName);
     this.collectionsService.updateCollectionFromName(organizationName, collectionName);
     this.isAdmin$ = this.userQuery.isAdmin$;
     this.isCurator$ = this.userQuery.isCurator$;


### PR DESCRIPTION
Two changes:

1. Originally the collections page was: getting the organization by name at the same time as getting collection by name, then using that collection (which has organization ID) to get the organization by Id again followed by other stuff.  I removed the get organization by name.
2. Made the loading bar either/or, haven't really noticed double loading bar especially since