### PR TITLE
Disable name and display name when editing organization

### DIFF
--- a/src/app/organizations/registerOrganization/register-organization.component.html
+++ b/src/app/organizations/registerOrganization/register-organization.component.html
@@ -21,7 +21,7 @@
   </p>
   <app-alert></app-alert>
   <form [formGroup]="registerOrganizationForm">
-    <mat-form-field>
+    <mat-form-field [matTooltip]="data.mode === TagEditorMode.Edit ? 'Contact Dockstore to change name' : ''">
       <input type="text" matInput formControlName="name" placeholder="Name" required />
       <mat-error *ngIf="name.hasError('required')">Name is required</mat-error>
       <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
@@ -29,7 +29,7 @@
       <mat-error *ngIf="name.hasError('pattern')">Name can only contain alphanumeric characters. It must begin with a letter.</mat-error>
       <mat-hint>The name of the organization</mat-hint>
     </mat-form-field>
-    <mat-form-field>
+    <mat-form-field [matTooltip]="data.mode === TagEditorMode.Edit ? 'Contact Dockstore to change display name' : ''">
       <input type="text" matInput formControlName="displayName" placeholder="Display Name" required />
       <mat-error *ngIf="displayName.hasError('required')">Display Name is required</mat-error>
       <mat-error *ngIf="displayName.hasError('minlength')">Display Name should be at least 3 characters long</mat-error>

--- a/src/app/organizations/registerOrganization/register-organization.component.html
+++ b/src/app/organizations/registerOrganization/register-organization.component.html
@@ -21,7 +21,7 @@
   </p>
   <app-alert></app-alert>
   <form [formGroup]="registerOrganizationForm">
-    <mat-form-field [matTooltip]="data.mode === TagEditorMode.Edit ? 'Contact Dockstore to change name' : ''">
+    <mat-form-field [matTooltip]="data.organization?.status === Organization.StatusEnum.APPROVED ? 'Contact Dockstore to change name' : ''">
       <input type="text" matInput formControlName="name" placeholder="Name" required />
       <mat-error *ngIf="name.hasError('required')">Name is required</mat-error>
       <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
@@ -29,7 +29,9 @@
       <mat-error *ngIf="name.hasError('pattern')">Name can only contain alphanumeric characters. It must begin with a letter.</mat-error>
       <mat-hint>The name of the organization</mat-hint>
     </mat-form-field>
-    <mat-form-field [matTooltip]="data.mode === TagEditorMode.Edit ? 'Contact Dockstore to change display name' : ''">
+    <mat-form-field
+      [matTooltip]="data.organization?.status === Organization.StatusEnum.APPROVED ? 'Contact Dockstore to change display name' : ''"
+    >
       <input type="text" matInput formControlName="displayName" placeholder="Display Name" required />
       <mat-error *ngIf="displayName.hasError('required')">Display Name is required</mat-error>
       <mat-error *ngIf="displayName.hasError('minlength')">Display Name should be at least 3 characters long</mat-error>

--- a/src/app/organizations/registerOrganization/register-organization.component.ts
+++ b/src/app/organizations/registerOrganization/register-organization.component.ts
@@ -17,6 +17,7 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { AkitaNgFormsManager } from '@datorama/akita-ng-forms-manager';
+import { Organization } from 'app/shared/swagger';
 
 import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
 import { FormsState, RegisterOrganizationService } from '../state/register-organization.service';
