### PR TITLE
broken loading gif

### DIFF
--- a/src/app/loginComponents/auth/auth.component.html
+++ b/src/app/loginComponents/auth/auth.component.html
@@ -1,5 +1,5 @@
 <div class="container">
   <div class="absCenter">
-    <img src="/assets/images/dockstore/loading.gif" />
+    <img src="../../../assets/images/dockstore/loading.gif" />
   </div>
 </div>


### PR DESCRIPTION
dockstore/dockstore#3446
https://github.com/dockstore/dockstore-ui2/blob/develop/.circleci/config.yml#L178
The src for this image only had a `/` in front so it was not being picked up by the regex above so the image wasn't being served by gui.dockstore.org
