### PR TITLE
error message for tools with no git url

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -34,7 +34,7 @@
   >
     <mat-card class="alert alert-info" role="alert">
       <mat-icon>warning</mat-icon> This Quay.io tool does not have an associated Git repository. Please view the Quay.io repository and add
-      a build trigger for a valid Git repository.
+      a build trigger for a valid Git repository. Once the build has been added, refresh the tool.
     </mat-card>
   </div>
 

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -26,7 +26,20 @@
     </div>
   </div>
 
-  <div class="row m-1" *ngIf="tool?.mode == 'MANUAL_IMAGE_PATH' && tool?.workflowVersions?.length === 0">
+  <div
+    class="row m-1"
+    *ngIf="
+      (tool?.mode === 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS' || tool?.mode === 'AUTO_DETECT_QUAY_TAGS_WITH_MIXED') &&
+      (tool?.gitUrl === '' || tool?.gitUrl === null)
+    "
+  >
+    <mat-card class="alert alert-info" role="alert">
+      <mat-icon>warning</mat-icon> This Quay.io tool does not have an associated Git repository. Please view the Quay.io repository and add
+      a build trigger for a valid Git repository.
+    </mat-card>
+  </div>
+
+  <div class="row m-1" *ngIf="tool?.mode === 'HOSTED' && tool?.workflowVersions?.length === 0">
     <mat-card class="alert alert-info" role="alert">
       <mat-icon>warning</mat-icon> Your manually added tool does not have any tags. Go to the versions tab to add one.
     </mat-card>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -29,8 +29,7 @@
   <div
     class="row m-1"
     *ngIf="
-      (tool?.mode === 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS' || tool?.mode === 'AUTO_DETECT_QUAY_TAGS_WITH_MIXED') &&
-      (tool?.gitUrl === '' || tool?.gitUrl === null)
+      (tool?.mode === ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS || tool?.mode === ModeEnum.AUTODETECTQUAYTAGSWITHMIXED) && !tool?.gitUrl
     "
   >
     <mat-card class="alert alert-info" role="alert">
@@ -39,7 +38,7 @@
     </mat-card>
   </div>
 
-  <div class="row m-1" *ngIf="tool?.mode === 'HOSTED' && tool?.workflowVersions?.length === 0">
+  <div class="row m-1" *ngIf="tool?.mode === ModeEnum.HOSTED && tool?.workflowVersions?.length === 0">
     <mat-card class="alert alert-info" role="alert">
       <mat-icon>warning</mat-icon> Your manually added tool does not have any tags. Go to the versions tab to add one.
     </mat-card>


### PR DESCRIPTION
![Screen Shot 2020-06-25 at 2 34 03 PM](https://user-images.githubusercontent.com/6331159/85778968-1ee63b80-b6f1-11ea-9ed1-047052cb6507.png)

https://ucsc-cgl.atlassian.net/browse/SEAB-1393

If an auto tool from Quay.io has no build triggers with a Git URL, display a message asking to add a build trigger.

Edit: message is now

> This Quay.io tool does not have an associated Git repository. Please view the Quay.io repository and add a build trigger for a valid Git repository. Once the build has been added, refresh the tool.