### PR TITLE
Add a notification when smoke test fails.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@1.0.0
+  slack: circleci/slack@3.4.2
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
@@ -41,7 +42,10 @@ jobs:
       - run:
           name: Run remote verification test against dev (with auth)
           command: bash -i -c 'npm run test-dev-auth'
-
+      - slack/status:
+          fail_only: true
+          failure_message: Smoke tests failed!
+          webhook: https://hooks.slack.com/services/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
   lint_unit_test_coverage:
     working_directory: ~/repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - slack/status:
           fail_only: true
           failure_message: Smoke tests failed!
-          webhook: https://hooks.slack.com/services/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
+          webhook: $SLACK_WEBHOOK
   lint_unit_test_coverage:
     working_directory: ~/repo
     docker:


### PR DESCRIPTION
This change should add a notification (that includes a link to the build) when a failure occurs during the smoke tests. There isn't a great way to test it since it requires the job to run and fail, and its set to run on a timer. To verify this worked we will have to wait until a smoke test runs (and fails). However, the tests appear to be failing at the moment so that should happen pretty quickly.

https://circleci.com/workflow-run/6168c2f9-e770-40a6-97f7-67a2c1420b96