### PR TITLE
Feature/2062/search in authors

### DIFF
--- a/src/app/search/basic-search/facet-search.component.html
+++ b/src/app/search/basic-search/facet-search.component.html
@@ -1,5 +1,6 @@
 <div>
-  <mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>Search for an author</mat-label>
     <input
       matInput
       [formControl]="searchFormControl"

--- a/src/app/search/basic-search/facet-search.component.html
+++ b/src/app/search/basic-search/facet-search.component.html
@@ -1,0 +1,12 @@
+<mat-form-field>
+  <input
+    matInput
+    [formControl]="searchFormControl"
+    matTooltip="Find tools and workflows"
+    [matTooltipPosition]="'after'"
+    list="suggestions"
+    class="w-100 mb-3"
+    placeholder="Enter search term"
+    type="text"
+  />
+</mat-form-field>

--- a/src/app/search/basic-search/facet-search.component.html
+++ b/src/app/search/basic-search/facet-search.component.html
@@ -1,12 +1,17 @@
-<mat-form-field>
-  <input
-    matInput
-    [formControl]="searchFormControl"
-    matTooltip="Find tools and workflows"
-    [matTooltipPosition]="'after'"
-    list="suggestions"
-    class="w-100 mb-3"
-    placeholder="Enter search term"
-    type="text"
-  />
-</mat-form-field>
+<div>
+  <mat-form-field>
+    <input
+      matInput
+      [formControl]="searchFormControl"
+      matTooltip="Find tools and workflows"
+      [matTooltipPosition]="'after'"
+      list="suggestions"
+      class="w-100 mb-3"
+      placeholder="Search for an author"
+      type="text"
+    />
+  </mat-form-field>
+  <mat-autocomplete #auto="matAutocomplete">
+    <mat-option *ngFor="let option of autocompleteTerms$ | async" [value]="option">{{ option }}</mat-option>
+  </mat-autocomplete>
+</div>

--- a/src/app/search/basic-search/facet-search.component.html
+++ b/src/app/search/basic-search/facet-search.component.html
@@ -3,7 +3,8 @@
     <input
       matInput
       [formControl]="searchFormControl"
-      matTooltip="Find tools and workflows"
+      [matAutocomplete]="auto"
+      matTooltip="Find authors"
       [matTooltipPosition]="'after'"
       list="suggestions"
       class="w-100 mb-3"
@@ -12,6 +13,6 @@
     />
   </mat-form-field>
   <mat-autocomplete #auto="matAutocomplete">
-    <mat-option *ngFor="let option of autocompleteTerms$ | async" [value]="option">{{ option }}</mat-option>
+    <mat-option *ngFor="let option of authorAutocompleteTerms$ | async" [value]="option">{{ option }}</mat-option>
   </mat-autocomplete>
 </div>

--- a/src/app/search/basic-search/facet-search.component.scss
+++ b/src/app/search/basic-search/facet-search.component.scss
@@ -3,3 +3,10 @@ input[type='text']:focus,
 textarea:focus {
   border: none;
 }
+mat-form-field {
+  width: 100%;
+}
+
+input.mat-input-element:not(:focus) {
+  height: 1rem;
+}

--- a/src/app/search/basic-search/facet-search.component.scss
+++ b/src/app/search/basic-search/facet-search.component.scss
@@ -1,0 +1,5 @@
+// Overriding the border added in the style.scss because we're using material now
+input[type='text']:focus,
+textarea:focus {
+  border: none;
+}

