### PR TITLE
Footer improvements and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13431,12 +13431,11 @@
       }
     },
     "ngx-clipboard": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/ngx-clipboard/-/ngx-clipboard-12.2.1.tgz",
-      "integrity": "sha512-9TzgVUKcVHGMYRa/DIit05+uVieiQhd8UEo7f97HTDiDeC1iXFgJjdHSGYyVWfVEQ5WuoryXmk6uYkgugf0y2g==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-clipboard/-/ngx-clipboard-13.0.1.tgz",
+      "integrity": "sha512-e7QBsw7bX5ajhVR2++NAaYZYw90hKeEBlb006TW85WDUA3kmlrXpMDwOvVJuRewU6Nh+U1QiQMJq5a0ivk0zWg==",
       "requires": {
-        "ngx-window-token": "^2.0.0",
-        "tslib": "^1.9.0"
+        "ngx-window-token": ">=3.0.0"
       }
     },
     "ngx-markdown": {
@@ -13460,12 +13459,9 @@
       }
     },
     "ngx-window-token": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-window-token/-/ngx-window-token-2.0.1.tgz",
-      "integrity": "sha512-rvqdqJEfnWXQFU5fyfYt06E10tR/UtFOYdF3QebfcOh5VIJhnTKiprX8e4B9OrX7WEVFm9BT8uV72xXcEgsaKA==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-window-token/-/ngx-window-token-3.0.0.tgz",
+      "integrity": "sha512-MDVIQB2SqFCbpoTqEXhO2529hsvpCYyw/iogjU6uskKqUKh79XVKWSMpRH9S1yTr0Ucgh8nFeNcpv2DnFdikJA=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "~3.4.1",
     "ng2-ui-auth": "^10.0.1",
-    "ngx-clipboard": "^12.2.1",
+    "ngx-clipboard": "^13.0.1",
     "ngx-markdown": "^9.1.1",
     "ngx-sharebuttons": "^8.0.0",
     "pipeline-builder": "^0.3.10-dev.313",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -177,7 +177,8 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     RefreshAlertModule,
     RequestsModule,
     HomePageModule,
