### PR TITLE
Use bound href attribute (lgtm fixes)

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -49,7 +49,7 @@
     <div class="col-md-7">
       <h3 id="tool-path">
         <span id="verifiedIcon" *ngIf="(extendedTool$ | async)?.versionVerified">
-          <a href="{{ getVerifiedLink() }}" class="verified-check">
+          <a [href]="getVerifiedLink()" class="verified-check">
             <mat-icon matTooltip="Verified">done</mat-icon>
           </a>
         </span>
@@ -262,7 +262,7 @@
             <span *ngFor="let sortedVersion of sortedVersions">
               <p class="top-down-padding m-0">
                 <span id="verifiedIcon" *ngIf="sortedVersion?.verified">
-                  <a href="{{ getVerifiedLink() }}" class="verified-check">
+                  <a [href]="getVerifiedLink()" class="verified-check">
                     <mat-icon matTooltip="Verified">done</mat-icon>
                   </a>
                 </span>

--- a/src/app/container/deregister-modal/deregister-modal.component.ts
+++ b/src/app/container/deregister-modal/deregister-modal.component.ts
@@ -15,10 +15,9 @@
  */
 
 import { Component, Input, OnInit } from '@angular/core';
-import { first, takeUntil } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { ConfirmationDialogData } from '../../confirmation-dialog/confirmation-dialog.component';
 import { ConfirmationDialogService } from '../../confirmation-dialog/confirmation-dialog.service';
-import { Base } from '../../shared/base';
 import { bootstrap4mediumModalSize } from '../../shared/constants';
 import { RegisterToolService } from './../register-tool/register-tool.service';
 

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -273,7 +273,7 @@
         </div>
         <div>
           <strong matTooltip="E-mail of corresponding author for tool">E-mail</strong>:
-          <a href="mailto:{{ selectedVersion?.email }}" *ngIf="selectedVersion?.email">
+          <a [href]="'mailto:' + selectedVersion?.email" *ngIf="selectedVersion?.email">
             {{ selectedVersion?.email }}
           </a>
           <span *ngIf="!selectedVersion?.email">

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -295,7 +295,7 @@
             <span ng-show="!containerObj.description">
               No description associated with this tool. See
               <a
