### PR TITLE
fill input fields to available width when editing in info tab

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -60,28 +60,23 @@
             </li>
           </span>
           <li *ngIf="tool?.default_dockerfile_path || !isPublic">
-            <form #editDockerfileForm="ngForm" class="form-inline">
-              <div class="form-group">
+            <form #editDockerfileForm="ngForm" class="form-inline inline-flex-form">
+              <div class="form-group inline-flex-form flex-grow-1">
                 <strong matTooltip="Path in Git repository to the tool's Dockerfile">Dockerfile Path</strong>:
-                <span *ngIf="!dockerFileEditing">{{ tool?.default_dockerfile_path }}</span>
+                <span *ngIf="!dockerFileEditing" class="hori-offset-4">{{ tool?.default_dockerfile_path }}</span>
                 <input
                   *ngIf="dockerFileEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.dockerfilePath"
                   type="text"
-                  class="input-default form-control"
+                  class="input-default form-control flex-grow-1 hori-offset-4"
                   name="contDockerfilePath"
                   [(ngModel)]="tool.default_dockerfile_path"
                   placeholder="e.g. /Dockerfile"
                 />
               </div>
-              <div
-                *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
-                class="btn-group push-right"
-                role="group"
-                aria-label="Basic example"
-              >
+              <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                 <button *ngIf="!isPublic && dockerFileEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                   <mat-icon>cancel</mat-icon> Cancel
                 </button>
@@ -100,10 +95,10 @@
             </form>
           </li>
           <li *ngIf="tool?.default_cwl_path || !isPublic">
-            <form #editCWLPathForm="ngForm" class="form-inline">
-              <div class="form-group">
+            <form #editCWLPathForm="ngForm" class="form-inline inline-flex-form">
+              <div class="form-group inline-flex-form flex-grow-1">
                 <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Path</strong>:
-                <span *ngIf="!cwlPathEditing"> {{ tool?.default_cwl_path || 'n/a' }}</span>
+                <span *ngIf="!cwlPathEditing" class="hori-offset-4"> {{ tool?.default_cwl_path || 'n/a' }}</span>
                 <input
                   *ngIf="cwlPathEditing"
                   [required]="!tool?.default_wdl_path"
@@ -111,18 +106,13 @@
                   maxlength="256"
                   [pattern]="validationPatterns.cwlPath"
                   type="text"
-                  class="input-default form-control"
+                  class="input-default form-control flex-grow-1 hori-offset-4"
                   name="contCWLPath"
                   [(ngModel)]="tool.default_cwl_path"
                   [placeholder]="exampleDescriptorPatterns.cwl"
                 />
               </div>
-              <div
-                *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
-                class="btn-group push-right"
-                role="group"
-                aria-label="Basic example"
-              >
+              <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                 <button *ngIf="!isPublic && cwlPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                   <mat-icon>cancel</mat-icon> Cancel
                 </button>
@@ -141,10 +131,10 @@
             </form>
           </li>
           <li *ngIf="tool?.default_wdl_path || !isPublic">
-            <form #editWDLPathForm="ngForm" class="form-inline">
-              <div class="form-group">
+            <form #editWDLPathForm="ngForm" class="form-inline inline-flex-form">
+              <div class="form-group inline-flex-form flex-grow-1">
                 <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Path</strong>:
-                <span *ngIf="!wdlPathEditing">{{ tool?.default_wdl_path || 'n/a' }}</span>
+                <span *ngIf="!wdlPathEditing" class="hori-offset-4">{{ tool?.default_wdl_path || 'n/a' }}</span>
                 <input
                   *ngIf="wdlPathEditing"
                   [required]="!tool?.default_cwl_path"
@@ -152,18 +142,13 @@
                   maxlength="256"
                   [pattern]="validationPatterns.wdlPath"
                   type="text"
-                  class="input-default form-control"
+                  class="input-default form-control flex-grow-1 hori-offset-4"
                   name="contWDLPath"
                   [(ngModel)]="tool.default_wdl_path"
                   [placeholder]="exampleDescriptorPatterns.wdl"
                 />
               </div>
