### PR TITLE
Feature/seab 1367/assist lambda display

### DIFF
--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -10,7 +10,7 @@
     <!-- *ngIf doesn't work with the sorting implementation, using hidden for now -->
     <div [hidden]="showContent !== 'table'">
       <mat-form-field>
-        <mat-label>Filter (except Date)</mat-label>
+        <mat-label>Filter</mat-label>
         <input #filter matInput (keyup)="applyFilter(filter.value)" placeholder="Ex. PUSH" />
       </mat-form-field>
       <table mat-table [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z3 w-100" matSort>

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -22,10 +22,9 @@
           <th mat-header-cell *matHeaderCellDef mat-sort-header>GitHub Username</th>
           <td mat-cell *matCellDef="let element">{{ element.githubUsername }}</td>
         </ng-container>
-
         <ng-container matColumnDef="{{ column }}" *ngFor="let column of columnsToDisplay">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column | titlecase }}</th>
-          <td mat-cell *matCellDef="let element">{{ element[column] }}</td>
+          <td mat-cell *matCellDef="let element">{{ column | mapFriendlyValue: element[column] }}</td>
         </ng-container>
 
         <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -22,9 +22,10 @@ import { finalize } from 'rxjs/operators';
   styleUrls: ['./github-apps-logs.component.scss'],
   animations: [
     trigger('detailExpand', [
-      state('collapsed', style({ height: '0px', minHeight: '0' })),
+      state('collapsed, void', style({ height: '0px', minHeight: '0' })),
       state('expanded', style({ height: '*' })),
-      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)'))
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+      transition('expanded <=> void', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)'))
     ])
   ]
 })

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -1,4 +1,5 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
+import { DatePipe } from '@angular/common';
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatPaginator, MatSnackBar, MatSort, MatTableDataSource } from '@angular/material';
 import { AlertService } from 'app/shared/alert/state/alert.service';