-                href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started-with-cwl.html"
+                [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-cwl.html'"
                 target="_blank"
                 rel="noopener noreferrer"
                 >Dockstore's Getting Started With CWL</a

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -37,7 +37,7 @@
         Version
         <a
           *ngIf="!publicPage"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#what-is-a-default-version-of-a-tool-or-workflow"
+          [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#what-is-a-default-version-of-a-tool-or-workflow'"
           target="_blank"
           rel="noopener noreferrer"
           ><mat-icon>info</mat-icon></a

--- a/src/app/containers/list/list.component.html
+++ b/src/app/containers/list/list.component.html
@@ -40,7 +40,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell *matCellDef="let tool">
-        <a *ngIf="getVerified(tool)" href="{{ verifiedLink }}">
+        <a *ngIf="getVerified(tool)" [href]="verifiedLink">
           <mat-icon matTooltip="Verified">check</mat-icon>
         </a>
       </mat-cell>

--- a/src/app/docs/docs.component.html
+++ b/src/app/docs/docs.component.html
@@ -22,7 +22,7 @@
       <h2 class="text-center">Dockstore documentation has moved to its own site!</h2>
       <p class="text-center">You can find the new docs at the following link:</p>
       <p class="text-center">
-        <a href="{{ redirectLink }}">{{ getPrettyLink() }}</a>
+        <a [href]="redirectLink">{{ getPrettyLink() }}</a>
       </p>
       <p class="text-center"><small>You will be redirected in 5 seconds.</small></p>
     </div>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -22,7 +22,7 @@
           <li class="m-0">Dockstore</li>
           <li class="m-0">
             <a
-              href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html"
+              [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html'"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -182,14 +182,14 @@
     <div fxLayout="row wrap" fxLayout.lt-md="column" fxLayoutAlign="center center" fxLayoutGap="20px" class="mb-4">
       <a
         mat-stroked-button
-        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+        [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started.html'"
         target="_blank"
         rel="noopener noreferrer"
         data-cy="homepage-getting-started-link"
       >
         Developer tutorial <mat-icon>open_in_new</mat-icon>
       </a>
-      <a mat-stroked-button href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html" target="_blank" rel="noopener noreferrer">
+      <a mat-stroked-button [href]="Dockstore.DOCUMENTATION_URL + '/launch-with/launch.html'" target="_blank" rel="noopener noreferrer">
         Launch workflows <mat-icon>open_in_new</mat-icon>
       </a>
       <button mat-stroked-button routerLink="/organizations" (click)="scrollToTop()" data-cy="homepage-organizations-button">

--- a/src/app/home-page/widget/getting-started/getting-started.component.html
+++ b/src/app/home-page/widget/getting-started/getting-started.component.html
@@ -13,7 +13,7 @@
         color="accent"
         target="_blank"
         rel="noopener noreferrer"
-        href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+        [href]="Dockstore.DOCUMENTATION_URL + '/launch-with/launch.html'"
         >Learn how to launch tools and workflows <mat-icon>open_in_new</mat-icon>
       </a>
     </div>
@@ -31,7 +31,7 @@
         color="accent"
         target="_blank"
         rel="noopener noreferrer"
-        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+        [href]="Dockstore.DOCUMENTATION_URL + 'getting-started/getting-started.html'"
         >Learn more about containers and descriptors <mat-icon>open_in_new</mat-icon>
       </a>
       <a
@@ -40,7 +40,7 @@
         color="accent"
         target="_blank"
         rel="noopener noreferrer"
-        href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/register-on-dockstore.html#linking-with-external-services"
+        [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/register-on-dockstore.html#linking-with-external-services'"
         >Learn how to register content <mat-icon>open_in_new</mat-icon>
       </a>
     </div>
@@ -58,7 +58,7 @@
         color="accent"
         target="_blank"
         rel="noopener noreferrer"
-        href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
+        [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/organizations-and-collections.html'"
         >Read about organizations and collections <mat-icon>open_in_new</mat-icon>
       </a>
     </div>

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -94,7 +94,7 @@
           color="accent"
           target="_blank"
           rel="noopener noreferrer"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html"
+          [href]="Dockstore.DOCUMENTATION_URL + '/launch-with/launch.html'"
           >Learn how to launch tools and workflows <mat-icon>open_in_new</mat-icon></a
         >
       </div>
@@ -111,7 +111,7 @@
           color="accent"
           target="_blank"
           rel="noopener noreferrer"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started.html"
+          [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started.html'"
           >Learn how to register content <mat-icon>open_in_new</mat-icon></a
         >
       </div>
@@ -128,7 +128,7 @@
           color="accent"
           target="_blank"
           rel="noopener noreferrer"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/organizations-and-collections.html"
+          [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/organizations-and-collections.html'"
           >Read about organizations and collections <mat-icon>open_in_new</mat-icon></a
         >
       </div>
@@ -140,7 +140,7 @@
         Dockstore developers and the general Dockstore audience.
       </p>
       <div class="button-row">
-        <a mat-button color="accent" target="_blank" rel="noopener noreferrer" href="{{ Dockstore.DOCUMENTATION_URL }}"
+        <a mat-button color="accent" target="_blank" rel="noopener noreferrer" [href]="Dockstore.DOCUMENTATION_URL"
           >Documentation <mat-icon> open_in_new</mat-icon></a
         >
         <a mat-button color="accent" target="_blank" rel="noopener noreferrer" href="https://discuss.dockstore.org"

--- a/src/app/loginComponents/onboarding/quickstart.component.html
+++ b/src/app/loginComponents/onboarding/quickstart.component.html
@@ -28,7 +28,7 @@
         <button class="changePage" (click)="prevStep()"><mat-icon>chevron_left</mat-icon>Previous</button>
       </li>
       <li>
-        <a href="{{ Dockstore.DOCUMENTATION_URL }}/launch-with/launch.html" target="_blank" rel="noopener noreferrer"
+        <a [href]="Dockstore.DOCUMENTATION_URL + '/launch-with/launch.html'" target="_blank" rel="noopener noreferrer"
           >Finish<mat-icon>chevron_right</mat-icon></a
         >
       </li>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -26,10 +26,10 @@
         <a mat-button class="icon" (click)="resetPageNumber()" routerLink="/organizations">
           <mat-icon class="hidden-sm">people</mat-icon> Organizations
         </a>
-        <a mat-button class="icon" href="{{ Dockstore.DOCUMENTATION_URL }}" target="_blank" rel="noopener noreferrer">
+        <a mat-button class="icon" [href]="Dockstore.DOCUMENTATION_URL" target="_blank" rel="noopener noreferrer">
           <img class="site-icons-small hidden-sm" src="../assets/images/dockstore/dockstore-documentation.png" alt="stacked pages" /> Docs
         </a>
-        <a mat-button class="icon" href="{{ Dockstore.DISCOURSE_URL }}" target="_blank" rel="noopener noreferrer">
+        <a mat-button class="icon" [href]="Dockstore.DISCOURSE_URL" target="_blank" rel="noopener noreferrer">
           <mat-icon class="hidden-sm">help_outline</mat-icon> Help
         </a>
         <span class="spacer"></span>
@@ -89,7 +89,7 @@
     <div class="container-fluid navbar-holder">
       <a mat-button class="icon icon-sm" routerLink="/search">Search</a>
       <a mat-button class="icon icon-sm" routerLink="/organizations">Organizations</a>
-      <a mat-button class="icon icon-sm" href="{{ Dockstore.DOCUMENTATION_URL }}" target="_blank" rel="noopener noreferrer">Docs</a>
+      <a mat-button class="icon icon-sm" [href]="Dockstore.DOCUMENTATION_URL" target="_blank" rel="noopener noreferrer">Docs</a>
     </div>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -40,7 +40,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
-        <a *ngIf="tool.verified" href="{{ verifiedLink }}">
+        <a *ngIf="tool.verified" [href]="verifiedLink">
           <mat-icon matTooltip="Verified">check</mat-icon>
         </a>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -23,7 +23,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">
-        <a *ngIf="workflow.verified" href="{{ verifiedLink }}">
+        <a *ngIf="workflow.verified" [href]="verifiedLink">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>
       </mat-cell>

--- a/src/app/sitemap/sitemap.component.html
+++ b/src/app/sitemap/sitemap.component.html
@@ -43,17 +43,17 @@
     <h3 class="documentation">Using Dockstore</h3>
     <ul>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/news.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/news.html'" rel="noopener noreferrer">
           News and Events
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/advanced-features.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/advanced-features.html'" rel="noopener noreferrer">
           Advanced Features
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/faq.html'" rel="noopener noreferrer">
           FAQ
         </a>
       </li>
@@ -78,26 +78,30 @@
     <h3>Adding to Dockstore</h3>
     <ul>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/register-on-dockstore.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/register-on-dockstore.html'" rel="noopener noreferrer">
           Sign Up for Accounts
         </a>
       </li>
       <li>
         <a
           target="_blank"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started-with-docker.html"
+          [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-docker.html'"
           rel="noopener noreferrer"
         >
           Create Your Tool
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started-with-cwl.html" rel="noopener noreferrer">
+        <a
+          target="_blank"
+          [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-cwl.html'"
+          rel="noopener noreferrer"
+        >
           Describe Your Tool
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/dockstore-tools.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/dockstore-tools.html'" rel="noopener noreferrer">
           Register Your Tool in Dockstore
         </a>
       </li>
@@ -105,35 +109,35 @@
     <h3>About Dockstore</h3>
     <ul>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html'" rel="noopener noreferrer">
           About the Dockstore
         </a>
       </li>
       <li>
         <a
           target="_blank"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html#built-with-docker-and-git"
+          [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html#built-with-docker-and-git'"
           rel="noopener noreferrer"
         >
           Built with Quay.io and Github
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html#strategies" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html#strategies'" rel="noopener noreferrer">
           Best Practices
         </a>
       </li>
       <li>
         <a
           target="_blank"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html#promoting-standards"
+          [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html#promoting-standards'"
           rel="noopener noreferrer"
         >
           Promoting Standards
         </a>
       </li>
       <li>
-        <a target="_blank" href="{{ Dockstore.DOCUMENTATION_URL }}/dockstore-introduction.html#future-plans" rel="noopener noreferrer">
+        <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/dockstore-introduction.html#future-plans'" rel="noopener noreferrer">
           Future Plans
         </a>
       </li>

--- a/src/app/sponsors/sponsors.component.html
+++ b/src/app/sponsors/sponsors.component.html
@@ -20,7 +20,7 @@
     <!-- TODO: Will need to adjust spacing once the Broad Logo is added -->
     <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">
       <div *ngFor="let sponsor of sponsors" class="pb-5 px-1">
-        <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer">
+        <a [href]="sponsor.url" target="_blank" rel="noopener noreferrer">
           <!-- Get the sponsor website name from its URL to use as alt text-->
           <img [src]="sponsor.current" [alt]="sponsor.url.hostname + ' logo'" />
         </a>
@@ -32,7 +32,7 @@
     <br />
     <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">
       <div *ngFor="let partner of languages" class="pb-5 px-1">
-        <a href="{{ partner.url }}" target="_blank" rel="noopener noreferrer">
+        <a [href]="partner.url" target="_blank" rel="noopener noreferrer">
           <img [src]="partner.current" />
         </a>
       </div>
@@ -43,7 +43,7 @@
     <br />
     <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">
       <div *ngFor="let partner of partners" class="pb-5 px-1">
-        <a href="{{ partner.url }}" target="_blank" rel="noopener noreferrer">
+        <a [href]="partner.url" target="_blank" rel="noopener noreferrer">
           <img [src]="partner.current" [alt]="partner.url.hostname + ' logo'" />
         </a>
       </div>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -38,8 +38,8 @@
             <span mat-line>
               <small class="spacing">Last updated {{ tool?.lastUpdated | date }}</small>
               <span class="spacing" *ngFor="let type of tool?.descriptorType">{{ type | uppercase }}</span>
-              <a class="spacing" *ngIf="tool?.provider" href="{{ tool?.providerUrl }}">{{ tool?.provider }}</a>
-              <a class="spacing" *ngIf="tool?.imgProvider" href="{{ tool?.imgProviderUrl }}">{{ tool?.imgProvider }}</a>
+              <a class="spacing" *ngIf="tool?.provider" [href]="tool?.providerUrl">{{ tool?.provider }}</a>
+              <a class="spacing" *ngIf="tool?.imgProvider" [href]="tool?.imgProviderUrl">{{ tool?.imgProvider }}</a>
             </span>
             <app-starring class="pull-right" style="width: 100px;" [tool]="tool" (change)="starGazersChange()"></app-starring>
             <mat-divider></mat-divider>
@@ -70,7 +70,7 @@
             <span mat-line>
               <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
               <span class="spacing">{{ workflow?.descriptorType | uppercase }}</span>
-              <a class="spacing" *ngIf="workflow?.provider" href="{{ workflow?.providerUrl }}">{{ workflow?.provider }}</a>
+              <a class="spacing" *ngIf="workflow?.provider" [href]="workflow?.providerUrl">{{ workflow?.provider }}</a>
             </span>
             <app-starring class="pull-right" style="width: 100px;" [workflow]="workflow" (change)="starGazersChange()"></app-starring>
             <mat-divider></mat-divider>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -191,7 +191,7 @@
       </div>
       <div>
         <strong matTooltip="E-mail of corresponding author for workflow">E-mail</strong>:
-        <a href="mailto:{{ selectedVersion?.email }}" *ngIf="selectedVersion?.email">
+        <a [href]="'mailto:' + selectedVersion?.email" *ngIf="selectedVersion?.email">
           {{ workflow?.email }}
         </a>
         <span *ngIf="!selectedVersion?.email">

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -25,7 +25,7 @@
   >
     Keep your workflow automatically in sync with GitHub with our new registration process. Click
     <a
-      href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml"
+      [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml'"
       target="_blank"
       rel="noopener noreferrer"
       class="link-with-underline"
@@ -216,7 +216,7 @@
                 <span *ngSwitchCase="ToolDescriptor.TypeEnum.CWL">
                   See&nbsp;
                   <a
-                    href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/best-practices/best-practices.html#authorship-metadata"
+                    [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/best-practices/best-practices.html#authorship-metadata'"
                     target="_blank"
                     rel="noopener noreferrer"
                     >CWL Best Practices</a
@@ -227,7 +227,7 @@
                 <span *ngSwitchCase="ToolDescriptor.TypeEnum.WDL">
                   See&nbsp;
                   <a
-                    href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/best-practices/wdl-best-practices.html#authorship-metadata"
+                    [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/best-practices/wdl-best-practices.html#authorship-metadata'"
                     target="_blank"
                     rel="noopener noreferrer"
                     >WDL Best Practices</a
@@ -236,7 +236,7 @@
                 <span *ngSwitchCase="ToolDescriptor.TypeEnum.NFL">
                   See&nbsp;
                   <a
-                    href="{{ Dockstore.DOCUMENTATION_URL }}/advanced-topics/best-practices/nfl-best-practices.html#authorship-metadata"
+                    [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/best-practices/nfl-best-practices.html#authorship-metadata'"
                     target="_blank"
                     rel="noopener noreferrer"
                     >Nextflow Best Practices</a

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -53,7 +53,7 @@
       <div *ngIf="selectedOption?.value === 0">
         <p>
           Navigate to GitHub to install our GitHub app on your repositories/organizations. See our
-          <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps.html" target="_blank" rel="noopener noreferrer">
+          <a [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/github-apps.html'" target="_blank" rel="noopener noreferrer">
             documentation <mat-icon>open_in_new</mat-icon>
           </a>
           for how to use GitHub Apps to automatically sync your workflows with GitHub. A .dockstore.yml file is required.

--- a/src/app/workflow/tool-tab/tool-tab.component.html
+++ b/src/app/workflow/tool-tab/tool-tab.component.html
@@ -41,7 +41,7 @@
           <strong>docker</strong>:&nbsp;{{ tool?.docker }}
           <br />
           <strong>link</strong>:&nbsp;<a
-            href="{{ tool?.link }}"
+            [href]="tool?.link"
             target="_blank"
             *ngIf="tool?.link !== 'Not Specified'"
             rel="noopener noreferrer"

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -37,7 +37,7 @@
         Git Reference&nbsp;
         <a
           class="ds-green"
-          href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#what-is-a-default-version-of-a-tool-or-workflow"
+          [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#what-is-a-default-version-of-a-tool-or-workflow'"
           target="_blank"
           rel="noopener noreferrer"
           ><mat-icon>info</mat-icon></a
@@ -48,7 +48,7 @@
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="{{ Dockstore.DOCUMENTATION_URL }}/faq.html#what-is-a-default-version-of-a-tool-or-workflow"
+            [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#what-is-a-default-version-of-a-tool-or-workflow'"
             ><span *ngIf="defaultVersion === version.name" class="label label-primary">Default</span></a
           >
           <i *ngIf="version.referenceType === 'BRANCH'" class="fa fa-code-fork" aria-hidden="true" title="Branch"></i>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -49,7 +49,7 @@
     <div class="col-md-7">
       <h3 id="workflow-path" data-cy="workflowTitle" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="1rem">
         <span id="verifiedIcon" *ngIf="(extendedWorkflow$ | async)?.versionVerified">
-          <a href="{{ getVerifiedLink() }}" class="verified-check">
+          <a [href]="getVerifiedLink()" class="verified-check">
             <mat-icon matTooltip="Verified">done</mat-icon>
           </a>
         </span>
@@ -390,7 +390,7 @@
             <span *ngFor="let sortedVersion of sortedVersions">
               <p class="top-down-padding m-0">
                 <span id="verifiedIcon" *ngIf="sortedVersion?.verified">
-                  <a href="{{ getVerifiedLink() }}" class="verified-check">
+                  <a [href]="getVerifiedLink()" class="verified-check">
                     <mat-icon matTooltip="Verified">done</mat-icon>
                   </a>
                 </span>

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -37,7 +37,7 @@
     <ng-container matColumnDef="verified">
       <mat-header-cell *matHeaderCellDef>Verified</mat-header-cell>
       <mat-cell *matCellDef="let workflow">
-        <a *ngIf="getVerified(workflow)" href="{{ verifiedLink }}">
+        <a *ngIf="getVerified(workflow)" [href]="verifiedLink">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>
       </mat-cell>


### PR DESCRIPTION
This PR accepts two suggested changes from [LGTM](https://lgtm.com/projects/g/dockstore/dockstore-ui2/alerts/?mode=list).

1. Use bound attributes in links instead of double braces. Using double-braces in a link can cause rendering of a broken link in some circumstances. [more info](https://lgtm.com/rules/1945880031/)
1. remove unused imports

This issue was also observed in reviewing the LGTM alerts. https://github.com/dockstore/dockstore/issues/3645