### PR TITLE
Feature/3455/remove source file refs

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,6 +97,6 @@ export function goToUnexpandedSidebarEntry(organization: string, repo: RegExp | 
 
 export function approvePotatoMembership() {
   cy.exec(
-    'PGPASSWORD=dockstore psql -h localhost -c \'update organization_user set accepted=true where userid=2 and organizationid=1\' webservice_test -U dockstore'
+    "PGPASSWORD=dockstore psql -h localhost -c 'update organization_user set accepted=true where userid=2 and organizationid=1' webservice_test -U dockstore"
   );
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,6 +97,6 @@ export function goToUnexpandedSidebarEntry(organization: string, repo: RegExp | 
 
 export function approvePotatoMembership() {
   cy.exec(
-    "PGPASSWORD=dockstore psql -h localhost -c 'update organization_user set accepted=true where userid=2 and organizationid=1' webservice_test -U dockstore"
+    'PGPASSWORD=dockstore psql -h localhost -c \'update organization_user set accepted=true where userid=2 and organizationid=1\' webservice_test -U dockstore'
   );
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/4076/workflows/28f61707-ede4-4377-a8df-95c28f257374/jobs/4484"
+    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/4129/workflows/83a4e516-e6dc-4641-aa95-a16544fcae0f/jobs/4566"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://4392-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://4398-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://4398-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://4430-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://4484-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://4392-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://4430-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://4566-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 #JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-JAR_PATH="https://4398-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
+JAR_PATH="https://4430-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 #JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-JAR_PATH="https://4392-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
+JAR_PATH="https://4398-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 #JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-JAR_PATH="https://4430-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
+JAR_PATH="https://4566-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 #JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-JAR_PATH="https://4484-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
+JAR_PATH="https://4392-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.10.0-alpha.0-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClient, HttpClientModule } from '@angular/common/http';
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -173,7 +173,8 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     CustomMaterialModule,
     RefreshAlertModule,
     RequestsModule,
-    HomePageModule
+    HomePageModule,
+    HttpClientModule
   ],
   providers: [
     AccountsService,

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -196,6 +196,7 @@
                   id="versionsTab"
                   [verifiedSource]="(extendedTool$ | async)?.verifiedSources"
                   [selectedVersion]="selectedVersion"
+                  [verifiedVersionPlatforms]="versionsWithVerirfiedPlatforms"
                 >
                 </app-versions-container>
               </div>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -180,6 +180,7 @@
               [path]="tool?.tool_path"
               [toolname]="tool?.toolname"
               [mode]="tool?.mode"
+              [versionsFileTypes]="versionsFileTypes"
             ></app-launch>
             <ng-template #noTags>
               <div class="p-3">

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -225,6 +225,7 @@
                     [default]="defaultVersion"
                     [selectedVersion]="selectedVersion"
                     [publicPage]="publicPage"
+                    [versionsFileTypes]="versionsFileTypes"
                   >
                   </app-files-container>
                 </div>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -342,7 +342,11 @@
         </div>
       </div>
       <current-collections [id]="tool.id"></current-collections>
-      <app-verified-by *ngIf="selectedVersion" [version]="selectedVersion"></app-verified-by>
+      <app-verified-by
+        *ngIf="selectedVersion"
+        [version]="selectedVersion"
+        [verifiedByPlatform]="versionsWithVerirfiedPlatforms"
+      ></app-verified-by>
       <div class="panel panel-default mb-3" *ngIf="tool">
         <div class="panel-heading">
           <h3>Sharing</h3>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -197,7 +197,7 @@
                   id="versionsTab"
                   [verifiedSource]="(extendedTool$ | async)?.verifiedSources"
                   [selectedVersion]="selectedVersion"
-                  [verifiedVersionPlatforms]="versionsWithVerirfiedPlatforms"
+                  [verifiedVersionPlatforms]="versionsWithVerifiedPlatforms"
                 >
                 </app-versions-container>
               </div>
@@ -346,7 +346,7 @@
       <app-verified-by
         *ngIf="selectedVersion"
         [version]="selectedVersion"
-        [verifiedByPlatform]="versionsWithVerirfiedPlatforms"
+        [verifiedByPlatform]="versionsWithVerifiedPlatforms"
       ></app-verified-by>
       <div class="panel panel-default mb-3" *ngIf="tool">
         <div class="panel-heading">

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -33,10 +33,11 @@ import { Entry } from '../shared/entry';
 import { ExtendedDockstoreToolQuery } from '../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { GA4GHFilesService } from '../shared/ga4gh-files/ga4gh-files.service';
 import { ImageProviderService } from '../shared/image-provider.service';
-import { EntriesService, VersionVerifiedPlatform } from '../shared/openapi';
+import { ContainertagsService, EntriesService, VersionVerifiedPlatform } from '../shared/openapi';
 import { ProviderService } from '../shared/provider.service';
 import { SessionQuery } from '../shared/session/session.query';
 import { SessionService } from '../shared/session/session.service';
+import { SourceFile } from '../shared/swagger/model/sourceFile';
 import { Tag } from '../shared/swagger/model/tag';
 import { WorkflowVersion } from '../shared/swagger/model/workflowVersion';
 import { ToolQuery } from '../shared/tool/tool.query';
@@ -73,6 +74,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public extendedTool$: Observable<ExtendedDockstoreTool>;
   public isRefreshing$: Observable<boolean>;
   public versionsWithVerirfiedPlatforms: Array<VersionVerifiedPlatform> = [];
+  public versionsFileTypes: Array<SourceFile.TypeEnum>;
   constructor(
     private dockstoreService: DockstoreService,
     dateService: DateService,
@@ -98,7 +100,8 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     public dialog: MatDialog,
     private toolService: ToolService,
     private alertService: AlertService,
-    private entryService: EntriesService
+    private entryService: EntriesService,
+    private containerTagsService: ContainertagsService
   ) {
     super(
       trackLoginService,
@@ -197,7 +200,9 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.entryService.getVerifiedPlatforms(tool.id).subscribe((verifiedVersions: Array<VersionVerifiedPlatform>) => {
         this.versionsWithVerirfiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
-        console.log(this.versionsWithVerirfiedPlatforms);
+      });
+      this.entryService.getTagsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
+        this.versionsFileTypes = fileTypes;
       });
     }
   }

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -71,6 +71,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public schema: BioschemaTool;
   public extendedTool$: Observable<ExtendedDockstoreTool>;
   public isRefreshing$: Observable<boolean>;
+  public versionsWithVerirfiedPlatforms: Array<VersionVerifiedPlatform> = [];
   constructor(
     private dockstoreService: DockstoreService,
     dateService: DateService,
@@ -95,7 +96,8 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     private alertQuery: AlertQuery,
     public dialog: MatDialog,
     private toolService: ToolService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private entryService: EntriesService
   ) {
     super(
       trackLoginService,
@@ -192,6 +194,10 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
+      this.entryService.getVerifiedPlatforms(tool.id).subscribe((verifiedVersions: Array<VersionVerifiedPlatform>) => {
+        this.versionsWithVerirfiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
+        console.log(this.versionsWithVerirfiedPlatforms);
+      });
     }
   }
 

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -73,7 +73,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public schema: BioschemaTool;
   public extendedTool$: Observable<ExtendedDockstoreTool>;
   public isRefreshing$: Observable<boolean>;
-  public versionsWithVerirfiedPlatforms: Array<VersionVerifiedPlatform> = [];
+  public versionsWithVerifiedPlatforms: Array<VersionVerifiedPlatform> = [];
   public versionsFileTypes: Array<SourceFile.TypeEnum>;
   constructor(
     private dockstoreService: DockstoreService,
@@ -179,8 +179,14 @@ export class ContainerComponent extends Entry implements AfterViewInit {
         this.published = this.tool.is_published;
         if (this.tool.workflowVersions.length === 0) {
           this.selectedVersion = null;
+          this.versionsFileTypes = [];
         } else {
           this.selectedVersion = this.selectTag(this.tool.workflowVersions, this.urlVersion, this.tool.defaultVersion);
+          if (this.selectedVersion) {
+            this.entryService.getVersionsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
+              this.versionsFileTypes = fileTypes;
+            });
+          }
         }
       }
       // Select version
@@ -199,13 +205,8 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.entryService.getVerifiedPlatforms(tool.id).subscribe((verifiedVersions: Array<VersionVerifiedPlatform>) => {
-        this.versionsWithVerirfiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
+        this.versionsWithVerifiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
       });
-      if (this.selectedVersion) {
-        this.entryService.getVersionsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
-          this.versionsFileTypes = fileTypes;
-        });
-      }
     }
   }
 

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -202,7 +202,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
         this.versionsWithVerirfiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
       });
       if (this.selectedVersion) {
-        this.entryService.getTagsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
+        this.entryService.getVersionsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
           this.versionsFileTypes = fileTypes;
         });
       }

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -201,9 +201,11 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.entryService.getVerifiedPlatforms(tool.id).subscribe((verifiedVersions: Array<VersionVerifiedPlatform>) => {
         this.versionsWithVerirfiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
       });
-      this.entryService.getTagsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
-        this.versionsFileTypes = fileTypes;
-      });
+      if (this.selectedVersion) {
+        this.entryService.getTagsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
+          this.versionsFileTypes = fileTypes;
+        });
+      }
     }
   }
 

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -33,6 +33,7 @@ import { Entry } from '../shared/entry';
 import { ExtendedDockstoreToolQuery } from '../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { GA4GHFilesService } from '../shared/ga4gh-files/ga4gh-files.service';
 import { ImageProviderService } from '../shared/image-provider.service';
+import { EntriesService, VersionVerifiedPlatform } from '../shared/openapi';
 import { ProviderService } from '../shared/provider.service';
 import { SessionQuery } from '../shared/session/session.query';
 import { SessionService } from '../shared/session/session.service';

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -15,6 +15,7 @@
  */
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Location } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewInit, Component } from '@angular/core';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
@@ -183,9 +184,17 @@ export class ContainerComponent extends Entry implements AfterViewInit {
         } else {
           this.selectedVersion = this.selectTag(this.tool.workflowVersions, this.urlVersion, this.tool.defaultVersion);
           if (this.selectedVersion) {
-            this.entryService.getVersionsFileTypes(tool.id, this.selectedVersion.id).subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
-              this.versionsFileTypes = fileTypes;
-            });
+            this.alertService.start('Getting version\'s unique file types');
+            this.entryService.getVersionsFileTypes(tool.id, this.selectedVersion.id).subscribe(
+              (fileTypes: Array<SourceFile.TypeEnum>) => {
+                this.versionsFileTypes = fileTypes;
+                this.alertService.simpleSuccess();
+              },
+              (error: HttpErrorResponse) => {
+                this.alertService.detailedError(error);
+                this.versionsFileTypes = [];
+              }
+            );
           }
         }
       }
@@ -204,9 +213,17 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
-      this.entryService.getVerifiedPlatforms(tool.id).subscribe((verifiedVersions: Array<VersionVerifiedPlatform>) => {
-        this.versionsWithVerifiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
-      });
+      this.alertService.start('Getting the tool\'s verified platforms');
+      this.entryService.getVerifiedPlatforms(tool.id).subscribe(
+        (verifiedVersions: Array<VersionVerifiedPlatform>) => {
+          this.versionsWithVerifiedPlatforms = verifiedVersions.map(value => Object.assign({}, value));
+          this.alertService.simpleSuccess();
+        },
+        error => {
+          this.alertService.detailedError(error);
+          this.versionsWithVerifiedPlatforms = [];
+        }
+      );
     }
   }
 

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -15,7 +15,6 @@
  */
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Location } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
 import { AfterViewInit, Component } from '@angular/core';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
@@ -34,11 +33,10 @@ import { Entry } from '../shared/entry';
 import { ExtendedDockstoreToolQuery } from '../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { GA4GHFilesService } from '../shared/ga4gh-files/ga4gh-files.service';
 import { ImageProviderService } from '../shared/image-provider.service';
-import { ContainertagsService, EntriesService, VersionVerifiedPlatform } from '../shared/openapi';
+import { ContainertagsService, EntriesService } from '../shared/openapi';
 import { ProviderService } from '../shared/provider.service';
 import { SessionQuery } from '../shared/session/session.query';
 import { SessionService } from '../shared/session/session.service';
-import { SourceFile } from '../shared/swagger/model/sourceFile';
 import { Tag } from '../shared/swagger/model/tag';
 import { WorkflowVersion } from '../shared/swagger/model/workflowVersion';
 import { ToolQuery } from '../shared/tool/tool.query';

