### PR TITLE
info-tab DOI links

### DIFF
--- a/cypress/integration/manualTests/zenodo.ts
+++ b/cypress/integration/manualTests/zenodo.ts
@@ -215,6 +215,6 @@ describe('Create Zenodo DOI for workflow version', () => {
     cy.get('[class=mat-card-header]').should('contain', 'Workflow Version Information');
 
     // Check that the DOI appears on the Info page for the new version
-    cy.get('div').should('contain', '10.5072/zenodo.');
+    cy.get('[data-cy=info-tab-DOI-badge]').should('be.visible');
   });
 });

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -176,14 +176,14 @@
           <div>
             <strong matTooltip="Digital Object Identifier for all workflow versions">DOI</strong>:
             <a
-              href="https://doi.org/{{ workflow.conceptDoi }}"
+              [href]="'https://doi.org/' + workflow.conceptDoi"
               *ngIf="workflow.conceptDoi"
               matTooltip="Click to view the DOI entry information for all versions."
               target="_blank"
               rel="noopener noreferrer"
               ><img src="{{ zenodoUrl }}/badge/DOI/{{ workflow.conceptDoi }}.svg" alt="{{ workflow.conceptDoi }}"
             /></a>
-            {{ workflow && workflow.conceptDoi ? '' : 'n/a' }}
+            {{ workflow?.conceptDoi ? '' : 'n/a' }}
           </div>
         </div>
       </ul>
@@ -198,7 +198,7 @@
       <div *ngIf="(entryType$ | async) === EntryType.BioWorkflow">
         <strong matTooltip="Digital Object Identifier">DOI</strong>:
         <a
-          href="https://doi.org/{{ selectedVersion.doiURL }}"
+          [href]="'https://doi.org/' + selectedVersion.doiURL"
           *ngIf="selectedVersion.doiURL"
           data-cy="info-tab-DOI-badge"
           matTooltip="Click to view this version's DOI entry information."
@@ -206,7 +206,7 @@
           rel="noopener noreferrer"
           ><img src="{{ zenodoUrl }}/badge/DOI/{{ selectedVersion.doiURL }}.svg" alt="{{ selectedVersion.doiURL }}"
         /></a>
-        {{ selectedVersion && selectedVersion.doiURL ? '' : 'n/a' }}
+        {{ selectedVersion?.doiURL ? '' : 'n/a' }}
       </div>
       <div>
         <strong matTooltip="Author listed in descriptor">Author</strong>: {{ selectedVersion?.author ? selectedVersion?.author : 'n/a' }}

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -175,7 +175,15 @@
           </li>
           <div>
             <strong matTooltip="Digital Object Identifier for all workflow versions">DOI</strong>:
-            {{ (workflow && workflow.conceptDoi) || 'n/a' }}
+            <a
+              href="https://doi.org/{{ workflow.conceptDoi }}"
+              *ngIf="workflow.conceptDoi"
+              matTooltip="Click to view the DOI entry information for all versions."
+              target="_blank"
+              rel="noopener noreferrer"
+              ><img src="{{ zenodoUrl }}/badge/DOI/{{ workflow.conceptDoi }}.svg" alt="{{ workflow.conceptDoi }}"
+            /></a>
+            {{ workflow && workflow.conceptDoi ? '' : 'n/a' }}
           </div>
         </div>
       </ul>
@@ -189,7 +197,16 @@
     <mat-card-content class="p-3">
       <div *ngIf="(entryType$ | async) === EntryType.BioWorkflow">
         <strong matTooltip="Digital Object Identifier">DOI</strong>:
-        {{ selectedVersion && selectedVersion.doiURL ? selectedVersion.doiURL : 'n/a' }}
+        <a
+          href="https://doi.org/{{ selectedVersion.doiURL }}"
+          *ngIf="selectedVersion.doiURL"
+          data-cy="info-tab-DOI-badge"
+          matTooltip="Click to view this version's DOI entry information."
+          target="_blank"
+          rel="noopener noreferrer"
+          ><img src="{{ zenodoUrl }}/badge/DOI/{{ selectedVersion.doiURL }}.svg" alt="{{ selectedVersion.doiURL }}"
+        /></a>
+        {{ selectedVersion && selectedVersion.doiURL ? '' : 'n/a' }}
       </div>
       <div>
         <strong matTooltip="Author listed in descriptor">Author</strong>: {{ selectedVersion?.author ? selectedVersion?.author : 'n/a' }}

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -48,6 +48,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   currentVersion: WorkflowVersion;
   downloadZipLink: string;
   isValidVersion = false;
+  zenodoUrl: string;
   @Input() selectedVersion: WorkflowVersion;
 
   public validationPatterns = validationDescriptorPatterns;
@@ -105,6 +106,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   }
 
   ngOnInit() {
+    this.zenodoUrl = Dockstore.ZENODO_AUTH_URL ? Dockstore.ZENODO_AUTH_URL.replace('oauth/authorize', '') : '';
     this.descriptorLanguages$ = this.descriptorLanguageService.filteredDescriptorLanguages$;
     this.descriptorType$ = this.workflowQuery.descriptorType$;
     this.isNFL$ = this.workflowQuery.isNFL$;


### PR DESCRIPTION
Main issue: https://github.com/dockstore/dockstore/issues/3673

Use Zenodo-badge DOI links on Info tab:

![Screenshot_2020-09-08 Dockstore My Workflows(1)](https://user-images.githubusercontent.com/5513934/92521782-d3213980-f1eb-11ea-9e09-9f836e4cd871.png)

Copying the usage in the Versions tab:

![Screenshot_2020-09-08 Dockstore My Workflows](https://user-images.githubusercontent.com/5513934/92521795-d9171a80-f1eb-11ea-9b4e-35b6ef54eff4.png)