--- a/src/app/search/basic-search/facet-search.component.spec.ts
+++ b/src/app/search/basic-search/facet-search.component.spec.ts
@@ -1,0 +1,35 @@
+/* tslint:disable:no-unused-variable */
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CustomMaterialModule } from '../../shared/modules/material.module';
+import { ProviderService } from '../../shared/provider.service';
+import { SearchStubService } from '../../test/service-stubs';
+import { SearchService } from '../state/search.service';
+import { FacetSearchComponent } from './facet-search.component';
+
+describe('FacetSearchComponent', () => {
+  let component: FacetSearchComponent;
+  let fixture: ComponentFixture<FacetSearchComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MatAutocompleteModule, RouterTestingModule, BrowserAnimationsModule, CustomMaterialModule],
+      declarations: [FacetSearchComponent],
+      providers: [ProviderService, { provide: SearchService, useClass: SearchStubService }],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FacetSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/search/basic-search/facet-search.component.ts
+++ b/src/app/search/basic-search/facet-search.component.ts
@@ -9,35 +9,34 @@ import { AdvancedSearchComponent } from '../advancedsearch/advancedsearch.compon
 import { SearchQuery } from '../state/search.query';
 import { SearchService } from '../state/search.service';
 
-
 @Component({
   selector: 'app-facet-search',
-  templateUrl: './facet-search.component.html'
+  templateUrl: './facet-search.component.html',
 })
 export class FacetSearchComponent extends Base implements OnInit {
-    constructor(private searchService: SearchService, private searchQuery: SearchQuery, private matDialog: MatDialog) {
-      super();
-    }
-    public searchFormControl = new FormControl();
-    public autocompleteTerms$: Observable<Array<string>>;
-    public hasAutoCompleteTerms$: Observable<boolean>;
+  constructor(private searchService: SearchService, private searchQuery: SearchQuery, private matDialog: MatDialog) {
+    super();
+  }
+  public searchFormControl = new FormControl();
+  public autocompleteTerms$: Observable<Array<string>>;
+  public hasAutoCompleteTerms$: Observable<boolean>;
 
-    ngOnInit() {
-        this.searchQuery.searchText$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((searchText) => {
-            // This keeps the state and the view in sync but this is slightly awkward
-            // Changes to the searchText$ state will change searchFormControl
-            // However, changes to searchFormControl will change searchText$
-            // The ONLY reason why this doesn't go infinite loop is because Akita doesn't emit when it's the same value
-            // Ideally, we should probably be using AkitaFormManager because then there would only be one variable
-            this.searchFormControl.setValue(searchText);
-          });
-          this.autocompleteTerms$ = this.searchQuery.autoCompleteTerms$;
-          this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
+  ngOnInit() {
+    this.searchQuery.facetSearchText$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((searchText) => {
+      // This keeps the state and the view in sync but this is slightly awkward
+      // Changes to the searchText$ state will change searchFormControl
+      // However, changes to searchFormControl will change searchText$
+      // The ONLY reason why this doesn't go infinite loop is because Akita doesn't emit when it's the same value
+      // Ideally, we should probably be using AkitaFormManager because then there would only be one variable
+      this.searchFormControl.setValue(searchText);
+    });
+    this.autocompleteTerms$ = this.searchQuery.autoCompleteTerms$;
+    this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
 
-          this.searchFormControl.valueChanges
-            .pipe(debounceTime(formInputDebounceTime), distinctUntilChanged(), takeUntil(this.ngUnsubscribe))
-            .subscribe((searchText) => {
-              console.log(searchText);
-            });
-    }
+    this.searchFormControl.valueChanges
+      .pipe(debounceTime(formInputDebounceTime), distinctUntilChanged(), takeUntil(this.ngUnsubscribe))
+      .subscribe((searchText) => {
+        this.searchService.setFacetSearchText(searchText);
+      });
+  }
 }

--- a/src/app/search/basic-search/facet-search.component.ts
+++ b/src/app/search/basic-search/facet-search.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { Base } from '../../shared/base';
+import { bootstrap4largeModalSize, formInputDebounceTime } from '../../shared/constants';
+import { AdvancedSearchComponent } from '../advancedsearch/advancedsearch.component';
+import { SearchQuery } from '../state/search.query';
+import { SearchService } from '../state/search.service';
+
+
+@Component({
+  selector: 'app-facet-search',
+  templateUrl: './facet-search.component.html'
+})
+export class FacetSearchComponent extends Base implements OnInit {
+    constructor(private searchService: SearchService, private searchQuery: SearchQuery, private matDialog: MatDialog) {
+      super();
+    }
+    public searchFormControl = new FormControl();
+    public autocompleteTerms$: Observable<Array<string>>;
+    public hasAutoCompleteTerms$: Observable<boolean>;
+
+    ngOnInit() {
+        this.searchQuery.searchText$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((searchText) => {
+            // This keeps the state and the view in sync but this is slightly awkward
+            // Changes to the searchText$ state will change searchFormControl
+            // However, changes to searchFormControl will change searchText$
+            // The ONLY reason why this doesn't go infinite loop is because Akita doesn't emit when it's the same value
+            // Ideally, we should probably be using AkitaFormManager because then there would only be one variable
+            this.searchFormControl.setValue(searchText);
+          });
+          this.autocompleteTerms$ = this.searchQuery.autoCompleteTerms$;
+          this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
+
+          this.searchFormControl.valueChanges
+            .pipe(debounceTime(formInputDebounceTime), distinctUntilChanged(), takeUntil(this.ngUnsubscribe))
+            .subscribe((searchText) => {
+              console.log(searchText);
+            });
+    }
+}

--- a/src/app/search/basic-search/facet-search.component.ts
+++ b/src/app/search/basic-search/facet-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
@@ -13,6 +13,7 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['./facet-search.component.scss'],
 })
 export class FacetSearchComponent extends Base implements OnInit {
+  @Input() facet: string;
   constructor(private searchService: SearchService, private searchQuery: SearchQuery, private matDialog: MatDialog) {
     super();
   }

--- a/src/app/search/basic-search/facet-search.component.ts
+++ b/src/app/search/basic-search/facet-search.component.ts
@@ -4,21 +4,20 @@ import { MatDialog } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
-import { bootstrap4largeModalSize, formInputDebounceTime } from '../../shared/constants';
-import { AdvancedSearchComponent } from '../advancedsearch/advancedsearch.component';
 import { SearchQuery } from '../state/search.query';
 import { SearchService } from '../state/search.service';
 
 @Component({
   selector: 'app-facet-search',
   templateUrl: './facet-search.component.html',
+  styleUrls: ['./facet-search.component.scss'],
 })
 export class FacetSearchComponent extends Base implements OnInit {
   constructor(private searchService: SearchService, private searchQuery: SearchQuery, private matDialog: MatDialog) {
     super();
   }
   public searchFormControl = new FormControl();
-  public autocompleteTerms$: Observable<Array<string>>;
+  public authorAutocompleteTerms$: Observable<Array<string>>;
   public hasAutoCompleteTerms$: Observable<boolean>;
   public inputDebounceTime = 500;
 
@@ -31,7 +30,7 @@ export class FacetSearchComponent extends Base implements OnInit {
       // Ideally, we should probably be using AkitaFormManager because then there would only be one variable
       this.searchFormControl.setValue(searchText);
     });
-    this.autocompleteTerms$ = this.searchQuery.autoCompleteTerms$;
+    this.authorAutocompleteTerms$ = this.searchQuery.authorAutocompleteTerms$;
     this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
 
     this.searchFormControl.valueChanges

--- a/src/app/search/basic-search/facet-search.component.ts
+++ b/src/app/search/basic-search/facet-search.component.ts
@@ -20,6 +20,7 @@ export class FacetSearchComponent extends Base implements OnInit {
   public searchFormControl = new FormControl();
   public autocompleteTerms$: Observable<Array<string>>;
   public hasAutoCompleteTerms$: Observable<boolean>;
+  public inputDebounceTime = 500;
 
   ngOnInit() {
     this.searchQuery.facetSearchText$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((searchText) => {
@@ -34,7 +35,7 @@ export class FacetSearchComponent extends Base implements OnInit {
     this.hasAutoCompleteTerms$ = this.searchQuery.hasAutoCompleteTerms$;
 
     this.searchFormControl.valueChanges
-      .pipe(debounceTime(formInputDebounceTime), distinctUntilChanged(), takeUntil(this.ngUnsubscribe))
+      .pipe(debounceTime(this.inputDebounceTime), distinctUntilChanged(), takeUntil(this.ngUnsubscribe))
       .subscribe((searchText) => {
         this.searchService.setFacetSearchText(searchText);
       });

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -110,24 +110,6 @@ export class QueryBuilderService {
     return tableQuery;
   }
 
-  getFacetSearchQuery(
-    query_size: number,
-    values: string,
-    advancedSearchObject: AdvancedSearchObject,
-    searchTerm: boolean,
-    filters: any,
-    sortModeMap: any
-  ): string {
-    const count = this.getNumberOfFilters(filters);
-    let facetBody = bodybuilder().size(query_size);
-    facetBody = this.excludeContent(facetBody);
-    facetBody = this.appendQuery(facetBody, values, advancedSearchObject, searchTerm);
-    facetBody = this.appendAggregationsFacetSearch(count, facetBody, filters, sortModeMap, 'author');
-    const builtSideBarBody = facetBody.build();
-    const facetSearchQuery = JSON.stringify(builtSideBarBody);
-    return facetSearchQuery;
-  }
-
   /**===============================================
    *                Append Functions
    * ==============================================
@@ -246,27 +228,6 @@ export class QueryBuilderService {
         body = body.agg('terms', key, key, { size: this.shard_size, order });
       }
     });
-    return body;
-  }
-
-  /**
-   * Append aggregations for searching within a specific facet
-   *
-   * @param {number} count number of filters
-   * @param {*} body the body builder object
-   * @param {string} facet category to search within
-   * @returns {*} the new body builder object
-   * @memberof SearchComponent
-   */
-  appendAggregationsFacetSearch(count: number, body: any, filters: any, sortModeMap: any, facet: string): any {
-    const order = this.searchService.parseOrderBy(facet, sortModeMap);
-    if (count > 0) {
-      body = body.agg('filter', facet, facet, (a) => {
-        return this.appendFilter(a, facet, filters).aggregation('terms', facet, facet, { size: this.shard_size, order });
-      });
-    } else {
-      body = body.agg('terms', facet, facet, { size: this.shard_size, order });
-    }
     return body;
   }
 

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -197,12 +197,6 @@ export class QueryBuilderService {
     );
   }
 
-  searchAuthor(body: any, searchString: string): void {
-    body = body.filter('bool', (filter) =>
-      filter.orFilter('bool', (authorFilter) => authorFilter.filter('match_phrase', 'author', searchString))
-    );
-  }
-
   /**===============================================
    *                Advanced Search Functions
    * ===============================================

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -44,8 +44,8 @@
             {{ friendlyNames.get(key) }}
             <mat-icon *ngIf="toolTips.get(key)" matTooltip="{{ toolTips.get(key) }}">help_outline</mat-icon>
           </mat-expansion-panel-header>
+          <app-facet-search *ngIf="key === 'author'"></app-facet-search>
           <div *ngIf="orderedBuckets.get(key).Items.size > 10">
-            <app-facet-search *ngIf="key === 'author'"></app-facet-search>
             <button
               mat-stroked-button
               (click)="clickSortMode(key, false)"

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -44,7 +44,10 @@
             {{ friendlyNames.get(key) }}
             <mat-icon *ngIf="toolTips.get(key)" matTooltip="{{ toolTips.get(key) }}">help_outline</mat-icon>
           </mat-expansion-panel-header>
-          <app-facet-search *ngIf="key === 'author'"></app-facet-search>
+          <div *ngIf="key === 'author'">
+            <app-facet-search></app-facet-search>
+            <mat-card *ngIf="!hasFacetSearchResults" class="alert alert-warning"> Sorry, no authors found. </mat-card>
+          </div>
           <div *ngIf="orderedBuckets.get(key).Items.size > 10">
             <button
               mat-stroked-button

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -46,7 +46,7 @@
           </mat-expansion-panel-header>
           <div *ngIf="key === 'author'">
             <app-facet-search></app-facet-search>
-            <mat-card *ngIf="!hasFacetSearchResults" class="alert alert-warning"> Sorry, no authors found. </mat-card>
+            <mat-card *ngIf="noFacetSearchResults" class="alert alert-warning"> Sorry, no authors found. </mat-card>
           </div>
           <div *ngIf="orderedBuckets.get(key).Items.size > 10">
             <button

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -45,6 +45,7 @@
             <mat-icon *ngIf="toolTips.get(key)" matTooltip="{{ toolTips.get(key) }}">help_outline</mat-icon>
           </mat-expansion-panel-header>
           <div *ngIf="orderedBuckets.get(key).Items.size > 10">
+            <app-facet-search *ngIf="key === 'author'"></app-facet-search>
             <button
               mat-stroked-button
               (click)="clickSortMode(key, false)"

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -84,6 +84,7 @@ describe('SearchComponent', () => {
     component = fixture.componentInstance;
     searchQuery = TestBed.inject(SearchQuery) as jasmine.SpyObj<SearchQuery>;
     searchQuery.searchText$ = of('');
+    searchQuery.facetSearchText$ = of('');
     searchQuery.getValue.and.returnValue({
       shortUrl: null,
       workflowhit: null,

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -47,6 +47,12 @@ class BasicSearchComponent {}
 })
 class HeaderComponent {}
 
+@Component({
+  selector: 'app-facet-search',
+  template: '',
+})
+class FacetSearchComponent {}
+
 /* tslint:disable:no-unused-variable */
 describe('SearchComponent', () => {
   let component: SearchComponent;
@@ -55,13 +61,20 @@ describe('SearchComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchComponent, MapFriendlyValuesPipe, HeaderComponent, BasicSearchComponent, SearchResultsComponent],
+      declarations: [
+        SearchComponent,
+        MapFriendlyValuesPipe,
+        HeaderComponent,
+        BasicSearchComponent,
+        SearchResultsComponent,
+        FacetSearchComponent,
+      ],
       imports: [CustomMaterialModule, ClipboardModule, FontAwesomeModule, RouterTestingModule, MdePopoverModule],
       providers: [
         { provide: SearchService, useClass: SearchStubService },
         { provide: QueryBuilderService, useClass: QueryBuilderStubService },
         { provide: ProviderService, useClass: ProviderStubService },
-        { provide: SearchQuery, useValue: jasmine.createSpyObj('SearchQuery', ['select', 'getValue', 'searchText']) },
+        { provide: SearchQuery, useValue: jasmine.createSpyObj('SearchQuery', ['select', 'getValue', 'searchText', 'facetSearchText']) },
       ],
     }).compileComponents();
   }));
@@ -78,8 +91,10 @@ describe('SearchComponent', () => {
       showToolTagCloud: false,
       showWorkflowTagCloud: false,
       searchText: '',
+      facetSearchText: '',
       filterKeys: [],
       autocompleteTerms: [],
+      authorAutocompleteTerms: [],
       suggestTerm: '',
       pageSize: 10,
       pageIndex: 0,

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -30,6 +30,7 @@ import { PipeModule } from '../shared/pipe/pipe.module';
 import { PrivateIconModule } from '../shared/private-icon/private-icon.module';
 import { AdvancedSearchComponent } from './advancedsearch/advancedsearch.component';
 import { BasicSearchComponent } from './basic-search/basic-search.component';
+import { FacetSearchComponent } from './basic-search/facet-search.component';
 import { QueryBuilderService } from './query-builder.service';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { SearchToolTableComponent } from './search-tool-table/search-tool-table.component';
@@ -46,6 +47,7 @@ import { SearchService } from './state/search.service';
     SearchToolTableComponent,
     SearchWorkflowTableComponent,
     BasicSearchComponent,
+    FacetSearchComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/search/state/search.query.ts
+++ b/src/app/search/state/search.query.ts
@@ -34,6 +34,7 @@ export class SearchQuery extends Query<SearchState> {
   public showWorkflowTagCloud$: Observable<boolean> = this.select((state) => state.showWorkflowTagCloud);
   public filterKeys$: Observable<Array<string>> = this.select((state) => state.filterKeys);
   public autoCompleteTerms$: Observable<Array<string>> = this.select((state) => state.autocompleteTerms);
+  public authorAutocompleteTerms$: Observable<Array<string>> = this.select((state) => state.authorAutocompleteTerms);
   public hasAutoCompleteTerms$: Observable<boolean> = this.autoCompleteTerms$.pipe(map((terms) => terms.length > 0));
   public suggestTerm$: Observable<string> = this.select((state) => state.suggestTerm);
   public pageSize$: Observable<number> = this.select((state) => state.pageSize);

--- a/src/app/search/state/search.query.ts
+++ b/src/app/search/state/search.query.ts
@@ -29,6 +29,7 @@ export class SearchQuery extends Query<SearchState> {
   public noWorkflowHits$: Observable<boolean> = this.workflows$.pipe(map((workflows: Array<Workflow>) => this.haveNoHits(workflows)));
   public searchText$: Observable<string> = this.select((state) => state.searchText);
   public basicSearchText$: Observable<string> = this.searchText$.pipe(map((searchText) => this.joinComma(searchText)));
+  public facetSearchText$: Observable<string> = this.select((state) => state.facetSearchText);
   public showToolTagCloud$: Observable<boolean> = this.select((state) => state.showToolTagCloud);
   public showWorkflowTagCloud$: Observable<boolean> = this.select((state) => state.showWorkflowTagCloud);
   public filterKeys$: Observable<Array<string>> = this.select((state) => state.filterKeys);

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -579,13 +579,6 @@ export class SearchService {
   hasResults(searchTerm: boolean, hits: any) {
     return searchTerm && hits && hits.length > 0;
   }
-  /**
-   * Returns true if author search returns no results
-   */
-  noFacetSearchResults() {
-    return true;
-    // return searchTerm && hits && hits.aggregations.author.length === 0;
-  }
 
   /**
    * Returns true if at least one filter is set

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -285,6 +285,22 @@ export class SearchService {
     });
   }
 
+  setAuthorAutocomplete(hits: any) {
+    let authorAutocompleteTerms;
+    try {
+      authorAutocompleteTerms = hits.aggregations.autocomplete.buckets.map((term) => term.key);
+    } catch (error) {
+      console.error('Could not retrieve autocomplete terms');
+      authorAutocompleteTerms = [];
+    }
+    this.searchStore.update((state) => {
+      return {
+        ...state,
+        authorAutocompleteTerms: authorAutocompleteTerms,
+      };
+    });
+  }
+
   /**
    * By default, bodybuilder will create a aggregation name called agg_<aggregationType>_<fieldToAggregate>
    * This converts it to just <fieldToAggregate>

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -563,6 +563,13 @@ export class SearchService {
   hasResults(searchTerm: boolean, hits: any) {
     return searchTerm && hits && hits.length > 0;
   }
+  /**
+   * Returns true if author search returns no results
+   */
+  noFacetSearchResults() {
+    return true;
+    // return searchTerm && hits && hits.aggregations.author.length === 0;
+  }
 
   /**
    * Returns true if at least one filter is set

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -153,6 +153,19 @@ export class SearchService {
     }
   }
 
+  @transaction()
+  setFacetSearchText(text: string) {
+    this.searchStore.update((state) => {
+      return {
+        ...state,
+        facetSearchText: text,
+      };
+    });
+    if (text) {
+      this.clear();
+    }
+  }
+
   searchSuggestTerm() {
     const suggestTerm = this.searchQuery.getValue().suggestTerm;
     this.setSearchText(suggestTerm);

--- a/src/app/search/state/search.store.ts
+++ b/src/app/search/state/search.store.ts
@@ -24,6 +24,7 @@ export interface SearchState {
   showToolTagCloud: boolean;
   showWorkflowTagCloud: boolean;
   searchText: string;
+  facetSearchText: string;
   filterKeys: Array<string>;
   autocompleteTerms: Array<string>;
   suggestTerm: string;
@@ -41,6 +42,7 @@ export function createInitialState(): SearchState {
     showToolTagCloud: false,
     showWorkflowTagCloud: false,
     searchText: '',
+    facetSearchText: '',
     filterKeys: [],
     autocompleteTerms: [],
     suggestTerm: '',

--- a/src/app/search/state/search.store.ts
+++ b/src/app/search/state/search.store.ts
@@ -27,6 +27,7 @@ export interface SearchState {
   facetSearchText: string;
   filterKeys: Array<string>;
   autocompleteTerms: Array<string>;
+  authorAutocompleteTerms: Array<string>;
   suggestTerm: string;
   pageSize: number;
   pageIndex: number;
@@ -45,6 +46,7 @@ export function createInitialState(): SearchState {
     facetSearchText: '',
     filterKeys: [],
     autocompleteTerms: [],
+    authorAutocompleteTerms: [],
     suggestTerm: '',
     pageSize: 10,
     advancedSearch: { ...initialAdvancedSearchObject },


### PR DESCRIPTION
For [#2062](https://github.com/dockstore/dockstore/issues/2062)
Added search bar to search within Authors, with autocomplete terms.
<img width="283" alt="Screen Shot 2020-10-13 at 4 41 27 PM" src="https://user-images.githubusercontent.com/50606789/95913922-0028b500-0d73-11eb-9285-a72ad472bba7.png">
Queries for the search term within the field 'author' and sets the results into the appropriate place in the checkBoxMap and entryOrder map, so the search updates the Author facet in the sidebar.
