### PR TITLE
Feature/dockstore yml file viewer

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -159,6 +159,27 @@ describe('Dockstore my workflows', () => {
       .should('be.visible')
       .click();
     cy.contains('button', 'Refresh Version').should('be.disabled');
+
+    cy.get('body').type('{esc}');
+
+    goToTab('Files');
+
+    cy.contains('Configuration');
+
+    cy.contains('/.dockstore.yml');
+
+    goToTab('Descriptor Files');
+    cy.contains('/Dockstore.cwl');
+    cy.contains('class: Workflow');
+
+    cy.get('mat-tab-body').within((tabBody) => {
+      cy.get('mat-select').eq(1).click();
+    });
+    cy.get('mat-option')
+      .contains('md5sum-tool.cwl')
+      .click();
+
+    cy.contains('class: CommandLineTool');
   });
 
   it('Should be able to refresh a workflow version', () => {

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -162,10 +162,9 @@ describe('Dockstore my workflows', () => {
 
     cy.get('body').type('{esc}');
 
+    // Test file content
     goToTab('Files');
-
     cy.contains('Configuration');
-
     cy.contains('/.dockstore.yml');
 
     goToTab('Descriptor Files');
@@ -175,10 +174,10 @@ describe('Dockstore my workflows', () => {
     cy.get('mat-tab-body').within((tabBody) => {
       cy.get('mat-select').eq(1).click();
     });
+
     cy.get('mat-option')
       .contains('md5sum-tool.cwl')
       .click();
-
     cy.contains('class: CommandLineTool');
   });
 

--- a/cypress/integration/immutableDatabaseTests/services.ts
+++ b/cypress/integration/immutableDatabaseTests/services.ts
@@ -136,8 +136,16 @@ describe('Dockstore Home', () => {
     cy.contains('subclass: docker-compose');
 
     // Files Tab
-    goToTab('Files');
+    goToTab('Service Files');
     cy.contains('README.md');
     cy.contains('# another-test-serviceaaaa');
+
+    cy.get('mat-tab-body').within((tabBody) => {
+      cy.get('mat-select').eq(1).click();
+    });
+    cy.get('mat-option')
+      .contains('docker-compose.yml')
+      .click();
+    cy.contains('docker-compose.yml');
   }
 });

--- a/cypress/integration/immutableDatabaseTests/services.ts
+++ b/cypress/integration/immutableDatabaseTests/services.ts
@@ -131,6 +131,12 @@ describe('Dockstore Home', () => {
   }
   function checkFilesTab() {
     goToTab('Files');
+    // Configuration tab
+    cy.contains('.dockstore.yml');
+    cy.contains('subclass: docker-compose');
+
+    // Files Tab
+    goToTab('Files');
     cy.contains('README.md');
     cy.contains('# another-test-serviceaaaa');
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.9.0-alpha.10"
+    "webservice_version": "1.9.0-beta.0"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.9.0-alpha.8"
+    "webservice_version": "1.9.0-alpha.10"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -15,7 +15,7 @@
  */
 import { Pipe, PipeTransform } from '@angular/core';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
-import { ToolFile, Workflow } from 'app/shared/swagger';
+import { SourceFile, ToolFile, Workflow } from 'app/shared/swagger';
 
 @Pipe({
   name: 'mapFriendlyValue'
@@ -83,6 +83,25 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         [ToolFile.FileTypeEnum.TESTFILE, 'Test Parameter Files'],
         [ToolFile.FileTypeEnum.CONTAINERFILE, 'Dockerfile'],
         [ToolFile.FileTypeEnum.OTHER, 'Files']
+      ])
+    ],
+    [
+      'SourceFile.TypeEnum',
+      new Map([
+        [SourceFile.TypeEnum.DOCKERFILE, 'Dockerfile'],
+        [SourceFile.TypeEnum.DOCKSTORECWL, 'Descriptor Files'],
+        [SourceFile.TypeEnum.DOCKSTOREWDL, 'Descriptor Files'],
+        [SourceFile.TypeEnum.NEXTFLOW, 'Descriptor Files'],
+        [SourceFile.TypeEnum.NEXTFLOWCONFIG, 'Descriptor Files'],
+        [SourceFile.TypeEnum.DOCKSTOREGXFORMAT2, 'Descriptor Files'],
+        [SourceFile.TypeEnum.CWLTESTJSON, 'Test Parameter Files'],
+        [SourceFile.TypeEnum.WDLTESTJSON, 'Test Parameter Files'],
+        [SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, 'Test Parameter Files'],
+        [SourceFile.TypeEnum.GXFORMAT2TESTFILE, 'Test Parameter Files'],
+        [SourceFile.TypeEnum.DOCKSTORESERVICETESTJSON, 'Test Parameter Files'],
+        [SourceFile.TypeEnum.DOCKSTORESERVICEYML, 'Configuration'],
+        [SourceFile.TypeEnum.DOCKSTOREYML, 'Configuration'],
+        [SourceFile.TypeEnum.DOCKSTORESERVICEOTHER, 'Files'],
       ])
     ]
   ]);

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -101,7 +101,7 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         [SourceFile.TypeEnum.DOCKSTORESERVICETESTJSON, 'Test Parameter Files'],
         [SourceFile.TypeEnum.DOCKSTORESERVICEYML, 'Configuration'],
         [SourceFile.TypeEnum.DOCKSTOREYML, 'Configuration'],
-        [SourceFile.TypeEnum.DOCKSTORESERVICEOTHER, 'Files'],
+        [SourceFile.TypeEnum.DOCKSTORESERVICEOTHER, 'Service Files']
       ])
     ]
   ]);

