### PR TITLE
Add preview to friendly name

### DIFF
--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -101,7 +101,7 @@ const extendedService: ExtendedDescriptorLanguageBean = {
 
 const extendedGalaxy: ExtendedDescriptorLanguageBean = {
   value: 'gxformat2',
-  shortFriendlyName: 'Galaxy',
+  shortFriendlyName: 'Galaxy (preview)',
   friendlyName: 'Galaxy Workflow Format',
   defaultDescriptorPath: '/Dockstore.yml',
   descriptorPathPattern: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(ga|yaml|yml)',


### PR DESCRIPTION
Simple change that appends `(preview)` to almost every place that mentions Galaxy.  This includes every dropdown in the register modal, the info tab (both stub dropdown and current descriptor type), also the search page galaxy bucket filter