### PR TITLE
fix authorized automated smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,8 +208,8 @@ workflows:
   everything:
     jobs:
       - uptime_monitor_auth
-          branches:
-            tags:
+          filters:
+            branches:
               only: /.*/
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
 #      - lint_unit_test_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,57 +207,53 @@ workflows:
   version: 2
   everything:
     jobs:
-      - uptime_monitor_auth:
+#      # Add the tags filter to all jobs so they will run before upload_to_s3
+      - lint_unit_test_coverage:
           filters:
+            tags:
+              only: /.*/
+      - licenses_test:
+          filters:
+            tags:
+              only: /.*/
+      - integration_test_1:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - lint_unit_test_coverage
+            - licenses_test
+      - integration_test_2:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - lint_unit_test_coverage
+            - licenses_test
+      - integration_test_3:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - lint_unit_test_coverage
+            - licenses_test
+      # Upload builds for tags and branches to s3.
+      - upload_to_s3:
+          requires:
+            - integration_test_1
+            - integration_test_2
+            - integration_test_3
+          filters:
+            tags:
+              only: /.*/
             branches:
               only: /.*/
-#      # Add the tags filter to all jobs so they will run before upload_to_s3
-#      - lint_unit_test_coverage:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - licenses_test:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - integration_test_1:
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - lint_unit_test_coverage
-#            - licenses_test
-#      - integration_test_2:
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - lint_unit_test_coverage
-#            - licenses_test
-#      - integration_test_3:
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - lint_unit_test_coverage
-#            - licenses_test
-#      # Upload builds for tags and branches to s3.
-#      - upload_to_s3:
-#          requires:
-#            - integration_test_1
-#            - integration_test_2
-#            - integration_test_3
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              only: /.*/
-#      - check_build_develop:
-#          requires:
-#            - upload_to_s3
-#          filters:
-#            branches:
-#              only: /^develop/
+      - check_build_develop:
+          requires:
+            - upload_to_s3
+          filters:
+            branches:
+              only: /^develop/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,53 +207,57 @@ workflows:
   version: 2
   everything:
     jobs:
+      - uptime_monitor_auth
+          branches:
+            tags:
+              only: /.*/
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
-      - lint_unit_test_coverage:
-          filters:
-            tags:
-              only: /.*/
-      - licenses_test:
-          filters:
-            tags:
-              only: /.*/
-      - integration_test_1:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - lint_unit_test_coverage
-            - licenses_test
-      - integration_test_2:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - lint_unit_test_coverage
-            - licenses_test
-      - integration_test_3:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - lint_unit_test_coverage
-            - licenses_test
-      # Upload builds for tags and branches to s3.
-      - upload_to_s3:
-          requires:
-            - integration_test_1
-            - integration_test_2
-            - integration_test_3
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/
-      - check_build_develop:
-          requires:
-            - upload_to_s3
-          filters:
-            branches:
-              only: /^develop/
+#      - lint_unit_test_coverage:
+#          filters:
+#            tags:
+#              only: /.*/
+#      - licenses_test:
+#          filters:
+#            tags:
+#              only: /.*/
+#      - integration_test_1:
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - lint_unit_test_coverage
+#            - licenses_test
+#      - integration_test_2:
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - lint_unit_test_coverage
+#            - licenses_test
+#      - integration_test_3:
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - lint_unit_test_coverage
+#            - licenses_test
+#      # Upload builds for tags and branches to s3.
+#      - upload_to_s3:
+#          requires:
+#            - integration_test_1
+#            - integration_test_2
+#            - integration_test_3
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              only: /.*/
+#      - check_build_develop:
+#          requires:
+#            - upload_to_s3
+#          filters:
+#            branches:
+#              only: /^develop/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ workflows:
   version: 2
   everything:
     jobs:
-      - uptime_monitor_auth
+      - uptime_monitor_auth:
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,10 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-dev-auth-[hash].xml
       - upload_nightly_artifacts
-      # Disable until fixed; makes noisy alerts. SEAB-1454 to fix them
-#      - slack/status:
-#          fail_only: true
-#          failure_message: Nightly auth tests failed!
-#          webhook: $SLACK_WEBHOOK
+      - slack/status:
+          fail_only: true
+          failure_message: Nightly auth tests failed!
+          webhook: $SLACK_WEBHOOK
   lint_unit_test_coverage:
     working_directory: ~/repo
     docker:

--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -16,7 +16,9 @@ function storeToken() {
 function unpublishTool() {
   it('unpublish the tool', () => {
     storeToken();
-    cy.get('#publishToolButton').contains('Unpublish').click();
+    cy.get('#publishToolButton')
+      .contains('Unpublish')
+      .click();
   });
 }
 
@@ -41,17 +43,13 @@ function registerQuayTool(repo: string, name: string) {
     cy.server();
     // get quay.io organization/namespaces accessible to user
     cy.route('/api/users/dockerRegistries/quay.io/organizations').as('orgs');
-    // cy.route('**/tokens').as('tokens');
     cy.route('**/repositories').as('repos');
     cy.route('**/containers').as('containers');
     cy.route('post', '**/publish').as('publish');
 
     cy.visit('/my-tools');
     // click thru the steps of registering a tool
-    // cy.wait('@tokens');
-    cy.wait(2000);
-    // cy.wait('@containers');
-    // cy.get('#register_tool_button').should('be.visible').and('contains', 'Register tool').click();
+    cy.wait(2000); // hardcoded 2s wait least flaky right now, revisit in future
     cy.get('#register_tool_button').click();
     cy.wait('@orgs');
     // cy.wait(1000);
@@ -69,11 +67,8 @@ function registerQuayTool(repo: string, name: string) {
     });
     cy.wait('@containers');
     cy.contains('button', 'Finish').click();
-    // cy.wait(1000);
-    // cy.get('#publishToolButton').should('be.visible').and('contains', 'Publish');
     cy.get('#publishToolButton').click();
     cy.wait('@publish');
-    // cy.wait('@containers');
   });
 }
 
