### PR TITLE
Update UI to use TRS 2.0 final rather than beta endpoints

### DIFF
--- a/cypress/integration/immutableDatabaseTests/searchTable.ts
+++ b/cypress/integration/immutableDatabaseTests/searchTable.ts
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { ga4ghExtendedPath } from '../../../src/app/shared/constants';
 import { setTokenUserViewPort } from '../../support/commands';
 import { goToTab } from '../../support/commands';
 
@@ -24,7 +25,7 @@ describe('Dockstore tool/workflow search table', () => {
     cy.server();
     // Tools/worflows not starred in this response.
     cy.route({
-      url: '*/api/ga4gh/v2/extended/tools/entry/_search',
+      url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
       method: 'POST',
       status: 200,
       response: {
@@ -350,7 +351,7 @@ describe('Dockstore tool/workflow search table', () => {
     // First tool and workflow starred
     cy.fixture('searchTableResponse').then(json => {
       cy.route({
-        url: '*/api/ga4gh/v2/extended/tools/entry/_search',
+        url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
         method: 'POST',
         response: json
       });
@@ -382,7 +383,7 @@ describe('search table items per page', () => {
     cy.server();
     cy.fixture('searchTableResponse').then(json => {
       cy.route({
-        url: '*/api/ga4gh/v2/extended/tools/entry/_search',
+        url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
         method: 'POST',
         response: json
       });

--- a/cypress/integration/immutableDatabaseTests/verification.ts
+++ b/cypress/integration/immutableDatabaseTests/verification.ts
@@ -1,3 +1,4 @@
+import { ga4ghExtendedPath } from '../../../src/app/shared/constants';
 import { Dockstore } from '../../../src/app/shared/dockstore.model';
 import { setTokenUserViewPort } from '../../support/commands';
 
@@ -5,7 +6,7 @@ describe('See verification information and logs', () => {
   setTokenUserViewPort();
   it('should see logs', () => {
     cy.exec(
-      `curl -X POST "${Dockstore.API_URI}/api/ga4gh/v2/extended/quay.io%2Fgaryluu%2Fdockstore-cgpmap%2Fcgpmap-cramOut/versions/3.0.0-rc8/CWL/tests/..%2Fexamples%2Fcgpmap%2FcramOut%2Ffastq_gz_input.json?platform=Dockstore%20CLI&platform_version=1.6.0&verified=true&metadata=Potato" -H "accept: application/json" -H "Authorization: Bearer imamafakedockstoretoken2"`
+      `curl -X POST "${Dockstore.API_URI}${ga4ghExtendedPath}/quay.io%2Fgaryluu%2Fdockstore-cgpmap%2Fcgpmap-cramOut/versions/3.0.0-rc8/CWL/tests/..%2Fexamples%2Fcgpmap%2FcramOut%2Ffastq_gz_input.json?platform=Dockstore%20CLI&platform_version=1.6.0&verified=true&metadata=Potato" -H "accept: application/json" -H "Authorization: Bearer imamafakedockstoretoken2"`
     );
     cy.server();
     cy.fixture('toolTesterLogs').then(json => {

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -1,3 +1,4 @@
+import { ga4ghPath } from '../../../src/app/shared/constants';
 import { Dockstore } from '../../../src/app/shared/dockstore.model';
 import { goToTab } from '../../support/commands';
 
@@ -157,14 +158,16 @@ const workflowVersionTuples = [
     '1.32.0',
     'develop',
     window.location.origin +
-      '/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
+      '/api' +
+      ga4ghPath +
+      '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
     'WDL'
   ],
   [
     'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
     'dev',
     'master',
-    window.location.origin + '/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FNCI-GDC%2Fgdc-dnaseq-cwl%2FGDC_DNASeq/versions/master',
+    window.location.origin + '/api' + ga4ghPath + '/tools/%23workflow%2Fgithub.com%2FNCI-GDC%2Fgdc-dnaseq-cwl%2FGDC_DNASeq/versions/master',
     'CWL'
   ],
   ['github.com/nf-core/vipr', 'dev', 'master', '', 'NFL']

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { ListWorkflowsModule } from './shared/modules/list-workflows.module';
 import { CustomMaterialModule } from './shared/modules/material.module';
 import { OrderByModule } from './shared/modules/orderby.module';
 import { ApiModule as ApiModule2 } from './shared/openapi/api.module';
+import { GA4GHV20Service } from './shared/openapi/api/gA4GHV20.service';
 import { PagenumberService } from './shared/pagenumber.service';
 import { ProviderService } from './shared/provider.service';
 import { RefreshService } from './shared/refresh.service';
@@ -195,6 +196,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     PagenumberService,
     TwitterService,
     GA4GHService,
+    GA4GHV20Service,
     DescriptorLanguageService,
     UrlResolverService,
     MetadataService,

--- a/src/app/banner/banner.component.spec.ts
+++ b/src/app/banner/banner.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MetadataService } from '../metadata/metadata.service';
-import { GA4GHService } from './../shared/swagger/api/gA4GH.service';
-import { GA4GHStubService } from './../test/service-stubs';
+import { GA4GHV20Service } from './../shared/openapi/api/gA4GHV20.service';
+import { GA4GHV20StubService } from './../test/service-stubs';
 import { BannerComponent } from './banner.component';
 
 describe('BannerComponent', () => {
@@ -11,7 +11,7 @@ describe('BannerComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [BannerComponent],
-      providers: [MetadataService, { provide: GA4GHService, useClass: GA4GHStubService }]
+      providers: [MetadataService, { provide: GA4GHV20Service, useClass: GA4GHV20StubService }]
     }).compileComponents();
   }));
 

--- a/src/app/banner/banner.component.spec.ts
+++ b/src/app/banner/banner.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MetadataService } from '../metadata/metadata.service';
-import { GA4GHV20Service } from './../shared/openapi/api/gA4GHV20.service';
-import { GA4GHV20StubService } from './../test/service-stubs';
+import { GA4GHService } from './../shared/swagger/api/gA4GH.service';
+import { GA4GHStubService } from './../test/service-stubs';
 import { BannerComponent } from './banner.component';
 
 describe('BannerComponent', () => {
@@ -11,7 +11,7 @@ describe('BannerComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [BannerComponent],
-      providers: [MetadataService, { provide: GA4GHV20Service, useClass: GA4GHV20StubService }]
+      providers: [MetadataService, { provide: GA4GHService, useClass: GA4GHStubService }]
     }).compileComponents();
   }));
 

--- a/src/app/container/descriptors/descriptors.component.spec.ts
+++ b/src/app/container/descriptors/descriptors.component.spec.ts
@@ -18,12 +18,12 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-import { ContainersStubService, ContainerStubService, EntryStubService, GA4GHStubService } from '../../../../src/app/test/service-stubs';
+import { ContainersStubService, ContainerStubService, EntryStubService, GA4GHV20StubService } from '../../../../src/app/test/service-stubs';
 import { ContainerService } from '../../shared/container.service';
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
-import { EntriesService } from '../../shared/openapi';
-import { ContainersService, GA4GHService } from '../../shared/swagger';
+import { EntriesService, GA4GHV20Service } from '../../shared/openapi';
+import { ContainersService } from '../../shared/swagger';
 import { sampleToolVersion } from '../../test/mocked-objects';
 import { DescriptorsComponent } from './descriptors.component';
 
@@ -44,7 +44,7 @@ describe('DescriptorsComponent', () => {
         { provide: ContainersService, useClass: ContainersStubService },
         { provide: ContainerService, useClass: ContainerStubService },
         { provide: FileService, useClass: FileStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService },
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService },
         { provide: EntriesService, useClass: EntryStubService }
       ]
     }).compileComponents();

--- a/src/app/container/descriptors/descriptors.component.ts
+++ b/src/app/container/descriptors/descriptors.component.ts
@@ -20,9 +20,9 @@ import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
-import { EntriesService } from '../../shared/openapi';
+import { EntriesService, GA4GHV20Service } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { FilesQuery } from '../../workflow/files/state/files.query';
@@ -44,7 +44,7 @@ export class DescriptorsComponent extends EntryFileSelector implements OnChanges
 
   constructor(
     private descriptorsService: DescriptorService,
-    protected gA4GHService: GA4GHService,
+    protected gA4GHService: GA4GHV20Service,
     private toolQuery: ToolQuery,
     private gA4GHFilesQuery: GA4GHFilesQuery,
     public fileService: FileService,

--- a/src/app/container/launch/tool-launch.service.spec.ts
+++ b/src/app/container/launch/tool-launch.service.spec.ts
@@ -15,6 +15,7 @@
  */
 import { inject, TestBed } from '@angular/core/testing';
 
+import { ga4ghPath } from '../../shared/constants';
 import { ToolLaunchService } from './tool-launch.service';
 
 describe('ToolLaunchService', () => {
@@ -43,10 +44,10 @@ describe('ToolLaunchService', () => {
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).toContain('cwl-runner');
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).not.toContain('non-strict');
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).toContain(
-      'api/ga4gh/v2/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
     );
     expect(service.getCwlString('quay.io/a/b/d', 'c', '%2Fpotato')).toContain(
-      'api/ga4gh/v2/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
     );
   }));
   it('should getConsonanceString', inject([ToolLaunchService], (service: ToolLaunchService) => {

--- a/src/app/container/paramfiles/paramfiles.component.ts
+++ b/src/app/container/paramfiles/paramfiles.component.ts
@@ -19,9 +19,9 @@ import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
-import { EntriesService } from '../../shared/openapi';
+import { EntriesService, GA4GHV20Service } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
-import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { Tag } from '../../shared/swagger/model/tag';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { FilesQuery } from '../../workflow/files/state/files.query';
@@ -44,7 +44,7 @@ export class ParamfilesComponent extends EntryFileSelector implements OnChanges 
   protected entryType: 'tool' | 'workflow' = 'tool';
   public downloadFilePath: string;
   constructor(
-    protected gA4GHService: GA4GHService,
+    protected gA4GHService: GA4GHV20Service,
     private paramfilesService: ParamfilesService,
     protected gA4GHFilesService: GA4GHFilesService,
     public fileService: FileService,

--- a/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
+++ b/src/app/entry/entry-file-tab/state/entry-file-tab.service.ts
@@ -8,9 +8,10 @@ import { FileService } from 'app/shared/file.service';
 import { GA4GHFiles } from 'app/shared/ga4gh-files/ga4gh-files.model';
 import { GA4GHFilesQuery } from 'app/shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from 'app/shared/ga4gh-files/ga4gh-files.service';
+import { GA4GHV20Service } from 'app/shared/openapi';
 import { SessionQuery } from 'app/shared/session/session.query';
 import { WorkflowQuery } from 'app/shared/state/workflow.query';
-import { FileWrapper, GA4GHService, ToolDescriptor, ToolFile, WorkflowVersion } from 'app/shared/swagger';
+import { FileWrapper, ToolDescriptor, ToolFile, WorkflowVersion } from 'app/shared/swagger';
 import { takeUntil } from 'rxjs/operators';
 import { Validation } from '../../../shared/swagger/model/validation';
 import { EntryFileTabQuery } from './entry-file-tab.query';
@@ -23,7 +24,7 @@ export class EntryFileTabService extends Base {
     private workflowQuery: WorkflowQuery,
     private entryFileTabQuery: EntryFileTabQuery,
     private gA4GHFilesQuery: GA4GHFilesQuery,
-    private ga4ghService: GA4GHService,
+    private ga4ghService: GA4GHV20Service,
     private ga4ghFilesService: GA4GHFilesService,
     private descriptorTypeCompatService: DescriptorTypeCompatService,
     private fileService: FileService,

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -18,8 +18,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MetadataService } from '../metadata/metadata.service';
-import { GA4GHV20Service } from './../shared/openapi/api/gA4GHV20.service';
-import { GA4GHV20StubService } from './../test/service-stubs';
+import { GA4GHService } from './../shared/swagger/api/gA4GH.service';
+import { GA4GHStubService } from './../test/service-stubs';
 
 import { FooterComponent } from './footer.component';
 
@@ -31,7 +31,7 @@ describe('FooterComponent', () => {
     TestBed.configureTestingModule({
       declarations: [FooterComponent],
       imports: [RouterTestingModule, MatIconModule],
-      providers: [MetadataService, { provide: GA4GHV20Service, useClass: GA4GHV20StubService }]
+      providers: [MetadataService, { provide: GA4GHService, useClass: GA4GHStubService }]
     }).compileComponents();
   }));
 

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -18,8 +18,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MetadataService } from '../metadata/metadata.service';
-import { GA4GHService } from './../shared/swagger/api/gA4GH.service';
-import { GA4GHStubService } from './../test/service-stubs';
+import { GA4GHV20Service } from './../shared/openapi/api/gA4GHV20.service';
+import { GA4GHV20StubService } from './../test/service-stubs';
 
 import { FooterComponent } from './footer.component';
 
@@ -31,7 +31,7 @@ describe('FooterComponent', () => {
     TestBed.configureTestingModule({
       declarations: [FooterComponent],
       imports: [RouterTestingModule, MatIconModule],
-      providers: [MetadataService, { provide: GA4GHService, useClass: GA4GHStubService }]
+      providers: [MetadataService, { provide: GA4GHV20Service, useClass: GA4GHV20StubService }]
     }).compileComponents();
   }));
 

--- a/src/app/search/elastic-search-client.ts
+++ b/src/app/search/elastic-search-client.ts
@@ -15,11 +15,11 @@
  */
 import { Client } from 'elasticsearch-browser';
 
-import { ga4ghPath } from '../shared/constants';
+import { ga4ghExtendedPath } from './../shared/constants';
 import { Dockstore } from './../shared/dockstore.model';
 
 export const ELASTIC_SEARCH_CLIENT = new Client({
-  host: Dockstore.API_URI + ga4ghPath + '/extended',
+  host: Dockstore.API_URI + ga4ghExtendedPath,
   apiVersion: '5.6',
   log: 'warning'
 });

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -16,7 +16,8 @@
 
 import { User } from './openapi/model/user';
 
-export const ga4ghPath = '/api/ga4gh/v2';
+export const ga4ghPath = '/ga4gh/trs/v2';
+export const ga4ghExtendedPath = '/api/ga4gh/v2/extended';
 export const formInputDebounceTime = 250;
 export const ga4ghWorkflowIdPrefix = '#workflow/';
 export const ga4ghServiceIdPrefix = '#service/';

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -58,8 +58,9 @@ describe('FileService', () => {
     const downloadFilePath = fileService.getDownloadFilePath(id, versionId, type, relativePath);
     expect(downloadFilePath).toEqual(
       Dockstore.API_URI +
+        ga4ghPath +
         // tslint:disable-next-line: max-line-length
-        '/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN-WDL/descriptor/HISAT2.wdl'
+        '/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN-WDL/descriptor/HISAT2.wdl'
     );
   }));
 

--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -16,14 +16,15 @@
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
 import { FilesService } from '../../workflow/files/state/files.service';
-import { GA4GHService, ToolDescriptor } from '../swagger';
+import { GA4GHV20Service } from '../openapi';
+import { ToolDescriptor } from '../swagger';
 import { GA4GHFilesStore } from './ga4gh-files.store';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GA4GHFilesService {
-  constructor(private ga4ghFilesStore: GA4GHFilesStore, private ga4ghService: GA4GHService, private filesService: FilesService) {}
+  constructor(private ga4ghFilesStore: GA4GHFilesStore, private ga4ghService: GA4GHV20Service, private filesService: FilesService) {}
 
   /**
    * Updates all GA4GH files from all descriptor types unless specific ones provided
@@ -81,10 +82,10 @@ export class GA4GHFilesService {
    * Since the swagger.yaml does not indicate the endpoints are optionally authenticated,
    * the generated classes will not try and use authentication.  This manually injects it in for use.
    *
-   * @param {GA4GHService} ga4ghService
+   * @param {GA4GHV20Service} ga4ghService
    * @memberof GA4GHFilesService
    */
-  public injectAuthorizationToken(ga4ghService: GA4GHService) {
+  public injectAuthorizationToken(ga4ghService: GA4GHV20Service) {
     const auth = ga4ghService.configuration.apiKeys['Authorization'];
     if (auth) {
       ga4ghService.defaultHeaders = ga4ghService.defaultHeaders.set('Authorization', auth);

--- a/src/app/shared/refresh.service.spec.ts
+++ b/src/app/shared/refresh.service.spec.ts
@@ -23,7 +23,7 @@ import {
   ContainerStubService,
   DateStubService,
   DockstoreStubService,
-  GA4GHStubService,
+  GA4GHV20StubService,
   ProviderStubService,
   UsersStubService,
   WorkflowsStubService
@@ -32,11 +32,11 @@ import { AlertQuery } from './alert/state/alert.query';
 import { ContainerService } from './container.service';
 import { DateService } from './date.service';
 import { DockstoreService } from './dockstore.service';
+import { GA4GHV20Service } from './openapi';
 import { ProviderService } from './provider.service';
 import { RefreshService } from './refresh.service';
 import { WorkflowQuery } from './state/workflow.query';
 import { WorkflowService } from './state/workflow.service';
-import { GA4GHService } from './swagger';
 import { ContainersService } from './swagger/api/containers.service';
 import { UsersService } from './swagger/api/users.service';
 import { WorkflowsService } from './swagger/api/workflows.service';
@@ -60,7 +60,7 @@ describe('RefreshService', () => {
         { provide: ProviderService, useClass: ProviderStubService },
         { provide: DateService, useClass: DateStubService },
         { provide: DockstoreService, useClass: DockstoreStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService },
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService },
         { provide: WorkflowService, useClass: WorkflowService },
         { provide: UsersService, useClass: UsersStubService }
       ]

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -24,8 +24,8 @@ import { AlertService } from '../alert/state/alert.service';
 import { ga4ghWorkflowIdPrefix } from '../constants';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
-import { EntriesService } from '../openapi';
-import { FileWrapper, GA4GHService, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
+import { EntriesService, GA4GHV20Service } from '../openapi';
+import { FileWrapper, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
 
 /**
  * Abstract class to be implemented by components that have select boxes for a given entry and version
@@ -59,7 +59,7 @@ export abstract class EntryFileSelector implements OnDestroy {
   constructor(
     protected fileService: FileService,
     protected gA4GHFilesService: GA4GHFilesService,
-    protected gA4GHService: GA4GHService,
+    protected gA4GHService: GA4GHV20Service,
     protected filesService: FilesService,
     protected filesQuery: FilesQuery,
     protected entryService: EntriesService,

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -130,6 +130,8 @@ export class GA4GHStubService {
   }
 }
 
+export class GA4GHV20StubService {}
+
 export class SearchStubService {
   workflowhit$ = observableOf([]);
   toolhit$ = observableOf([]);

--- a/src/app/workflow/descriptors/descriptors.component.spec.ts
+++ b/src/app/workflow/descriptors/descriptors.component.spec.ts
@@ -20,9 +20,9 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
+import { GA4GHV20Service } from '../../shared/openapi';
 import { WorkflowService } from '../../shared/state/workflow.service';
-import { GA4GHService } from '../../shared/swagger';
-import { DescriptorsStubService, FileStubService, GA4GHStubService, WorkflowStubService } from '../../test/service-stubs';
+import { DescriptorsStubService, FileStubService, GA4GHV20StubService, WorkflowStubService } from '../../test/service-stubs';
 import { DescriptorsWorkflowComponent } from './descriptors.component';
 
 describe('DescriptorsWorkflowComponent', () => {
@@ -37,7 +37,7 @@ describe('DescriptorsWorkflowComponent', () => {
         { provide: DescriptorService, useClass: DescriptorsStubService },
         { provide: FileService, useClass: FileStubService },
         { provide: WorkflowService, useClass: WorkflowStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService }
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/workflow/descriptors/descriptors.component.ts
+++ b/src/app/workflow/descriptors/descriptors.component.ts
@@ -21,10 +21,10 @@ import { DescriptorService } from '../../shared/descriptor.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
-import { EntriesService } from '../../shared/openapi';
+import { EntriesService, GA4GHV20Service } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { FilesQuery } from '../files/state/files.query';
 import { FilesService } from '../files/state/files.service';
@@ -44,7 +44,7 @@ export class DescriptorsWorkflowComponent extends EntryFileSelector implements O
 
   constructor(
     private descriptorService: DescriptorService,
-    public gA4GHService: GA4GHService,
+    public gA4GHService: GA4GHV20Service,
     public fileService: FileService,
     protected gA4GHFilesService: GA4GHFilesService,
     private workflowQuery: WorkflowQuery,

--- a/src/app/workflow/files/files.component.spec.ts
+++ b/src/app/workflow/files/files.component.spec.ts
@@ -17,8 +17,8 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
-import { GA4GHService } from '../../shared/swagger';
-import { GA4GHStubService, ParamFilesStubService } from '../../test/service-stubs';
+import { GA4GHV20Service } from '../../shared/openapi';
+import { GA4GHV20StubService, ParamFilesStubService } from '../../test/service-stubs';
 import { FilesWorkflowComponent } from './files.component';
 
 describe('FilesWorkflowComponent', () => {
@@ -29,7 +29,10 @@ describe('FilesWorkflowComponent', () => {
     TestBed.configureTestingModule({
       declarations: [FilesWorkflowComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      providers: [{ provide: ParamfilesService, useClass: ParamFilesStubService }, { provide: GA4GHService, useClass: GA4GHStubService }]
+      providers: [
+        { provide: ParamfilesService, useClass: ParamFilesStubService },
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService }
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { AlertService } from 'app/shared/alert/state/alert.service';
+import { ga4ghPath } from 'app/shared/constants';
 import { DescriptorTypeCompatService } from 'app/shared/descriptor-type-compat.service';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { EntryType } from 'app/shared/enum/entry-type';
@@ -42,8 +43,9 @@ describe('ValueService', () => {
     const descriptorPath = '/metaphlan_wfl.cwl';
     const entryType: EntryType = EntryType.BioWorkflow;
     expect(service.getTRSLink(path, versionName, descriptorType, descriptorPath, entryType)).toContain(
-      // tslint:disable-next-line: max-line-length
-      '/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FMetaphlan-ISBCGC/versions/master/plain-CWL/descriptor//metaphlan_wfl.cwl'
+      ga4ghPath +
+        // tslint:disable-next-line: max-line-length
+        '/tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FMetaphlan-ISBCGC/versions/master/plain-CWL/descriptor//metaphlan_wfl.cwl'
     );
     // TODO: service test
   });

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpClientModule } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
+import { ga4ghPath } from '../../shared/constants';
 import { Dockstore } from '../../shared/dockstore.model';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
 import { GA4GHFilesStore } from '../../shared/ga4gh-files/ga4gh-files.store';
@@ -57,7 +58,8 @@ describe('LaunchThirdPartyComponent', () => {
       nativeElement.querySelector(
         'a[href="https://platform.dnanexus.com/panx/tools/import-workflow?source=' +
           Dockstore.API_URI +
-          '/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/master"]'
+          ga4ghPath +
+          '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/master"]'
       )
     ).toBeTruthy();
     expect(

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -7,7 +7,7 @@ import { Dockstore } from '../../shared/dockstore.model';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
 import { GA4GHFilesStore } from '../../shared/ga4gh-files/ga4gh-files.store';
 import { CustomMaterialModule } from '../../shared/modules/material.module';
-import { GA4GHService } from '../../shared/swagger';
+import { GA4GHV20Service } from '../../shared/openapi';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { sampleWdlWorkflow2, sampleWorkflowVersion } from '../../test/mocked-objects';
 import { WorkflowsStubService } from '../../test/service-stubs';
@@ -23,7 +23,7 @@ describe('LaunchThirdPartyComponent', () => {
     TestBed.configureTestingModule({
       declarations: [LaunchThirdPartyComponent],
       imports: [CustomMaterialModule, HttpClientModule],
-      providers: [GA4GHFilesService, GA4GHService, GA4GHFilesStore, { provide: WorkflowsService, useClass: WorkflowsStubService }],
+      providers: [GA4GHFilesService, GA4GHV20Service, GA4GHFilesStore, { provide: WorkflowsService, useClass: WorkflowsStubService }],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   }));

--- a/src/app/workflow/launch-third-party/state/descriptors.service.spec.ts
+++ b/src/app/workflow/launch-third-party/state/descriptors.service.spec.ts
@@ -1,5 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 
+import { ga4ghPath } from '../../../shared/constants';
 import { Dockstore } from '../../../shared/dockstore.model';
 import { DescriptorsStore } from './descriptors-store';
 import { DescriptorsService } from './descriptors.service';
@@ -22,7 +23,7 @@ describe('DescriptorsService', () => {
     expect(service.trsUrl(path, version))
       // tslint:disable:max-line-length
       .toEqual(
-        `${Dockstore.API_URI}/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fgatk-workflows%2Fgatk4-germline-snps-indels/versions/1.0.1`
+        `${Dockstore.API_URI}${ga4ghPath}/tools/%23workflow%2Fgithub.com%2Fgatk-workflows%2Fgatk4-germline-snps-indels/versions/1.0.1`
       );
   }));
 });

--- a/src/app/workflow/launch/launch.component.spec.ts
+++ b/src/app/workflow/launch/launch.component.spec.ts
@@ -18,14 +18,14 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ContainerService } from '../../shared/container.service';
 import { DescriptorService } from '../../shared/descriptor.service';
+import { GA4GHV20Service } from '../../shared/openapi';
 import { CheckerWorkflowService } from '../../shared/state/checker-workflow.service';
 import { WorkflowService } from '../../shared/state/workflow.service';
-import { GA4GHService } from '../../shared/swagger';
 import {
   CheckerWorkflowStubService,
   ContainerStubService,
   DescriptorsStubService,
-  GA4GHStubService,
+  GA4GHV20StubService,
   WorkflowStubService
 } from '../../test/service-stubs';
 import { LaunchWorkflowComponent } from './launch.component';
@@ -45,7 +45,7 @@ describe('LaunchWorkflowComponent', () => {
         { provide: DescriptorService, useClass: DescriptorsStubService },
         { provide: CheckerWorkflowService, useClass: CheckerWorkflowStubService },
         { provide: WorkflowService, useClass: WorkflowStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService }
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService }
       ]
     }).compileComponents();
   }));

--- a/src/app/workflow/launch/workflow-launch.service.spec.ts
+++ b/src/app/workflow/launch/workflow-launch.service.spec.ts
@@ -15,6 +15,7 @@
  */
 import { inject, TestBed } from '@angular/core/testing';
 
+import { ga4ghPath } from '../../shared/constants';
 import { Dockstore } from '../../shared/dockstore.model';
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { ToolDescriptor } from '../../shared/swagger';
@@ -47,7 +48,7 @@ describe('WorkflowLaunchService', () => {
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).toContain('cwl-runner');
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).not.toContain('non-strict');
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).toContain(
-      'api/ga4gh/v2/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
     );
   }));
   it('should getConsonanceString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {
@@ -67,21 +68,21 @@ describe('WorkflowLaunchService', () => {
       service.getTestJsonString('#workflow/github.com/garyluu/example_cwl_workflow', 'v1.0', ToolDescriptor.TypeEnum.CWL, 'test.json')
     ).toBe(
       `wget --header='Accept: text/plain' ` +
-        `${Dockstore.API_URI}/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_CWL/descriptor/test.json ` +
+        `${Dockstore.API_URI}${ga4ghPath}/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_CWL/descriptor/test.json ` +
         `-O Dockstore.json`
     );
     expect(
       service.getTestJsonString('#workflow/github.com/garyluu/example_cwl_workflow', 'v1.0', ToolDescriptor.TypeEnum.WDL, 'test.json')
     ).toBe(
       `wget --header='Accept: text/plain' ` +
-        `${Dockstore.API_URI}/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_WDL/descriptor/test.json ` +
+        `${Dockstore.API_URI}${ga4ghPath}/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_WDL/descriptor/test.json ` +
         `-O Dockstore.json`
     );
     expect(
       service.getTestJsonString('#workflow/github.com/garyluu/example_cwl_workflow', 'v1.0', ToolDescriptor.TypeEnum.NFL, 'test.json')
     ).toBe(
       `wget --header='Accept: text/plain' ` +
-        `${Dockstore.API_URI}/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_NFL/descriptor/test.json ` +
+        `${Dockstore.API_URI}${ga4ghPath}/tools/%23workflow%2Fgithub.com%2Fgaryluu%2Fexample_cwl_workflow/versions/v1.0/PLAIN_NFL/descriptor/test.json ` +
         `-O Dockstore.json`
     );
     expect(
@@ -93,7 +94,7 @@ describe('WorkflowLaunchService', () => {
       )
     ).toBe(
       `wget --header='Accept: text/plain' ` +
-        `${Dockstore.API_URI}/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN_WDL/descriptor/..%2F..%2Ftest/smartseq2_single_sample/pr/dockstore_test_inputs.json ` +
+        `${Dockstore.API_URI}${ga4ghPath}/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN_WDL/descriptor/..%2F..%2Ftest/smartseq2_single_sample/pr/dockstore_test_inputs.json ` +
         `-O Dockstore.json`
     );
   }));

--- a/src/app/workflow/paramfiles/paramfiles.component.spec.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.spec.ts
@@ -20,9 +20,9 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ParamfilesService } from '../../container/paramfiles/paramfiles.service';
 import { FileService } from '../../shared/file.service';
+import { GA4GHV20Service } from '../../shared/openapi';
 import { WorkflowService } from '../../shared/state/workflow.service';
-import { GA4GHService } from '../../shared/swagger';
-import { FileStubService, GA4GHStubService, ParamFilesStubService, WorkflowStubService } from '../../test/service-stubs';
+import { FileStubService, GA4GHV20StubService, ParamFilesStubService, WorkflowStubService } from '../../test/service-stubs';
 import { ParamfilesWorkflowComponent } from './paramfiles.component';
 
 describe('ParamfilesWorkflowComponent', () => {
@@ -37,7 +37,7 @@ describe('ParamfilesWorkflowComponent', () => {
         { provide: ParamfilesService, useClass: ParamFilesStubService },
         { provide: FileService, useClass: FileStubService },
         { provide: WorkflowService, useClass: WorkflowStubService },
-        { provide: GA4GHService, useClass: GA4GHStubService }
+        { provide: GA4GHV20Service, useClass: GA4GHV20StubService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/workflow/paramfiles/paramfiles.component.ts
+++ b/src/app/workflow/paramfiles/paramfiles.component.ts
@@ -21,10 +21,10 @@ import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileService } from '../../shared/file.service';
 import { GA4GHFilesQuery } from '../../shared/ga4gh-files/ga4gh-files.query';
 import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service';
-import { EntriesService } from '../../shared/openapi';
+import { EntriesService, GA4GHV20Service } from '../../shared/openapi';
 import { EntryFileSelector } from '../../shared/selectors/entry-file-selector';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { GA4GHService, SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
+import { SourceFile, ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { FilesQuery } from '../files/state/files.query';
 import { FilesService } from '../files/state/files.service';
@@ -46,7 +46,7 @@ export class ParamfilesWorkflowComponent extends EntryFileSelector implements On
 
   constructor(
     private paramfilesService: ParamfilesService,
-    protected gA4GHService: GA4GHService,
+    protected gA4GHService: GA4GHV20Service,
     public fileService: FileService,
     protected gA4GHFilesService: GA4GHFilesService,
     private workflowQuery: WorkflowQuery,


### PR DESCRIPTION
Main issue: https://github.com/dockstore/dockstore/issues/3468

See https://dockstore.org/api/static/swagger-ui/index.html for API reference.

**Goal:**
- Convert GA4GH (TRS 2.0.0 beta) `/api/ga4gh/v2` URLs to GA4GHV20 (TRS 2.0.0 final) `/ga4gh/trs/v2`

**Exceptions:**
- extendedGA4GH URLs use `/api/ga4gh/v2/extended`
- `/api/ga4gh/v2/metadata` has no equivalent in TRS 2.0.0 final
  + used by `MetaDataService` & `DownloadCLIClientComponent`

**Changes:**
- Update `ga4ghPath` constant to be `/ga4gh/trs/v2`
- Create new `ga4ghExtendedPath` constant `/api/ga4gh/v2/extended` to replace `ga4ghPath` for GA4GH API extensions
- Use these constants for URL strings wherever possible
- Replace `GA4GHService` with `GA4GHV20Service` everywhere except for `MetaDataService` & `DownloadCLIClientComponent`