### PR TITLE
Feature/reinstate tool tests

### DIFF
--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -47,13 +47,7 @@ function registerQuayTool(repo: string, name: string) {
     cy.visit('/my-tools');
     // click thru the steps of registering a tool
     cy.wait('@tokens');
-
-    // Commented out until tool delete issue is fixed
-    // See https://github.com/dockstore/dockstore/pull/3494/files
-    // tool will already be there, so no need to register it
-
     cy.get('#register_tool_button').should('be.visible');
-
     cy.get('#register_tool_button').click();
     cy.get('mat-dialog-content').within(() => {
       cy.wait('@orgs');
@@ -263,9 +257,5 @@ function testCollection(org: string, collection: string, registry: string, repo:
 }
 
 testCollection(collectionTuple[0], collectionTuple[1], toolTuple[0], toolTuple[1], toolTuple[2]);
-
-// Commented out until tool delete fix is merged
-// See https://github.com/dockstore/dockstore/pull/3494/files
 testTool(toolTuple[0], toolTuple[1], toolTuple[2]);
-
 testWorkflow(workflowTuple[0], workflowTuple[1], workflowTuple[2]);

--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -22,6 +22,7 @@ function unpublishTool() {
 
 function deleteTool() {
   it('delete the tool', () => {
+    cy.wait(1000);
     cy.contains('button', 'Delete').should('be.visible');
     cy.contains('button', 'Delete').click();
     cy.contains('div', 'Are you sure you wish to delete this tool?').within(() => {
@@ -50,21 +51,25 @@ function registerQuayTool(repo: string, name: string) {
     // Commented out until tool delete issue is fixed
     // See https://github.com/dockstore/dockstore/pull/3494/files
     // tool will already be there, so no need to register it
-    //
-    // cy.get('#register_tool_button').should('be.visible');
-    //
-    // cy.get('#register_tool_button').click();
-    // cy.get('mat-dialog-content').within(() => {
-    //   cy.wait('@orgs');
-    //   cy.contains('mat-radio-button', 'Quickly register Quay.io tools').click();
-    //   cy.contains('button', 'Next').click();
-    //   cy.contains('mat-form-field', 'Select namespace').click();
-    // });
-    // cy.contains('mat-option', repo).click();
-    // cy.wait('@repos');
-    // cy.contains('mat-icon', 'sync').click();
-    // cy.wait('@containers');
-    // cy.contains('button', 'Finish').click();
+
+    cy.get('#register_tool_button').should('be.visible');
+
+    cy.get('#register_tool_button').click();
+    cy.get('mat-dialog-content').within(() => {
+      cy.wait('@orgs');
+      cy.contains('mat-radio-button', 'Quickly register Quay.io tools').click();
+      cy.contains('button', 'Next').click();
+      cy.contains('mat-form-field', 'Select namespace').click();
+    });
+    cy.contains('mat-option', repo).click();
+    cy.wait('@repos');
+    cy.get('mat-dialog-content').within(() => {
+      cy.contains('div', name).within(() => {
+        cy.contains('mat-icon', 'sync').click();
+      });
+    });
+    cy.wait('@containers');
+    cy.contains('button', 'Finish').click();
     cy.contains('button', 'Publish').click();
     cy.wait('@publish');
     cy.wait('@containers');
@@ -253,6 +258,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.visit('/my-tools');
     });
     unpublishTool();
+    deleteTool();
   });
 }
 
@@ -260,6 +266,6 @@ testCollection(collectionTuple[0], collectionTuple[1], toolTuple[0], toolTuple[1
 
 // Commented out until tool delete fix is merged
 // See https://github.com/dockstore/dockstore/pull/3494/files
-// testTool(toolTuple[0], toolTuple[1], toolTuple[2]);
+testTool(toolTuple[0], toolTuple[1], toolTuple[2]);
 
 testWorkflow(workflowTuple[0], workflowTuple[1], workflowTuple[2]);


### PR DESCRIPTION
- IMO the cy.wait(1000) is justified here. Since the delete function is reused in multiple contexts, there's no specific XHR or html content to wait for. But this was a common point of failure/flakiness and the wait seems to resolve it.

- Uncommented tests that were commented out due to the tool deleting issue
