### PR TITLE
partial github app feedback

### DIFF
--- a/src/app/entry/entry-file-tab/entry-file-tab.component.html
+++ b/src/app/entry/entry-file-tab/entry-file-tab.component.html
@@ -19,7 +19,7 @@
           <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">
             <mat-form-field *ngIf="selectedFile$ | async as selected" class="w-50">
               <mat-select [value]="selected" (selectionChange)="matSelectChange($event)">
-                <mat-option [value]="file" *ngFor="let file of files$ | async"> {{ file.path }} </mat-option>
+                <mat-option [value]="file" *ngFor="let file of files$ | async"> {{ file.path | filePathPipe }} </mat-option>
               </mat-select>
             </mat-form-field>
             <span>

--- a/src/app/entry/file-path.pipe.ts
+++ b/src/app/entry/file-path.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+/*
+ * File paths are show relative to the primary descriptor, but the .dockstore.yml file can only ever be in one place
+ * so only display it as /.dockstore.yml
+ */
+@Pipe({ name: 'filePathPipe' })
+export class FilePathPipe implements PipeTransform {
+  transform(filePath: String): String {
+    if (filePath.endsWith('.dockstore.yml')) {
+      return '/.dockstore.yml';
+    }
+    return filePath;
+  }
+}

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { GithubNameToIdPipe } from 'app/github-name-to-id.pipe';
+import { FilePathPipe } from '../../entry/file-path.pipe';
 import { TimeAgoMsgPipe } from '../../organizations/organization/time-ago-msg.pipe';
 import { MapFriendlyValuesPipe } from '../../search/map-friendly-values.pipe';
 import { SelectTabPipe } from '../entry/select-tab.pipe';
 
-const DECLARATIONS: any[] = [MapFriendlyValuesPipe, SelectTabPipe, TimeAgoMsgPipe, GithubNameToIdPipe];
+const DECLARATIONS: any[] = [FilePathPipe, MapFriendlyValuesPipe, SelectTabPipe, TimeAgoMsgPipe, GithubNameToIdPipe];
 @NgModule({
   imports: [CommonModule],
   declarations: DECLARATIONS,

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -63,8 +63,6 @@
             type="button"
             color="primary"
             [href]="gitHubAppInstallationLink$ | async"
-            target="_blank"
-            rel="noopener noreferrer"
             matTooltip="Manage Dockstore Installations on GitHub"
             ><mat-icon>add</mat-icon> Manage Dockstore Installations on GitHub</a
           >


### PR DESCRIPTION
dockstore/dockstore#3490
https://docs.google.com/document/d/1cJDSe4TSBdkZ-rt6nlxGGHPuh-W8t39BQlDw487Uzhg/edit

Addressed some of the comments Charles made
- Don't open GitHub installations page in new tab
- only ever display /.dockstore.yml as its path
- We decided the dialog pop up didn't make sense so not doing that

I didn't see an obvious way to change the default files tab, but I can look more into it if others agree with the comment.