-              <div
-                *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
-                class="btn-group push-right"
-                role="group"
-                aria-label="Basic example"
-              >
+              <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                 <button *ngIf="!isPublic && wdlPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                   <mat-icon>cancel</mat-icon> Cancel
                 </button>
@@ -182,17 +167,17 @@
             </form>
           </li>
           <li>
-            <form #editCWLTestPathForm="ngForm" class="form-inline">
-              <div class="form-group">
+            <form #editCWLTestPathForm="ngForm" class="form-inline inline-flex-form">
+              <div class="form-group inline-flex-form flex-grow-1">
                 <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Test Parameter File Path</strong>:
-                <span *ngIf="!cwlTestPathEditing"> {{ tool?.defaultCWLTestParameterFile || 'n/a' }}</span>
+                <span *ngIf="!cwlTestPathEditing" class="hori-offset-4"> {{ tool?.defaultCWLTestParameterFile || 'n/a' }}</span>
                 <input
                   *ngIf="cwlTestPathEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.testFilePath"
                   type="text"
-                  class="input-default form-control"
+                  class="input-default form-control flex-grow-1 hori-offset-4"
                   name="CWLTestPath"
                   [(ngModel)]="tool.defaultCWLTestParameterFile"
                   placeholder="e.g. /test.cwl.json"
@@ -202,7 +187,7 @@
                 *ngIf="!isPublic && tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
                 type="button"
                 [disabled]="!(!somethingIsBeingEdited() || (cwlTestPathEditing && editCWLTestPathForm.valid))"
-                class="btn btn-link push-right"
+                class="btn btn-link"
                 (click)="toggleEditCWLTestPath()"
               >
                 <mat-icon *ngIf="cwlTestPathEditing">save</mat-icon>
@@ -212,17 +197,17 @@
             </form>
           </li>
           <li>
-            <form #editWDLTestPathForm="ngForm" class="form-inline">
-              <div class="form-group">
+            <form #editWDLTestPathForm="ngForm" class="form-inline inline-flex-form">
+              <div class="form-group inline-flex-form flex-grow-1">
                 <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Test Parameter File Path</strong>:
-                <span *ngIf="!wdlTestPathEditing">{{ tool?.defaultWDLTestParameterFile || 'n/a' }}</span>
+                <span *ngIf="!wdlTestPathEditing" class="hori-offset-4">{{ tool?.defaultWDLTestParameterFile || 'n/a' }}</span>
                 <input
                   *ngIf="wdlTestPathEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.testFilePath"
                   type="text"
-                  class="input-default form-control"
+                  class="input-default form-control flex-grow-1 hori-offset-4"
                   name="WDLTestPath"
                   [(ngModel)]="tool.defaultWDLTestParameterFile"
                   placeholder="e.g. /test.wdl.json"
@@ -232,7 +217,7 @@
                 *ngIf="!isPublic && tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
                 type="button"
                 [disabled]="!(!somethingIsBeingEdited() || (wdlTestPathEditing && editWDLTestPathForm.valid))"
-                class="btn btn-link push-right"
+                class="btn btn-link"
                 (click)="toggleEditWDLTestPath()"
               >
                 <mat-icon *ngIf="wdlTestPathEditing">save</mat-icon>

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -60,20 +60,22 @@
             </li>
           </span>
           <li *ngIf="tool?.default_dockerfile_path || !isPublic">
-            <form #editDockerfileForm="ngForm" class="form-inline inline-flex-form">
-              <div class="form-group inline-flex-form flex-grow-1">
+            <form #editDockerfileForm="ngForm" class="form-inline" fxLayout>
+              <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                 <strong matTooltip="Path in Git repository to the tool's Dockerfile">Dockerfile Path</strong>:
-                <span *ngIf="!dockerFileEditing" class="hori-offset-4">{{ tool?.default_dockerfile_path }}</span>
+                <span *ngIf="!dockerFileEditing" fxFlexOffset="4px">{{ tool?.default_dockerfile_path }}</span>
                 <input
                   *ngIf="dockerFileEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.dockerfilePath"
                   type="text"