@@ -32,12 +33,13 @@ import { FormsState, RegisterOrganizationService } from '../state/register-organ
 @Component({
   selector: 'register-organization',
   templateUrl: './register-organization.component.html',
-  styleUrls: ['./register-organization.component.scss']
+  styleUrls: ['./register-organization.component.scss'],
 })
 export class RegisterOrganizationComponent implements OnInit, OnDestroy {
   registerOrganizationForm: FormGroup;
   public title: string;
   public TagEditorMode = TagEditorMode;
+  public Organization = Organization;
   constructor(
     private registerOrganizationService: RegisterOrganizationService,
     private formsManager: AkitaNgFormsManager<FormsState>,

--- a/src/app/organizations/state/register-organization.service.ts
+++ b/src/app/organizations/state/register-organization.service.ts
@@ -108,11 +108,11 @@ export class RegisterOrganizationService {
     }
     const registerOrganizationForm = this.builder.group({
       name: [
-        name,
+        { value: name, disabled: data.mode === TagEditorMode.Edit },
         [Validators.required, Validators.maxLength(39), Validators.minLength(3), Validators.pattern(this.organizationNameRegex)]
       ],
       displayName: [
-        displayName,
+        { value: displayName, disabled: data.mode === TagEditorMode.Edit },
         [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(this.organizationDisplayNameRegex)]
       ],
       topic: [topic, Validators.required],

--- a/src/app/organizations/state/register-organization.service.ts
+++ b/src/app/organizations/state/register-organization.service.ts
@@ -96,8 +96,8 @@ export class RegisterOrganizationService {
     let location = null;
     let contactEmail = null;
     let avatarUrl = null;
+    const organization: Organization = data.organization;
     if (data.mode !== TagEditorMode.Add) {
-      const organization: Organization = data.organization;
       name = organization.name;
       displayName = organization.displayName;
       topic = organization.topic;
@@ -108,18 +108,18 @@ export class RegisterOrganizationService {
     }
     const registerOrganizationForm = this.builder.group({
       name: [
-        { value: name, disabled: data.mode === TagEditorMode.Edit },
-        [Validators.required, Validators.maxLength(39), Validators.minLength(3), Validators.pattern(this.organizationNameRegex)]
+        { value: name, disabled: organization?.status === Organization.StatusEnum.APPROVED },
+        [Validators.required, Validators.maxLength(39), Validators.minLength(3), Validators.pattern(this.organizationNameRegex)],
       ],
       displayName: [
-        { value: displayName, disabled: data.mode === TagEditorMode.Edit },
-        [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(this.organizationDisplayNameRegex)]
+        { value: displayName, disabled: organization?.status === Organization.StatusEnum.APPROVED },
+        [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(this.organizationDisplayNameRegex)],
       ],
       topic: [topic, Validators.required],
       link: [link, Validators.pattern(this.urlRegex)],
       location: [location],
       contactEmail: [contactEmail, [Validators.email]],
-      avatarUrl: [avatarUrl, Validators.pattern(this.logoUrlRegex)]
+      avatarUrl: [avatarUrl, Validators.pattern(this.logoUrlRegex)],
     });
     formsManager.upsert('registerOrganization', registerOrganizationForm);
     return registerOrganizationForm;
@@ -158,7 +158,7 @@ export class RegisterOrganizationService {
         email: organizationFormState.contactEmail,
         status: Organization.StatusEnum.PENDING,
         avatarUrl: organizationFormState.avatarUrl || null,
-        users: []
+        users: [],
       };
       this.alertService.start('Adding organization');
       this.organizationsService.createOrganization(newOrganization).subscribe(
@@ -207,7 +207,7 @@ export class RegisterOrganizationService {
         status: Organization.StatusEnum.PENDING,
         avatarUrl: organizationFormState.avatarUrl || null,
         description: organizationDescription,
-        users: []
+        users: [],
       };
       this.alertService.start('Updating organization');
       this.organizationsService.updateOrganization(organizationId, editedOrganization).subscribe(


### PR DESCRIPTION
Part 1 of 2 Draft for https://ucsc-cgl.atlassian.net/browse/SEAB-203

The idea is we disable all normal users from editing the approved organization name and display name. In the kind of unlikely case where they want to do so, they'll need to contact Dockstore (us). We would use the exact same endpoint (PUT) in the swagger-ui.

Other PR https://github.com/dockstore/dockstore/pull/3815

Disabled Material input looks like:
![image](https://user-images.githubusercontent.com/24548904/93530537-b7b0df80-f90b-11ea-911a-71ebbcc22bad.png)
