### PR TITLE
Feature/3458/remove ngx bs popover and dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11976,11 +11976,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "ngx-bootstrap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.0.1.tgz",
-      "integrity": "sha512-ni91yYtn8ldgf/pxrlwl9lkVcLURGzopSpJnEbbgG1v1EZWTobI8y7J3mx4Kxptkn0EeiQwnLel67G7XJSox4A=="
-    },
     "ngx-clipboard": {
       "version": "12.2.1",
       "resolved": "https://registry.npmjs.org/ngx-clipboard/-/ngx-clipboard-12.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,6 +1859,7 @@
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -1868,6 +1869,7 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
           "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.6.0",
             "jsesc": "^2.5.1",
@@ -1889,7 +1891,8 @@
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
           "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "@babel/template": {
           "version": "7.6.0",
@@ -1926,6 +1929,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1937,6 +1941,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1945,7 +1950,8 @@
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
           "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json5": {
           "version": "2.1.0",
@@ -1968,7 +1974,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1998,6 +2005,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -2088,6 +2096,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2317,6 +2326,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.4.4"
       },
@@ -2326,6 +2336,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2339,6 +2350,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
       "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.5.5"
       },
@@ -2348,6 +2360,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2361,6 +2374,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -2370,6 +2384,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
       "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
@@ -2384,6 +2399,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -2392,7 +2408,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@babel/helper-regex": {
       "version": "7.4.3",
@@ -2409,6 +2426,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-wrap-function": "^7.1.0",
@@ -2422,6 +2440,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
       "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
@@ -2434,6 +2453,7 @@
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -2443,6 +2463,7 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
           "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.6.0",
             "jsesc": "^2.5.1",
@@ -2455,6 +2476,7 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
           "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.4.4"
           }
@@ -2463,13 +2485,15 @@
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
           "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "@babel/traverse": {
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
           "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.6.2",
@@ -2487,6 +2511,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2498,6 +2523,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2506,13 +2532,15 @@
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
           "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2521,6 +2549,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/template": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -2540,6 +2569,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/template": "^7.1.0",
@@ -2586,7 +2616,8 @@
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
           "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "@babel/template": {
           "version": "7.6.0",
@@ -2635,6 +2666,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -2845,6 +2877,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2854,6 +2887,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2863,6 +2897,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2889,6 +2924,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -2898,6 +2934,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -3232,6 +3269,7 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
           "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -3838,6 +3876,14 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@material-extended/mde": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@material-extended/mde/-/mde-2.3.1.tgz",
+      "integrity": "sha512-UFbeOcfgpDxn3TRIVOMLOfXuIZOfu2cwnxFj0SSCY+s+2PPt7Oz/B7Ru2iZvekLbw6YXkRlx24O0h7Fm6gUwoQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "@ngtools/webpack": {
       "version": "8.3.25",
@@ -6066,7 +6112,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -8363,7 +8410,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8381,11 +8429,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8398,15 +8448,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8509,7 +8562,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8519,6 +8573,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8531,17 +8586,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8558,6 +8616,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8630,7 +8689,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8640,6 +8700,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8715,7 +8776,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8745,6 +8807,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8762,6 +8825,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8800,11 +8864,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "font-awesome": "^4.7.0",
     "jquery": "^3.4.0",
     "ng2-ui-auth": "^10.0.1",
-    "ngx-bootstrap": "^3.0.1",
     "ngx-clipboard": "^12.2.1",
     "ngx-markdown": "^8.1.0",
     "pipeline-builder": "^0.3.10-dev.313",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
+    "@material-extended/mde": "^2.3.1",
     "@ngx-lite/json-ld": "^0.6.2",
     "@ngx-share/button": "^7.1.4",
     "@ngx-share/buttons": "^7.1.4",

--- a/src/app/aliases/aliases.module.ts
+++ b/src/app/aliases/aliases.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { AlertModule } from 'ngx-bootstrap';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HeaderModule } from '../shared/modules/header.module';
 import { CustomMaterialModule } from '../shared/modules/material.module';