--- a/src/app/container/descriptors/descriptors.component.spec.ts
+++ b/src/app/container/descriptors/descriptors.component.spec.ts
@@ -13,14 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ContainersStubService, ContainerStubService, GA4GHStubService } from '../../../../src/app/test/service-stubs';
+import { ContainersStubService, ContainerStubService, EntryStubService, GA4GHStubService } from '../../../../src/app/test/service-stubs';
 import { ContainerService } from '../../shared/container.service';
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
+import { EntriesService } from '../../shared/openapi';
 import { ContainersService, GA4GHService } from '../../shared/swagger';
+import { sampleToolVersion } from '../../test/mocked-objects';
 import { DescriptorsComponent } from './descriptors.component';
 
 describe('DescriptorsComponent', () => {
@@ -33,13 +36,15 @@ describe('DescriptorsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DescriptorsComponent],
+      imports: [HttpClientModule],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         DescriptorService,
         { provide: ContainersService, useClass: ContainersStubService },
         { provide: ContainerService, useClass: ContainerStubService },
         { provide: FileService, useClass: FileStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService }
+        { provide: GA4GHService, useClass: GA4GHStubService },
+        { provide: EntriesService, useClass: EntryStubService }
       ]
     }).compileComponents();
   }));
@@ -48,7 +53,7 @@ describe('DescriptorsComponent', () => {
     fixture = TestBed.createComponent(DescriptorsComponent);
     component = fixture.componentInstance;
     component.id = 5;
-    component.selectedVersion = null;
+    component.selectedVersion = sampleToolVersion;
     fixture.detectChanges();
   });
 

--- a/src/app/container/descriptors/descriptors.component.spec.ts
+++ b/src/app/container/descriptors/descriptors.component.spec.ts
@@ -16,6 +16,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ContainersStubService, ContainerStubService, EntryStubService, GA4GHStubService } from '../../../../src/app/test/service-stubs';
 import { ContainerService } from '../../shared/container.service';
@@ -36,7 +37,7 @@ describe('DescriptorsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DescriptorsComponent],
-      imports: [HttpClientModule],
+      imports: [HttpClientModule, MatSnackBarModule],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         DescriptorService,

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DescriptorService } from '../../shared/descriptor.service';
@@ -33,15 +33,12 @@ import { FilesService } from '../../workflow/files/state/files.service';
   templateUrl: './descriptors.component.html',
   styleUrls: ['./descriptors.component.scss']
 })
