### PR TITLE
use id to track workflow path

### DIFF
--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -53,7 +53,7 @@
             <mat-icon matTooltip="Verified">done</mat-icon>
           </a>
         </span>
-        <span>
+        <span id="workflow-path-gtm">
           {{ title
           }}<span *ngIf="workflow?.workflowVersions.length > 0"
             >:<span class="ds-green">{{ selectedVersion?.name }}</span></span


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1447
Add this id so I can grab just the workflow path. Can't use the id above since it could contain `done` or `preview` in the text google tag manager will grab using the id.