@@ -85,7 +80,7 @@ function registerRemoteSitesTool(repo: string, name: string) {
     cy.route('post', '**/publish').as('publish');
 
     cy.visit('/my-tools');
-    cy.wait(2000);
+    cy.wait(2000); // hardcoded 2s wait least flaky right now, revisit in future
     cy.get('#register_tool_button').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on remote sites').click();
@@ -135,6 +130,7 @@ function testTool(registry: string, repo: string, name: string) {
   });
 
   // disable test until hiding versions for Tools are working on dev
+
   // describe('Hide and un-hide a tool version', () => {
   //   registerQuayTool(repo, name);
   //   it('hide a version', () => {
@@ -175,10 +171,16 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.visit(`/my-workflows`);
       cy.wait('@tokens');
       cy.wait('@workflow');
-      cy.get('[data-cy=refreshButton]').click();
 
-      cy.contains('button', 'Publish').should('be.enabled').click();
+      //  refresh stubbed workflow to full and publish
+      cy.get('[data-cy=refreshButton]').click();
+      cy.contains('button', 'Publish')
+        .should('be.enabled')
+        .click();
     });
+
+    // Test some snapshot and versions stuff
+    // WARNING: don't actually snapshot since it can't be undone
     it('snapshot', () => {
       // define routes to watch for
       cy.server();
@@ -188,7 +190,6 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('td', 'Actions')
         .first()
         .click();
-      // WARNING: don't actually snapshot since it can't be undone
       cy.get('.mat-menu-content').within(() => {
         cy.contains('button', 'Snapshot');
         cy.contains('button', 'Edit').click();
@@ -197,7 +198,9 @@ function testWorkflow(registry: string, repo: string, name: string) {
     });
     it('unpublish and stub', () => {
       storeToken();
-      cy.get('#publishButton').contains('Unpublish').click({ force: true });
+      cy.get('#publishButton')
+        .contains('Unpublish')
+        .click({ force: true });
 
       goToTab('Info');
       cy.contains('button', 'Restub').click();

--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -27,6 +27,7 @@ function storeToken() {
 function unpublishTool() {
   it('unpublish the tool', () => {
     storeToken();
+    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#publishToolButton')
       .contains('Unpublish')
       .click();

--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -27,7 +27,6 @@ function storeToken() {
 function unpublishTool() {
   it('unpublish the tool', () => {
     storeToken();
-    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#publishToolButton')
       .contains('Unpublish')
       .click();
@@ -261,10 +260,10 @@ function testCollection(org: string, collection: string, registry: string, repo:
       storeToken();
       // define routes to watch for
       cy.server();
-      cy.route('**/collections').as('collections');
+      // cy.route('**/collections').as('collections');
       cy.route('post', '**/collections/**').as('postToCollection');
       cy.visit(`/containers/quay.io/${repo}/${name}:develop?tab=info`);
-      cy.wait('@collections');
+      // cy.wait('@collections');
       cy.get('#addToolToCollectionButton')
         .should('be.visible')
         .click();
@@ -288,6 +287,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
 
     it('be able to remove an entry from a collection', () => {
       storeToken();
+      cy.server();
       cy.visit(`/organizations/${org}/collections/${collection}`);
       cy.contains(`quay.io/${repo}/${name}`);
       cy.get('#removeEntryButton').click();
@@ -295,7 +295,11 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.contains('This collection has no associated entries');
       cy.visit(`/organizations/${org}`);
       cy.contains('Members').should('be.visible');
+
+      cy.route('**/tokens').as('tokens');
       cy.visit('/my-tools');
+      cy.wait('@tokens');
+      cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
     });
     unpublishTool();
     deleteTool();

--- a/cypress/integration/manualTests/auth-tests.ts
+++ b/cypress/integration/manualTests/auth-tests.ts
@@ -260,10 +260,8 @@ function testCollection(org: string, collection: string, registry: string, repo:
       storeToken();
       // define routes to watch for
       cy.server();
-      // cy.route('**/collections').as('collections');
       cy.route('post', '**/collections/**').as('postToCollection');
       cy.visit(`/containers/quay.io/${repo}/${name}:develop?tab=info`);
-      // cy.wait('@collections');
       cy.get('#addToolToCollectionButton')
         .should('be.visible')
         .click();


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1454

Fixes the auth smoke tests so that they run on dev, also made changes to make the tests less flaky. 

Not sure why, but certain operations seem more flaky when pointing to a live server (dev). Tried a bunch of the official cypress best practices, but they either didn't help with the flakiness or in some cases made things worse. 
- Should assertions and routes are particularly flaky
- pretty much whenever visit() is used only hardcoded wait times consistently resolved flakiness, I minimized using this, but nothing else worked in the places where they're added here.
- Usually using routes + waits helps resolve some flakiness, but didn't seem to help much for some parts of the auth tests on dev.  
- Sometimes waiting for the routes to resolve actually caused more flakiness because they occasionally received a response before the wait event is even triggered, causing an error. I've removed these ones.
- I've kept most routes + waits and added since sometimes they do help and might just be missing something to look into later.
- I've also added to the some comments on whats required for the auth tests to be set up properly
- disabled the tests on hiding versions for tools until the feature is working on dev again