### PR TITLE
descriptor type bug

### DIFF
--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -121,6 +121,7 @@ export class InfoTabService {
     this.workflowsService.updateWorkflow(this.originalWorkflow.id, workflow).subscribe(
       (updatedWorkflow: Workflow) => {
         this.workflowService.upsertWorkflowToWorkflow(updatedWorkflow);
+        this.workflowService.setWorkflow(updatedWorkflow);
         this.alertService.detailedSuccess();
       },
       (error: HttpErrorResponse) => {


### PR DESCRIPTION
dockstore/dockstore#3489
The original ticket isn't really right. That behavior happens any time you switch descriptor types on a stub and update/save the primary descriptor path. Ended up being just this missing this line.....