@@ -9,7 +8,7 @@ import { AliasesComponent } from './aliases.component';
 import { AliasesRouting } from './aliases.routing';
 
 @NgModule({
-  imports: [CommonModule, AlertModule.forRoot(), HeaderModule, AliasesRouting, CustomMaterialModule, RefreshAlertModule, FlexLayoutModule],
+  imports: [CommonModule, HeaderModule, AliasesRouting, CustomMaterialModule, RefreshAlertModule, FlexLayoutModule],
   declarations: [AliasesComponent],
   exports: [AliasesComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,11 +24,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AkitaNgDevtools } from '@datorama/akita-ngdevtools';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { AuthService, Ng2UiAuthModule } from 'ng2-ui-auth';
-import { AccordionModule } from 'ngx-bootstrap/accordion';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 import { MarkdownModule } from 'ngx-markdown';
 import { environment } from '../environments/environment';
@@ -92,7 +87,6 @@ import { RefreshService } from './shared/refresh.service';
 import { ApiModule } from './shared/swagger/api.module';
 import { GA4GHService } from './shared/swagger/api/gA4GH.service';
 import { Configuration } from './shared/swagger/configuration';
-import { getTooltipConfig } from './shared/tooltip';
 import { TrackLoginService } from './shared/track-login.service';
 import { TwitterService } from './shared/twitter.service';
 import { UrlResolverService } from './shared/url-resolver.service';
@@ -164,10 +158,6 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     HeaderModule,
     ListContainersModule,
     ListWorkflowsModule,
-    BsDropdownModule.forRoot(),
-    AccordionModule.forRoot(),
-    TabsModule.forRoot(),
-    TooltipModule.forRoot(),
     ClipboardModule,
     OrderByModule,
     FlexLayoutModule,
@@ -175,7 +165,6 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     OrganizationStarringModule,
     OrganizationStargazersModule,
     routing,
-    ModalModule.forRoot(),
     StargazersModule,
     MarkdownModule.forRoot(),
     ReactiveFormsModule,
@@ -188,7 +177,6 @@ export function configurationServiceFactory(configurationService: ConfigurationS
   ],
   providers: [
     AccountsService,
-    { provide: TooltipConfig, useFactory: getTooltipConfig },
     AuthService,
     LoginService,
     RegisterService,

--- a/src/app/home-page/home-logged-in/home-logged-in.component.spec.ts
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.spec.ts
@@ -5,7 +5,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TabsModule } from 'ngx-bootstrap';
 import { TwitterService } from '../../shared/twitter.service';
 import { HomeLoggedInComponent } from './home-logged-in.component';
 
@@ -17,7 +16,7 @@ describe('HomeLoggedInComponent', () => {
     TestBed.configureTestingModule({
       declarations: [HomeLoggedInComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [TabsModule.forRoot(), RouterTestingModule, MatButtonModule, MatIconModule, MatDialogModule],
+      imports: [RouterTestingModule, MatButtonModule, MatIconModule, MatDialogModule],
       providers: [TwitterService]
     }).compileComponents();
   }));

--- a/src/app/home-page/home-logged-out/home.component.spec.ts
+++ b/src/app/home-page/home-logged-out/home.component.spec.ts
@@ -19,7 +19,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TwitterService } from '../../shared/twitter.service';
 import { HomeComponent } from './home.component';
 
@@ -31,7 +30,7 @@ describe('HomeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [TabsModule.forRoot(), CustomMaterialModule, RouterTestingModule, HttpClientTestingModule],
+      imports: [CustomMaterialModule, RouterTestingModule, HttpClientTestingModule],
       providers: [TwitterService, DescriptorLanguageService]
     }).compileComponents();
   }));

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -11,7 +11,6 @@ import { EntryToDisplayNamePipe } from 'app/shared/entry-to-display-name.pipe';
 import { ListContainersModule } from 'app/shared/modules/list-containers.module';
 import { ListWorkflowsModule } from 'app/shared/modules/list-workflows.module';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
-import { TabsModule } from 'ngx-bootstrap';
 import { MarkdownModule } from 'ngx-markdown';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HomePageComponent } from './home-page.component';
