### PR TITLE
Feature/3638/reduce any types part 1

### DIFF
--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -39,7 +39,7 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
   addTagForm: NgForm;
   @ViewChild('addTagForm', { static: true }) currentForm: NgForm;
   public DescriptorType = ToolDescriptor.TypeEnum;
-  public tool: DockstoreTool;
+  public tool;
   public formErrors = formErrors;
   public validationPatterns = validationDescriptorPatterns;
   public trackByIndex: number;

--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -39,16 +39,16 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
   addTagForm: NgForm;
   @ViewChild('addTagForm', { static: true }) currentForm: NgForm;
   public DescriptorType = ToolDescriptor.TypeEnum;
-  public tool;
+  public tool: DockstoreTool;
   public formErrors = formErrors;
   public validationPatterns = validationDescriptorPatterns;
-  public trackByIndex;
+  public trackByIndex: number;
   editMode = true;
   unsavedVersion: Tag;
   unsavedTestCWLFile = '';
   unsavedTestWDLFile = '';
-  unsavedCWLTestParameterFilePaths = [];
-  unsavedWDLTestParameterFilePaths = [];
+  unsavedCWLTestParameterFilePaths: string[] = [];
+  unsavedWDLTestParameterFilePaths: string[] = [];
   // Originally set to false because we made the defaults not duplicate of each other
   public hasDuplicateCWL = false;
   public hasDuplicateWDL = false;

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -24,7 +24,7 @@ import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ListContainersService } from '../containers/list/list.service';
 import { AlertQuery } from '../shared/alert/state/alert.query';
-import { BioschemaService } from '../shared/bioschema.service';
+import { BioschemaService, BioschemaTool } from '../shared/bioschema.service';
 import { includesValidation } from '../shared/constants';
 import { ContainerService } from '../shared/container.service';
 import { DateService } from '../shared/date.service';
@@ -68,7 +68,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public isManualMode$: Observable<boolean>;
   validTabs = ['info', 'launch', 'versions', 'files'];
   separatorKeysCodes = [ENTER, COMMA];
-  public schema;
+  public schema: BioschemaTool;
   public extendedTool$: Observable<ExtendedDockstoreTool>;
   public isRefreshing$: Observable<boolean>;
   constructor(
@@ -260,7 +260,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     this.labelsEditMode = false;
   }
 
