### PR TITLE
Change alert style

### DIFF
--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="!(events$ | async) || (events$ | async).length === 0">
     <mat-card class="alert alert-info mx-1" role="alert">
       <mat-icon>info</mat-icon> No events found. Star entries or organizations to see events for them. Read
-      <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">starring-tools-and-workflows</a>
+      <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">Starring Tools and Workflows</a>
       to learn how to star entries.</mat-card
     >
   </div>

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="!(events$ | async) || (events$ | async).length === 0">
     <mat-card class="alert alert-info mx-1" role="alert">
       <mat-icon>info</mat-icon> No events found. Star entries or organizations to see events for them. Read
-      <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">{{ starringDocUrl }}</a>
+      <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">starring-tools-and-workflows</a>
       to learn how to star entries.</mat-card
     >
   </div>

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -815,7 +815,6 @@ mat-panel-title.org-accordion-header {
 }
 
 .alert-info {
-  color: #31708f !important;
   background-color: #d9edf7 !important;
   border-color: #bce8f1 !important;
   border: 0px !important;


### PR DESCRIPTION
For dockstore/dockstore#3219

We currently have several ways of displaying links right now.

1. Black sentence text:  use blue link with underline on hover
2. Link only: use blue link with underline on hover
3. External link only: use blue link + icon with underline on hover
4. Blue sentence text: use blue link (full URL) with underline on hover

This PR removes number 4 by simply not using blue sentences anywhere.