@@ -32,9 +31,7 @@ import { RequestsComponent } from './widget/requests/requests.component';
     RouterModule,
     ListWorkflowsModule,
     ListContainersModule,
-    TabsModule,
     FormsModule,
-    TabsModule,
     HttpClientModule,
     RefreshAlertModule,
     MarkdownModule

--- a/src/app/mytools/mytools.module.ts
+++ b/src/app/mytools/mytools.module.ts
@@ -26,7 +26,6 @@ import { RegisterToolComponent } from './../container/register-tool/register-too
 import { RegisterToolService } from './../container/register-tool/register-tool.service';
 import { AccountsService } from './../loginComponents/accounts/external/accounts.service';
 import { CustomMaterialModule } from './../shared/modules/material.module';
-import { getTooltipConfig } from './../shared/tooltip';
 import { MyToolComponent } from './my-tool/my-tool.component';
 import { MyToolsComponent } from './mytools.component';
 import { mytoolsRouting } from './mytools.routing';

--- a/src/app/search/advancedsearch/advancedsearch.component.html
+++ b/src/app/search/advancedsearch/advancedsearch.component.html
@@ -25,17 +25,17 @@
   <div mat-dialog-actions class="form-horizontal dialog-actions mb-0">
     Find tools and workflows with
     <span *ngIf="searchMode === 'description'"> a </span>
-    <span class="btn-group" dropdown>
-      <button dropdownToggle type="button" class="btn btn-secondary dropdown-toggle">{{ searchMode }} <span class="caret"></span></button>
-      <ul *dropdownMenu class="dropdown-menu" role="menu">
-        <li *ngIf="searchMode !== 'description'" role="menuitem">
-          <a class="dropdown-item" (click)="switchSearchMode('description')">description</a>
-        </li>
-        <li *ngIf="searchMode !== 'files'" role="menuitem">
-          <a class="dropdown-item" (click)="switchSearchMode('files')">files</a>
-        </li>
-      </ul>
-    </span>
+    <mat-form-field>
+      <mat-label class="dropdown-display"> {{ searchMode }} </mat-label>
+      <mat-select>
+        <a *ngIf="searchMode !== 'description'">
+          <mat-option class="dropdown-item" (click)="switchSearchMode('description')">description</mat-option>
+        </a>
+        <a *ngIf="searchMode !== 'files'">
+          <mat-option class="dropdown-item" (click)="switchSearchMode('files')">files</mat-option>
+        </a>
+      </mat-select>
+    </mat-form-field>
     that
     <span *ngIf="searchMode === 'description'"> has </span>
     <span *ngIf="searchMode === 'files'"> have </span>

--- a/src/app/search/advancedsearch/advancedsearch.component.scss
+++ b/src/app/search/advancedsearch/advancedsearch.component.scss
@@ -17,3 +17,8 @@
 .dialog-actions {
   display: block;
 }
+
+.dropdown-display {
+  display: block;
+  text-align: center;
+}

--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -19,7 +19,6 @@ import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TagCloudModule } from 'angular-tag-cloud-module';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { QueryBuilderStubService, SearchStubService } from './../../test/service-stubs';
 import { QueryBuilderService } from './../query-builder.service';
 