--- a/src/app/shared/modules/workflow.module.ts
+++ b/src/app/shared/modules/workflow.module.ts
@@ -30,6 +30,7 @@ import { ParamfilesService } from '../../container/paramfiles/paramfiles.service
 import { CurrentCollectionsModule } from '../../entry/current-collections.module';
 import { AddEntryModule } from '../../organizations/collection/add-entry.module';
 import { OrderByModule } from '../../shared/modules/orderby.module';
+import { SourceFileTabsComponent } from '../../source-file-tabs/source-file-tabs.component';
 import { StargazersModule } from '../../stargazers/stargazers.module';
 import { StarringModule } from '../../starring/starring.module';
 import { DescriptorsWorkflowComponent } from '../../workflow/descriptors/descriptors.component';
@@ -78,7 +79,8 @@ import { getTooltipConfig } from './../tooltip';
     WorkflowActionsComponent,
     InfoTabComponent,
     ToolTabComponent,
-    EntryFileTabComponent
+    EntryFileTabComponent,
+    SourceFileTabsComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/shared/modules/workflow.module.ts
+++ b/src/app/shared/modules/workflow.module.ts
@@ -44,6 +44,7 @@ import { VersionsWorkflowComponent } from '../../workflow/versions/versions.comp
 import { ViewWorkflowComponent } from '../../workflow/view/view.component';
 import { WorkflowFileEditorComponent } from '../../workflow/workflow-file-editor/workflow-file-editor.component';
 import { WorkflowComponent } from '../../workflow/workflow.component';
+import { RefreshAlertModule } from '../alert/alert.module';
 import { DateService } from '../date.service';
 import { WorkflowActionsComponent } from '../entry-actions/workflow-actions.component';
 import { FileService } from '../file.service';
@@ -104,7 +105,8 @@ import { getTooltipConfig } from './../tooltip';
     ClipboardModule,
     EntryModule,
     AddEntryModule,