@@ -28,11 +29,7 @@ import { finalize } from 'rxjs/operators';
   ]
 })
 export class GithubAppsLogsComponent implements OnInit {
-  constructor(
-    @Inject(MAT_DIALOG_DATA) public data: string,
-    private lambdaEventsService: LambdaEventsService,
-    private matSnackBar: MatSnackBar
-  ) {}
+  pipe: DatePipe;
   columnsToDisplay: string[] = ['repository', 'reference', 'success', 'type'];
   displayedColumns: string[] = ['eventDate', 'githubUsername', ...this.columnsToDisplay];
   lambdaEvents: LambdaEvent[] | null;
@@ -44,6 +41,20 @@ export class GithubAppsLogsComponent implements OnInit {
   expandedElement: LambdaEvent | null;
   showContent: 'table' | 'error' | 'empty' | null;
   isExpansionDetailRow = (i: number, row: Object) => row.hasOwnProperty('detailRow');
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: string,
+    private lambdaEventsService: LambdaEventsService,
+    private matSnackBar: MatSnackBar
+  ) {
+    this.pipe = new DatePipe('en');
+    const defaultPredicate = this.dataSource.filterPredicate;
+    // tslint:disable-next-line:no-shadowed-variable
+    this.dataSource.filterPredicate = (data, filter) => {
+      const formatted = this.pipe.transform(data.eventDate, 'medium').toLowerCase();
+      return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
+    };
+  }
 
   ngOnInit() {
     this.loading = true;

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -41,13 +41,12 @@ export class GithubAppsLogsComponent implements OnInit {
   isExpansionDetailRow = (i: number, row: Object) => row.hasOwnProperty('detailRow');
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: string,
+    @Inject(MAT_DIALOG_DATA) public matDialogData: string,
     private lambdaEventsService: LambdaEventsService,
     private matSnackBar: MatSnackBar
   ) {
     this.pipe = new DatePipe('en');
     const defaultPredicate = this.dataSource.filterPredicate;
-    // tslint:disable-next-line:no-shadowed-variable
     this.dataSource.filterPredicate = (data, filter) => {
       const formatted = this.pipe.transform(data.eventDate, 'medium').toLowerCase();
       return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
@@ -59,7 +58,7 @@ export class GithubAppsLogsComponent implements OnInit {
     this.dataSource.sort = this.sort;
     this.dataSource.paginator = this.paginator;
     this.lambdaEventsService
-      .getLambdaEventsByOrganization(this.data)
+      .getLambdaEventsByOrganization(this.matDialogData)
       .pipe(
         finalize(() => {
           this.loading = false;

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -8,9 +8,6 @@ import { finalize } from 'rxjs/operators';
 
 /**
  * Based on https://material.angular.io/components/table/examples example with expandable rows
- * TODO: Filter by date (datasource is using timestamp instead of medium date)
- * TODO: Friendly value map for reference (maybe success, maybe type too)
- * TODO: Fix sort expanding every row
  * TODO: Add backend pagination
  * @export
  * @class GithubAppsLogsComponent

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -5,6 +5,7 @@ import { MAT_DIALOG_DATA, MatPaginator, MatSnackBar, MatSort, MatTableDataSource
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { LambdaEvent, LambdaEventsService } from 'app/shared/openapi';
 import { finalize } from 'rxjs/operators';
+import { MapFriendlyValuesPipe } from '../../../search/map-friendly-values.pipe';
 
 /**
  * Based on https://material.angular.io/components/table/examples example with expandable rows
@@ -27,7 +28,8 @@ import { finalize } from 'rxjs/operators';
   ]
 })
 export class GithubAppsLogsComponent implements OnInit {
-  pipe: DatePipe;
+  datePipe: DatePipe;
+  mapPipe: MapFriendlyValuesPipe;
   columnsToDisplay: string[] = ['repository', 'reference', 'success', 'type'];
   displayedColumns: string[] = ['eventDate', 'githubUsername', ...this.columnsToDisplay];
   lambdaEvents: LambdaEvent[] | null;
@@ -45,10 +47,15 @@ export class GithubAppsLogsComponent implements OnInit {
     private lambdaEventsService: LambdaEventsService,
     private matSnackBar: MatSnackBar
   ) {
-    this.pipe = new DatePipe('en');
+    this.datePipe = new DatePipe('en');
+    this.mapPipe = new MapFriendlyValuesPipe();
     const defaultPredicate = this.dataSource.filterPredicate;
     this.dataSource.filterPredicate = (data, filter) => {
-      const formatted = this.pipe.transform(data.eventDate, 'medium').toLowerCase();
+      const formatted = this.datePipe.transform(data.eventDate, 'medium').toLowerCase();
+      return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
+    };
+    this.dataSource.filterPredicate = (data, filter) => {
+      const formatted = this.mapPipe.transform('success', String(data.success)).toLowerCase();
       return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
     };
   }

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -51,12 +51,9 @@ export class GithubAppsLogsComponent implements OnInit {
     this.mapPipe = new MapFriendlyValuesPipe();
     const defaultPredicate = this.dataSource.filterPredicate;
     this.dataSource.filterPredicate = (data, filter) => {
-      const formatted = this.datePipe.transform(data.eventDate, 'medium').toLowerCase();
-      return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
-    };
-    this.dataSource.filterPredicate = (data, filter) => {
-      const formatted = this.mapPipe.transform('success', String(data.success)).toLowerCase();
-      return formatted.indexOf(filter) >= 0 || defaultPredicate(data, filter);
+      const formattedDate = this.datePipe.transform(data.eventDate, 'medium').toLowerCase();
+      const formattedStatus = this.mapPipe.transform('success', String(data.success)).toLowerCase();
+      return formattedDate.indexOf(filter) >= 0 || formattedStatus.indexOf(filter) >= 0 || defaultPredicate(data, filter);
     };
   }
 

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.module.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.module.ts
@@ -19,10 +19,11 @@ import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RefreshAlertModule } from 'app/shared/alert/alert.module';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
+import { PipeModule } from '../../../shared/pipe/pipe.module';
 import { GithubAppsLogsComponent } from './github-apps-logs.component';
 
 @NgModule({
-  imports: [CustomMaterialModule, CommonModule, RefreshAlertModule, FlexLayoutModule],
+  imports: [CustomMaterialModule, CommonModule, RefreshAlertModule, FlexLayoutModule, PipeModule],
   declarations: [GithubAppsLogsComponent],
   entryComponents: [GithubAppsLogsComponent]
 })

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -105,7 +105,7 @@ export class MapFriendlyValuesPipe implements PipeTransform {
       ])
     ],
     ['success', new Map([['true', 'Success'], ['false', 'Failed']])],
-    ['type', new Map([['PUSH', 'Git Push'], ['DELETE', 'Git Delete'], ['INSTALL', 'Install']])]
+    ['type', new Map([['PUSH', 'Push'], ['DELETE', 'Delete'], ['INSTALL', 'Install']])]
   ]);
 
   /**

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -103,7 +103,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         [SourceFile.TypeEnum.DOCKSTOREYML, 'Configuration'],
         [SourceFile.TypeEnum.DOCKSTORESERVICEOTHER, 'Service Files']
       ])
-    ]
+    ],
+    ['success', new Map([['true', 'Succeeded'], ['false', 'Failed']])]
   ]);
 
   /**

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -104,7 +104,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         [SourceFile.TypeEnum.DOCKSTORESERVICEOTHER, 'Service Files']
       ])
     ],
-    ['success', new Map([['true', 'Succeeded'], ['false', 'Failed']])]
+    ['success', new Map([['true', 'Success'], ['false', 'Failed']])],
+    ['type', new Map([['PUSH', 'Git Push'], ['DELETE', 'Git Delete'], ['INSTALL', 'Install']])]
   ]);
 
   /**


### PR DESCRIPTION
Assist Gary with the lambda display

SEAB-1367

Imported DatePipe in order to format the eventDate into a string,
which enables the filter string to match with the eventDate

Added a new animation state and transition in order to fix
material sort triggering expandable rows

Added a new map friendly value to replace the 'true' and 'false'
values to 'Success' and 'Failed' for the 'success' column

Added a new map friendly value to replace 'PUSH', 'DELETE', and 'INSTALL' to
'Git Push', 'Git Delete', and 'Install' for the 'type' column

Image of how the log would look with new friendly values:
<img width="870" alt="Screen Shot 2020-06-17 at 11 19 55 AM" src="https://user-images.githubusercontent.com/42463687/84937339-713fb080-b090-11ea-873e-6b4c56747b09.png">