-                  class="input-default form-control flex-grow-1 hori-offset-4"
+                  class="input-default form-control"
                   name="contDockerfilePath"
                   [(ngModel)]="tool.default_dockerfile_path"
                   placeholder="e.g. /Dockerfile"
+                  fxFlex="noshrink"
+                  fxFlexOffset="4px"
                 />
               </div>
               <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
@@ -95,10 +97,10 @@
             </form>
           </li>
           <li *ngIf="tool?.default_cwl_path || !isPublic">
-            <form #editCWLPathForm="ngForm" class="form-inline inline-flex-form">
-              <div class="form-group inline-flex-form flex-grow-1">
+            <form #editCWLPathForm="ngForm" class="form-inline" fxLayout>
+              <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                 <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Path</strong>:
-                <span *ngIf="!cwlPathEditing" class="hori-offset-4"> {{ tool?.default_cwl_path || 'n/a' }}</span>
+                <span *ngIf="!cwlPathEditing" fxFlexOffset="4px"> {{ tool?.default_cwl_path || 'n/a' }}</span>
                 <input
                   *ngIf="cwlPathEditing"
                   [required]="!tool?.default_wdl_path"
@@ -106,10 +108,12 @@
                   maxlength="256"
                   [pattern]="validationPatterns.cwlPath"
                   type="text"
-                  class="input-default form-control flex-grow-1 hori-offset-4"
+                  class="input-default form-control"
                   name="contCWLPath"
                   [(ngModel)]="tool.default_cwl_path"
                   [placeholder]="exampleDescriptorPatterns.cwl"
+                  fxFlex="noshrink"
+                  fxFlexOffset="4px"
                 />
               </div>
               <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
@@ -131,10 +135,10 @@
             </form>
           </li>
           <li *ngIf="tool?.default_wdl_path || !isPublic">
-            <form #editWDLPathForm="ngForm" class="form-inline inline-flex-form">
-              <div class="form-group inline-flex-form flex-grow-1">
+            <form #editWDLPathForm="ngForm" class="form-inline" fxLayout>
+              <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                 <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Path</strong>:
-                <span *ngIf="!wdlPathEditing" class="hori-offset-4">{{ tool?.default_wdl_path || 'n/a' }}</span>
+                <span *ngIf="!wdlPathEditing" fxFlexOffset="4px">{{ tool?.default_wdl_path || 'n/a' }}</span>
                 <input
                   *ngIf="wdlPathEditing"
                   [required]="!tool?.default_cwl_path"
@@ -142,10 +146,12 @@
                   maxlength="256"
                   [pattern]="validationPatterns.wdlPath"
                   type="text"
-                  class="input-default form-control flex-grow-1 hori-offset-4"
+                  class="input-default form-control"
                   name="contWDLPath"
                   [(ngModel)]="tool.default_wdl_path"
                   [placeholder]="exampleDescriptorPatterns.wdl"
+                  fxFlex="noshrink"
+                  fxFlexOffset="4px"
                 />
               </div>
               <div *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
@@ -167,20 +173,22 @@
             </form>
           </li>
           <li>
-            <form #editCWLTestPathForm="ngForm" class="form-inline inline-flex-form">
-              <div class="form-group inline-flex-form flex-grow-1">
+            <form #editCWLTestPathForm="ngForm" class="form-inline" fxLayout>
+              <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                 <strong matTooltip="Path in Git repository to main CWL descriptor file">CWL Test Parameter File Path</strong>:
-                <span *ngIf="!cwlTestPathEditing" class="hori-offset-4"> {{ tool?.defaultCWLTestParameterFile || 'n/a' }}</span>
+                <span *ngIf="!cwlTestPathEditing" fxFlexOffset="4px"> {{ tool?.defaultCWLTestParameterFile || 'n/a' }}</span>
                 <input
                   *ngIf="cwlTestPathEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.testFilePath"
                   type="text"
-                  class="input-default form-control flex-grow-1 hori-offset-4"
+                  class="input-default form-control"
                   name="CWLTestPath"
                   [(ngModel)]="tool.defaultCWLTestParameterFile"
                   placeholder="e.g. /test.cwl.json"
