### PR TITLE
Feature/2915/throw friendly error for large entity

### DIFF
--- a/src/app/shared/alert/state/alert.service.ts
+++ b/src/app/shared/alert/state/alert.service.ts
@@ -71,16 +71,17 @@ export class AlertService {
    * Handles error HTTP response and show both matSnackBar and an alert
    *
    * @param {HttpErrorResponse} error  The HttpErrorResponse received when the last HTTP request has errored
+   * @param {string} [customMessage]   Optional message to override the default message to provide a clearer reason for the error
    * @memberof AlertService
    */
-  public detailedError(error: HttpErrorResponse) {
+  public detailedError(error: HttpErrorResponse, customMessage?: string) {
     let message: string;
     let details: string;
     if (error.status === 0) {
       // Error code of 0 means the webservice is not responding, likely down
       message = 'The webservice is currently down, possibly due to load. Please wait and try again later.';
     } else {
-      message = 'The webservice encountered an error.';
+      message = customMessage ? customMessage : 'The webservice encountered an error.';
       details = AlertService.getDetailedErrorMessage(error);
     }
     const previousMessage = this.alertQuery.getValue().message;

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -142,7 +142,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
       },
       (error: HttpErrorResponse) => {
         if (error.status === 413) {
-          this.alertService.detailedError(error, 'Cannot upload new version: new version would exceed the 60 kilobyte limit');
+          this.alertService.detailedError(error, 'Cannot save new version: versions have a 60 kilobyte limit');
         } else if (error) {
           this.alertService.detailedError(error);
         }

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -142,7 +142,7 @@ export class WorkflowFileEditorComponent extends FileEditing {
       },
       (error: HttpErrorResponse) => {
         if (error.status === 413) {
-          this.alertService.detailedError(error, 'Cannot upload new version: new version would exceed the 100K byte limit');
+          this.alertService.detailedError(error, 'Cannot upload new version: new version would exceed the 60 kilobyte limit');
         } else if (error) {
           this.alertService.detailedError(error);
         }

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input } from '@angular/core';
 import { WorkflowsService as OpenApiWorkflowServices } from 'app/shared/openapi';
 import { Observable } from 'rxjs';
@@ -139,8 +140,10 @@ export class WorkflowFileEditorComponent extends FileEditing {
           this.handleNoContentResponse();
         }
       },
-      error => {
-        if (error) {
+      (error: HttpErrorResponse) => {
+        if (error.status === 413) {
+          this.alertService.detailedError(error, 'Cannot upload new version: new version would exceed the 100K byte limit');
+        } else if (error) {
           this.alertService.detailedError(error);
         }
       }


### PR DESCRIPTION
Friendly error message for large workflows

dockstore/dockstore#2915

Added a new optional parameter for detailedError() in alert.service.ts
which overrides the default message with a custom message

workflow-file-editor.component.ts now catches a 413 error and outputs
a custom message detailing the 100K byte limit