### PR TITLE
3701/alternative dockstore yml path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.9.0-beta.0"
+    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/4333/workflows/7d647f3a-5ca5-481d-93c1-9361afb142f1/jobs/4949/artifacts"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -9,9 +9,9 @@ GENERATOR_VERSION="3.3.4"
 
 
 # Uncomment this to use the actual Dockstore webservice release from the package.json
- BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
+#  BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-#CIRCLE_CI_PATH="https://3984-33383826-gh.circle-artifacts.com/0/tmp/artifacts" 
+CIRCLE_CI_PATH="https://4949-33383826-gh.circle-artifacts.com/0/tmp/artifacts" 
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -24,11 +24,11 @@ rm -Rf src/app/shared/openapi
 
 
 # Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
+# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
+# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
 # Uncomment these two lines to use the CircleCI swagger/openapi instead
-#java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
-#java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -l typescript-angular -o src/app/shared/openapi -c swagger-config.json
 
 
 

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -4,9 +4,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
-JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
+# JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar 
-#JAR_PATH="https://3984-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.9.0-alpha.11-SNAPSHOT.jar"
+JAR_PATH="https://4949-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.9.2-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/src/app/entry/file-path.pipe.ts
+++ b/src/app/entry/file-path.pipe.ts
@@ -7,7 +7,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FilePathPipe implements PipeTransform {
   transform(filePath: String): String {
     if (filePath.endsWith('.dockstore.yml')) {
-      return '/.dockstore.yml';
+      if (filePath === '.github/.dockstore.yml' || filePath === '/.github/.dockstore.yml') {
+        return '/.github/.dockstore.yml';
+      } else {
+        return '/.dockstore.yml';
+      }
     }
     return filePath;
   }

--- a/src/app/entry/file-path.pipe.ts
+++ b/src/app/entry/file-path.pipe.ts
@@ -7,7 +7,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FilePathPipe implements PipeTransform {
   transform(filePath: String): String {
     if (filePath.endsWith('.dockstore.yml')) {
-      if (filePath === '.github/.dockstore.yml' || filePath === '/.github/.dockstore.yml') {
+      if (filePath.endsWith('.github/.dockstore.yml')) {
         return '/.github/.dockstore.yml';
       } else {
         return '/.dockstore.yml';


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3701

Support .github/.dockstore.yml as a path. Depends on webservice changes.