### PR TITLE
Feature/update open api generator

### DIFF
--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -9,9 +9,9 @@ GENERATOR_VERSION="4.3.0"
 
 
 # Uncomment this to use the actual Dockstore webservice release from the package.json
- BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
+# BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-#CIRCLE_CI_PATH="https://3984-33383826-gh.circle-artifacts.com/0/tmp/artifacts" 
+CIRCLE_CI_PATH="https://4152-33383826-gh.circle-artifacts.com/0/tmp/artifacts" 
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -24,11 +24,11 @@ rm -Rf src/app/shared/openapi
 
 
 # Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
+#java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+#java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 # Uncomment these two lines to use the CircleCI swagger/openapi instead
-#java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
-#java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 
 
 

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-GENERATOR_VERSION="3.3.4"
+GENERATOR_VERSION="4.3.0"
 
 
 
@@ -24,8 +24,8 @@ rm -Rf src/app/shared/openapi
 
 
 # Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
+java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 # Uncomment these two lines to use the CircleCI swagger/openapi instead
 #java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
 #java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 #JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-JAR_PATH="https://4152-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.9.0-alpha.11-SNAPSHOT.jar"
+JAR_PATH="https://4152-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -4,9 +4,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
-JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
+#JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-#JAR_PATH="https://3984-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.9.0-alpha.11-SNAPSHOT.jar"
+JAR_PATH="https://4152-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.9.0-alpha.11-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -6,7 +6,7 @@ import { NotificationsService } from './state/notifications.service';
 
 interface DismissedNotification {
   id: number;
-  expiration: Date;
+  expiration: number;
 }
 
 @Component({
@@ -35,7 +35,7 @@ export class NotificationsComponent implements OnInit {
   removeExpiredDisabledNotifications() {
     const today = Date.now();
     this.dismissedNotifications = this.dismissedNotifications.filter(notification => {
-      return new Date(notification.expiration).getTime() > today;
+      return notification.expiration > today;
     });
     localStorage.setItem(this.storageKey, JSON.stringify(this.dismissedNotifications));
   }

--- a/src/app/shared/bioschema.service.spec.ts
+++ b/src/app/shared/bioschema.service.spec.ts
@@ -22,7 +22,7 @@ describe('BioschemaService', () => {
   it('should have expected attributes', inject([BioschemaService, DateService], (service: BioschemaService) => {
     // create a DockstoreTool object
     const tag: Tag = { name: '1.0.0', reference: '', id: 2 };
-    const date: Date = new Date('2017-06-28T18:48:18.000Z');
+    const date: number = new Date('2017-06-28T18:48:18.000Z').getTime();
     const tool: DockstoreTool = {
       // Attributes used in the method being tested
       author: 'me',

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -652,7 +652,7 @@ export const elasticSearchResponse: Hit[] = [
 
 export const exampleEntry: Version = {
   commitID: null,
-  dbUpdateDate: new Date(1568664818354),
+  dbUpdateDate: 1568664818354,
   dirtyBit: true,
   doiStatus: 'NOT_REQUESTED',
   doiURL: null,
@@ -735,5 +735,5 @@ export const expiredMockNotification: Notification = {
   message: 'Testing123',
   type: 'SITEWIDE',
   priority: 'LOW',
-  expiration: new Date('2018-11-25T00:00:00')
+  expiration: new Date('2018-11-25T00:00:00').getTime()
 };


### PR DESCRIPTION
Update openapi to...3rd newest version because the newest 2 versions do not like that services extends workflow but has no additional properties.

Skip swagger/openapi validations because the webservice already does validations (and it's not like the frontend can do much about it)