### PR TITLE
fixed base URL, made snapshot menu test less flaky

### DIFF
--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -178,21 +178,30 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('button', 'Publish').click();
     });
     it('snapshot', () => {
+      // define routes to watch for
+      cy.server();
+      cy.route('**/tools/**').as('tools');
+
       goToTab('Versions');
+      cy.wait('@tools');
       cy.contains('button', 'Actions').should('be.visible');
-      // assuming that the first version in the table is snapshot-able
       cy.contains('td', 'Actions')
         .first()
         .click();
-      cy.contains('button', 'Snapshot').click();
       // don't actually snapshot since it can't be undone
+      cy.get('.mat-menu-content').within(() => {
+        cy.contains('button', 'Snapshot');
+        cy.contains('button', 'Edit').click();
+      });
       cy.contains('button', 'Cancel').click();
     });
     it('unpublish and stub', () => {
       storeToken();
-      cy.contains('button', 'Unpublish').should('be.visible');
-      cy.contains('button', 'Unpublish').click();
+      cy.contains('button', 'Unpublish')
+        .should('be.visible')
+        .click({ force: true });
 
+      goToTab('Info');
       cy.contains('button', 'Restub').click();
       cy.contains('button', 'Publish').should('be.disabled');
     });

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test": "npx ng test",
     "lint": "npx ng lint",
     "e2e": "npx ng e2e",
-    "test-dev-no-auth": "npx cypress run --record -c baseUrl=https://staging.dockstore.org -s \"cypress/integration/manualTests/monitor.ts,cypress/integration/manualTests/basic-enduser.ts\"",
+    "test-dev-no-auth": "npx cypress run -c baseUrl=https://dev.dockstore.net -s \"cypress/integration/manualTests/monitor.ts,cypress/integration/manualTests/basic-enduser.ts\"",
     "test-staging-no-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/integration/manualTests/monitor.ts,cypress/integration/manualTests/basic-enduser.ts\"",
     "test-prod-no-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/integration/manualTests/monitor.ts,cypress/integration/manualTests/basic-enduser.ts\"",
-    "test-dev-auth": "npx cypress run --record -c baseUrl=https://staging.dockstore.org -s \"cypress/integration/manualTests/auth-tests.ts\"",
+    "test-dev-auth": "npx cypress run -c baseUrl=https://dev.dockstore.net -s \"cypress/integration/manualTests/auth-tests.ts\"",
     "test-staging-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/integration/manualTests/auth-tests.ts\"",
     "test-prod-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/integration/manualTests/auth-tests.ts\""
   },


### PR DESCRIPTION
- tests were failing because they were running against the wrong URL. Fixed this

- Actions menu was sometimes not going away, keeping Cypress from clicking on other parts of the page even though they are visible to the user. Added { force : true } to fix this.