-    HttpClientModule
+    HttpClientModule,
+    ClipboardModule
   ],
   providers: [
     AccountsService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { BannerComponent } from './banner/banner.component';
 import { ConfigurationService } from './configuration.service';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
 import { FooterComponent } from './footer/footer.component';
+import { GitTagPipe } from './footer/git-tag.pipe';
 import { FundingComponent } from './funding/funding.component';
 import { GithubCallbackComponent } from './github-callback/github-callback.component';
 import { YoutubeComponent } from './home-page/home-logged-out/home.component';
@@ -147,7 +148,8 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     ConfirmationDialogComponent,
     SessionExpiredComponent,
     TosBannerComponent,
-    LogoutComponent
+    LogoutComponent,
+    GitTagPipe
   ],
   imports: [
     environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -78,7 +78,7 @@ export class ConfigurationService {
     Dockstore.DOCUMENTATION_URL = config.documentationUrl;
     Dockstore.FEATURED_CONTENT_URL = config.featuredContentUrl;
 
-    Dockstore.DEPLOY_COMMIT_ID = config.deployCommitId;
+    Dockstore.DEPLOY_VERSION = config.deployVersion;
 
     Dockstore.COMPOSE_SETUP_VERSION = config.composeSetupVersion;
 

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -81,6 +81,8 @@ export class ConfigurationService {
     Dockstore.DEPLOY_COMMIT_ID = config.deployCommitId;
 
     Dockstore.COMPOSE_SETUP_VERSION = config.composeSetupVersion;
+
+    Dockstore.WEBSERVICE_COMMIT_ID = config.gitCommitId;
   }
 
   /**

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -77,6 +77,10 @@ export class ConfigurationService {
 
     Dockstore.DOCUMENTATION_URL = config.documentationUrl;
     Dockstore.FEATURED_CONTENT_URL = config.featuredContentUrl;
+
+    Dockstore.DEPLOY_COMMIT_ID = config.deployCommitId;
+
+    Dockstore.COMPOSE_SETUP_VERSION = config.composeSetupVersion;
   }
 
   /**

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -59,22 +59,22 @@
           </li>
           <li class="m-0">
             <a
-              href="https://github.com/dockstore/dockstore-ui2/{{ tag | gitTag }}"
+              href="https://github.com/dockstore/dockstore-ui2/{{ tag | gitTag: true }}"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>UI - {{ tag }}</small>
+              <small>UI - {{ tag | gitTag }}</small>
             </a>
           </li>
           <li class="m-0">
             <a
-              href="https://github.com/dockstore/compose_setup/commits/{{ Dockstore.COMPOSE_SETUP_VERSION }}"
+              href="https://github.com/dockstore/compose_setup/{{ Dockstore.COMPOSE_SETUP_VERSION | gitTag: true }}"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>Compose Setup - {{ Dockstore.COMPOSE_SETUP_VERSION }}</small>
+              <small>Deploy - {{ Dockstore.COMPOSE_SETUP_VERSION | gitTag }}</small>
             </a>
           </li>
           <li class="m-0">
@@ -84,7 +84,7 @@
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>Deploy - {{ Dockstore.DEPLOY_COMMIT_ID }}</small>
+              <small>Infrastructure - {{ Dockstore.DEPLOY_COMMIT_ID }}</small>
             </a>
           </li>
           <li class="m-0">

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -59,7 +59,7 @@
           </li>
           <li class="m-0">
             <a
-              href="https://github.com/dockstore/dockstore-ui2/releases/tag/{{ tag }}"
+              href="https://github.com/dockstore/dockstore-ui2/{{ tag | gitTag }}"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -68,11 +68,6 @@
             </a>
           </li>
           <li class="m-0">
-            <a href="javascript:void(0)" class="footer-link" ngxClipboard [cbContent]="content">
-              <mat-icon inline="true">content_copy</mat-icon><small> Build Info</small>
-            </a>
-          </li>
-          <li class="m-0">
             <a
               [href]="dsServerURI + '/metadata/rss'"
               target="_blank"
@@ -87,6 +82,11 @@
             <a routerLink="/sitemap" target="_blank" rel="noopener noreferrer" class="footer-link">
               <small>Sitemap</small>
             </a>
+          </li>
+          <li class="m-0">
+            <button mat-icon-button>
+              <mat-icon ngxClipboard [cbContent]="content">content_copy</mat-icon> <small>&nbsp;Build Info</small>
+            </button>
           </li>
         </ul>
       </div>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -68,22 +68,8 @@
             </a>
           </li>
           <li class="m-0">
-            <a
-              href="https://github.com/dockstore/compose_setup/{{ Dockstore.COMPOSE_SETUP_VERSION | gitTag: true }}"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="footer-link"
-            >
-              <small><button cdkCopyToClipboard="Hello">Copy Build Info</button></small>
-            </a>
-            <span> / </span>
-            <a
-              href="https://github.com/dockstore/dockstore-deploy/commits/{{ Dockstore.DEPLOY_COMMIT_ID }}"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="footer-link"
-            >
-              <small>Infrastructure</small>
+            <a href="javascript:void(0)" class="footer-link" ngxClipboard [cbContent]="content">
+              <mat-icon inline="true">content_copy</mat-icon><small> Copy Build Info</small>
             </a>
           </li>
           <li class="m-0">

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -74,7 +74,7 @@
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>Deploy</small>
+              <small><button cdkCopyToClipboard="Hello">Copy Build Info</button></small>
             </a>
             <span> / </span>
             <a

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -69,7 +69,7 @@
           </li>
           <li class="m-0">
             <a href="javascript:void(0)" class="footer-link" ngxClipboard [cbContent]="content">
-              <mat-icon inline="true">content_copy</mat-icon><small> Copy Build Info</small>
+              <mat-icon inline="true">content_copy</mat-icon><small> Build Info</small>
             </a>
           </li>
           <li class="m-0">

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -43,12 +43,12 @@
             </a>
             -
             <a
-              href="https://github.com/dockstore/dockstore/releases/tag/{{ version }}"
+              href="https://github.com/dockstore/dockstore/{{ version | gitTag: true }}"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>{{ version }} </small>
+              <small>{{ version | gitTag }} </small>
             </a>
             <a href="https://status.dockstore.org/" target="_blank" rel="noopener noreferrer" class="footer-link">
               <img
@@ -74,17 +74,16 @@
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>Deploy - {{ Dockstore.COMPOSE_SETUP_VERSION | gitTag }}</small>
+              <small>Deploy</small>
             </a>
-          </li>
-          <li class="m-0">
+            <span> / </span>
             <a
               href="https://github.com/dockstore/dockstore-deploy/commits/{{ Dockstore.DEPLOY_COMMIT_ID }}"
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"
             >
-              <small>Infrastructure - {{ Dockstore.DEPLOY_COMMIT_ID }}</small>
+              <small>Infrastructure</small>
             </a>
           </li>
           <li class="m-0">

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -69,6 +69,26 @@
           </li>
           <li class="m-0">
             <a
+              href="https://github.com/dockstore/compose_setup/commits/{{ Dockstore.COMPOSE_SETUP_VERSION }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="footer-link"
+            >
+              <small>Compose Setup - {{ Dockstore.COMPOSE_SETUP_VERSION }}</small>
+            </a>
+          </li>
+          <li class="m-0">
+            <a
+              href="https://github.com/dockstore/dockstore-deploy/commits/{{ Dockstore.DEPLOY_COMMIT_ID }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="footer-link"
+            >
+              <small>Deploy - {{ Dockstore.DEPLOY_COMMIT_ID }}</small>
+            </a>
+          </li>
+          <li class="m-0">
+            <a
               [href]="dsServerURI + '/metadata/rss'"
               target="_blank"
               rel="noopener noreferrer"
@@ -91,7 +111,7 @@
             Contact Us
           </li>
           <li class="m-0">
-            <a href="https://github.com/ga4gh/dockstore" target="_blank" rel="noopener noreferrer" class="footer-link">
+            <a href="https://github.com/dockstore/dockstore" target="_blank" rel="noopener noreferrer" class="footer-link">
               <img class="site-icons-tab hidden-sm" src="../assets/images/dockstore/github-mark-light.png" alt="small GitHub logo" /><small>
                 Github</small
               >
@@ -137,7 +157,7 @@
               target="_blank"
               rel="noopener noreferrer"
               class="footer-link"
-              ><small>&copy; 2019 OICR</small></a
+              ><small>&copy; {{ year }} OICR</small></a
             >
           </li>
           <li class="m-0">

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -22,6 +22,7 @@ import { GA4GHService } from './../shared/swagger/api/gA4GH.service';
 import { GA4GHStubService } from './../test/service-stubs';
 
 import { FooterComponent } from './footer.component';
+import { GitTagPipe } from './git-tag.pipe';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -29,7 +30,7 @@ describe('FooterComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [FooterComponent],
+      declarations: [FooterComponent, GitTagPipe],
       imports: [RouterTestingModule, MatIconModule],
       providers: [MetadataService, { provide: GA4GHService, useClass: GA4GHStubService }]
     }).compileComponents();

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -61,7 +61,12 @@ export class FooterComponent extends Base implements OnInit {
       .subscribe(
         (metadata: Metadata) => {
           if (metadata.hasOwnProperty('version')) {
-            this.version = metadata['version'];
+            const metadatum = metadata['version'];
+            if ((metadatum && metadatum.indexOf('SNAPSHOT') !== -1) || metadatum.indexOf('development-build') !== -1) {
+              this.version = Dockstore.WEBSERVICE_COMMIT_ID;
+            } else {
+              this.version = metadatum;
+            }
           } else {
             throw new Error('Version undefined');
           }

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -21,6 +21,7 @@ import { MetadataService } from '../metadata/metadata.service';
 import { Base } from '../shared/base';
 import { Dockstore } from './../shared/dockstore.model';
 import { Metadata } from './../shared/swagger/model/metadata';
+import { FooterService } from './footer.service';
 import { versions } from './versions';
 
 @Component({
@@ -35,6 +36,7 @@ export class FooterComponent extends Base implements OnInit {
   public dsServerURI: any;
   Dockstore = Dockstore;
   year: number;
+  content: string;
 
   /**
    * API Status codes that can indicate the web service is down
@@ -47,7 +49,7 @@ export class FooterComponent extends Base implements OnInit {
    */
   private readonly WEBSERVICE_DOWN_STATUS_CODES = [0, 404, 502, 504];
 
-  constructor(private metadataService: MetadataService) {
+  constructor(private metadataService: MetadataService, private footerService: FooterService) {
     super();
   }
 
@@ -67,6 +69,13 @@ export class FooterComponent extends Base implements OnInit {
             } else {
               this.version = metadatum;
             }
+            this.content = this.footerService.versionsToMarkdown(
+              this.version,
+              this.tag,
+              Dockstore.COMPOSE_SETUP_VERSION,
+              Dockstore.DEPLOY_VERSION
+            );
+            console.log('content', this.content);
           } else {
             throw new Error('Version undefined');
           }

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -75,7 +75,6 @@ export class FooterComponent extends Base implements OnInit {
               Dockstore.COMPOSE_SETUP_VERSION,
               Dockstore.DEPLOY_VERSION
             );
-            console.log('content', this.content);
           } else {
             throw new Error('Version undefined');
           }

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -62,7 +62,7 @@ export class FooterComponent extends Base implements OnInit {
         (metadata: Metadata) => {
           if (metadata.hasOwnProperty('version')) {
             const metadatum = metadata['version'];
-            if ((metadatum && metadatum.indexOf('SNAPSHOT') !== -1) || metadatum.indexOf('development-build') !== -1) {
+            if (metadatum && (metadatum.includes('SNAPSHOT') || metadatum.includes('development-build'))) {
               this.version = Dockstore.WEBSERVICE_COMMIT_ID;
             } else {
               this.version = metadatum;

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -34,6 +34,7 @@ export class FooterComponent extends Base implements OnInit {
   public prod = true;
   public dsServerURI: any;
   Dockstore = Dockstore;
+  year: number;
 
   /**
    * API Status codes that can indicate the web service is down
@@ -51,6 +52,7 @@ export class FooterComponent extends Base implements OnInit {
   }
 
   ngOnInit() {
+    this.year = new Date().getFullYear();
     this.tag = versions.tag;
     this.dsServerURI = Dockstore.API_URI;
     this.metadataService

--- a/src/app/footer/footer.service.spec.ts
+++ b/src/app/footer/footer.service.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FooterService } from './footer.service';
+
+describe('FooterService', () => {
+  let service: FooterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FooterService);
+  });
+
+  it('should generate markdown', () => {
+    // sanity test the method; don't want to look for the exact value as that would just be writing it all over again
+    const markdown = service.versionsToMarkdown('981edd1', '2.6.1-39-g597aeeed', '1.9.0', '3723b1a"');
+    expect(markdown).toContain('981edd1');
+  });
+
+  it('should handle nulls', () => {
+    const markdown = service.versionsToMarkdown(null, null, null, null);
+    expect(markdown.length).toBeGreaterThan(100);
+  });
+});

--- a/src/app/footer/footer.service.ts
+++ b/src/app/footer/footer.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { GitTagPipe } from './git-tag.pipe';
+
+const DOCKSTORE_GITHUB_ORG = 'https://github.com/dockstore';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FooterService {
+  private gitTagPipe: GitTagPipe;
+
+  constructor() {
+    this.gitTagPipe = new GitTagPipe();
+  }
+
+  versionsToMarkdown(
+    webServiceVersion: string | null,
+    uiVersion: string | null,
+    composeSetupVersion: string | null,
+    deployVersion: string | null
+  ): string {
+    return `[Webservice](${this.gitHubUrl('dockstore', webServiceVersion)}) - ${webServiceVersion}
+
+[UI](${this.gitHubUrl('dockstore-ui2', uiVersion)}) - ${uiVersion}
+
+[Compose Setup](${this.gitHubUrl('compose_setup', composeSetupVersion)}) - ${composeSetupVersion}
+
+[Deploy](${this.gitHubUrl('dockstore-deploy', deployVersion)}) - ${deployVersion}`;
+  }
+
+  private gitHubUrl(repo: string, commitOrVersion: string | null): string {
+    return `${DOCKSTORE_GITHUB_ORG}/${repo}/${this.gitTagPipe.transform(commitOrVersion, true)}`;
+  }
+}

--- a/src/app/footer/git-tag.pipe.spec.ts
+++ b/src/app/footer/git-tag.pipe.spec.ts
@@ -1,0 +1,16 @@
+import { GitTagPipe } from './git-tag.pipe';
+
+describe('GitTagPipe', () => {
+  it('create an instance', () => {
+    const pipe = new GitTagPipe();
+    expect(pipe).toBeTruthy();
+  });
+  it('handles dev UI instance', () => {
+    const pipe = new GitTagPipe();
+    expect(pipe.transform('2.6.1-26-geb3771b6')).toEqual('/commits/eb3771b6');
+  });
+  it('handles a release instance', () => {
+    const pipe = new GitTagPipe();
+    expect(pipe.transform('2.6.1')).toEqual('/releases/tags/2.6.1');
+  });
+});

--- a/src/app/footer/git-tag.pipe.spec.ts
+++ b/src/app/footer/git-tag.pipe.spec.ts
@@ -20,4 +20,9 @@ describe('GitTagPipe', () => {
     expect(pipe.transform('e422a55')).toEqual('e422a55');
     expect(pipe.transform('e422a55', true)).toEqual('commits/e422a55');
   });
+  it('handles nulls', () => {
+    const pipe = new GitTagPipe();
+    expect(pipe.transform(null)).toEqual('');
+    expect(pipe.transform(null, true)).toEqual('');
+  });
 });

--- a/src/app/footer/git-tag.pipe.spec.ts
+++ b/src/app/footer/git-tag.pipe.spec.ts
@@ -15,4 +15,9 @@ describe('GitTagPipe', () => {
     expect(pipe.transform('2.6.1')).toEqual('2.6.1');
     expect(pipe.transform('2.6.1', true)).toEqual('releases/tag/2.6.1');
   });
+  it('handles a plain old commit id', () => {
+    const pipe = new GitTagPipe();
+    expect(pipe.transform('e422a55')).toEqual('e422a55');
+    expect(pipe.transform('e422a55', true)).toEqual('commits/e422a55');
+  });
 });

--- a/src/app/footer/git-tag.pipe.spec.ts
+++ b/src/app/footer/git-tag.pipe.spec.ts
@@ -7,10 +7,12 @@ describe('GitTagPipe', () => {
   });
   it('handles dev UI instance', () => {
     const pipe = new GitTagPipe();
-    expect(pipe.transform('2.6.1-26-geb3771b6')).toEqual('/commits/eb3771b6');
+    expect(pipe.transform('2.6.1-26-geb3771b6')).toEqual('eb3771b6');
+    expect(pipe.transform('2.6.1-26-geb3771b6', true)).toEqual('commits/eb3771b6');
   });
   it('handles a release instance', () => {
     const pipe = new GitTagPipe();
-    expect(pipe.transform('2.6.1')).toEqual('/releases/tags/2.6.1');
+    expect(pipe.transform('2.6.1')).toEqual('2.6.1');
+    expect(pipe.transform('2.6.1', true)).toEqual('releases/tag/2.6.1');
   });
 });

--- a/src/app/footer/git-tag.pipe.ts
+++ b/src/app/footer/git-tag.pipe.ts
@@ -24,6 +24,9 @@ export class GitTagPipe implements PipeTransform {
   private readonly gitShaRegEx = /[a-f0-9]{7,}/;
 
   transform(tag: string, withPath?: boolean): string {
+    if (!tag) {
+      return '';
+    }
     const execArray = this.gitTagRegEx.exec(tag);
     if (execArray || this.gitShaRegEx.test(tag)) {
       const actualTag = execArray ? execArray[1] : tag;

--- a/src/app/footer/git-tag.pipe.ts
+++ b/src/app/footer/git-tag.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Transforms the value returned by `git describe --tag` into a GitHub path.
+ * If you run `git describe --tag` when the GIT HEAD is a tag, then it returns the
+ * tag name, e.g., 2.6.1.
+ * If you run `git describe --tag` when the GIT HEAD is not a tag, then it returns
+ * the most recent tag name in the branch, the number of commits since the tag, and the
+ * commit id, preceded by `g`, e.g., 2.6.1-26-geb3771b6.
+ */
+@Pipe({
+  name: 'gitTag'
+})
+export class GitTagPipe implements PipeTransform {
+  readonly versionRegEx = /-\d+-g(\w{8})/;
+
+  transform(tag: string): string {
+    const execArray = this.versionRegEx.exec(tag);
+    if (execArray) {
+      return `/commits/${execArray[1]}`;
+    }
+    return `/releases/tags/${tag}`;
+  }
+}

--- a/src/app/footer/git-tag.pipe.ts
+++ b/src/app/footer/git-tag.pipe.ts
@@ -12,17 +12,22 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'gitTag'
 })
 export class GitTagPipe implements PipeTransform {
-  private readonly gitTagRegEx = /-\d+-g(\w{8})/;
+  /**
+   * Regex for "2.6.1-26-geb3771b6"
+   * @private
+   */
+  private readonly gitTagRegEx = /-\d+-g(\w{7,})/;
   /**
    * Less than perfect test for commit sha -- hexadecimal for at least 7 chars long
    * @private
    */
-  private readonly gitShaRegEx = /[a-f0-9]{8,}/;
+  private readonly gitShaRegEx = /[a-f0-9]{7,}/;
 
   transform(tag: string, withPath?: boolean): string {
     const execArray = this.gitTagRegEx.exec(tag);
-    if (execArray || this.gitTagRegEx.test(tag)) {
-      return withPath ? `commits/${execArray[1]}` : execArray[1];
+    if (execArray || this.gitShaRegEx.test(tag)) {
+      const actualTag = execArray ? execArray[1] : tag;
+      return withPath ? `commits/${actualTag}` : actualTag;
     }
     return withPath ? `releases/tag/${tag}` : tag;
   }

--- a/src/app/footer/git-tag.pipe.ts
+++ b/src/app/footer/git-tag.pipe.ts
@@ -23,7 +23,7 @@ export class GitTagPipe implements PipeTransform {
    */
   private readonly gitShaRegEx = /[a-f0-9]{7,}/;
 
-  transform(tag: string, withPath?: boolean): string {
+  transform(tag: string | null, withPath?: boolean): string {
     if (!tag) {
       return '';
     }

--- a/src/app/footer/git-tag.pipe.ts
+++ b/src/app/footer/git-tag.pipe.ts
@@ -12,13 +12,18 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'gitTag'
 })
 export class GitTagPipe implements PipeTransform {
-  readonly versionRegEx = /-\d+-g(\w{8})/;
+  private readonly gitTagRegEx = /-\d+-g(\w{8})/;
+  /**
+   * Less than perfect test for commit sha -- hexadecimal for at least 7 chars long
+   * @private
+   */
+  private readonly gitShaRegEx = /[a-f0-9]{8,}/;
 
-  transform(tag: string): string {
-    const execArray = this.versionRegEx.exec(tag);
-    if (execArray) {
-      return `/commits/${execArray[1]}`;
+  transform(tag: string, withPath?: boolean): string {
+    const execArray = this.gitTagRegEx.exec(tag);
+    if (execArray || this.gitTagRegEx.test(tag)) {
+      return withPath ? `commits/${execArray[1]}` : execArray[1];
     }
-    return `/releases/tags/${tag}`;
+    return withPath ? `releases/tag/${tag}` : tag;
   }
 }

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -79,6 +79,9 @@ export class Dockstore {
   static DOCUMENTATION_URL = 'https://docs.dockstore.org';
   static FEATURED_CONTENT_URL = 'will be filled in by configuration.service';
 
+  static DEPLOY_COMMIT_ID = '';
+  static COMPOSE_SETUP_VERSION = '';
+
   static FEATURES = {
     enableCwlViewer: true
   };

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -79,7 +79,7 @@ export class Dockstore {
   static DOCUMENTATION_URL = 'https://docs.dockstore.org';
   static FEATURED_CONTENT_URL = 'will be filled in by configuration.service';
 
-  static DEPLOY_COMMIT_ID = '';
+  static DEPLOY_VERSION = '';
   static COMPOSE_SETUP_VERSION = '';
   static WEBSERVICE_COMMIT_ID = '';
 

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -81,6 +81,7 @@ export class Dockstore {
 
   static DEPLOY_COMMIT_ID = '';
   static COMPOSE_SETUP_VERSION = '';
+  static WEBSERVICE_COMMIT_ID = '';
 
   static FEATURES = {
     enableCwlViewer: true


### PR DESCRIPTION
dockstore/dockstore#3509

* Update copyright year by making it dynamic
* Change link to ga4gh/dockstore to dockstore/dockstore

dockstore/dockstore#3698

* Link for UI (and web service) works for actual commits. Try to figure out if the link should be to a tag
or commit and generate link accordingly.
* For web service, if the version is a SNAPSHOT jar (which it is on dev), or a `development-build`, show commit id

SEAB-1552

Add a "Build Info" link, which copies build info in markdown form to clipboard:

```
[Webservice](https://github.com/dockstore/dockstore/commits/981edd1) - 981edd1

[UI](https://github.com/dockstore/dockstore-ui2/commits/597aeeed) - 2.6.1-39-g597aeeed

[Compose Setup](https://github.com/dockstore/compose_setup/releases/tag/1.9.0) - 1.9.0

[Deploy](https://github.com/dockstore/dockstore-deploy/commits/3723b1a) - 3723b1a
```

which look like this:

[Webservice](https://github.com/dockstore/dockstore/commits/981edd1) - 981edd1

[UI](https://github.com/dockstore/dockstore-ui2/commits/597aeeed) - 2.6.1-39-g597aeeed

[Compose Setup](https://github.com/dockstore/compose_setup/releases/tag/1.9.0) - 1.9.0

[Deploy](https://github.com/dockstore/dockstore-deploy/commits/3723b1a) - 3723b1a

![Screen Shot 2020-09-08 at 9 20 14 AM](https://user-images.githubusercontent.com/1049340/92502619-0399b100-f1b5-11ea-9c76-6d8dda519d2e.png)
