### PR TITLE
timestamps on news and updates UI

### DIFF
--- a/src/app/home-page/recent-events/recent-events.component.scss
+++ b/src/app/home-page/recent-events/recent-events.component.scss
@@ -1,8 +1,3 @@
-.subtitle {
-  font-size: smaller;
-  color: rgba(0, 0, 0, 0.54);
-}
-
 // The padding between events is 1.6 rem, this puts it in the middle
 .custom-margin {
   margin-top: 0.8rem;

--- a/src/app/home-page/widget/news-updates/news-updates.component.html
+++ b/src/app/home-page/widget/news-updates/news-updates.component.html
@@ -2,6 +2,9 @@
   <div class="news-card" *ngIf="notification.type === notificationTypeEnum.NEWSBODY">
     <markdown class="markdown-remove-pmargin">
       {{ notification.message }}
+      <span class="subtitle">
+        {{ notification.dbCreateDate | date: 'mediumDate' }}
+      </span>
     </markdown>
   </div>
 </div>

--- a/src/app/home-page/widget/news-updates/news-updates.component.scss
+++ b/src/app/home-page/widget/news-updates/news-updates.component.scss
@@ -2,8 +2,3 @@
   padding: 1rem;
   border-bottom: 0.1rem solid #e0e1e2;
 }
-
-.subtitle {
-  font-size: smaller;
-  color: rgba(0, 0, 0, 0.54);
-}

--- a/src/app/home-page/widget/news-updates/news-updates.component.scss
+++ b/src/app/home-page/widget/news-updates/news-updates.component.scss
@@ -2,3 +2,8 @@
   padding: 1rem;
   border-bottom: 0.1rem solid #e0e1e2;
 }
+
+.subtitle {
+  font-size: smaller;
+  color: rgba(0, 0, 0, 0.54);
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1249,3 +1249,9 @@ mat-tab-group.no-pagination {
     display: none;
   }
 }
+
+//color from mat-card-subtitle
+.subtitle {
+  font-size: smaller;
+  color: rgba(0, 0, 0, 0.54);
+}


### PR DESCRIPTION
As described in https://github.com/dockstore/dockstore/issues/3307

The changes add timestamps to `News and Updates` entries as seen in the following screenshot:
![Screenshot_2020-06-25 Dockstore(2)](https://user-images.githubusercontent.com/5513934/85793647-52ca5c80-b703-11ea-91d4-737bc16a7d7b.png)