+                  fxFlex="noshrink"
+                  fxFlexOffset="4px"
                 />
               </div>
               <button
@@ -197,20 +205,22 @@
             </form>
           </li>
           <li>
-            <form #editWDLTestPathForm="ngForm" class="form-inline inline-flex-form">
-              <div class="form-group inline-flex-form flex-grow-1">
+            <form #editWDLTestPathForm="ngForm" class="form-inline" fxLayout>
+              <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                 <strong matTooltip="Path in Git repository to main WDL descriptor file">WDL Test Parameter File Path</strong>:
-                <span *ngIf="!wdlTestPathEditing" class="hori-offset-4">{{ tool?.defaultWDLTestParameterFile || 'n/a' }}</span>
+                <span *ngIf="!wdlTestPathEditing" fxFlexOffset="4px">{{ tool?.defaultWDLTestParameterFile || 'n/a' }}</span>
                 <input
                   *ngIf="wdlTestPathEditing"
                   minlength="3"
                   maxlength="256"
                   [pattern]="validationPatterns.testFilePath"
                   type="text"
-                  class="input-default form-control flex-grow-1 hori-offset-4"
+                  class="input-default form-control"
                   name="WDLTestPath"
                   [(ngModel)]="tool.defaultWDLTestParameterFile"
                   placeholder="e.g. /test.wdl.json"
+                  fxFlex="noshrink"
+                  fxFlexOffset="4px"
                 />
               </div>
               <button

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -58,28 +58,27 @@
         <div *ngIf="(entryType$ | async) === EntryType.BioWorkflow">
           <span>
             <li *ngIf="workflow?.workflow_path || !isPublic">
-              <form #editWorkflowPathForm="ngForm" class="form-inline" *ngIf="workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML">
-                <div class="form-group">
+              <form
+                #editWorkflowPathForm="ngForm"
+                class="form-inline inline-flex-form"
+                *ngIf="workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML"
+              >
+                <div class="form-group inline-flex-form flex-grow-1">
                   <strong [matTooltip]="tooltip.workflowPath">Workflow Path: </strong>
-                  <span *ngIf="!workflowPathEditing"> {{ workflow.workflow_path }} </span>
+                  <span *ngIf="!workflowPathEditing" class="hori-offset-4"> {{ workflow.workflow_path }} </span>
                   <input
                     *ngIf="workflowPathEditing"
                     minlength="3"
                     maxlength="256"
                     [pattern]="validationPatterns.workflowDescriptorPath"
                     type="text"
-                    class="input-default form-control"
+                    class="input-default form-control flex-grow-1 hori-offset-4"
                     name="workflowPath"
                     [(ngModel)]="workflow.workflow_path"
                     placeholder="e.g. /Dockstore.cwl"
                   />
                 </div>
-                <div
-                  *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED"
-                  class="btn-group push-right"
-                  role="group"
-                  aria-label="Basic example"
-                >
+                <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                   <button *ngIf="!isPublic && workflowPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
@@ -98,19 +97,19 @@
               </form>
               <form
                 #editTestFilePathForm="ngForm"
-                class="form-inline"
+                class="form-inline inline-flex-form"
                 *ngIf="!(isNFL$ | async) && workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML"
               >
-                <div class="form-group">
+                <div class="form-group inline-flex-form flex-grow-1">
                   <strong matTooltip="Path in Git repository to main descriptor file">Test File Path</strong>:
-                  <span *ngIf="!defaultTestFilePathEditing"> {{ workflow?.defaultTestParameterFilePath }} </span>
+                  <span *ngIf="!defaultTestFilePathEditing" class="hori-offset-4"> {{ workflow?.defaultTestParameterFilePath }} </span>
                   <input
                     *ngIf="defaultTestFilePathEditing"
                     minlength="3"
                     maxlength="256"
                     [pattern]="validationPatterns.testFilePath"
                     type="text"
