### PR TITLE
Feature/3617/cypress retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,8 @@
   "viewportHeight": 900,
   "viewportWidth": 1440,
   "defaultCommandTimeout": 30000,
-  "requestTimeout": 30000
+  "requestTimeout": 30000,
+  "env": {
+	  "RETRIES": 2
+  }
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -30,6 +30,7 @@
 
 // Import commands.js and defaults.js
 // using ES2015 syntax:
+import 'cypress-plugin-retries';
 import './commands';
 import './defaults';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6855,6 +6855,67 @@
         }
       }
     },
+    "cypress-plugin-retries": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-retries/-/cypress-plugin-retries-1.5.2.tgz",
+      "integrity": "sha512-o1xVIGtv4WvNVxoVJ2X08eAuvditPHrePRzHqhwwHbMKu3C2rtxCdanRCZdO5fjh8ww+q4v4V0e9GmysbOvu3A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "cytoscape": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/node": "^10.14.19",
     "codelyzer": "^5.0.1",
     "cypress": "^4.0.1",
+    "cypress-plugin-retries": "^1.5.2",
     "husky": "^3.0.5",
     "jasmine-core": "^3.5.0",
     "jasmine-spec-reporter": "^4.2.1",


### PR DESCRIPTION
For dockstore/dockstore#3617

Enables Cypress retries.  No obvious way of telling when retry has occurred, but it does appear to work locally.  Does not appear to retry the db reset issue (because it's in beforeAll).