-  public toolCopyBtnClick(copyBtn): void {
+  public toolCopyBtnClick(copyBtn: string): void {
     this.containerService.setCopyBtn(copyBtn);
   }
 

--- a/src/app/container/deregister-modal/deregister-modal.component.ts
+++ b/src/app/container/deregister-modal/deregister-modal.component.ts
@@ -28,7 +28,7 @@ import { RegisterToolService } from './../register-tool/register-tool.service';
   styleUrls: ['./deregister-modal.component.css']
 })
 export class ModalComponent implements OnInit {
-  @Input() refreshMessage;
+  @Input() refreshMessage: boolean;
 
   constructor(private registerToolService: RegisterToolService, private confirmationDialogService: ConfirmationDialogService) {}
 

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -70,7 +70,7 @@ export class EmailService {
    * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
    * @param email The tool author's email address
    */
-  private getInquiryEmailMailTo(email): string {
+  private getInquiryEmailMailTo(email: string): string {
     return email;
   }
 

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -20,7 +20,7 @@ import { Dockstore } from '../../shared/dockstore.model';
 import { ExtendedToolsService } from '../../shared/extended-tools.service';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
 import { SessionQuery } from '../../shared/session/session.query';
-import { ToolDescriptor, ToolVersion } from '../../shared/swagger';
+import { ToolDescriptor, ToolVersion, WorkflowVersion } from '../../shared/swagger';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Tag } from '../../shared/swagger/model/tag';
 import { exampleDescriptorPatterns, validationDescriptorPatterns } from '../../shared/validationMessages.model';
@@ -35,9 +35,9 @@ import DescriptorTypeEnum = ToolVersion.DescriptorTypeEnum;
 })
 export class InfoTabComponent implements OnInit, OnChanges {
   currentVersion: Tag;
-  @Input() validVersions;
+  @Input() validVersions: Array<WorkflowVersion | Tag>;
   @Input() selectedVersion: Tag;
-  @Input() privateOnlyRegistry;
+  @Input() privateOnlyRegistry: boolean;
   @Input() extendedDockstoreTool: ExtendedDockstoreTool;
   public validationPatterns = validationDescriptorPatterns;
   public exampleDescriptorPatterns = exampleDescriptorPatterns;

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -24,6 +24,13 @@ import { formInputDebounceTime } from '../../shared/constants';
 import { formErrors, validationDescriptorPatterns, validationMessages } from '../../shared/validationMessages.model';
 import { RegisterToolService } from './register-tool.service';
 
+interface HostedTool {
+  path: string;
+  registry: string;
+  registryProvider: string;
+  entryName?: string;
+}
+
 @Component({
   selector: 'app-register-tool',
   templateUrl: './register-tool.component.html',
@@ -40,7 +47,7 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
   public disablePrivateCheckbox = false;
   public loading$: Observable<boolean>;
   public isRefreshing$: Observable<boolean>;
-  public hostedTool = {
+  public hostedTool: HostedTool = {
     path: '',
     registry: 'quay.io',
     registryProvider: 'Quay.io',

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -21,6 +21,7 @@ import { BehaviorSubject } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { ContainerService } from '../../shared/container.service';
+import { SourceControlBean } from '../../shared/swagger';
 import { ContainersService } from '../../shared/swagger/api/containers.service';
 import { HostedService } from '../../shared/swagger/api/hosted.service';
 import { MetadataService } from '../../shared/swagger/api/metadata.service';
@@ -35,10 +36,10 @@ export class RegisterToolService {
   public showCustomDockerRegistryPath: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public disabledPrivateCheckbox = false;
   private dockerRegistryMap = [];
-  private sourceControlMap = [];
+  private sourceControlMap: Array<SourceControlBean> = [];
   refreshing: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  private tools;
-  private selectedTool;
+  private tools: DockstoreTool[];
+  private selectedTool: DockstoreTool;
   isModalShown: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   tool: BehaviorSubject<any> = new BehaviorSubject<Tool>(
@@ -100,7 +101,7 @@ export class RegisterToolService {
     this.isModalShown.next(isModalShown);
   }
 
-  registerTool(newTool: Tool, customDockerRegistryPath) {
+  registerTool(newTool: Tool, customDockerRegistryPath: string) {
     this.setTool(newTool);
     this.alertService.start('Registering new tool');
     const normalizedToolObj: DockstoreTool = this.getNormalizedToolObj(newTool, customDockerRegistryPath);
@@ -187,7 +188,7 @@ export class RegisterToolService {
     }
   }
 
-  getImagePath(imagePath, part) {
+  getImagePath(imagePath: string, part: string) {
     /** Defines the regex that an image path (namespace/name) must match.
          Group 1 = namespace, Group 2 = name*/
     const imagePathRegexp = /^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)\/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$/i;
@@ -199,7 +200,7 @@ export class RegisterToolService {
     return imageName;
   }
 
-  getGitUrl(gitPath, scrProvider) {
+  getGitUrl(gitPath: string, scrProvider: string) {
     let gitUrl = '';
     switch (scrProvider) {
       case 'GitHub':
@@ -217,7 +218,7 @@ export class RegisterToolService {
     return gitUrl;
   }
 
-  createPath(toolObj: Tool, customDockerRegistryPath) {
+  createPath(toolObj: Tool, customDockerRegistryPath: string) {
     let path = '';
     if (customDockerRegistryPath !== null) {
       path += customDockerRegistryPath;
@@ -249,7 +250,7 @@ export class RegisterToolService {
     }
   }
 
-  getImageRegistryPath(irProvider): string {
+  getImageRegistryPath(irProvider: string): string {
     let foundEnum;
     this.dockerRegistryMap.forEach(element => {
       if (irProvider === element.friendlyName) {
@@ -259,7 +260,7 @@ export class RegisterToolService {
     return foundEnum;
   }
 
-  getToolRegistry(irProvider, customDockerRegistryPath): string {
+  getToolRegistry(irProvider: string, customDockerRegistryPath: string): string {
     let foundPath;
     this.dockerRegistryMap.forEach(element => {
       if (irProvider === element.friendlyName) {

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -28,10 +28,10 @@ import { Tag } from './../../shared/swagger/model/tag';
   styleUrls: ['./tool-file-editor.component.scss']
 })
 export class ToolFileEditorComponent extends FileEditing {
-  dockerFile = [];
-  descriptorFiles = [];
-  testParameterFiles = [];
-  originalSourceFiles = [];
+  dockerFile: Array<SourceFile> = [];
+  descriptorFiles: Array<SourceFile> = [];
+  testParameterFiles: Array<SourceFile> = [];
+  originalSourceFiles: Array<SourceFile> = [];
   currentVersion: Tag;
   selectedDescriptorType: ToolDescriptor.TypeEnum = ToolDescriptor.TypeEnum.CWL;
   isNewestVersion = false;
@@ -76,7 +76,7 @@ export class ToolFileEditorComponent extends FileEditing {
    * @return {Array<SourceFile>} Array of sourcefiles
    */
   getCombinedSourceFiles(): Array<SourceFile> {
-    let baseFiles = [];
+    let baseFiles: Array<SourceFile> = [];
     if (this.descriptorFiles) {
       baseFiles = baseFiles.concat(this.descriptorFiles);
     }

--- a/src/app/container/version-modal/version-modal.component.ts
+++ b/src/app/container/version-modal/version-modal.component.ts
@@ -47,7 +47,7 @@ export class VersionModalComponent extends Base implements OnInit, AfterViewChec
   public editMode: boolean;
   public mode: TagEditorMode;
   public tool: DockstoreTool;
-  public unsavedVersion;
+  public unsavedVersion: Tag;
   private savedCWLTestParameterFilePaths: Array<string>;
   private savedWDLTestParameterFilePaths: Array<string>;
   public unsavedCWLTestParameterFilePaths: Array<string> = [];
@@ -80,7 +80,7 @@ export class VersionModalComponent extends Base implements OnInit, AfterViewChec
   }
 
   // Almost all these functions should be moved to a service
-  getSizeString(size) {
+  getSizeString(size: number) {
     return this.versionModalService.getSizeString(size);
   }
 
@@ -282,7 +282,7 @@ export class VersionModalComponent extends Base implements OnInit, AfterViewChec
     this.savedWDLTestParameterFilePaths = [];
   }
 
-  getDateTimeMessage(timestamp) {
+  getDateTimeMessage(timestamp: number) {
     return this.dateService.getDateTimeMessage(timestamp);
   }
 

--- a/src/app/docs/docs.component.ts
+++ b/src/app/docs/docs.component.ts
@@ -70,7 +70,7 @@ export class DocsComponent implements OnInit {
   }
 
   // Returns a function to test elements of an array against a path
-  findDoc(filteredPath) {
+  findDoc(filteredPath: string) {
     return function(element) {
       return element.existingPath === filteredPath;
     };

--- a/src/app/entry/state/current-collections.service.ts
+++ b/src/app/entry/state/current-collections.service.ts
@@ -23,7 +23,7 @@ export class CurrentCollectionsService {
     this.currentCollectionsStore.add(currentCollection);
   }
 
-  update(id, currentCollection: Partial<CollectionOrganization>) {
+  update(id: ID, currentCollection: Partial<CollectionOrganization>) {
     this.currentCollectionsStore.update(id, currentCollection);
   }
 

--- a/src/app/home-page/state/recent-events.service.ts
+++ b/src/app/home-page/state/recent-events.service.ts
@@ -25,7 +25,7 @@ export class RecentEventsService {
     this.recentEventsStore.add(recentEvent);
   }
 
-  update(id, recentEvent: Partial<Event>) {
+  update(id: ID, recentEvent: Partial<Event>) {
     this.recentEventsStore.update(id, recentEvent);
   }
 

--- a/src/app/home-page/widget/filtered-list.ts
+++ b/src/app/home-page/widget/filtered-list.ts
@@ -3,7 +3,7 @@ import { Base } from 'app/shared/base';
 import { UserQuery } from 'app/shared/user/user.query';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { EntriesService, UsersService } from '../../shared/openapi';
+import { EntriesService, OrganizationUpdateTime, UsersService } from '../../shared/openapi';
 
 /**
  * Base class for logged in homepage widgets that have a filter list
@@ -12,8 +12,8 @@ export abstract class FilteredList extends Base implements OnInit {
   userId$: Observable<number>;
   public hasItems = false;
   public firstCall = true;
-  public myItems;
-  public filterText;
+  public myItems: Array<OrganizationUpdateTime>;
+  public filterText: string;
   public isLoading = true;
   private subject: Subject<string> = new Subject();
 

--- a/src/app/home-page/widget/requests/requests.component.ts
+++ b/src/app/home-page/widget/requests/requests.component.ts
@@ -12,9 +12,9 @@ import { UserQuery } from '../../../shared/user/user.query';
   styleUrls: ['./requests.component.scss']
 })
 export class RequestsComponent extends Base implements OnInit {
-  public myOrganizationInvites;
-  public myOrganizationRequests;
-  public myPendingOrganizationRequests;
+  public myOrganizationInvites: Array<OrganizationUser>;
+  public myOrganizationRequests: Array<OrganizationUser>;
+  public myPendingOrganizationRequests: Array<Organization>;
 
   isAdmin$: Observable<boolean>;
   isCurator$: Observable<boolean>;

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -160,7 +160,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   }
 
   // Show linked services in the UI
-  private setAvailableTokens(tokens) {
+  private setAvailableTokens(tokens: Token[]) {
     for (const account of this.accountsInfo) {
       const found = tokens.find(token => token.tokenSource === account.source);
       if (found) {
@@ -172,7 +172,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   }
 
   // Set tokens and linked services
-  private setTokens(tokens): void {
+  private setTokens(tokens: Token[]): void {
     this.tokens = tokens;
     if (tokens) {
       this.setAvailableTokens(tokens);

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -17,6 +17,7 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatAccordion } from '@angular/material/expansion';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { faSortAlphaDown, faSortAlphaUp, faSortNumericDown, faSortNumericUp } from '@fortawesome/free-solid-svg-icons';
+import { SearchResponse } from 'elasticsearch';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { formInputDebounceTime } from '../shared/constants';
@@ -279,7 +280,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    * @param {*} hits The response hits from elastic search
    * @memberof SearchComponent
    */
-  setupAllBuckets(hits: any) {
+  setupAllBuckets(hits: SearchResponse<Hit>) {
     this.checkboxMap = new Map<string, Map<string, boolean>>();
     const aggregations = hits.aggregations;
     Object.entries(aggregations).forEach(([key, value]) => {

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -44,7 +44,7 @@ export abstract class Entry implements OnInit, OnDestroy {
   public title: string;
   protected _toolType: string;
   protected isLoggedIn: boolean;
-  protected validVersions;
+  protected validVersions: Array<WorkflowVersion | Tag>;
   protected defaultVersion;
   protected published: boolean;
   public labelPattern = validationDescriptorPatterns.label;


### PR DESCRIPTION
Reducing 'any' types part 1

dockstore/dockstore#3638

add-tag.component.ts's 'trackByIndex' is now referenced as a number

deregister-modal.component.ts's 'refreshMessage' is now referenced as a
boolean

info-tab.component.ts now references specific types

register-tool.component.ts now has an interface for 'hostedTool' to
reference

register-tool.service.ts's fields now references specific types with the
exception of 'dockerRegistryMap'

tool-file-editor.component.ts's implicit any type fields now reference
Array<SourceFile>

version-modal.component.ts's 'unsavedVersion' is now referenced as 'Tag'
and method parameters now reference a type

container.component.ts's 'schema' is now referenced as 'BioschemaTool'
and methods' parameters now reference a type

email.service.ts's getInquiryEmailMailTo()'s parameter now references
the string type

docs.component.ts's findDoc()'s parameter now references the string type

current-collections.service.ts's parameter 'id' is now referenced as ID

recent-events.service.ts's parameter 'id' is now referenced as ID

requests.component.ts implicit any fields now reference
Array<OriganizationUser> and Array<Origanizations>

filtered-list.ts's field 'myItems' now reference
Array<OrganizationUpdateTime>

accounts.component.ts's 'tokens' parameter now references Token[] type

search.component.ts's setupAllBuckets()'s 'hits' parameter is now
referenced as a SearchResponse<Hit> type

entry.ts's field 'validVersions' is now referenced as an
Array<WorkflowVersion | Tag> type