@@ -35,7 +34,7 @@ describe('SearchResultsComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SearchResultsComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [TabsModule.forRoot(), TagCloudModule, RouterTestingModule],
+      imports: [TagCloudModule, RouterTestingModule],
       providers: [
         { provide: SearchService, useClass: SearchStubService },
         { provide: QueryBuilderService, useClass: QueryBuilderStubService }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -142,35 +142,35 @@
           >
         </mat-card>
 
+        <mde-popover #appPopover="mdePopover" [mdePopoverOverlapTrigger]="false">
+          <mat-card class="row">
+            <div>Link to this page</div>
+            <div class="input-group" style="padding:5px;">
+              <input type="text" class="form-control" [value]="shortUrl$ | async" readonly />
+              <span class="input-group-btn">
+                <button
+                  class="btn btn-default"
+                  [ngClass]="{ 'btn-copy': isCopied }"
+                  type="button"
+                  ngxClipboard
+                  [cbContent]="shortUrl$ | async"
+                  (cbOnSuccess)="isCopied = true"
+                >
+                  <mat-icon>file_copy</mat-icon>
+                </button>
+              </span>
+            </div>
+          </mat-card>
+        </mde-popover>
+
         <div *ngIf="searchService.hasSearchText(advancedSearchObject, searchTerm, hits) || searchService.hasFilters(filters)">
           <mat-card class="alert alert-info">
-            <ng-template #popTemplate>
-              <div class="row">
-                <div class="input-group" style="padding:5px;">
-                  <input type="text" class="form-control" [value]="shortUrl$ | async" readonly />
-                  <span class="input-group-btn">
-                    <button
-                      class="btn btn-default"
-                      [ngClass]="{ 'btn-copy': isCopied }"
-                      type="button"
-                      ngxClipboard
-                      [cbContent]="shortUrl$ | async"
-                      (cbOnSuccess)="isCopied = true"
-                    >
-                      <mat-icon>file_copy</mat-icon>
-                    </button>
-                  </span>
-                </div>
-              </div>
-            </ng-template>
             <button
               mat-raised-button
               type="button"
               color="primary"
-              [popover]="popTemplate"
-              popoverTitle="Link to this page"
-              placement="bottom"
-              [outsideClick]="true"
+              [mdePopoverTriggerFor]="appPopover"
+              mdePopoverTriggerOn="click"
               class="mr-2"
             >
               <i class="fa fa-share-alt" aria-hidden="true"></i>

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -28,6 +28,7 @@ import { QueryBuilderService } from './query-builder.service';
 import { SearchComponent } from './search.component';
 import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
+import { MdePopoverModule } from '@material-extended/mde';
 
 @Component({
   selector: 'app-search-results',
@@ -56,7 +57,7 @@ describe('SearchComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SearchComponent, MapFriendlyValuesPipe, HeaderComponent, BasicSearchComponent, SearchResultsComponent],
-      imports: [CustomMaterialModule, ClipboardModule, PopoverModule.forRoot(), FontAwesomeModule, RouterTestingModule],
+      imports: [CustomMaterialModule, ClipboardModule, PopoverModule.forRoot(), FontAwesomeModule, RouterTestingModule, MdePopoverModule],
       providers: [
         { provide: SearchService, useClass: SearchStubService },
         { provide: QueryBuilderService, useClass: QueryBuilderStubService },

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -18,7 +18,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { MdePopoverModule } from '@material-extended/mde';
-import { PopoverModule } from 'ngx-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
 import { of } from 'rxjs';
 import { CustomMaterialModule } from '../shared/modules/material.module';
@@ -57,7 +56,7 @@ describe('SearchComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SearchComponent, MapFriendlyValuesPipe, HeaderComponent, BasicSearchComponent, SearchResultsComponent],
-      imports: [CustomMaterialModule, ClipboardModule, PopoverModule.forRoot(), FontAwesomeModule, RouterTestingModule, MdePopoverModule],
+      imports: [CustomMaterialModule, ClipboardModule, FontAwesomeModule, RouterTestingModule, MdePopoverModule],
       providers: [
         { provide: SearchService, useClass: SearchStubService },
         { provide: QueryBuilderService, useClass: QueryBuilderStubService },

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -17,6 +17,7 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { MdePopoverModule } from '@material-extended/mde';
 import { PopoverModule } from 'ngx-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
 import { of } from 'rxjs';
@@ -28,7 +29,6 @@ import { QueryBuilderService } from './query-builder.service';
 import { SearchComponent } from './search.component';
 import { SearchQuery } from './state/search.query';
 import { SearchService } from './state/search.service';
-import { MdePopoverModule } from '@material-extended/mde';
 
 @Component({
   selector: 'app-search-results',

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -47,7 +47,6 @@ import { Hit, SearchService } from './state/search.service';
   styleUrls: ['./search.component.scss']
 })
 export class SearchComponent implements OnInit, OnDestroy {
-  faSort = faSort;
   faSortAlphaDown = faSortAlphaDown;
   faSortAlphaUp = faSortAlphaUp;
   faSortNumericDown = faSortNumericDown;

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -20,16 +20,14 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { MdePopoverModule } from '@material-extended/mde';
 import { TagCloudModule } from 'angular-tag-cloud-module';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { PopoverModule } from 'ngx-bootstrap/popover';
 import { ClipboardModule } from 'ngx-clipboard';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HeaderModule } from '../shared/modules/header.module';
 import { CustomMaterialModule } from '../shared/modules/material.module';
 import { PipeModule } from '../shared/pipe/pipe.module';
 import { PrivateIconModule } from '../shared/private-icon/private-icon.module';
-import { getTooltipConfig } from '../shared/tooltip';
 import { AdvancedSearchComponent } from './advancedsearch/advancedsearch.component';
 import { BasicSearchComponent } from './basic-search/basic-search.component';
 import { QueryBuilderService } from './query-builder.service';
@@ -57,8 +55,6 @@ import { SearchService } from './state/search.service';
     FormsModule,
     HeaderModule,
     TagCloudModule,
-    BsDropdownModule.forRoot(),
-    PopoverModule.forRoot(),
     PipeModule,
     ClipboardModule,
     searchRouting,
@@ -66,7 +62,8 @@ import { SearchService } from './state/search.service';
     PrivateIconModule,
     ReactiveFormsModule,
     RefreshAlertModule,
-    FlexLayoutModule
+    FlexLayoutModule,
+    MdePopoverModule
   ],
   providers: [SearchService, QueryBuilderService],
   exports: [SearchComponent],

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -17,9 +17,8 @@ import { Location } from '@angular/common';
 import { Injectable, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatChipInputEvent } from '@angular/material/chips';
-import { MatTabChangeEvent } from '@angular/material/tabs';
+import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, NavigationEnd, Params, Router, RouterEvent } from '@angular/router/';
-import { TabsetComponent } from 'ngx-bootstrap';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Dockstore } from '../shared/dockstore.model';
@@ -38,7 +37,7 @@ import { validationDescriptorPatterns, validationMessages } from './validationMe
 
 @Injectable()
 export abstract class Entry implements OnInit, OnDestroy {
-  @ViewChild('entryTabs', { static: false }) entryTabs: TabsetComponent;
+  @ViewChild('entryTabs', { static: false }) entryTabs: MatTabGroup;
   protected shareURL: string;
   public starGazersClicked = false;
   private totalShare = 0;

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -20,8 +20,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { NgxJsonLdModule } from '@ngx-lite/json-ld';
 import { ShareButtonsModule } from '@ngx-share/buttons';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 import { RefreshAlertModule } from '../alert/alert.module';
 import { AvailableLogsModule } from '../available-logs.module';
@@ -47,9 +45,7 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
   imports: [
     AvailableLogsModule,
     CommonModule,
-    TooltipModule.forRoot(),
     FormsModule,
-    ModalModule,
     CustomMaterialModule,
     FlexLayoutModule,
     NgxJsonLdModule,

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.spec.ts
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.spec.ts
@@ -16,11 +16,10 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
-
 import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
 import { CheckerWorkflowStubService, RegisterCheckerWorkflowStubService } from '../../../test/service-stubs';
+import { CustomMaterialModule } from '../../modules/material.module';
 import { CheckerWorkflowService } from '../../state/checker-workflow.service';
 import { RegisterCheckerWorkflowService } from '../register-checker-workflow/register-checker-workflow.service';
 import { InfoTabCheckerWorkflowPathComponent } from './info-tab-checker-workflow-path.component';
@@ -31,7 +30,7 @@ describe('InfoTabCheckerWorkflowPathComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [TooltipModule.forRoot(), FormsModule, RouterTestingModule, MatDialogModule],
+      imports: [FormsModule, RouterTestingModule, MatDialogModule, CustomMaterialModule],
       providers: [
         { provide: CheckerWorkflowService, useClass: CheckerWorkflowStubService },
         { provide: RegisterCheckerWorkflowService, useClass: RegisterCheckerWorkflowStubService }

--- a/src/app/shared/modules/list-containers.module.ts
+++ b/src/app/shared/modules/list-containers.module.ts
@@ -16,7 +16,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { TabsModule } from 'ngx-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
 import { ListContainersComponent } from '../../containers/list/list.component';
 import { ListContainersService } from '../../containers/list/list.service';
@@ -28,7 +27,7 @@ import { CustomMaterialModule } from './material.module';
 
 @NgModule({
   declarations: [ListContainersComponent],
-  imports: [CommonModule, RouterModule, ClipboardModule, CustomMaterialModule, HeaderModule, PrivateIconModule, TabsModule, EntryModule],
+  imports: [CommonModule, RouterModule, ClipboardModule, CustomMaterialModule, HeaderModule, PrivateIconModule, EntryModule],
   providers: [PublishedToolsDataSource, ListContainersService],
   exports: [ListContainersComponent]
 })

--- a/src/app/shared/modules/list-workflows.module.ts
+++ b/src/app/shared/modules/list-workflows.module.ts
@@ -16,7 +16,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { TabsModule } from 'ngx-bootstrap';
 import { ListWorkflowsComponent } from '../../workflows/list/list.component';
 import { PublishedWorkflowsDataSource } from '../../workflows/list/published-workflows.datasource';
 import { EntryModule } from '../entry/entry.module';
@@ -25,7 +24,7 @@ import { CustomMaterialModule } from './material.module';
 
 @NgModule({
   declarations: [ListWorkflowsComponent],
-  imports: [CommonModule, RouterModule, HeaderModule, CustomMaterialModule, TabsModule, EntryModule],
+  imports: [CommonModule, RouterModule, HeaderModule, CustomMaterialModule, EntryModule],
   providers: [PublishedWorkflowsDataSource],
   exports: [ListWorkflowsComponent]
 })

--- a/src/app/shared/modules/workflow.module.ts
+++ b/src/app/shared/modules/workflow.module.ts
@@ -18,12 +18,6 @@ import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { EntryFileTabComponent } from 'app/entry/entry-file-tab/entry-file-tab.component';
-import { AccordionModule } from 'ngx-bootstrap/accordion';
-import { AlertModule } from 'ngx-bootstrap/alert';
-import { ButtonsModule } from 'ngx-bootstrap/buttons';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ClipboardModule } from 'ngx-clipboard';
 import { MarkdownModule } from 'ngx-markdown';
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
@@ -60,7 +54,6 @@ import { VersionModalService } from './../../workflow/version-modal/version-moda
 import { EntryModule } from './../entry/entry.module';
 import { CustomMaterialModule } from './../modules/material.module';
 import { RefreshService } from './../refresh.service';
-import { getTooltipConfig } from './../tooltip';
 
 @NgModule({
   declarations: [
@@ -82,18 +75,12 @@ import { getTooltipConfig } from './../tooltip';
   ],
   imports: [
     CommonModule,
-    ButtonsModule.forRoot(),
-    AlertModule.forRoot(),
     CurrentCollectionsModule,
     FlexLayoutModule,
     HeaderModule,
     ListWorkflowsModule,
-    ModalModule.forRoot(),
     SelectModule,
     PipeModule,
-    TooltipModule.forRoot(),
-    TabsModule.forRoot(),
-    AccordionModule.forRoot(),
     StarringModule,
     OrderByModule,
     FormsModule,
@@ -105,7 +92,6 @@ import { getTooltipConfig } from './../tooltip';
     MarkdownModule
   ],
   providers: [
-    { provide: TooltipConfig, useFactory: getTooltipConfig },
     DateService,
     FileService,
     WorkflowLaunchService,

--- a/src/app/shared/tooltip.ts
+++ b/src/app/shared/tooltip.ts
@@ -1,4 +1,3 @@
-import { TooltipConfig } from 'ngx-bootstrap/tooltip';
 export const Tooltip = {
   testParameterFile: 'Relative path to a Test Parameter File in the Git repository',
   workflowPath: 'Path in Git repository to main descriptor file',
@@ -9,7 +8,3 @@ export const Tooltip = {
   workflowName: 'Name to distinguish between multiple workflows within the same repository',
   repository: 'Repository name within Dockstore'
 };
-
-export function getTooltipConfig(): TooltipConfig {
-  return Object.assign(new TooltipConfig(), { placement: 'auto' });
-}

--- a/src/app/starredentries/starredentries.module.ts
+++ b/src/app/starredentries/starredentries.module.ts
@@ -1,16 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { HeaderModule } from '../shared/modules/header.module';
 import { StarentryService } from '../shared/starentry.service';
 import { StargazersModule } from '../stargazers/stargazers.module';
 import { StarringModule } from '../starring/starring.module';
 import { StarringService } from '../starring/starring.service';
-import { getTooltipConfig } from './../shared/tooltip';
 
 @NgModule({
-  imports: [CommonModule, StargazersModule, TooltipModule.forRoot(), HeaderModule, StarringModule],
-  providers: [{ provide: TooltipConfig, useFactory: getTooltipConfig }, StarentryService, StarringService]
+  imports: [CommonModule, StargazersModule, HeaderModule, StarringModule],
+  providers: [StarentryService, StarringService]
 })
 export class StarredEntriesModule {}

--- a/src/app/workflow/versions/versions.component.spec.ts
+++ b/src/app/workflow/versions/versions.component.spec.ts
@@ -19,7 +19,6 @@ import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
-import { TooltipModule } from 'ngx-bootstrap';
 import { AlertQuery } from '../../shared/alert/state/alert.query';
 import { DateService } from '../../shared/date.service';
 import { DockstoreService } from '../../shared/dockstore.service';
@@ -69,7 +68,7 @@ describe('VersionsWorkflowComponent', () => {
   let fixture: ComponentFixture<VersionsWorkflowComponent>;
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [CustomMaterialModule, FormsModule, TooltipModule, FontAwesomeModule, BrowserAnimationsModule],
+      imports: [CustomMaterialModule, FormsModule, FontAwesomeModule, BrowserAnimationsModule],
       declarations: [
         VersionsWorkflowComponent,
         OrderBy,

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
@@ -10,7 +10,6 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { TabsModule } from 'ngx-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { CodeEditorListComponent } from './../../shared/code-editor-list/code-editor-list.component';
@@ -40,7 +39,6 @@ describe('WorkflowFileEditorComponent', () => {
         PrivateFilePathPipe
       ],
       imports: [
-        TabsModule.forRoot(),
         MatButtonModule,
         MatTabsModule,
         MatToolbarModule,


### PR DESCRIPTION
Removed ngx-popover, ngx-dropdown and ngx-bootstrap

dockstore/dockstore#3458

Included material-extended/mde into the package.json in order to
implement a replacement for ngx-bootstrap popover

Replaced ngx-bootstrap popover with material-extended popover

Replaced ngx-bootstrap dropdown with Material Select

Removed the rest of the ngx-bootstrap dependencies from search.module

Removed ngx-bootstrap from all of the modules and package.json

Adjusted the spec files to have the material counterpart of
ngx-bootstrap import

Removed getTooltipConfig() from tooltip.ts and removed that method
from all modules importing it

Replaced TabsetComponent in entry.ts with MatTabGroup for the
entryTabs ViewChild

<img width="399" alt="Screen Shot 2020-05-29 at 12 45 32 PM" src="https://user-images.githubusercontent.com/42463687/83912232-5715e200-a722-11ea-90c6-972a6fb50e16.png">
<img width="590" alt="Screen Shot 2020-05-29 at 12 45 56 PM" src="https://user-images.githubusercontent.com/42463687/83912236-58470f00-a722-11ea-9af0-72a835aeb06c.png">
<img width="594" alt="Screen Shot 2020-05-29 at 12 46 00 PM" src="https://user-images.githubusercontent.com/42463687/83912238-58dfa580-a722-11ea-8e13-59a74a31ef09.png">
