### PR TITLE
Bump jQuery version from 3.4.0 to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10466,9 +10466,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-levenshtein": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cytoscape-popper": "^1.0.4",
     "elasticsearch-browser": "^15.0.0",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.4.0",
+    "jquery": "~3.4.1",
     "ng2-ui-auth": "^10.0.1",
     "ngx-bootstrap": "^3.0.1",
     "ngx-clipboard": "^12.2.1",


### PR DESCRIPTION
This PR bumps the jQuery version embedded on the Dockstore page from 3.4.0 to 3.4.1, per the recommended Netsparker remediation. This is a temporary fix for the problem of an out-of-date jQuery version; the long-term fix is to remove components that depend on jQuery, and then to remove jQuery itself. Work to accomplish this is ongoing.

Related Jira ticket: [SEAB-1204](https://ucsc-cgl.atlassian.net/browse/SEAB-1204)