-                    class="input-default form-control"
+                    class="input-default form-control flex-grow-1 hori-offset-4"
                     name="workflowPath"
                     [(ngModel)]="workflow.defaultTestParameterFilePath"
                     placeholder="e.g. /Dockstore.cwl"
@@ -121,7 +120,7 @@
                     *ngIf="!isPublic"
                     type="button"
                     [disabled]="workflowPathEditing || (defaultTestFilePathEditing && !editTestFilePathForm.valid)"
-                    class="btn btn-link push-right"
+                    class="btn btn-link"
                     (click)="toggleEditDefaultTestFilePath()"
                   >
                     <mat-icon *ngIf="defaultTestFilePathEditing">save</mat-icon>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -60,22 +60,25 @@
             <li *ngIf="workflow?.workflow_path || !isPublic">
               <form
                 #editWorkflowPathForm="ngForm"
-                class="form-inline inline-flex-form"
+                class="form-inline"
+                fxLayout
                 *ngIf="workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML"
               >
-                <div class="form-group inline-flex-form flex-grow-1">
+                <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                   <strong [matTooltip]="tooltip.workflowPath">Workflow Path: </strong>
-                  <span *ngIf="!workflowPathEditing" class="hori-offset-4"> {{ workflow.workflow_path }} </span>
+                  <span *ngIf="!workflowPathEditing" fxFlexOffset="4px"> {{ workflow.workflow_path }} </span>
                   <input
                     *ngIf="workflowPathEditing"
                     minlength="3"
                     maxlength="256"
                     [pattern]="validationPatterns.workflowDescriptorPath"
                     type="text"
-                    class="input-default form-control flex-grow-1 hori-offset-4"
+                    class="input-default form-control"
                     name="workflowPath"
                     [(ngModel)]="workflow.workflow_path"
                     placeholder="e.g. /Dockstore.cwl"
+                    fxFlex="noshrink"
+                    fxFlexOffset="4px"
                   />
                 </div>
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
@@ -97,22 +100,25 @@
               </form>
               <form
                 #editTestFilePathForm="ngForm"
-                class="form-inline inline-flex-form"
+                class="form-inline"
+                fxLayout
                 *ngIf="!(isNFL$ | async) && workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML"
               >
-                <div class="form-group inline-flex-form flex-grow-1">
+                <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                   <strong matTooltip="Path in Git repository to main descriptor file">Test File Path</strong>:
-                  <span *ngIf="!defaultTestFilePathEditing" class="hori-offset-4"> {{ workflow?.defaultTestParameterFilePath }} </span>
+                  <span *ngIf="!defaultTestFilePathEditing" fxFlexOffset="4px"> {{ workflow?.defaultTestParameterFilePath }} </span>
                   <input
                     *ngIf="defaultTestFilePathEditing"
                     minlength="3"
                     maxlength="256"
                     [pattern]="validationPatterns.testFilePath"
                     type="text"
-                    class="input-default form-control flex-grow-1 hori-offset-4"
+                    class="input-default form-control"
                     name="workflowPath"
                     [(ngModel)]="workflow.defaultTestParameterFilePath"
                     placeholder="e.g. /Dockstore.cwl"
+                    fxFlex="noshrink"
+                    fxFlexOffset="4px"
                   />
                 </div>
                 <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -499,6 +499,15 @@ textarea:focus {
   right: 20px;
 }
 
+.inline-flex-form {
+  display: flex !important;
+  align-items: center;
+}
+
+.flex-grow-1 {
+  flex-grow: 1;
+}
+
 /* BUTTONS - - - - - - - - - - - - - */
 
 div.button {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -499,15 +499,6 @@ textarea:focus {
   right: 20px;
 }
 
-.inline-flex-form {
-  display: flex !important;
-  align-items: center;
-}
-
-.flex-grow-1 {
-  flex-grow: 1;
-}
-
 /* BUTTONS - - - - - - - - - - - - - */
 
 div.button {


### PR DESCRIPTION
Main issue: https://github.com/dockstore/dockstore/issues/1450

Using `flex` for the inline forms in a very similar way as Bootstrap 4.1+ https://getbootstrap.com/docs/4.1/utilities/flex/

Screenshots in next comment