### PR TITLE
Feature/3758/infinite loading when editing unpub tools

### DIFF
--- a/cypress/integration/group1/hostedTools.ts
+++ b/cypress/integration/group1/hostedTools.ts
@@ -160,4 +160,26 @@ describe('Dockstore hosted tools', () => {
       cy.get('table').find('a').should('not.contain', '3');
     });
   });
+
+  describe('Should not be able to edit unpublished tools', () => {
+    it('Should return an error when editing an unpublished hosted tool', () => {
+      getTool();
+      goToTab('Versions');
+      cy.get('[data-cy=actionsButton]').first().click();
+      cy.get('[data-cy=editTagButton]').click();
+      cy.get('.alert').should('exist');
+      cy.get('.error-output').contains('[HTTP 403] Forbidden: Entry not published').should('exist');
+    });
+    it('Should not return an error when editing a published hosted tool', () => {
+      getTool();
+      goToTab('Versions');
+      cy.get('#publishToolButton').click();
+      // Disabled since it is already published
+      cy.get('#publishToolButton').contains('Unpublish');
+      cy.get('[data-cy=actionsButton]').first().click();
+      cy.get('[data-cy=editTagButton]').click();
+      cy.get('.alert').should('not.exist');
+      cy.get('[data-cy=editToolVersionDialog]').should('exist');
+    });
+  });
 });

--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -13,7 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<div>
+<div data-cy="editToolVersionDialog">
   <h4 mat-dialog-title>{{ TagEditorMode[mode] }} Version Tag</h4>
   <div mat-dialog-content>
     <app-alert></app-alert>

--- a/src/app/container/view/view.component.html
+++ b/src/app/container/view/view.component.html
@@ -15,10 +15,10 @@
   -->
 
 <!-- Button trigger modal -->
-<button mat-button [matMenuTriggerFor]="menu">Actions<mat-icon>arrow_drop_down</mat-icon></button>
+<button data-cy="actionsButton" mat-button [matMenuTriggerFor]="menu">Actions<mat-icon>arrow_drop_down</mat-icon></button>
 <mat-menu #menu="matMenu">
   <button type="button" mat-menu-item color="accent" *ngIf="isPublic$ | async" (click)="setMode(TagEditorMode.View); (false)">View</button>
-  <button type="button" mat-menu-item color="accent" *ngIf="!(isPublic$ | async)" (click)="setMode(TagEditorMode.Edit); (false)">
+  <button data-cy="editTagButton" type="button" mat-menu-item color="accent" *ngIf="!(isPublic$ | async)" (click)="setMode(TagEditorMode.Edit); (false)">
     Edit
   </button>
   <button type="button" mat-menu-item color="warn" *ngIf="!(isPublic$ | async) && isManualTool" (click)="deleteTag(); (false)">

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -20,10 +20,13 @@ import { ViewService } from 'app/container/view/view.service';
 import { AlertQuery } from 'app/shared/alert/state/alert.query';
 import { forkJoin, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { AlertService } from '../../shared/alert/state/alert.service';
 import { ContainerService } from '../../shared/container.service';
 import { DateService } from '../../shared/date.service';
 import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
+import { ContainersService } from '../../shared/openapi';
 import { SessionQuery } from '../../shared/session/session.query';
+import { ToolDescriptor } from '../../shared/swagger';
 import { ContainertagsService } from '../../shared/swagger/api/containertags.service';
 import { HostedService } from '../../shared/swagger/api/hosted.service';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
@@ -31,9 +34,6 @@ import { ToolQuery } from '../../shared/tool/tool.query';
 import { View } from '../../shared/view';
 import { VersionModalComponent } from '../version-modal/version-modal.component';
 import { VersionModalService } from '../version-modal/version-modal.service';
-import { ContainersService } from '../../shared/openapi';
-import { AlertService } from '../../shared/alert/state/alert.service';
-import { ToolDescriptor } from '../../shared/swagger';
 
 @Component({
   selector: 'app-view-container',

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -21,6 +21,7 @@ import { AlertQuery } from 'app/shared/alert/state/alert.query';
 import { forkJoin, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AlertService } from '../../shared/alert/state/alert.service';
+import {bootstrap4mediumModalSize} from '../../shared/constants';
 import { ContainerService } from '../../shared/container.service';
 import { DateService } from '../../shared/date.service';
 import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
@@ -72,7 +73,7 @@ export class ViewContainerComponent extends View implements OnInit {
     ]).subscribe(
       (items) => {
         this.versionModalService.setCurrentMode(mode);
-        this.matDialog.open(VersionModalComponent, { width: '600px' });
+        this.matDialog.open(VersionModalComponent, { width: bootstrap4mediumModalSize });
       },
       (error) => {
         this.alertService.detailedError(error);


### PR DESCRIPTION
Editing unpublished hosted tools no longer loads dialog

dockstore/dockstore#3758

Editing unpublished hosted tools no longer tries to load mat-dialog
indefinitely

Asserted that getTestParameterFiles() passed before opening the
mat dialog with VersionModalComponent

Included CypressCI tests and added a few data-cy tags