### PR TITLE
Override bootstrap

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -32,6 +32,12 @@
   flex: 1 1 auto;
 }
 
+/* This overrides bootstrap's "outline: 5px auto -webkit-focus-ring-color;", where Material shows nothing */
+/* Once bootstrap is removed, remove this too */
+a:focus {
+  outline: none;
+}
+
 .flex-toolbar {
   display: flex;
   flex-direction: row;

--- a/swagger-config.json
+++ b/swagger-config.json
@@ -1,4 +1,4 @@
 {
   "modelPropertyNaming": "original",
-  "ngVersion":"7" 
+  "ngVersion":"9" 
 }


### PR DESCRIPTION
For dockstore/dockstore#3552

Override bootstrap.  Wonder if I should move this to the styles.scss.  Can anyone think of another place where there's a dropdown with anchors?