-export class DescriptorsComponent extends EntryFileSelector {
+export class DescriptorsComponent extends EntryFileSelector implements OnChanges {
   @Input() id: number;
   @Input() entrypath: string;
   @Input() publicPage: boolean;
-  @Input() set selectedVersion(value: Tag) {
-    this.clearContent();
-    this.onVersionChange(value, this.id);
-    this.checkIfValid(true, value);
-  }
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
+  @Input() selectedVersion: Tag;
 
   protected entryType: 'tool' | 'workflow' = 'tool';
 
@@ -61,8 +58,14 @@ export class DescriptorsComponent extends EntryFileSelector {
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
-  getDescriptors(version: Tag, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
-    return this.descriptorsService.getDescriptors(this._selectedVersion, versionsFileTypes);
+  ngOnChanges(changes: SimpleChanges): void {
+    this.clearContent();
+    this.onVersionChange(this.selectedVersion, this.id);
+    this.checkIfValid(true, this.selectedVersion);
+  }
+
+  getDescriptors(version: Tag): Array<ToolDescriptor.TypeEnum> {
+    return this.descriptorsService.getDescriptors(this._selectedVersion, this.versionsFileTypes);
   }
 
   getValidDescriptors(version: Tag): Array<ToolDescriptor.TypeEnum> {

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -15,6 +15,7 @@
  */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
+import { AlertService } from '../../shared/alert/state/alert.service';
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
@@ -53,9 +54,10 @@ export class DescriptorsComponent extends EntryFileSelector {
     protected gA4GHFilesService: GA4GHFilesService,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected alertService: AlertService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService, alertService);
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -19,8 +19,9 @@ import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
+import { EntriesService } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-import { GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { FilesQuery } from '../../workflow/files/state/files.query';
@@ -37,7 +38,7 @@ export class DescriptorsComponent extends EntryFileSelector {
   @Input() publicPage: boolean;
   @Input() set selectedVersion(value: Tag) {
     this.clearContent();
-    this.onVersionChange(value);
+    this.onVersionChange(value, this.id);
     this.checkIfValid(true, value);
   }
 
@@ -51,14 +52,15 @@ export class DescriptorsComponent extends EntryFileSelector {
     public fileService: FileService,
     protected gA4GHFilesService: GA4GHFilesService,
     protected filesService: FilesService,
-    protected filesQuery: FilesQuery
+    protected filesQuery: FilesQuery,
+    protected entryService: EntriesService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
-  getDescriptors(version: Tag): Array<ToolDescriptor.TypeEnum> {
-    return this.descriptorsService.getDescriptors(this._selectedVersion);
+  getDescriptors(version: Tag, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
+    return this.descriptorsService.getDescriptors(this._selectedVersion, versionsFileTypes);
   }
 
   getValidDescriptors(version: Tag): Array<ToolDescriptor.TypeEnum> {

--- a/src/app/container/files/files.component.html
+++ b/src/app/container/files/files.component.html
@@ -24,14 +24,26 @@
 
   <mat-tab label="Descriptor Files">
     <ng-template matTabContent>
-      <app-descriptors-container [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion" [publicPage]="publicPage">
+      <app-descriptors-container
+        [entrypath]="entrypath"
+        [id]="id"
+        [selectedVersion]="selectedVersion"
+        [publicPage]="publicPage"
+        [versionsFileTypes]="versionsFileTypes"
+      >
       </app-descriptors-container>
     </ng-template>
   </mat-tab>
 
   <mat-tab label="Test Parameter Files">
     <ng-template matTabContent>
-      <app-paramfiles-container [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion" [publicPage]="publicPage">
+      <app-paramfiles-container
+        [entrypath]="entrypath"
+        [id]="id"
+        [selectedVersion]="selectedVersion"
+        [publicPage]="publicPage"
+        [versionsFileTypes]="versionsFileTypes"
+      >
       </app-paramfiles-container>
     </ng-template>
   </mat-tab>

--- a/src/app/container/files/files.component.ts
+++ b/src/app/container/files/files.component.ts
@@ -24,23 +24,17 @@ import { ParamfilesService } from '../paramfiles/paramfiles.service';
   selector: 'app-files-container',
   templateUrl: './files.component.html'
 })
-export class FilesContainerComponent extends Files implements OnInit, OnChanges {
+export class FilesContainerComponent extends Files implements OnChanges {
   @Input() selectedVersion: Tag;
-  versionsWithParamfiles: Array<any>;
   constructor(private paramfilesService: ParamfilesService, private gA4GHFilesService: GA4GHFilesService) {
     super();
   }
 
-  // FIX THIS
-  ngOnInit() {
-    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
-  }
   ngOnChanges() {
     if (!this.selectedVersion) {
       this.gA4GHFilesService.clearFiles();
     } else {
       this.gA4GHFilesService.updateFiles(this.entrypath, this.selectedVersion.name);
-      // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
     }
   }
 }

--- a/src/app/container/files/files.component.ts
+++ b/src/app/container/files/files.component.ts
@@ -17,6 +17,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 
 import { Files } from '../../shared/files';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
+import { SourceFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ParamfilesService } from '../paramfiles/paramfiles.service';
 
@@ -26,6 +27,7 @@ import { ParamfilesService } from '../paramfiles/paramfiles.service';
 })
 export class FilesContainerComponent extends Files implements OnChanges {
   @Input() selectedVersion: Tag;
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
   constructor(private paramfilesService: ParamfilesService, private gA4GHFilesService: GA4GHFilesService) {
     super();
   }

--- a/src/app/container/files/files.component.ts
+++ b/src/app/container/files/files.component.ts
@@ -31,15 +31,16 @@ export class FilesContainerComponent extends Files implements OnInit, OnChanges 
     super();
   }
 
+  // FIX THIS
   ngOnInit() {
-    this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
+    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
   ngOnChanges() {
     if (!this.selectedVersion) {
       this.gA4GHFilesService.clearFiles();
     } else {
       this.gA4GHFilesService.updateFiles(this.entrypath, this.selectedVersion.name);
-      this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
+      // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
     }
   }
 }

--- a/src/app/container/files/files.component.ts
+++ b/src/app/container/files/files.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 
 import { Files } from '../../shared/files';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -84,7 +84,7 @@ export class LaunchComponent extends Base {
     const newDescriptors: Array<DescriptorTypeEnum> = [];
 
     // Return empty array if no descriptors present yet
-    if (descriptors === undefined || version === undefined) {
+    if (descriptors === undefined || version === undefined || versionsFileTypes === undefined) {
       return newDescriptors;
     }
 

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -17,7 +17,7 @@ import { Component, Input } from '@angular/core';
 import { Base } from 'app/shared/base';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { ToolDescriptor } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor } from '../../shared/swagger';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { ToolQuery } from '../../shared/tool/tool.query';
@@ -36,13 +36,14 @@ export class LaunchComponent extends Base {
   @Input() path: string;
   @Input() toolname: string;
   @Input() mode: DockstoreTool.ModeEnum | Workflow.ModeEnum;
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
 
   _selectedVersion: Tag;
   @Input() set selectedVersion(value: Tag) {
     if (value != null) {
       this._selectedVersion = value;
       this.reactToDescriptor();
-      this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion);
+      this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
     }
   }
 
@@ -73,13 +74,13 @@ export class LaunchComponent extends Base {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((descriptors: Array<Workflow.DescriptorTypeEnum>) => {
         this.descriptors = descriptors;
-        this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion);
+        this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
       });
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
   // Returns an array of descriptors that are valid for the given tool version
-  filterDescriptors(descriptors: Array<DescriptorTypeEnum>, version: Tag): Array<string> {
+  filterDescriptors(descriptors: Array<DescriptorTypeEnum>, version: Tag, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<string> {
     const newDescriptors: Array<DescriptorTypeEnum> = [];
 
     // Return empty array if no descriptors present yet
@@ -91,10 +92,10 @@ export class LaunchComponent extends Base {
     let hasCwl = false;
     let hasWdl = false;
 
-    for (const sourceFile of version.sourceFiles) {
-      if (sourceFile.type.toString() === 'DOCKSTORE_CWL') {
+    for (const fileType of versionsFileTypes) {
+      if (fileType === SourceFile.TypeEnum.DOCKSTORECWL) {
         hasCwl = true;
-      } else if (sourceFile.type.toString() === 'DOCKSTORE_WDL') {
+      } else if (fileType === SourceFile.TypeEnum.DOCKSTOREWDL) {
         hasWdl = true;
       }
     }

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Base } from 'app/shared/base';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -31,7 +31,7 @@ import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
   templateUrl: './launch.component.html',
   styleUrls: ['./launch.component.css']
 })
-export class LaunchComponent extends Base {
+export class LaunchComponent extends Base implements OnInit, OnChanges {
   @Input() basePath: string;
   @Input() path: string;
   @Input() toolname: string;
@@ -39,13 +39,7 @@ export class LaunchComponent extends Base {
   @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
 
   _selectedVersion: Tag;
-  @Input() set selectedVersion(value: Tag) {
-    if (value != null) {
-      this._selectedVersion = value;
-      this.reactToDescriptor();
-      this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
-    }
-  }
+  @Input() selectedVersion: Tag;
 
   params: string;
   cli: string;
@@ -70,6 +64,9 @@ export class LaunchComponent extends Base {
     private descriptorLanguageService: DescriptorLanguageService
   ) {
     super();
+  }
+
+  ngOnInit(): void {
     this.descriptorLanguageService.filteredDescriptorLanguages$
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((descriptors: Array<Workflow.DescriptorTypeEnum>) => {
@@ -77,6 +74,12 @@ export class LaunchComponent extends Base {
         this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
       });
     this.published$ = this.toolQuery.toolIsPublished$;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this._selectedVersion = this.selectedVersion;
+    this.reactToDescriptor();
+    this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
   }
 
   // Returns an array of descriptors that are valid for the given tool version

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -63,8 +63,8 @@ export class ParamfilesComponent extends EntryFileSelector {
     return this.paramfilesService.getDescriptors(versionsFileTypes);
   }
 
-  getValidDescriptors(version): Array<any> {
-    return this.paramfilesService.getValidDescriptors(this._selectedVersion);
+  getValidDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
+    return this.paramfilesService.getValidDescriptors(this._selectedVersion, versionsFileTypes);
   }
 
   /**

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileService } from '../../shared/file.service';
@@ -33,15 +33,13 @@ import { ParamfilesService } from './paramfiles.service';
   templateUrl: './paramfiles.component.html',
   styleUrls: ['./paramfiles.component.scss']
 })
-export class ParamfilesComponent extends EntryFileSelector {
+export class ParamfilesComponent extends EntryFileSelector implements OnChanges {
   @Input() id: number;
   @Input() entrypath: string;
   @Input() publicPage: boolean;
-  @Input() set selectedVersion(value: Tag) {
-    this.clearContent();
-    this.onVersionChange(value, this.id);
-    this.checkIfValid(false, value);
-  }
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
+  @Input() selectedVersion: Tag;
+
   public filePath: string;
   protected entryType: 'tool' | 'workflow' = 'tool';
   public downloadFilePath: string;
@@ -61,12 +59,18 @@ export class ParamfilesComponent extends EntryFileSelector {
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
-  getDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
-    return this.paramfilesService.getDescriptors(versionsFileTypes);
+  ngOnChanges(changes: SimpleChanges): void {
+    this.clearContent();
+    this.onVersionChange(this.selectedVersion, this.id);
+    this.checkIfValid(false, this.selectedVersion);
   }
 
-  getValidDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
-    return this.paramfilesService.getValidDescriptors(this._selectedVersion, versionsFileTypes);
+  getDescriptors(version): Array<any> {
+    return this.paramfilesService.getDescriptors(this.versionsFileTypes);
+  }
+
+  getValidDescriptors(version): Array<any> {
+    return this.paramfilesService.getValidDescriptors(this._selectedVersion, this.versionsFileTypes);
   }
 
   /**

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -18,8 +18,9 @@ import { Observable } from 'rxjs';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
+import { EntriesService } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-import { GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { FilesQuery } from '../../workflow/files/state/files.query';
@@ -37,7 +38,7 @@ export class ParamfilesComponent extends EntryFileSelector {
   @Input() publicPage: boolean;
   @Input() set selectedVersion(value: Tag) {
     this.clearContent();
-    this.onVersionChange(value);
+    this.onVersionChange(value, this.id);
     this.checkIfValid(false, value);
   }
   public filePath: string;
@@ -51,14 +52,15 @@ export class ParamfilesComponent extends EntryFileSelector {
     private gA4GHFilesQuery: GA4GHFilesQuery,
     private toolQuery: ToolQuery,
     protected filesService: FilesService,
-    protected filesQuery: FilesQuery
+    protected filesQuery: FilesQuery,
+    protected entryService: EntriesService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
-  getDescriptors(version): Array<any> {
-    return this.paramfilesService.getDescriptors(this._selectedVersion);
+  getDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
+    return this.paramfilesService.getDescriptors(versionsFileTypes);
   }
 
   getValidDescriptors(version): Array<any> {

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -15,6 +15,7 @@
  */
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
+import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
@@ -53,9 +54,10 @@ export class ParamfilesComponent extends EntryFileSelector {
     private toolQuery: ToolQuery,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected alertService: AlertService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService, alertService);
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 

--- a/src/app/container/paramfiles/paramfiles.service.spec.ts
+++ b/src/app/container/paramfiles/paramfiles.service.spec.ts
@@ -208,6 +208,10 @@ describe('Service: paramFiles.service.ts', () => {
     ]
   };
 
+  const tag1FileTypes: Array<SourceFile.TypeEnum> = ['DOCKERFILE', 'DOCKSTORE_CWL', 'DOCKSTORE_WDL'];
+  const tag2FileTypes: Array<SourceFile.TypeEnum> = ['DOCKERFILE', 'DOCKSTORE_CWL', 'DOCKSTORE_WDL', 'CWL_TEST_JSON'];
+  const tag3FileTypes: Array<SourceFile.TypeEnum> = ['DOCKERFILE', 'DOCKSTORE_CWL', 'DOCKSTORE_WDL', 'WDL_TEST_JSON', 'CWL_TEST_JSON'];
+
   const versions: Tag[] = [tag1, tag2, tag3];
 
   it('should ...', inject([ParamfilesService], (service: ParamfilesService) => {
@@ -223,11 +227,14 @@ describe('Service: paramFiles.service.ts', () => {
       expect(files).toEqual([]);
     });
   }));
-  it('should get descriptors with parameter files', inject([ParamfilesService], (service: ParamfilesService) => {
-    expect(service.getVersions(versions)).toEqual([tag2, tag3]);
-  }));
+  // it('should get descriptors with parameter files', inject([ParamfilesService], (service: ParamfilesService) => {
+  //   expect(service.getVersions(versions)).toEqual([tag2, tag3]);
+  // }));
   // Tests valid cwl descriptor and test file, but invalid wdl descriptor and valid wdl test file
+  it('should get descriptors', inject([ParamfilesService], (service: ParamfilesService) => {
+    expect(service.getDescriptors(tag3FileTypes)).toEqual([ToolDescriptor.TypeEnum.WDL, ToolDescriptor.TypeEnum.CWL]);
+  }));
   it('should get valid descriptors with parameter files', inject([ParamfilesService], (service: ParamfilesService) => {
-    expect(service.getValidDescriptors(tag3)).toEqual([ToolDescriptor.TypeEnum.CWL]);
+    expect(service.getValidDescriptors(tag3, tag3FileTypes)).toEqual([ToolDescriptor.TypeEnum.CWL]);
   }));
 });

--- a/src/app/container/paramfiles/paramfiles.service.spec.ts
+++ b/src/app/container/paramfiles/paramfiles.service.spec.ts
@@ -227,9 +227,6 @@ describe('Service: paramFiles.service.ts', () => {
       expect(files).toEqual([]);
     });
   }));
-  // it('should get descriptors with parameter files', inject([ParamfilesService], (service: ParamfilesService) => {
-  //   expect(service.getVersions(versions)).toEqual([tag2, tag3]);
-  // }));
   // Tests valid cwl descriptor and test file, but invalid wdl descriptor and valid wdl test file
   it('should get descriptors', inject([ParamfilesService], (service: ParamfilesService) => {
     expect(service.getDescriptors(tag3FileTypes)).toEqual([ToolDescriptor.TypeEnum.WDL, ToolDescriptor.TypeEnum.CWL]);

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -74,7 +74,7 @@ export class ParamfilesService {
   getValidDescriptors(version: WorkflowVersion | Tag, versionsFileTypes: Array<SourceFile.TypeEnum>) {
     if (version) {
       const descriptorTypes: Array<ToolDescriptor.TypeEnum> = [];
-      if (version.validations) {
+      if (version.validations && versionsFileTypes) {
         if (this.checkValidFileType(version, SourceFile.TypeEnum.CWLTESTJSON, SourceFile.TypeEnum.DOCKSTORECWL, versionsFileTypes)) {
           descriptorTypes.push(ToolDescriptor.TypeEnum.CWL);
         }

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -144,7 +144,7 @@ export class ParamfilesService {
     return languageFile !== undefined;
   }
 
-  // FIX THIS
+  // We aren't doing anything with the information we get from this function? Deleted references that call this function
   // get versions which have test parameter files
   // getVersions(versions: Array<Tag | WorkflowVersion>) {
   //   const versionsWithParamfiles = [];

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -71,23 +71,27 @@ export class ParamfilesService {
    * @param version the current selected version of the workflow or tool
    * @returns an array that may contain 'CWL' or 'WDL' or 'NFL'
    */
-  getValidDescriptors(version: WorkflowVersion | Tag) {
+  getValidDescriptors(version: WorkflowVersion | Tag, versionsFileTypes: Array<SourceFile.TypeEnum>) {
     if (version) {
       const descriptorTypes: Array<ToolDescriptor.TypeEnum> = [];
       if (version.validations) {
-        if (this.checkValidFileType(version, SourceFile.TypeEnum.CWLTESTJSON, SourceFile.TypeEnum.DOCKSTORECWL)) {
+        if (this.checkValidFileType(version, SourceFile.TypeEnum.CWLTESTJSON, SourceFile.TypeEnum.DOCKSTORECWL, versionsFileTypes)) {
           descriptorTypes.push(ToolDescriptor.TypeEnum.CWL);
         }
 
-        if (this.checkValidFileType(version, SourceFile.TypeEnum.WDLTESTJSON, SourceFile.TypeEnum.DOCKSTOREWDL)) {
+        if (this.checkValidFileType(version, SourceFile.TypeEnum.WDLTESTJSON, SourceFile.TypeEnum.DOCKSTOREWDL, versionsFileTypes)) {
           descriptorTypes.push(ToolDescriptor.TypeEnum.WDL);
         }
 
-        if (this.checkValidFileType(version, SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, SourceFile.TypeEnum.NEXTFLOWCONFIG)) {
+        if (
+          this.checkValidFileType(version, SourceFile.TypeEnum.NEXTFLOWTESTPARAMS, SourceFile.TypeEnum.NEXTFLOWCONFIG, versionsFileTypes)
+        ) {
           descriptorTypes.push(ToolDescriptor.TypeEnum.NFL);
         }
 
-        if (this.checkValidFileType(version, SourceFile.TypeEnum.GXFORMAT2TESTFILE, SourceFile.TypeEnum.DOCKSTOREGXFORMAT2)) {
+        if (
+          this.checkValidFileType(version, SourceFile.TypeEnum.GXFORMAT2TESTFILE, SourceFile.TypeEnum.DOCKSTOREGXFORMAT2, versionsFileTypes)
+        ) {
           descriptorTypes.push(ToolDescriptor.TypeEnum.GXFORMAT2);
         }
         // DOCKSTORE-2428 - demo how to add new workflow language
@@ -108,7 +112,12 @@ export class ParamfilesService {
    * @param fileType Ex. SourceFile.TypeEnum.CWLTESTJSON
    * @param descriptorType Ex. SourceFile.TypeEnum.DOCKSTORECWL
    */
-  checkValidFileType(version: WorkflowVersion | Tag, fileType: SourceFile.TypeEnum, descriptorType: SourceFile.TypeEnum) {
+  checkValidFileType(
+    version: WorkflowVersion | Tag,
+    fileType: SourceFile.TypeEnum,
+    descriptorType: SourceFile.TypeEnum,
+    versionsFileTypes: Array<SourceFile.TypeEnum>
+  ) {
     // Check that the language has a valid descriptor
     const descriptorValidation = version.validations.find((validation: Validation) => {
       return validation.type === descriptorType;
@@ -128,8 +137,8 @@ export class ParamfilesService {
     }
 
     // Check that at least one file is present
-    const languageFile = version.sourceFiles.find(sourceFile => {
-      return sourceFile.type === fileType;
+    const languageFile = versionsFileTypes.find(type => {
+      return type === fileType;
     });
 
     return languageFile !== undefined;

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -41,18 +41,20 @@ export class ParamfilesService {
   }
 
   // get descriptors which have test parameter files
-  getDescriptors(version: WorkflowVersion | Tag): Array<ToolDescriptor.TypeEnum> {
+  getDescriptors(versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
     const descriptorsWithParamfiles: Array<ToolDescriptor.TypeEnum> = [];
-    if (version) {
-      for (const file of version.sourceFiles) {
-        const type = file.type;
-        if (type === 'CWL_TEST_JSON' && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.CWL)) {
+    if (versionsFileTypes) {
+      for (const type of versionsFileTypes) {
+        if (type === SourceFile.TypeEnum.CWLTESTJSON && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.CWL)) {
           descriptorsWithParamfiles.push(ToolDescriptor.TypeEnum.CWL);
-        } else if (type === 'WDL_TEST_JSON' && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.WDL)) {
+        } else if (type === SourceFile.TypeEnum.WDLTESTJSON && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.WDL)) {
           descriptorsWithParamfiles.push(ToolDescriptor.TypeEnum.WDL);
-        } else if (type === 'NEXTFLOW_TEST_PARAMS' && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.NFL)) {
+        } else if (type === SourceFile.TypeEnum.NEXTFLOWTESTPARAMS && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.NFL)) {
           descriptorsWithParamfiles.push(ToolDescriptor.TypeEnum.NFL);
-        } else if (type === 'GXFORMAT2_TEST_FILE' && !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.GXFORMAT2)) {
+        } else if (
+          type === SourceFile.TypeEnum.GXFORMAT2TESTFILE &&
+          !descriptorsWithParamfiles.includes(ToolDescriptor.TypeEnum.GXFORMAT2)
+        ) {
           descriptorsWithParamfiles.push(ToolDescriptor.TypeEnum.GXFORMAT2);
         }
         // DOCKSTORE-2428 - demo how to add new workflow language
@@ -133,16 +135,17 @@ export class ParamfilesService {
     return languageFile !== undefined;
   }
 
+  // FIX THIS
   // get versions which have test parameter files
-  getVersions(versions: Array<Tag | WorkflowVersion>) {
-    const versionsWithParamfiles = [];
-    if (versions) {
-      for (const version of versions) {
-        if (this.getDescriptors(version).length) {
-          versionsWithParamfiles.push(version);
-        }
-      }
-    }
-    return versionsWithParamfiles;
-  }
+  // getVersions(versions: Array<Tag | WorkflowVersion>) {
+  //   const versionsWithParamfiles = [];
+  //   if (versions) {
+  //     for (const version of versions) {
+  //       if (this.getDescriptors(version).length) {
+  //         versionsWithParamfiles.push(version);
+  //       }
+  //     }
+  //   }
+  //   return versionsWithParamfiles;
+  // }
 }

--- a/src/app/container/paramfiles/paramfiles.service.ts
+++ b/src/app/container/paramfiles/paramfiles.service.ts
@@ -143,18 +143,4 @@ export class ParamfilesService {
 
     return languageFile !== undefined;
   }
-
-  // We aren't doing anything with the information we get from this function? Deleted references that call this function
-  // get versions which have test parameter files
-  // getVersions(versions: Array<Tag | WorkflowVersion>) {
-  //   const versionsWithParamfiles = [];
-  //   if (versions) {
-  //     for (const version of versions) {
-  //       if (this.getDescriptors(version).length) {
-  //         versionsWithParamfiles.push(version);
-  //       }
-  //     }
-  //   }
-  //   return versionsWithParamfiles;
-  // }
 }

--- a/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MatButtonModule } from '@angular/material/button';
@@ -51,7 +52,8 @@ describe('ToolFileEditorComponent', () => {
         MatTooltipModule,
         MatCardModule,
         BrowserAnimationsModule,
-        ClipboardModule
+        ClipboardModule,
+        HttpClientModule
       ],
       providers: [
         { provide: HostedService, useClass: HostedStubService },

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -69,6 +69,9 @@ export class ToolFileEditorComponent extends FileEditing {
   /**
    * Fix the JSON.parse later.  Currently used to deep copy values but not keep the read-only attribute of state management.
    * Splits up the sourcefiles for the version into descriptor files and test parameter files
+   * Reason for JSON -> stringify -> JSON:
+   * Leftover issue with Akita integration. Akita has readonly objects but we sometimes use it as-is with something like
+   * ngModel which will not work.
    */
   loadVersionSourcefiles(): void {
     this.containerTagsService.getTagsSourcefiles(this.id, this.currentVersion.id).subscribe((sourcefiles: Array<SourceFile>) => {
@@ -83,7 +86,7 @@ export class ToolFileEditorComponent extends FileEditing {
    * Combines sourcefiles into one array
    * @return {Array<SourceFile>} Array of sourcefiles
    */
-  getCombinedSourceFiles(): Array<any> {
+  getCombinedSourceFiles(): Array<SourceFile> {
     let baseFiles = [];
     if (this.descriptorFiles) {
       baseFiles = baseFiles.concat(this.descriptorFiles);

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -16,10 +16,11 @@
 import { Component, Input } from '@angular/core';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileEditing } from '../../shared/file-editing';
-import { ContainertagsService, SourceFile } from '../../shared/openapi';
+import { ContainertagsService } from '../../shared/openapi';
 import { DockstoreTool, ToolDescriptor } from '../../shared/swagger';
 import { ContainerService } from './../../shared/container.service';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
+import { SourceFile } from './../../shared/swagger/model/sourceFile';
 import { Tag } from './../../shared/swagger/model/tag';
 
 @Component({
@@ -28,10 +29,10 @@ import { Tag } from './../../shared/swagger/model/tag';
   styleUrls: ['./tool-file-editor.component.scss']
 })
 export class ToolFileEditorComponent extends FileEditing {
-  dockerFile = [];
-  descriptorFiles = [];
-  testParameterFiles = [];
-  originalSourceFiles = [];
+  dockerFile: Array<SourceFile> = [];
+  descriptorFiles: Array<SourceFile> = [];
+  testParameterFiles: Array<SourceFile> = [];
+  originalSourceFiles: Array<SourceFile> = [];
   currentVersion: Tag;
   selectedDescriptorType: ToolDescriptor.TypeEnum = ToolDescriptor.TypeEnum.CWL;
   isNewestVersion = false;

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -45,7 +45,6 @@ export class ToolFileEditorComponent extends FileEditing {
     this.editing = false;
     this.clearSourceFiles();
     if (value != null) {
-      // Fix the JSON.parse later.  Currently used to deep copy values but not keep the read-only attribute of state management.
       this.loadVersionSourcefiles();
     }
   }

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -102,7 +102,7 @@
         Verified Platforms
       </th>
       <td mat-cell *matCellDef="let version">
-        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version?.sourceFiles | verifiedPlatforms }}</span>
+        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version | verifiedPlatforms: verifiedVersionPlatforms }}</span>
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -102,7 +102,7 @@
         Verified Platforms
       </th>
       <td mat-cell *matCellDef="let version">
-        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version | verifiedPlatforms: verifiedVersionPlatforms }}</span>
+        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version.id | verifiedPlatforms: verifiedVersionPlatforms }}</span>
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/src/app/container/versions/versions.component.ts
+++ b/src/app/container/versions/versions.component.ts
@@ -23,9 +23,10 @@ import { Dockstore } from '../../shared/dockstore.model';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedDockstoreToolQuery } from '../../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { ExtendedDockstoreTool } from '../../shared/models/ExtendedDockstoreTool';
+import { VersionVerifiedPlatform } from '../../shared/openapi';
 import { SessionQuery } from '../../shared/session/session.query';
+import { Tag } from '../../shared/swagger';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
-import { Tag } from '../../shared/swagger/model/tag';
 import { Versions } from '../../shared/versions';
 
 @Component({
@@ -35,6 +36,7 @@ import { Versions } from '../../shared/versions';
 })
 export class VersionsContainerComponent extends Versions implements OnInit, OnChanges, AfterViewInit {
   @Input() versions: Array<any>;
+  @Input() verifiedVersionPlatforms: Array<VersionVerifiedPlatform>;
   Dockstore = Dockstore;
   selectedTag: Tag;
   public DockstoreToolType = DockstoreTool;

--- a/src/app/containers/list/published-tools.datasource.spec.ts
+++ b/src/app/containers/list/published-tools.datasource.spec.ts
@@ -19,8 +19,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
 import { ImageProviderService } from '../../shared/image-provider.service';
 import { ProviderService } from '../../shared/provider.service';
-import { ContainersService } from '../../shared/swagger';
-import { ContainersStubService } from './../../test/service-stubs';
+import { ContainersService, MetadataService } from '../../shared/swagger';
+import { ContainersStubService, MetadataStubService } from './../../test/service-stubs';
 import { PublishedToolsDataSource } from './published-tools.datasource';
 
 describe('Service: PublishedToolsDataSource', () => {
@@ -30,7 +30,8 @@ describe('Service: PublishedToolsDataSource', () => {
         PublishedToolsDataSource,
         ImageProviderService,
         ProviderService,
-        { provide: ContainersService, useClass: ContainersStubService }
+        { provide: ContainersService, useClass: ContainersStubService },
+        { provide: ContainersService, useClass: ContainersStubService },
       ],
       imports: [HttpClientTestingModule]
     });

--- a/src/app/shared/available-logs/available-logs.component.html
+++ b/src/app/shared/available-logs/available-logs.component.html
@@ -26,7 +26,12 @@
         </mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
-        <app-verified-display *ngIf="version?.verified" [sourceFiles]="version?.sourceFiles"></app-verified-display>
+        <app-verified-display
+          *ngIf="version?.verified"
+          [sourceFiles]="version?.sourceFiles"
+          [version]="version"
+          [verifiedByPlatform]="verifiedByPlatform"
+        ></app-verified-display>
       </mat-card-content>
     </mat-card>
     <mat-card *ngIf="(availableLogs$ | async).length > 0">

--- a/src/app/shared/available-logs/available-logs.component.html
+++ b/src/app/shared/available-logs/available-logs.component.html
@@ -28,7 +28,6 @@
       <mat-card-content>
         <app-verified-display
           *ngIf="version?.verified"
-          [sourceFiles]="version?.sourceFiles"
           [version]="version"
           [verifiedByPlatform]="verifiedByPlatform"
         ></app-verified-display>

--- a/src/app/shared/available-logs/available-logs.component.ts
+++ b/src/app/shared/available-logs/available-logs.component.ts
@@ -4,6 +4,7 @@ import { ID } from '@datorama/akita';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Base } from '../base';
+import { VersionVerifiedPlatform } from '../openapi';
 import { ToolTesterLog } from '../openapi/model/toolTesterLog';
 import { AvailableLogsQuery } from '../state/available-logs.query';
 import { AvailableLogsService } from '../state/available-logs.service';
@@ -17,6 +18,7 @@ import { Tag, WorkflowVersion } from '../swagger';
 })
 export class AvailableLogsComponent extends Base implements OnInit {
   version: Tag | WorkflowVersion | null;
+  verifiedByPlatform: Array<VersionVerifiedPlatform>;
   versionName: string | null;
   availableLogs$: Observable<ToolTesterLog[]>;
   isLoading$: Observable<boolean>;
@@ -26,10 +28,11 @@ export class AvailableLogsComponent extends Base implements OnInit {
     private availableLogsQuery: AvailableLogsQuery,
     private checkerWorkflowQuery: CheckerWorkflowQuery,
     private availableLogsService: AvailableLogsService,
-    @Inject(MAT_DIALOG_DATA) public data: Tag | WorkflowVersion | null
+    @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     super();
-    this.version = data;
+    this.version = data.version;
+    this.verifiedByPlatform = data.verifiedByPlatform;
     this.versionName = this.version ? this.version.name : null;
   }
 

--- a/src/app/shared/available-logs/available-logs.component.ts
+++ b/src/app/shared/available-logs/available-logs.component.ts
@@ -11,6 +11,11 @@ import { AvailableLogsService } from '../state/available-logs.service';
 import { CheckerWorkflowQuery } from '../state/checker-workflow.query';
 import { Tag, WorkflowVersion } from '../swagger';
 
+interface VersionVerifiedInformation {
+  version: WorkflowVersion | Tag;
+  verifiedByPlatform: Array<VersionVerifiedPlatform>;
+}
+
 @Component({
   selector: 'available-logs',
   templateUrl: './available-logs.component.html',
@@ -28,7 +33,7 @@ export class AvailableLogsComponent extends Base implements OnInit {
     private availableLogsQuery: AvailableLogsQuery,
     private checkerWorkflowQuery: CheckerWorkflowQuery,
     private availableLogsService: AvailableLogsService,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: VersionVerifiedInformation
   ) {
     super();
     this.version = data.version;

--- a/src/app/shared/descriptor.service.spec.ts
+++ b/src/app/shared/descriptor.service.spec.ts
@@ -97,12 +97,23 @@ describe('DescriptorService', () => {
     ]
   };
 
+  const sampleVersionsFileTypes: Array<SourceFile.TypeEnum> = [
+    'DOCKERFILE',
+    'DOCKSTORE_CWL',
+    'DOCKSTORE_WDL',
+    'WDL_TEST_JSON',
+    'CWL_TEST_JSON'
+  ];
+
   it('should be created', inject([DescriptorService], (service: DescriptorService) => {
     expect(service).toBeTruthy();
   }));
 
   it('should get descriptors', inject([DescriptorService], (service: DescriptorService) => {
-    expect(service.getDescriptors(sampleVersion)).toEqual([ToolDescriptor.TypeEnum.CWL, ToolDescriptor.TypeEnum.WDL]);
+    expect(service.getDescriptors(sampleVersion, sampleVersionsFileTypes)).toEqual([
+      ToolDescriptor.TypeEnum.CWL,
+      ToolDescriptor.TypeEnum.WDL
+    ]);
   }));
   // Tests valid cwl descriptor, but invalid wdl descriptor
   it('should get valid descriptors only', inject([DescriptorService], (service: DescriptorService) => {

--- a/src/app/shared/descriptor.service.ts
+++ b/src/app/shared/descriptor.service.ts
@@ -29,11 +29,10 @@ export class DescriptorService {
    * @returns an array that may contain 'cwl' or 'wdl' or 'nfl'
    * @memberof DescriptorService
    */
-  getDescriptors(version): Array<ToolDescriptor.TypeEnum> {
+  getDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
     const descriptorTypes: Array<ToolDescriptor.TypeEnum> = [];
-    if (version) {
-      const unique = new Set(version.sourceFiles.map((sourceFile: SourceFile) => sourceFile.type));
-      unique.forEach((element: SourceFile.TypeEnum) => {
+    if (versionsFileTypes) {
+      versionsFileTypes.forEach((element: SourceFile.TypeEnum) => {
         extendedDescriptorLanguages.forEach(extendedDescriptorLanguage => {
           if (extendedDescriptorLanguage.descriptorFileTypes.includes(element)) {
             descriptorTypes.push(extendedDescriptorLanguage.toolDescriptorEnum);

--- a/src/app/shared/entry/verified-by/verified-by.component.ts
+++ b/src/app/shared/entry/verified-by/verified-by.component.ts
@@ -19,7 +19,7 @@ export class VerifiedByComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.version) {
-      this.verifiedByStringArray = this.verifiedByService.getVerifiedByString(this.verifiedByPlatform, this.version);
+      this.verifiedByStringArray = this.verifiedByService.getVerifiedByString(this.verifiedByPlatform, this.version.id);
     }
   }
 

--- a/src/app/shared/entry/verified-by/verified-by.component.ts
+++ b/src/app/shared/entry/verified-by/verified-by.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AvailableLogsComponent } from '../../available-logs/available-logs.component';
 import { bootstrap4largeModalSize } from '../../constants';
+import { VersionVerifiedPlatform } from '../../openapi';
 import { Tag, WorkflowVersion } from '../../swagger';
 import { VerifiedByService } from '../../verified-by.service';
 
@@ -12,12 +13,13 @@ import { VerifiedByService } from '../../verified-by.service';
 })
 export class VerifiedByComponent implements OnChanges {
   @Input() version: WorkflowVersion | Tag;
+  @Input() verifiedByPlatform: Array<VersionVerifiedPlatform> = [];
   public verifiedByStringArray: Array<string> = [];
   constructor(private verifiedByService: VerifiedByService, private matDialog: MatDialog) {}
 
   ngOnChanges() {
     if (this.version) {
-      this.verifiedByStringArray = this.verifiedByService.getVerifiedByString(this.version.sourceFiles);
+      this.verifiedByStringArray = this.verifiedByService.getVerifiedByString(this.verifiedByPlatform, this.version);
     }
   }
 
@@ -26,7 +28,14 @@ export class VerifiedByComponent implements OnChanges {
    *
    * @memberof VerifiedByComponent
    */
+  //
   openVerificationAndAvailableLogsDialog() {
-    this.matDialog.open(AvailableLogsComponent, { data: this.version, width: bootstrap4largeModalSize });
+    this.matDialog.open(AvailableLogsComponent, {
+      data: {
+        version: this.version,
+        verifiedByPlatform: this.verifiedByPlatform
+      },
+      width: bootstrap4largeModalSize
+    });
   }
 }

--- a/src/app/shared/entry/verified-by/verified-by.component.ts
+++ b/src/app/shared/entry/verified-by/verified-by.component.ts
@@ -28,7 +28,6 @@ export class VerifiedByComponent implements OnChanges {
    *
    * @memberof VerifiedByComponent
    */
-  //
   openVerificationAndAvailableLogsDialog() {
     this.matDialog.open(AvailableLogsComponent, {
       data: {

--- a/src/app/shared/entry/verified-display/verified-display.component.spec.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.spec.ts
@@ -2,12 +2,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { testSourceFiles } from '../../../test/mocked-objects';
+import { versionVerifiedPlatform } from '../../../test/mocked-objects';
 import { CustomMaterialModule } from '../../modules/material.module';
-import { SourceFile } from '../../swagger';
 import { VerifiedDisplayComponent } from './verified-display.component';
 
-// fix this test
 describe('VerifiedDisplayComponent', () => {
   let component: VerifiedDisplayComponent;
   let fixture: ComponentFixture<VerifiedDisplayComponent>;
@@ -44,6 +42,6 @@ describe('VerifiedDisplayComponent', () => {
   ];
 
   it('should create datasource data from sourcefiles', () => {
-    expect(component.getCustomVerificationInformationArray(testSourceFiles)).toEqual(expectedObject);
+    expect(component.getCustomVerificationInformationArray(1, versionVerifiedPlatform)).toEqual(expectedObject);
   });
 });

--- a/src/app/shared/entry/verified-display/verified-display.component.spec.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.spec.ts
@@ -7,6 +7,7 @@ import { CustomMaterialModule } from '../../modules/material.module';
 import { SourceFile } from '../../swagger';
 import { VerifiedDisplayComponent } from './verified-display.component';
 
+// fix this test
 describe('VerifiedDisplayComponent', () => {
   let component: VerifiedDisplayComponent;
   let fixture: ComponentFixture<VerifiedDisplayComponent>;

--- a/src/app/shared/entry/verified-display/verified-display.component.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.ts
@@ -16,8 +16,8 @@
 import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-
-import { SourceFile, VerificationInformation } from '../../swagger';
+import { VersionVerifiedPlatform } from '../../openapi';
+import { SourceFile, Tag, VerificationInformation, WorkflowVersion } from '../../swagger';
 
 @Component({
   selector: 'app-verified-display',
@@ -26,6 +26,8 @@ import { SourceFile, VerificationInformation } from '../../swagger';
 })
 export class VerifiedDisplayComponent implements OnInit, OnChanges {
   @Input() sourceFiles: SourceFile[];
+  @Input() verifiedByPlatform: Array<VersionVerifiedPlatform>;
+  @Input() version: Tag | WorkflowVersion | null;
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   public dataSource: MatTableDataSource<any>;
   public displayedColumns = ['platform', 'platformVersion', 'path', 'metadata'];
@@ -39,7 +41,9 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     // Update the dataSource's data
-    this.dataSource.data = this.getCustomVerificationInformationArray(this.sourceFiles);
+    // fix this
+    // this.dataSource.data = this.getCustomVerificationInformationArray(this.sourceFiles);
+    this.dataSource.data = this.getCustomVerificationInformationArray2(this.version, this.verifiedByPlatform);
   }
 
   /**
@@ -49,6 +53,7 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
    * @returns {Array<CustomVerificationInformationObject>}   Custom object array (that contains path, verifier, platform)
    * @memberof VerifiedDisplayComponent
    */
+  //
   getCustomVerificationInformationArray(sourceFiles: Array<SourceFile>): Array<any> {
     const customVerificationInformationArray: Array<VerificationInformation> = new Array();
     sourceFiles.forEach((sourceFile: SourceFile) => {
@@ -69,6 +74,32 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
         }
       });
     });
+    console.log('verified-display.component.ts' + this.verifiedByPlatform);
+    return customVerificationInformationArray;
+  }
+
+  getCustomVerificationInformationArray2(
+    version: Tag | WorkflowVersion | null,
+    verifiedByPlatform: Array<VersionVerifiedPlatform>
+  ): Array<any> {
+    const customVerificationInformationArray: Array<VerificationInformation> = new Array();
+    if (version && verifiedByPlatform) {
+      verifiedByPlatform
+        .filter((vs: VersionVerifiedPlatform) => vs.versionId === version.id)
+        .forEach(vs => {
+          if (vs.verified) {
+            const customVerificationInformationObject = {
+              // This allows the string to break after every slash for word-wrapping purposes
+              path: vs.path.replace(/\//g, '/' + '\u2028'),
+              platform: vs.source,
+              platformVersion: vs.platformVersion ? vs.platformVersion : 'N/A',
+              metadata: vs.metadata
+            };
+            customVerificationInformationArray.push(customVerificationInformationObject);
+          }
+        });
+    }
+    console.log('verified-display.component.ts' + this.verifiedByPlatform);
     return customVerificationInformationArray;
   }
 }

--- a/src/app/shared/entry/verified-display/verified-display.component.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.ts
@@ -17,7 +17,7 @@ import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { VersionVerifiedPlatform } from '../../openapi';
-import { SourceFile, Tag, VerificationInformation, WorkflowVersion } from '../../swagger';
+import { Tag, VerificationInformation, WorkflowVersion } from '../../swagger';
 
 @Component({
   selector: 'app-verified-display',

--- a/src/app/shared/entry/verified-display/verified-display.component.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.ts
@@ -41,51 +41,22 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     // Update the dataSource's data
-    // fix this
-    // this.dataSource.data = this.getCustomVerificationInformationArray(this.sourceFiles);
-    this.dataSource.data = this.getCustomVerificationInformationArray2(this.version, this.verifiedByPlatform);
+    this.dataSource.data = this.getCustomVerificationInformationArray(this.version.id, this.verifiedByPlatform);
   }
 
   /**
    * Extracts the custom verification information object array from the sourcefiles
    *
-   * @param {Array<SourceFile>} sourceFiles  The list of sourcefiles from an entry's version
+   * @param {number} versionid The versionid to get verfication information for
+   * @param {Array<VersionVerifiedPlatform>} sourceFiles  The list of sourcefiles from an entry's version
    * @returns {Array<CustomVerificationInformationObject>}   Custom object array (that contains path, verifier, platform)
    * @memberof VerifiedDisplayComponent
    */
-  //
-  getCustomVerificationInformationArray(sourceFiles: Array<SourceFile>): Array<any> {
+  getCustomVerificationInformationArray(versionid: number, verifiedByPlatform: Array<VersionVerifiedPlatform>): Array<any> {
     const customVerificationInformationArray: Array<VerificationInformation> = new Array();
-    sourceFiles.forEach((sourceFile: SourceFile) => {
-      const verifiedBySource = sourceFile.verifiedBySource;
-      const verifiedBySourceArray = Object.entries(verifiedBySource);
-      verifiedBySourceArray.forEach(arrayElement => {
-        const platform: string = arrayElement[0];
-        const verifiedInformation: VerificationInformation = arrayElement[1];
-        if (verifiedInformation.verified) {
-          const customVerificationInformationObject = {
-            // This allows the string to break after every slash for word-wrapping purposes
-            path: sourceFile.path.replace(/\//g, '/' + '\u2028'),
-            platform: platform,
-            platformVersion: verifiedInformation.platformVersion ? verifiedInformation.platformVersion : 'N/A',
-            metadata: verifiedInformation.metadata
-          };
-          customVerificationInformationArray.push(customVerificationInformationObject);
-        }
-      });
-    });
-    console.log('verified-display.component.ts' + this.verifiedByPlatform);
-    return customVerificationInformationArray;
-  }
-
-  getCustomVerificationInformationArray2(
-    version: Tag | WorkflowVersion | null,
-    verifiedByPlatform: Array<VersionVerifiedPlatform>
-  ): Array<any> {
-    const customVerificationInformationArray: Array<VerificationInformation> = new Array();
-    if (version && verifiedByPlatform) {
+    if (versionid && verifiedByPlatform) {
       verifiedByPlatform
-        .filter((vs: VersionVerifiedPlatform) => vs.versionId === version.id)
+        .filter((vs: VersionVerifiedPlatform) => vs.versionId === versionid)
         .forEach(vs => {
           if (vs.verified) {
             const customVerificationInformationObject = {
@@ -99,7 +70,6 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
           }
         });
     }
-    console.log('verified-display.component.ts' + this.verifiedByPlatform);
     return customVerificationInformationArray;
   }
 }

--- a/src/app/shared/entry/verified-display/verified-display.component.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.ts
@@ -25,7 +25,6 @@ import { SourceFile, Tag, VerificationInformation, WorkflowVersion } from '../..
   styleUrls: ['./verified-display.component.scss']
 })
 export class VerifiedDisplayComponent implements OnInit, OnChanges {
-  @Input() sourceFiles: SourceFile[];
   @Input() verifiedByPlatform: Array<VersionVerifiedPlatform>;
   @Input() version: Tag | WorkflowVersion | null;
   @ViewChild(MatSort, { static: true }) sort: MatSort;

--- a/src/app/shared/entry/verified-platforms.pipe.spec.ts
+++ b/src/app/shared/entry/verified-platforms.pipe.spec.ts
@@ -1,9 +1,9 @@
-import { testSourceFiles } from '../../test/mocked-objects';
+import { versionVerifiedPlatform } from '../../test/mocked-objects';
 import { VerifiedPlatformsPipe } from './verified-platforms.pipe';
 
 describe('Pipe: VerifiedPlatforms', () => {
   it('create an instance', () => {
     const pipe = new VerifiedPlatformsPipe();
-    expect(pipe.transform(testSourceFiles)).toEqual('Dockstore CLI');
+    expect(pipe.transform(1, versionVerifiedPlatform)).toEqual('Dockstore CLI');
   });
 });

--- a/src/app/shared/entry/verified-platforms.pipe.ts
+++ b/src/app/shared/entry/verified-platforms.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Version, VersionVerifiedPlatform } from '../openapi';
+import { VersionVerifiedPlatform } from '../openapi';
 
 @Pipe({
   name: 'verifiedPlatforms'

--- a/src/app/shared/entry/verified-platforms.pipe.ts
+++ b/src/app/shared/entry/verified-platforms.pipe.ts
@@ -1,20 +1,19 @@
 import { Pipe, PipeTransform } from '@angular/core';
-
-import { SourceFile } from '../swagger';
+import { Version, VersionVerifiedPlatform } from '../openapi';
 
 @Pipe({
   name: 'verifiedPlatforms'
 })
 export class VerifiedPlatformsPipe implements PipeTransform {
-  transform(sourcefiles: SourceFile[]): string {
+  transform(version: Version, versionVerifiedPlatform: Array<VersionVerifiedPlatform>): string {
     const platforms = new Set<string>();
-    sourcefiles.forEach((sourcefile: SourceFile) => {
-      Object.keys(sourcefile.verifiedBySource).forEach((platform: string) => {
-        if (sourcefile.verifiedBySource[platform].verified) {
-          platforms.add(platform);
+    if (versionVerifiedPlatform) {
+      versionVerifiedPlatform.forEach(value => {
+        if (value.versionId === version.id) {
+          platforms.add(value.source);
         }
       });
-    });
+    }
     return Array.from(platforms).join(', ');
   }
 }

--- a/src/app/shared/entry/verified-platforms.pipe.ts
+++ b/src/app/shared/entry/verified-platforms.pipe.ts
@@ -5,11 +5,11 @@ import { Version, VersionVerifiedPlatform } from '../openapi';
   name: 'verifiedPlatforms'
 })
 export class VerifiedPlatformsPipe implements PipeTransform {
-  transform(version: Version, versionVerifiedPlatform: Array<VersionVerifiedPlatform>): string {
+  transform(versionid: number, versionVerifiedPlatform: Array<VersionVerifiedPlatform>): string {
     const platforms = new Set<string>();
-    if (versionVerifiedPlatform) {
+    if (versionVerifiedPlatform && versionid) {
       versionVerifiedPlatform.forEach(value => {
-        if (value.versionId === version.id) {
+        if (value.versionId === versionid) {
           platforms.add(value.source);
         }
       });

--- a/src/app/shared/extended-dockstoreTool/extended-dockstoreTool.service.ts
+++ b/src/app/shared/extended-dockstoreTool/extended-dockstoreTool.service.ts
@@ -54,7 +54,7 @@ export class ExtendedDockstoreToolService {
   remove() {
     this.extendedDockstoreToolStore.update({});
   }
-  /////
+
   extendTool(tool: DockstoreTool): ExtendedDockstoreTool {
     if (tool) {
       let extendedTool: ExtendedDockstoreTool = { ...tool };

--- a/src/app/shared/extended-dockstoreTool/extended-dockstoreTool.service.ts
+++ b/src/app/shared/extended-dockstoreTool/extended-dockstoreTool.service.ts
@@ -54,7 +54,7 @@ export class ExtendedDockstoreToolService {
   remove() {
     this.extendedDockstoreToolStore.update({});
   }
-
+  /////
   extendTool(tool: DockstoreTool): ExtendedDockstoreTool {
     if (tool) {
       let extendedTool: ExtendedDockstoreTool = { ...tool };

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -73,7 +73,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   reactToVersion(entryid: number): void {
     this.loading = true;
     this.entryService
-      .getTagsFileTypes(entryid, this._selectedVersion.id)
+      .getVersionsFileTypes(entryid, this._selectedVersion.id)
       .pipe(finalize(() => (this.loading = false)))
       .subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
         this.versionsFileTypes = fileTypes;

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -69,7 +69,6 @@ export abstract class EntryFileSelector implements OnDestroy {
     return this.fileService.getDescriptorPath(path, this._selectedVersion, this.currentFile, this.currentDescriptor, entryType);
   }
 
-  //
   reactToVersion(entryid: number): void {
     this.loading = true;
     this.entryService

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -25,14 +25,13 @@ import { ga4ghWorkflowIdPrefix } from '../constants';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
 import { EntriesService } from '../openapi';
-import { FileWrapper, GA4GHService, SourceFile, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
+import { FileWrapper, GA4GHService, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
 
 /**
  * Abstract class to be implemented by components that have select boxes for a given entry and version
  */
 export abstract class EntryFileSelector implements OnDestroy {
   _selectedVersion: any;
-  // versionsFileTypes: Array<SourceFile.TypeEnum> = [];
   id: number;
 
   private ngUnsubscribe: Subject<{}> = new Subject();

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -53,7 +53,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   content: string = null;
 
   abstract getDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any>;
-  abstract getValidDescriptors(version): Array<any>;
+  abstract getValidDescriptors(version, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any>;
   abstract getFiles(descriptor): Observable<any>;
 
   constructor(
@@ -78,7 +78,7 @@ export abstract class EntryFileSelector implements OnDestroy {
       .subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
         this.versionsFileTypes = fileTypes;
         this.descriptors = this.getDescriptors(this._selectedVersion, this.versionsFileTypes);
-        this.validDescriptors = this.getValidDescriptors(this._selectedVersion);
+        this.validDescriptors = this.getValidDescriptors(this._selectedVersion, this.versionsFileTypes);
         if (this.descriptors) {
           this.nullDescriptors = false;
           if (this.descriptors.length) {

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -20,6 +20,7 @@ import { finalize, takeUntil } from 'rxjs/operators';
 
 import { FilesQuery } from '../../workflow/files/state/files.query';
 import { FilesService } from '../../workflow/files/state/files.service';
+import { AlertService } from '../alert/state/alert.service';
 import { ga4ghWorkflowIdPrefix } from '../constants';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
@@ -62,7 +63,8 @@ export abstract class EntryFileSelector implements OnDestroy {
     protected gA4GHService: GA4GHService,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected alertService: AlertService
   ) {}
 
   protected getDescriptorPath(path: string, entryType: 'tool' | 'workflow'): string {
@@ -71,26 +73,34 @@ export abstract class EntryFileSelector implements OnDestroy {
 
   reactToVersion(entryid: number): void {
     this.loading = true;
+    this.alertService.start('Switching versions: Getting the version\'s unique file types');
     this.entryService
       .getVersionsFileTypes(entryid, this._selectedVersion.id)
       .pipe(finalize(() => (this.loading = false)))
-      .subscribe((fileTypes: Array<SourceFile.TypeEnum>) => {
-        this.versionsFileTypes = fileTypes;
-        this.descriptors = this.getDescriptors(this._selectedVersion, this.versionsFileTypes);
-        this.validDescriptors = this.getValidDescriptors(this._selectedVersion, this.versionsFileTypes);
-        if (this.descriptors) {
-          this.nullDescriptors = false;
-          if (this.descriptors.length) {
-            if (this.validDescriptors && this.validDescriptors.length) {
-              this.onDescriptorChange(this.validDescriptors[0]);
-            } else {
-              this.onDescriptorChange(this.descriptors[0]);
+      .subscribe(
+        (fileTypes: Array<SourceFile.TypeEnum>) => {
+          this.versionsFileTypes = fileTypes;
+          this.descriptors = this.getDescriptors(this._selectedVersion, this.versionsFileTypes);
+          this.validDescriptors = this.getValidDescriptors(this._selectedVersion, this.versionsFileTypes);
+          if (this.descriptors) {
+            this.nullDescriptors = false;
+            if (this.descriptors.length) {
+              if (this.validDescriptors && this.validDescriptors.length) {
+                this.onDescriptorChange(this.validDescriptors[0]);
+              } else {
+                this.onDescriptorChange(this.descriptors[0]);
+              }
             }
+          } else {
+            this.nullDescriptors = true;
           }
-        } else {
-          this.nullDescriptors = true;
+          this.alertService.simpleSuccess();
+        },
+        error => {
+          this.versionsFileTypes = [];
+          this.alertService.detailedError(error);
         }
-      });
+      );
   }
 
   onDescriptorChange(descriptor: ToolDescriptor.TypeEnum) {

--- a/src/app/shared/verified-by.service.spec.ts
+++ b/src/app/shared/verified-by.service.spec.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-variable */
 
-import { async, inject, TestBed } from '@angular/core/testing';
-import { testSourceFiles } from '../test/mocked-objects';
+import { inject, TestBed } from '@angular/core/testing';
+import { versionVerifiedPlatform } from '../test/mocked-objects';
 import { VerifiedByService } from './verified-by.service';
 
 describe('Service: VerifiedBy', () => {
@@ -12,8 +12,8 @@ describe('Service: VerifiedBy', () => {
   });
 
   it('should get verified-by string', inject([VerifiedByService], (service: VerifiedByService) => {
-    expect(service.getVerifiedByString(null)).toEqual([]);
-    expect(service.getVerifiedByString([])).toEqual([]);
-    expect(service.getVerifiedByString(testSourceFiles)).toEqual(['Dockstore CLI 1.0.0']);
+    expect(service.getVerifiedByString(null, null)).toEqual([]);
+    expect(service.getVerifiedByString([], 1)).toEqual([]);
+    expect(service.getVerifiedByString(versionVerifiedPlatform, 1)).toEqual(['Dockstore CLI 1.0.0']);
   }));
 });

--- a/src/app/shared/verified-by.service.ts
+++ b/src/app/shared/verified-by.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-
-import { SourceFile } from './swagger';
+import { VersionVerifiedPlatform } from './openapi';
+import { SourceFile, Tag, WorkflowVersion } from './swagger';
 
 @Injectable({
   providedIn: 'root'
@@ -16,28 +16,24 @@ export class VerifiedByService {
    * @returns {Array<string>}                    An array of strings to be displayed seperated by newlines
    * @memberof VerifiedByService
    */
-  getVerifiedByString(sourceFiles: Array<SourceFile>): Array<string> {
+
+  getVerifiedByString(verifiedSources: Array<VersionVerifiedPlatform>, version: Tag | WorkflowVersion): Array<string> {
     const verifiedSourceMap = new Map<string, Set<string>>();
-    if (sourceFiles) {
-      sourceFiles.forEach(sourceFile => {
-        const verifiedBySource = sourceFile.verifiedBySource;
-        if (verifiedBySource) {
-          const verifiedBySourceArray = Object.entries(verifiedBySource);
-          verifiedBySourceArray.forEach(arrayElement => {
-            const platform: string = arrayElement[0];
-            const verified: boolean = arrayElement[1].verified;
-            const platformVersion: string = arrayElement[1].platformVersion;
-            if (verified) {
-              if (!verifiedSourceMap[platform]) {
-                verifiedSourceMap[platform] = new Set<string>();
-              }
-              if (platformVersion) {
-                verifiedSourceMap[platform].add(platformVersion);
-              }
+    if (version && verifiedSources) {
+      verifiedSources
+        .filter((vs: VersionVerifiedPlatform) => vs.versionId === version.id)
+        .forEach(vs => {
+          if (vs.verified) {
+            const platform: string = vs.source;
+            const platformVersion: string = vs.platformVersion;
+            if (!verifiedSourceMap[platform]) {
+              verifiedSourceMap[platform] = new Set<string>();
             }
-          });
-        }
-      });
+            if (platformVersion) {
+              verifiedSourceMap[platform].add(platformVersion);
+            }
+          }
+        });
       const verifiedSourceArray = Object.entries(verifiedSourceMap);
       const verifiedByStringArray: Array<string> = [];
       verifiedSourceArray.forEach(arrayElement => {

--- a/src/app/shared/verified-by.service.ts
+++ b/src/app/shared/verified-by.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { VersionVerifiedPlatform } from './openapi';
-import { SourceFile, Tag, WorkflowVersion } from './swagger';
+import { SourceFile } from './swagger';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/shared/verified-by.service.ts
+++ b/src/app/shared/verified-by.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { VersionVerifiedPlatform } from './openapi';
-import { SourceFile } from './swagger';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +11,8 @@ export class VerifiedByService {
    * This converts the verified source in a version's sourcefiles into a an array of strings
    * to be display in the right sidebar of an entry component
    *
-   * @param {Array<SourceFile>} sourceFiles  The sourcesfiles of an entry's version
+   * @param {Array<VersionVerifiedPlatform>} verifiedSources  The sourcesfiles of an entry's version
+   * @param {number} versionid id of the version you want verified sources for.
    * @returns {Array<string>}                    An array of strings to be displayed seperated by newlines
    * @memberof VerifiedByService
    */

--- a/src/app/shared/verified-by.service.ts
+++ b/src/app/shared/verified-by.service.ts
@@ -17,11 +17,11 @@ export class VerifiedByService {
    * @memberof VerifiedByService
    */
 
-  getVerifiedByString(verifiedSources: Array<VersionVerifiedPlatform>, version: Tag | WorkflowVersion): Array<string> {
+  getVerifiedByString(verifiedSources: Array<VersionVerifiedPlatform>, versionid: number): Array<string> {
     const verifiedSourceMap = new Map<string, Set<string>>();
-    if (version && verifiedSources) {
+    if (versionid && verifiedSources) {
       verifiedSources
-        .filter((vs: VersionVerifiedPlatform) => vs.versionId === version.id)
+        .filter((vs: VersionVerifiedPlatform) => vs.versionId === versionid)
         .forEach(vs => {
           if (vs.verified) {
             const platform: string = vs.source;

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -18,7 +18,8 @@ import { OrgToolObject } from '../mytools/my-tool/my-tool.component';
 import { Hit } from '../search/state/search.service';
 import { ExtendedDockstoreTool } from '../shared/models/ExtendedDockstoreTool';
 import { ExtendedWorkflow } from '../shared/models/ExtendedWorkflow';
-import { WorkflowVersion } from '../shared/swagger';
+import { VersionVerifiedPlatform } from '../shared/openapi';
+import { Tag, WorkflowVersion } from '../shared/swagger';
 import { Notification } from '../shared/swagger/model/notification';
 import { DockstoreTool } from './../shared/swagger/model/dockstoreTool';
 import { SourceFile } from './../shared/swagger/model/sourceFile';
@@ -136,6 +137,12 @@ export const sampleWdlWorkflow2: Workflow = {
 };
 
 export const sampleWorkflowVersion: WorkflowVersion = {
+  id: 1,
+  reference: '',
+  name: 'master'
+};
+
+export const sampleToolVersion: Tag = {
   id: 1,
   reference: '',
   name: 'master'
@@ -466,6 +473,25 @@ export const sampleSourceFile: SourceFile = {
   absolutePath: '',
   type: SourceFile.TypeEnum.CWLTESTJSON
 };
+
+export const versionVerifiedPlatform: Array<VersionVerifiedPlatform> = [
+  {
+    metadata: 'Docktesters group',
+    path: '/Dockstore-BTCA-SG.json',
+    platformVersion: '1.0.0',
+    source: 'Dockstore CLI',
+    verified: true,
+    versionId: 1
+  },
+  {
+    metadata: 'Docktesters group',
+    path: '/Dockstore.json',
+    platformVersion: null,
+    source: 'Dockstore CLI',
+    verified: true,
+    versionId: 1
+  }
+];
 
 export const testSourceFiles: Array<SourceFile> = [
   {

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -348,7 +348,7 @@ export class WorkflowStubService {
 }
 
 export class EntryStubService {
-  getTagsFileTypes(entryid: number, versionid: number): Observable<Array<string>> {
+  getVersionsFileTypes(entryid: number, versionid: number): Observable<Array<string>> {
     return observableOf([]);
   }
 }

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -347,6 +347,12 @@ export class WorkflowStubService {
   }
 }
 
+export class EntryStubService {
+  getTagsFileTypes(entryid: number, versionid: number): Observable<Array<string>> {
+    return observableOf([]);
+  }
+}
+
 export class HostedStubService {
   deleteHostedWorkflowVersion(id: string, version: string) {
     return observableOf({});

--- a/src/app/workflow/descriptors/descriptors.component.spec.ts
+++ b/src/app/workflow/descriptors/descriptors.component.spec.ts
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -30,6 +31,7 @@ describe('DescriptorsWorkflowComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DescriptorsWorkflowComponent],
+      imports: [HttpClientModule],
       providers: [
         { provide: DescriptorService, useClass: DescriptorsStubService },
         { provide: FileService, useClass: FileStubService },

--- a/src/app/workflow/descriptors/descriptors.component.spec.ts
+++ b/src/app/workflow/descriptors/descriptors.component.spec.ts
@@ -16,6 +16,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
@@ -31,7 +32,7 @@ describe('DescriptorsWorkflowComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DescriptorsWorkflowComponent],
-      imports: [HttpClientModule],
+      imports: [HttpClientModule, MatSnackBarModule],
       providers: [
         { provide: DescriptorService, useClass: DescriptorsStubService },
         { provide: FileService, useClass: FileStubService },

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -20,9 +20,10 @@ import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
+import { EntriesService } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { FilesQuery } from '../files/state/files.query';
 import { FilesService } from '../files/state/files.service';
@@ -36,7 +37,7 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
   @Input() id: number;
   @Input() entrypath: string;
   @Input() set selectedVersion(value: WorkflowVersion) {
-    this.onVersionChange(value);
+    this.onVersionChange(value, this.id);
     this.checkIfValid(true, value);
   }
 
@@ -50,14 +51,15 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
     private workflowQuery: WorkflowQuery,
     private gA4GHFilesQuery: GA4GHFilesQuery,
     protected filesService: FilesService,
-    protected filesQuery: FilesQuery
+    protected filesQuery: FilesQuery,
+    protected entryService: EntriesService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
     this.published$ = this.workflowQuery.workflowIsPublished$;
   }
 
-  getDescriptors(version: WorkflowVersion): Array<ToolDescriptor.TypeEnum> {
-    return this.descriptorService.getDescriptors(this._selectedVersion);
+  getDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
+    return this.descriptorService.getDescriptors(this._selectedVersion, versionsFileTypes);
   }
 
   getValidDescriptors(version: WorkflowVersion): Array<any> {

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { AlertService } from '../../shared/alert/state/alert.service';
@@ -34,13 +34,11 @@ import { FilesService } from '../files/state/files.service';
   templateUrl: './descriptors.component.html',
   styleUrls: ['./descriptors.component.css']
 })
-export class DescriptorsWorkflowComponent extends EntryFileSelector {
+export class DescriptorsWorkflowComponent extends EntryFileSelector implements OnChanges {
   @Input() id: number;
   @Input() entrypath: string;
-  @Input() set selectedVersion(value: WorkflowVersion) {
-    this.onVersionChange(value, this.id);
-    this.checkIfValid(true, value);
-  }
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
+  @Input() selectedVersion: WorkflowVersion;
 
   protected entryType: 'tool' | 'workflow' = 'workflow';
 
@@ -60,8 +58,13 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
     this.published$ = this.workflowQuery.workflowIsPublished$;
   }
 
-  getDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
-    return this.descriptorService.getDescriptors(this._selectedVersion, versionsFileTypes);
+  ngOnChanges(changes: SimpleChanges): void {
+    this.onVersionChange(this.selectedVersion, this.id);
+    this.checkIfValid(true, this.selectedVersion);
+  }
+
+  getDescriptors(version: WorkflowVersion): Array<ToolDescriptor.TypeEnum> {
+    return this.descriptorService.getDescriptors(this._selectedVersion, this.versionsFileTypes);
   }
 
   getValidDescriptors(version: WorkflowVersion): Array<any> {

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -16,6 +16,7 @@
 import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { AlertService } from '../../shared/alert/state/alert.service';
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
@@ -52,9 +53,10 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector {
     private gA4GHFilesQuery: GA4GHFilesQuery,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected alertService: AlertService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService, alertService);
     this.published$ = this.workflowQuery.workflowIsPublished$;
   }
 

--- a/src/app/workflow/files/files.component.html
+++ b/src/app/workflow/files/files.component.html
@@ -18,12 +18,24 @@
   <!-- Keep this as lazy loaded -->
   <mat-tab label="Descriptor Files">
     <ng-template matTabContent>
-      <app-descriptors-workflow [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion"> </app-descriptors-workflow>
+      <app-descriptors-workflow
+        [entrypath]="entrypath"
+        [id]="id"
+        [selectedVersion]="selectedVersion"
+        [versionsFileTypes]="versionsFileTypes"
+      >
+      </app-descriptors-workflow>
     </ng-template>
   </mat-tab>
   <mat-tab label="Test Parameter Files">
     <ng-template matTabContent>
-      <app-paramfiles-workflow [entrypath]="entrypath" [id]="id" [selectedVersion]="selectedVersion"> </app-paramfiles-workflow>
+      <app-paramfiles-workflow
+        [entrypath]="entrypath"
+        [id]="id"
+        [selectedVersion]="selectedVersion"
+        [versionsFileTypes]="versionsFileTypes"
+      >
+      </app-paramfiles-workflow>
     </ng-template>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/workflow/files/files.component.ts
+++ b/src/app/workflow/files/files.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { Files } from '../../shared/files';

--- a/src/app/workflow/files/files.component.ts
+++ b/src/app/workflow/files/files.component.ts
@@ -17,7 +17,7 @@ import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { Files } from '../../shared/files';
-import { ToolDescriptor } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 
 @Component({
@@ -28,6 +28,7 @@ import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
   @Input() selectedVersion: WorkflowVersion;
   @Input() descriptorType: ToolDescriptor.TypeEnum;
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
   versionsWithParamfiles: Array<any>;
   previousEntryPath: string;
   previousVersionName: string;
@@ -35,10 +36,11 @@ export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
     super();
   }
 
+  // FIX THIS
   ngOnInit() {
-    this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
+    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
   ngOnChanges() {
-    this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
+    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
 }

--- a/src/app/workflow/files/files.component.ts
+++ b/src/app/workflow/files/files.component.ts
@@ -25,7 +25,7 @@ import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
   templateUrl: './files.component.html',
   styleUrls: ['./files.component.css']
 })
-export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
+export class FilesWorkflowComponent extends Files {
   @Input() selectedVersion: WorkflowVersion;
   @Input() descriptorType: ToolDescriptor.TypeEnum;
   @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
@@ -34,13 +34,5 @@ export class FilesWorkflowComponent extends Files implements OnInit, OnChanges {
   previousVersionName: string;
   constructor(private paramfilesService: ParamfilesService) {
     super();
-  }
-
-  // FIX THIS
-  ngOnInit() {
-    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
-  }
-  ngOnChanges() {
-    // this.versionsWithParamfiles = this.paramfilesService.getVersions(this.versions);
   }
 }

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -33,19 +33,14 @@ import { WorkflowLaunchService } from '../launch/workflow-launch.service';
   templateUrl: './launch.component.html',
   styleUrls: ['./launch.component.css']
 })
-export class LaunchWorkflowComponent extends EntryTab {
+export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChanges {
   @Input() basePath;
   @Input() path;
   currentDescriptor: ToolDescriptor.TypeEnum;
   @Input() mode: DockstoreTool.ModeEnum | Workflow.ModeEnum;
 
   _selectedVersion: WorkflowVersion;
-  @Input() set selectedVersion(value: WorkflowVersion) {
-    if (value != null) {
-      this._selectedVersion = value;
-      this.reactToDescriptor();
-    }
-  }
+  @Input() selectedVersion: WorkflowVersion;
 
   DockstoreToolType = DockstoreTool;
   WorkflowType = Workflow;
@@ -78,6 +73,9 @@ export class LaunchWorkflowComponent extends EntryTab {
     private gA4GHFilesQuery: GA4GHFilesQuery
   ) {
     super();
+  }
+
+  ngOnInit(): void {
     this.published$ = this.workflowQuery.workflowIsPublished$;
     this.descriptorType$ = this.workflowQuery.descriptorType$;
     this.descriptorType$
@@ -85,6 +83,12 @@ export class LaunchWorkflowComponent extends EntryTab {
       .subscribe((descriptorType: ToolDescriptor.TypeEnum) => (this.currentDescriptor = descriptorType));
     this.isNFL$ = this.workflowQuery.isNFL$;
   }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this._selectedVersion = this.selectedVersion;
+    this.reactToDescriptor();
+  }
+
   reactToDescriptor(): void {
     this.changeMessages(this.basePath, this.path, this._selectedVersion.name, this.currentDescriptor);
   }

--- a/src/app/workflow/paramfiles/paramfiles.component.spec.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.spec.ts
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -30,6 +31,7 @@ describe('ParamfilesWorkflowComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ParamfilesWorkflowComponent],
+      imports: [HttpClientModule],
       providers: [
         { provide: ParamfilesService, useClass: ParamFilesStubService },
         { provide: FileService, useClass: FileStubService },

--- a/src/app/workflow/paramfiles/paramfiles.component.spec.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.spec.ts
@@ -16,6 +16,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { FileService } from '../../shared/file.service';
@@ -31,7 +32,7 @@ describe('ParamfilesWorkflowComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ParamfilesWorkflowComponent],
-      imports: [HttpClientModule],
+      imports: [HttpClientModule, MatSnackBarModule],
       providers: [
         { provide: ParamfilesService, useClass: ParamFilesStubService },
         { provide: FileService, useClass: FileStubService },

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -20,9 +20,10 @@ import { ParamfilesService } from '../../container/paramfiles/paramfiles.service
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
+import { EntriesService } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { GA4GHService, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { FilesQuery } from '../files/state/files.query';
 import { FilesService } from '../files/state/files.service';
@@ -37,7 +38,7 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
   @Input() entrypath: string;
   @Input() set selectedVersion(value: WorkflowVersion) {
     this.clearContent();
-    this.onVersionChange(value);
+    this.onVersionChange(value, this.id);
     this.checkIfValid(false, value);
   }
   public isNFL$: Observable<boolean>;
@@ -53,14 +54,15 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
     private workflowService: WorkflowQuery,
     private gA4GHFilesQuery: GA4GHFilesQuery,
     protected filesService: FilesService,
-    protected filesQuery: FilesQuery
+    protected filesQuery: FilesQuery,
+    protected entryService: EntriesService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
     this.published$ = this.workflowService.workflowIsPublished$;
     this.isNFL$ = this.workflowQuery.isNFL$;
   }
-  getDescriptors(version: WorkflowVersion): Array<ToolDescriptor.TypeEnum> {
-    return this.paramfilesService.getDescriptors(this._selectedVersion);
+  getDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
+    return this.paramfilesService.getDescriptors(versionsFileTypes);
   }
 
   getValidDescriptors(version: WorkflowVersion): Array<any> {

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -65,8 +65,8 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
     return this.paramfilesService.getDescriptors(versionsFileTypes);
   }
 
-  getValidDescriptors(version: WorkflowVersion): Array<any> {
-    return this.paramfilesService.getValidDescriptors(this._selectedVersion);
+  getValidDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
+    return this.paramfilesService.getValidDescriptors(this._selectedVersion, versionsFileTypes);
   }
 
   /**

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
@@ -34,14 +34,12 @@ import { FilesService } from '../files/state/files.service';
   templateUrl: './paramfiles.component.html',
   styleUrls: ['./paramfiles.component.css']
 })
-export class ParamfilesWorkflowComponent extends EntryFileSelector {
+export class ParamfilesWorkflowComponent extends EntryFileSelector implements OnChanges {
   @Input() id: number;
   @Input() entrypath: string;
-  @Input() set selectedVersion(value: WorkflowVersion) {
-    this.clearContent();
-    this.onVersionChange(value, this.id);
-    this.checkIfValid(false, value);
-  }
+  @Input() versionsFileTypes: Array<SourceFile.TypeEnum>;
+  @Input() selectedVersion: WorkflowVersion;
+
   public isNFL$: Observable<boolean>;
   protected entryType: 'tool' | 'workflow' = 'workflow';
   public downloadFilePath: string;
@@ -63,12 +61,19 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
     this.published$ = this.workflowService.workflowIsPublished$;
     this.isNFL$ = this.workflowQuery.isNFL$;
   }
-  getDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<ToolDescriptor.TypeEnum> {
-    return this.paramfilesService.getDescriptors(versionsFileTypes);
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.clearContent();
+    this.onVersionChange(this.selectedVersion, this.id);
+    this.checkIfValid(false, this.selectedVersion);
   }
 
-  getValidDescriptors(version: WorkflowVersion, versionsFileTypes: Array<SourceFile.TypeEnum>): Array<any> {
-    return this.paramfilesService.getValidDescriptors(this._selectedVersion, versionsFileTypes);
+  getDescriptors(version: WorkflowVersion): Array<ToolDescriptor.TypeEnum> {
+    return this.paramfilesService.getDescriptors(this.versionsFileTypes);
+  }
+
+  getValidDescriptors(version: WorkflowVersion): Array<any> {
+    return this.paramfilesService.getValidDescriptors(this._selectedVersion, this.versionsFileTypes);
   }
 
   /**

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -17,6 +17,7 @@ import { Component, Input } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
+import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
@@ -55,9 +56,10 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector {
     private gA4GHFilesQuery: GA4GHFilesQuery,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected alertService: AlertService
   ) {
-    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService);
+    super(fileService, gA4GHFilesService, gA4GHService, filesService, filesQuery, entryService, alertService);
     this.published$ = this.workflowService.workflowIsPublished$;
     this.isNFL$ = this.workflowQuery.isNFL$;
   }

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -122,7 +122,7 @@
         <a class="ds-green" [href]="verifiedLink" target="_blank" rel="noopener noreferrer"><mat-icon>info</mat-icon></a>
       </th>
       <td mat-cell *matCellDef="let version">
-        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version?.sourceFiles | verifiedPlatforms }}</span>
+        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version | verifiedPlatforms: verifiedVersionPlatforms }}</span>
       </td>
     </ng-container>
 

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -122,7 +122,7 @@
         <a class="ds-green" [href]="verifiedLink" target="_blank" rel="noopener noreferrer"><mat-icon>info</mat-icon></a>
       </th>
       <td mat-cell *matCellDef="let version">
-        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version | verifiedPlatforms: verifiedVersionPlatforms }}</span>
+        <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version.id | verifiedPlatforms: verifiedVersionPlatforms }}</span>
       </td>
     </ng-container>
 

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -22,6 +22,7 @@ import { DateService } from '../../shared/date.service';
 import { Dockstore } from '../../shared/dockstore.model';
 import { DockstoreService } from '../../shared/dockstore.service';
 import { ExtendedWorkflow } from '../../shared/models/ExtendedWorkflow';
+import { VersionVerifiedPlatform } from '../../shared/openapi';
 import { SessionQuery } from '../../shared/session/session.query';
 import { ExtendedWorkflowQuery } from '../../shared/state/extended-workflow.query';
 import { Workflow } from '../../shared/swagger/model/workflow';

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -36,6 +36,7 @@ import { Versions } from '../../shared/versions';
 export class VersionsWorkflowComponent extends Versions implements OnInit, OnChanges, AfterViewInit {
   @Input() versions: Array<any>;
   @Input() workflowId: number;
+  @Input() verifiedVersionPlatforms: Array<VersionVerifiedPlatform>;
   zenodoUrl: string;
   _selectedVersion: WorkflowVersion;
   Dockstore = Dockstore;

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
@@ -1,5 +1,5 @@
+import { HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -49,7 +49,8 @@ describe('WorkflowFileEditorComponent', () => {
         ClipboardModule,
         MatSnackBarModule,
         MatCardModule,
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        HttpClientModule
       ],
       providers: [
         { provide: HostedService, useClass: HostedStubService },

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -14,9 +14,11 @@
  *    limitations under the License.
  */
 import { Component, Input } from '@angular/core';
+import { WorkflowsService as OpenApiWorkflowServices } from 'app/shared/openapi';
 import { Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileEditing } from '../../shared/file-editing';
+
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { ToolDescriptor, Workflow } from '../../shared/swagger';
@@ -38,6 +40,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
   public selectedDescriptorType$: Observable<ToolDescriptor.TypeEnum>;
   public isNFL$: Observable<boolean>;
   @Input() entrypath: string;
+  @Input() id: number;
   @Input() set selectedVersion(value: WorkflowVersion) {
     this._selectedVersion = value;
     this.editing = false;
@@ -52,6 +55,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
     private hostedService: HostedService,
     private workflowService: WorkflowService,
     private workflowsService: WorkflowsService,
+    private openapiWorkflowsService: OpenApiWorkflowServices,
     protected alertService: AlertService,
     private workflowQuery: WorkflowQuery
   ) {
@@ -83,8 +87,11 @@ export class WorkflowFileEditorComponent extends FileEditing {
    * Splits up the sourcefiles for the version into descriptor files and test parameter files
    */
   loadVersionSourcefiles() {
-    this.descriptorFiles = JSON.parse(JSON.stringify(this.getDescriptorFiles(this._selectedVersion.sourceFiles)));
-    this.testParameterFiles = JSON.parse(JSON.stringify(this.getTestFiles(this._selectedVersion.sourceFiles)));
+    this.openapiWorkflowsService.getWorkflowVersionsSourcefiles(this.id, this._selectedVersion.id).subscribe(sourcefiles => {
+      this.originalSourceFiles = sourcefiles;
+      this.descriptorFiles = JSON.parse(JSON.stringify(this.getDescriptorFiles(this.originalSourceFiles)));
+      this.testParameterFiles = JSON.parse(JSON.stringify(this.getTestFiles(this.originalSourceFiles)));
+    });
   }
 
   /**

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -213,6 +213,7 @@
                 [versions]="(extendedWorkflow$ | async)?.workflowVersions"
                 (selectedVersionChange)="onSelectedVersionChange($event)"
                 [verifiedSource]="(extendedWorkflow$ | async)?.verifiedSources"
+                [verifiedVersionPlatforms]="versionsWithVerirfiedPlatforms"
                 [workflowId]="workflow?.id"
                 [selectedVersion]="selectedVersion"
                 [canRead]="canRead"

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -426,7 +426,8 @@
         </div>
       </div>
       <current-collections [id]="workflow.id"></current-collections>
-      <app-verified-by *ngIf="selectedVersion" [version]="selectedVersion"></app-verified-by>
+      <app-verified-by *ngIf="selectedVersion" [version]="selectedVersion" [verifiedByPlatform]="versionsWithVerirfiedPlatforms">
+      </app-verified-by>
       <div class="panel panel-default mb-3" *ngIf="workflow">
         <div class="panel-heading">
           <h3>Sharing</h3>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -213,7 +213,7 @@
                 [versions]="(extendedWorkflow$ | async)?.workflowVersions"
                 (selectedVersionChange)="onSelectedVersionChange($event)"
                 [verifiedSource]="(extendedWorkflow$ | async)?.verifiedSources"
-                [verifiedVersionPlatforms]="versionsWithVerirfiedPlatforms"
+                [verifiedVersionPlatforms]="versionsWithVerifiedPlatforms"
                 [workflowId]="workflow?.id"
                 [selectedVersion]="selectedVersion"
                 [canRead]="canRead"
@@ -300,6 +300,7 @@
                   [canRead]="canRead"
                   [canWrite]="canWrite"
                   [isOwner]="isOwner"
+                  [versionsFileTypes]="versionsFileTypes"
                 >
                 </app-files-workflow>
               </ng-template>
@@ -426,7 +427,7 @@
         </div>
       </div>
       <current-collections [id]="workflow.id"></current-collections>
-      <app-verified-by *ngIf="selectedVersion" [version]="selectedVersion" [verifiedByPlatform]="versionsWithVerirfiedPlatforms">
+      <app-verified-by *ngIf="selectedVersion" [version]="selectedVersion" [verifiedByPlatform]="versionsWithVerifiedPlatforms">
       </app-verified-by>
       <div class="panel panel-default mb-3" *ngIf="workflow">
         <div class="panel-heading">

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -55,6 +55,7 @@ import { TrackLoginService } from '../shared/track-login.service';
 import { UrlResolverService } from '../shared/url-resolver.service';
 
 import RoleEnum = Permission.RoleEnum;
+import { EntriesService, VersionVerifiedPlatform } from '../shared/openapi';
 @Component({
   selector: 'app-workflow',
   templateUrl: './workflow.component.html',
@@ -90,6 +91,7 @@ export class WorkflowComponent extends Entry implements AfterViewInit {
   public extendedWorkflow$: Observable<ExtendedWorkflow>;
   public WorkflowModel = Workflow;
   public launchSupport$: Observable<boolean>;
+  public versionsWithVerirfiedPlatforms: Array<VersionVerifiedPlatform> = [];
   @Input() user;
 
   constructor(
@@ -112,7 +114,8 @@ export class WorkflowComponent extends Entry implements AfterViewInit {
     private alertQuery: AlertQuery,
     private descriptorTypeCompatService: DescriptorTypeCompatService,
     public dialog: MatDialog,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private entryService: EntriesService
   ) {
     super(
       trackLoginService,
@@ -247,6 +250,9 @@ export class WorkflowComponent extends Entry implements AfterViewInit {
             }
           });
       }
+      this.entryService.getVerifiedPlatforms(workflow.id).subscribe((verifiedVersion: Array<VersionVerifiedPlatform>) => {
+        this.versionsWithVerirfiedPlatforms = verifiedVersion.map(value => Object.assign({}, value));
+      });
     }
   }
 

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -250,9 +250,16 @@ export class WorkflowComponent extends Entry implements AfterViewInit {
             }
           });
       }
-      this.entryService.getVerifiedPlatforms(workflow.id).subscribe((verifiedVersion: Array<VersionVerifiedPlatform>) => {
-        this.versionsWithVerirfiedPlatforms = verifiedVersion.map(value => Object.assign({}, value));
-      });
+      this.alertService.start('Getting the workflow\'s verified platforms');
+      this.entryService.getVerifiedPlatforms(workflow.id).subscribe(
+        (verifiedVersion: Array<VersionVerifiedPlatform>) => {
+          this.versionsWithVerirfiedPlatforms = verifiedVersion.map(value => Object.assign({}, value));
+        },
+        error => {
+          this.alertService.detailedError(error);
+          this.versionsWithVerirfiedPlatforms = [];
+        }
+      );
     }
   }
 

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -46,7 +46,7 @@ import { SessionService } from '../shared/session/session.service';
 import { ExtendedWorkflowQuery } from '../shared/state/extended-workflow.query';
 import { WorkflowQuery } from '../shared/state/workflow.query';
 import { WorkflowService } from '../shared/state/workflow.service';
-import { Permission, SourceFile, ToolDescriptor } from '../shared/swagger';
+import { Permission, ToolDescriptor } from '../shared/swagger';
 import { WorkflowsService } from '../shared/swagger/api/workflows.service';
 import { Tag } from '../shared/swagger/model/tag';
 import { Workflow } from '../shared/swagger/model/workflow';


### PR DESCRIPTION
This https://github.com/dockstore/dockstore/pull/3699 needs to be merged first.
There are still .sourcefile references related to the query builder for elastic search. I tested it briefly locally, and the search still seemed fine. Not sure how it works.
Opening this as a draft PR for now.