-    MarkdownModule
+    MarkdownModule,
+    RefreshAlertModule
   ],
   providers: [
     { provide: TooltipConfig, useFactory: getTooltipConfig },

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,6 +1,6 @@
 <div>
   <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
-    <mat-tab *ngFor="let fileType of fileTypes" label="{{ fileType }}">
+    <mat-tab *ngFor="let fileType of fileTypes" label="{{ 'SourceFile.TypeEnum' | mapFriendlyValue: fileType }}">
       <ng-template matTabContent>
         <mat-toolbar color="primary">
           <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,0 +1,18 @@
+<div>
+  <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
+    <mat-tab *ngFor="let fileType of fileTypes" label="{{ fileType }}">
+      <ng-template matTabContent>
+        <mat-toolbar color="primary">
+          <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">
+            <mat-form-field class="w-50">
+              <mat-select [value]="currentFile" (selectionChange)="matSelectChange($event)">
+                <mat-option [value]="file" *ngFor="let file of filteredFiles"> {{ file.path }} </mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </mat-toolbar>
+        <app-code-editor [content]="currentFile.content" [filepath]="currentFile.path" [editing]="false"></app-code-editor>
+      </ng-template>
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="files">
-  <div *ngIf="version" class="p-3">
+  <div *ngIf="currentVersion" class="p-3">
     <mat-card class="alert alert-warning" *ngIf="validationMessage">
       <mat-icon>warning</mat-icon>
       &nbsp;

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,4 +1,4 @@
-<div>
+<div *ngIf="files">
   <div *ngIf="version" class="p-3">
     <mat-card class="alert alert-warning" *ngIf="validationMessage">
       <mat-icon>warning</mat-icon>
@@ -19,6 +19,11 @@
                 <mat-option [value]="file" *ngFor="let file of filteredFiles"> {{ file.path }} </mat-option>
               </mat-select>
             </mat-form-field>
+            <span>
+              <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="currentFile.content">
+                <mat-icon>file_copy</mat-icon>
+              </button>
+            </span>
           </div>
         </mat-toolbar>
         <app-code-editor [content]="currentFile.content" [filepath]="currentFile.path" [editing]="false"></app-code-editor>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,4 +1,14 @@
 <div>
+  <div *ngIf="version" class="p-3">
+    <mat-card class="alert alert-warning" *ngIf="validationMessage">
+      <mat-icon>warning</mat-icon>
+      &nbsp;
+      <span *ngFor="let item of validationMessage | keyvalue">
+        <strong>{{ item.key }}</strong
+        >: {{ item.value }}
+      </span>
+    </mat-card>
+  </div>
   <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
     <mat-tab *ngFor="let fileType of fileTypes" label="{{ 'SourceFile.TypeEnum' | mapFriendlyValue: fileType }}">
       <ng-template matTabContent>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -28,10 +28,11 @@
                 [download]="customDownloadPath"
                 type="button"
                 title="{{ filePath }}"
+                matTooltip="Download File"
               >
                 <mat-icon>save_alt</mat-icon>
               </a>
-              <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="currentFile.content">
+              <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="currentFile.content" matTooltip="Copy File">
                 <mat-icon>file_copy</mat-icon>
               </button>
             </span>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,4 +1,4 @@
-<app-loading class="w-100" [loading]="!files">
+<app-loading class="w-100" [loading]="loading">
   <div *ngIf="currentVersion" class="p-3">
     <mat-card class="alert alert-warning" *ngIf="validationMessage">
       <mat-icon>warning</mat-icon>
@@ -8,6 +8,9 @@
         >: {{ item.value }}
       </span>
     </mat-card>
+  </div>
+  <div *ngIf="!loading && !files">
+    <mat-card class="alert alert-warning"> <mat-icon>warning</mat-icon>This version has no files.</mat-card>
   </div>
   <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
     <mat-tab *ngFor="let fileType of fileTypes" label="{{ 'SourceFile.TypeEnum' | mapFriendlyValue: fileType }}">

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="files">
+<app-loading class="w-100" [loading]="!files">
   <div *ngIf="currentVersion" class="p-3">
     <mat-card class="alert alert-warning" *ngIf="validationMessage">
       <mat-icon>warning</mat-icon>
@@ -20,6 +20,17 @@
               </mat-select>
             </mat-form-field>
             <span>
+              <a
+                mat-icon-button
+                color="secondary"
+                class="mr-1"
+                [href]="customDownloadHREF"
+                [download]="customDownloadPath"
+                type="button"
+                title="{{ filePath }}"
+              >
+                <mat-icon>save_alt</mat-icon>
+              </a>
               <button mat-icon-button color="secondary" type="button" ngxClipboard [cbContent]="currentFile.content">
                 <mat-icon>file_copy</mat-icon>
               </button>
@@ -30,4 +41,4 @@
       </ng-template>
     </mat-tab>
   </mat-tab-group>
-</div>
+</app-loading>

--- a/src/app/source-file-tabs/source-file-tabs.component.spec.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SourceFileTabsComponent } from './source-file-tabs.component';
+
+describe('SourceFileTabsComponent', () => {
+  let component: SourceFileTabsComponent;
+  let fixture: ComponentFixture<SourceFileTabsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SourceFileTabsComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SourceFileTabsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/source-file-tabs/source-file-tabs.component.spec.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.spec.ts
@@ -1,5 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MapFriendlyValuesPipe } from 'app/search/map-friendly-values.pipe';
+import { DescriptorTypeCompatService } from 'app/shared/descriptor-type-compat.service';
+import { FileService } from 'app/shared/file.service';
+import { WorkflowsService } from 'app/shared/swagger';
+import { DescriptorTypeCompatStubService, FileStubService, WorkflowsStubService } from 'app/test/service-stubs';
 import { SourceFileTabsComponent } from './source-file-tabs.component';
 
 describe('SourceFileTabsComponent', () => {
@@ -8,13 +15,22 @@ describe('SourceFileTabsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SourceFileTabsComponent]
+      declarations: [SourceFileTabsComponent, MapFriendlyValuesPipe],
+      providers: [
+        { provide: FileService, useClass: FileStubService },
+        { provide: WorkflowsService, useClass: WorkflowsStubService },
+        { provide: DescriptorTypeCompatService, useClass: DescriptorTypeCompatStubService }
+      ],
+      imports: [HttpClientTestingModule],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SourceFileTabsComponent);
     component = fixture.componentInstance;
+    component.currentVersion = { id: 0 };
+    component.workflowId = 0;
     fixture.detectChanges();
   });
 

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { MatSelectChange, MatSnackBar, MatTabChangeEvent } from '@angular/material';
+import { MatSelectChange, MatTabChangeEvent } from '@angular/material';
 import { SafeUrl } from '@angular/platform-browser';
 import { DescriptorTypeCompatService } from 'app/shared/descriptor-type-compat.service';
 import { FileService } from 'app/shared/file.service';
@@ -37,7 +37,8 @@ export class SourceFileTabsComponent implements OnInit {
   constructor(
     private workflowsService: WorkflowsService,
     private fileService: FileService,
-    private descriptorTypeCompatService: DescriptorTypeCompatService) {}
+    private descriptorTypeCompatService: DescriptorTypeCompatService
+  ) {}
 
   ngOnInit() {
     this.setupVersionFileTabs();
@@ -45,28 +46,30 @@ export class SourceFileTabsComponent implements OnInit {
 
   setupVersionFileTabs() {
     this.loading = true;
-    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.currentVersion.id)
-    .pipe(
-      finalize(() => {
-        this.loading = false;
-      })
-    ).subscribe(
-      (sourceFiles: SourceFile[]) => {
-        this.files = sourceFiles;
-        this.fileTypes = [];
-        this.files.forEach((file: SourceFile) => {
-          if (!this.fileTypes.includes(file.type)) {
-            this.fileTypes.push(file.type);
+    this.workflowsService
+      .getWorkflowVersionsSourcefiles(this.workflowId, this.currentVersion.id)
+      .pipe(
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe(
+        (sourceFiles: SourceFile[]) => {
+          this.files = sourceFiles;
+          this.fileTypes = [];
+          this.files.forEach((file: SourceFile) => {
+            if (!this.fileTypes.includes(file.type)) {
+              this.fileTypes.push(file.type);
+            }
+          });
+          if (this.fileTypes.length > 0) {
+            this.changeFileType(this.fileTypes[0]);
           }
-        });
-        if (this.fileTypes.length > 0) {
-          this.changeFileType(this.fileTypes[0]);
+        },
+        error => {
+          console.log(error);
         }
-      },
-      error => {
-        console.log(error);
-      }
-    );
+      );
   }
 
   /**

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatSelectChange, MatTabChangeEvent } from '@angular/material';
 import { SourceFile, WorkflowsService, WorkflowVersion } from 'app/shared/openapi';
+import { Validation } from 'app/shared/swagger';
 
 @Component({
   selector: 'app-source-file-tabs',
@@ -15,6 +16,7 @@ export class SourceFileTabsComponent implements OnInit {
   currentFile: SourceFile;
   fileTypes: SourceFile.TypeEnum[];
   currentFileType: SourceFile.TypeEnum;
+  validationMessage: Object;
 
   constructor(private workflowsService: WorkflowsService) {}
 
@@ -53,5 +55,11 @@ export class SourceFileTabsComponent implements OnInit {
     if (this.filteredFiles.length > 0) {
       this.currentFile = this.filteredFiles[0];
     }
+    this.version.validations.forEach((validation: Validation) => {
+      this.validationMessage = null;
+      if (validation.type === this.currentFileType && !validation.valid) {
+        this.validationMessage = JSON.parse(validation.message);
+      }
+    });
   }
 }

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,0 +1,58 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatSelectChange, MatTabChangeEvent } from '@angular/material';
+import { SourceFile, WorkflowsService, WorkflowVersion } from 'app/shared/openapi';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-source-file-tabs',
+  templateUrl: './source-file-tabs.component.html',
+  styleUrls: ['./source-file-tabs.component.scss']
+})
+export class SourceFileTabsComponent implements OnInit {
+  @Input() workflowId: number;
+  @Input() version: WorkflowVersion;
+  files: SourceFile[];
+  filteredFiles: SourceFile[];
+  currentFile: SourceFile;
+  fileTypes: SourceFile.TypeEnum[];
+  currentFileType: SourceFile.TypeEnum;
+
+  constructor(private workflowsService: WorkflowsService) {}
+
+  ngOnInit() {
+    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.version.id).subscribe(
+      (sourceFiles: SourceFile[]) => {
+        this.files = sourceFiles;
+        this.fileTypes = [];
+        this.files.forEach((file: SourceFile) => {
+          if (!this.fileTypes.includes(file.type)) {
+            this.fileTypes.push(file.type);
+          }
+        });
+        this.changeFileType(this.fileTypes[0]);
+      },
+      error => console.log(error)
+    );
+  }
+
+  matTabChange(event: MatTabChangeEvent) {
+    const fileType: SourceFile.TypeEnum = this.fileTypes[event.index];
+    this.changeFileType(fileType);
+  }
+
+  matSelectChange(event: MatSelectChange) {
+    this.currentFile = event.value;
+  }
+
+  changeFileType(fileType: SourceFile.TypeEnum) {
+    this.currentFileType = fileType;
+
+    this.filteredFiles = this.files.filter((file: SourceFile) => {
+      return file.type === this.currentFileType;
+    });
+
+    if (this.filteredFiles.length > 0) {
+      this.currentFile = this.filteredFiles[0];
+    }
+  }
+}

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -10,7 +10,13 @@ import { Validation } from 'app/shared/swagger';
 })
 export class SourceFileTabsComponent implements OnInit {
   @Input() workflowId: number;
-  @Input() version: WorkflowVersion;
+  @Input() set version(value: WorkflowVersion) {
+    if (value != null) {
+      this.currentVersion = value;
+      this.setupVersionFileTabs();
+    }
+  }
+  currentVersion: WorkflowVersion;
   files: SourceFile[];
   filteredFiles: SourceFile[];
   currentFile: SourceFile;
@@ -21,7 +27,11 @@ export class SourceFileTabsComponent implements OnInit {
   constructor(private workflowsService: WorkflowsService) {}
 
   ngOnInit() {
-    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.version.id).subscribe(
+    this.setupVersionFileTabs();
+  }
+
+  setupVersionFileTabs() {
+    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.currentVersion.id).subscribe(
       (sourceFiles: SourceFile[]) => {
         this.files = sourceFiles;
         this.fileTypes = [];
@@ -30,19 +40,12 @@ export class SourceFileTabsComponent implements OnInit {
             this.fileTypes.push(file.type);
           }
         });
-        this.changeFileType(this.fileTypes[0]);
+        if (this.fileTypes.length > 0) {
+          this.changeFileType(this.fileTypes[0]);
+        }
       },
       error => console.log(error)
     );
-  }
-
-  matTabChange(event: MatTabChangeEvent) {
-    const fileType: SourceFile.TypeEnum = this.fileTypes[event.index];
-    this.changeFileType(fileType);
-  }
-
-  matSelectChange(event: MatSelectChange) {
-    this.currentFile = event.value;
   }
 
   changeFileType(fileType: SourceFile.TypeEnum) {
@@ -55,11 +58,20 @@ export class SourceFileTabsComponent implements OnInit {
     if (this.filteredFiles.length > 0) {
       this.currentFile = this.filteredFiles[0];
     }
-    this.version.validations.forEach((validation: Validation) => {
+    this.currentVersion.validations.forEach((validation: Validation) => {
       this.validationMessage = null;
       if (validation.type === this.currentFileType && !validation.valid) {
         this.validationMessage = JSON.parse(validation.message);
       }
     });
+  }
+
+  matTabChange(event: MatTabChangeEvent) {
+    const fileType: SourceFile.TypeEnum = this.fileTypes[event.index];
+    this.changeFileType(fileType);
+  }
+
+  matSelectChange(event: MatSelectChange) {
+    this.currentFile = event.value;
   }
 }

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { MatSelectChange, MatTabChangeEvent } from '@angular/material';
+import { MatSelectChange, MatSnackBar, MatTabChangeEvent } from '@angular/material';
 import { SafeUrl } from '@angular/platform-browser';
 import { DescriptorTypeCompatService } from 'app/shared/descriptor-type-compat.service';
 import { FileService } from 'app/shared/file.service';
 import { SourceFile, ToolDescriptor, WorkflowsService, WorkflowVersion } from 'app/shared/openapi';
 import { Validation } from 'app/shared/swagger';
-import { ga4ghPath, ga4ghWorkflowIdPrefix } from '../shared/constants';
+import { finalize } from 'rxjs/operators';
+import { ga4ghWorkflowIdPrefix } from '../shared/constants';
 
 @Component({
   selector: 'app-source-file-tabs',
@@ -21,6 +22,7 @@ export class SourceFileTabsComponent implements OnInit {
       this.setupVersionFileTabs();
     }
   }
+  loading = true;
   currentVersion: WorkflowVersion;
   files: SourceFile[];
   filteredFiles: SourceFile[];
@@ -42,7 +44,13 @@ export class SourceFileTabsComponent implements OnInit {
   }
 
   setupVersionFileTabs() {
-    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.currentVersion.id).subscribe(
+    this.loading = true;
+    this.workflowsService.getWorkflowVersionsSourcefiles(this.workflowId, this.currentVersion.id)
+    .pipe(
+      finalize(() => {
+        this.loading = false;
+      })
+    ).subscribe(
       (sourceFiles: SourceFile[]) => {
         this.files = sourceFiles;
         this.fileTypes = [];
@@ -55,7 +63,9 @@ export class SourceFileTabsComponent implements OnInit {
           this.changeFileType(this.fileTypes[0]);
         }
       },
-      error => console.log(error)
+      error => {
+        console.log(error);
+      }
     );
   }
 

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatSelectChange, MatTabChangeEvent } from '@angular/material';
 import { SourceFile, WorkflowsService, WorkflowVersion } from 'app/shared/openapi';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-source-file-tabs',

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -301,6 +301,11 @@ export class HttpStubService {
   }
 }
 
+export class DescriptorTypeCompatStubService {
+  stringToDescriptorType(descriptorType: string | Workflow.DescriptorTypeEnum) {}
+  toolDescriptorTypeEnumToPlainTRS(typeEnum: ToolDescriptor.TypeEnum) {}
+}
+
 export class WorkflowStubService {
   nsWorkflows$ = observableOf([]);
   nsSharedWorkflows$ = observableOf([]);

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -298,7 +298,11 @@
               </ng-template>
 
               <ng-template #dockstoreYmlComponent>
-                <app-source-file-tabs [workflowId]="workflow?.id" [version]="selectedVersion"></app-source-file-tabs>
+                <app-source-file-tabs
+                  [workflowId]="workflow?.id"
+                  [version]="selectedVersion"
+                  [descriptorType]="descriptorType$ | async"
+                ></app-source-file-tabs>
               </ng-template>
 
               <ng-template #hostedComponent>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -248,7 +248,7 @@
                     <ng-container *ngTemplateOutlet="hostedComponent"></ng-container>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML">
-                    <ng-container *ngTemplateOutlet="newComponent"></ng-container>
+                    <ng-container *ngTemplateOutlet="dockstoreYmlComponent"></ng-container>
                   </div>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.FULL">
                     <!-- For old languages, we use the old files component because it's well tested, for new unknown languages, use the new component -->
@@ -296,6 +296,11 @@
               <ng-template #newComponent>
                 <app-entry-file-tab [version]="selectedVersion"></app-entry-file-tab>
               </ng-template>
+
+              <ng-template #dockstoreYmlComponent>
+                <app-source-file-tabs [workflowId]="workflow?.id" [version]="selectedVersion"></app-source-file-tabs>
+              </ng-template>
+
               <ng-template #hostedComponent>
                 <app-workflow-file-editor
                   *ngIf="currentTab === 'files'"


### PR DESCRIPTION
This adds a file tab that uses the new sourcefiles endpoint. It is currently only for dockstore.yml workflows and services, though there is no reason why it wouldn't work with other workflows.

Probably missing some features/quirks that exist in the existing files tab, so let me know if you find anything missing.

https://ucsc-cgl.atlassian.net/browse/SEAB-1303