### PR TITLE
fix/3014/toolSeachPageName

### DIFF
--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -37,8 +37,14 @@ export abstract class SearchEntryTable extends Base implements OnInit {
   abstract dataSource: MatTableDataSource<Workflow | DockstoreTool>;
   abstract privateNgOnInit(): Observable<(DockstoreTool | Workflow)[]>;
 
-  constructor(protected dateService: DateService, protected searchQuery: SearchQuery, protected searchService: SearchService) {
+  constructor(
+    protected dateService: DateService,
+    protected searchQuery: SearchQuery,
+    protected searchService: SearchService,
+    private entryType: string
+  ) {
     super();
+    this.entryType = entryType;
     this.verifiedLink = this.dateService.getVerifiedLink();
   }
 
@@ -56,7 +62,7 @@ export abstract class SearchEntryTable extends Base implements OnInit {
       });
     this.dataSource.sortData = (data: DockstoreTool[] | Workflow[], sort: MatSort) => {
       return data.slice().sort((a: Workflow | DockstoreTool, b: Workflow | DockstoreTool) => {
-        return this.searchService.compareAttributes(a, b, sort.active, sort.direction);
+        return this.searchService.compareAttributes(a, b, sort.active, sort.direction, this.entryType);
       });
     };
   }

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -34,17 +34,12 @@ export abstract class SearchEntryTable extends Base implements OnInit {
   protected ngUnsubscribe: Subject<{}> = new Subject();
 
   public readonly displayedColumns = ['name', 'verified', 'author', 'descriptorType', 'projectLinks', 'starredUsers'];
+  abstract readonly entryType: 'tool' | 'workflow';
   abstract dataSource: MatTableDataSource<Workflow | DockstoreTool>;
   abstract privateNgOnInit(): Observable<(DockstoreTool | Workflow)[]>;
 
-  constructor(
-    protected dateService: DateService,
-    protected searchQuery: SearchQuery,
-    protected searchService: SearchService,
-    private entryType: string
-  ) {
+  constructor(protected dateService: DateService, protected searchQuery: SearchQuery, protected searchService: SearchService) {
     super();
-    this.entryType = entryType;
     this.verifiedLink = this.dateService.getVerifiedLink();
   }
 

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -17,9 +17,10 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['../../shared/styles/entry-table.scss', './search-tool-table.component.scss'],
 })
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
+  readonly entryType = 'tool';
   public dataSource: MatTableDataSource<DockstoreTool>;
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
-    super(dateService, searchQuery, searchService, 'tool');
+    super(dateService, searchQuery, searchService);
   }
 
   privateNgOnInit(): Observable<Array<DockstoreTool>> {

--- a/src/app/search/search-tool-table/search-tool-table.component.ts
+++ b/src/app/search/search-tool-table/search-tool-table.component.ts
@@ -19,7 +19,7 @@ import { SearchService } from '../state/search.service';
 export class SearchToolTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<DockstoreTool>;
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
-    super(dateService, searchQuery, searchService);
+    super(dateService, searchQuery, searchService, 'tool');
   }
 
   privateNgOnInit(): Observable<Array<DockstoreTool>> {

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -32,9 +32,10 @@ import { SearchService } from '../state/search.service';
   styleUrls: ['../../shared/styles/entry-table.scss', './search-workflow-table.component.scss'],
 })
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
+  readonly entryType = 'workflow';
   public dataSource: MatTableDataSource<Workflow>;
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
-    super(dateService, searchQuery, searchService, 'workflow');
+    super(dateService, searchQuery, searchService);
   }
 
   privateNgOnInit(): Observable<Array<Workflow>> {

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -34,7 +34,7 @@ import { SearchService } from '../state/search.service';
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
   public dataSource: MatTableDataSource<Workflow>;
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
-    super(dateService, searchQuery, searchService);
+    super(dateService, searchQuery, searchService, 'workflow');
   }
 
   privateNgOnInit(): Observable<Array<Workflow>> {

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -130,12 +130,12 @@ describe('SearchService', () => {
 
     const c: Workflow = { ...a, author: null, descriptorType: Workflow.DescriptorTypeEnum.WDL };
 
-    expect(searchService.compareAttributes(a, b, 'author', 'asc')).toEqual(-1);
-    expect(searchService.compareAttributes(a, b, 'author', 'desc')).toEqual(1);
-    expect(searchService.compareAttributes(b, c, 'author', 'asc')).toEqual(-1);
-    expect(searchService.compareAttributes(b, c, 'author', 'desc')).toEqual(-1);
-    expect(searchService.compareAttributes(a, c, 'descriptorType', 'asc')).toEqual(-1);
-    expect(searchService.compareAttributes(a, b, 'descriptorType', 'desc')).toEqual(-0);
-    expect(searchService.compareAttributes(a, b, 'starredUsers', 'asc')).toEqual(-1);
+    expect(searchService.compareAttributes(a, b, 'author', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(a, b, 'author', 'desc', 'workflow')).toEqual(1);
+    expect(searchService.compareAttributes(b, c, 'author', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(b, c, 'author', 'desc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(a, c, 'descriptorType', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(a, b, 'descriptorType', 'desc', 'workflow')).toEqual(-0);
+    expect(searchService.compareAttributes(a, b, 'starredUsers', 'asc', 'workflow')).toEqual(-1);
   }));
 });

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -124,11 +124,16 @@ describe('SearchService', () => {
       workflow_path: '',
       defaultTestParameterFilePath: '',
       descriptorTypeSubclass: Workflow.DescriptorTypeSubclassEnum.NOTAPPLICABLE,
+      full_workflow_path: 'abc'
     };
 
-    const b: Workflow = { ...a, author: 'B', starredUsers: [{ isAdmin: false, curator: false, setupComplete: true }] };
+    const b: Workflow = {
+      ...a, author: 'B',
+      full_workflow_path: 'Bcd',
+      starredUsers: [{ isAdmin: false, curator: false, setupComplete: true }]
+    };
 
-    const c: Workflow = { ...a, author: null, descriptorType: Workflow.DescriptorTypeEnum.WDL };
+    const c: Workflow = {...a, author: null, full_workflow_path: null, descriptorType: Workflow.DescriptorTypeEnum.WDL };
 
     expect(searchService.compareAttributes(a, b, 'author', 'asc', 'workflow')).toEqual(-1);
     expect(searchService.compareAttributes(a, b, 'author', 'desc', 'workflow')).toEqual(1);
@@ -137,5 +142,9 @@ describe('SearchService', () => {
     expect(searchService.compareAttributes(a, c, 'descriptorType', 'asc', 'workflow')).toEqual(-1);
     expect(searchService.compareAttributes(a, b, 'descriptorType', 'desc', 'workflow')).toEqual(-0);
     expect(searchService.compareAttributes(a, b, 'starredUsers', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(a, b, 'name', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(a, b, 'name', 'desc', 'workflow')).toEqual(1);
+    expect(searchService.compareAttributes(b, c, 'name', 'asc', 'workflow')).toEqual(-1);
+    expect(searchService.compareAttributes(b, c, 'name', 'desc', 'workflow')).toEqual(-1);
   }));
 });

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -86,7 +86,20 @@ export class SearchService {
    * @param attribute: workflow or tool property to sort by
    * @param direction: 'asc' or 'desc'
    */
-  compareAttributes(a: DockstoreTool | Workflow, b: DockstoreTool | Workflow, attribute: string, direction: SortDirection) {
+  compareAttributes(
+    a: DockstoreTool | Workflow,
+    b: DockstoreTool | Workflow,
+    attribute: string,
+    direction: SortDirection,
+    entryType: string
+  ) {
+    // For sorting tools by name, sort namespace property
+    // For sorting workflows by name, sort organization property
+    if (entryType === 'tool' && attribute === 'name') {
+      attribute = 'namespace';
+    } else if (entryType === 'workflow' && attribute === 'name') {
+      attribute = 'organization';
+    }
     let aVal = a[attribute];
     let bVal = b[attribute];
     const sortFactor = direction === 'asc' ? 1 : -1;

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -91,14 +91,14 @@ export class SearchService {
     b: DockstoreTool | Workflow,
     attribute: string,
     direction: SortDirection,
-    entryType: string
+    entryType: 'tool' | 'workflow'
   ) {
     // For sorting tools by name, sort namespace property
     // For sorting workflows by name, sort organization property
     if (entryType === 'tool' && attribute === 'name') {
-      attribute = 'namespace';
+      attribute = 'tool_path';
     } else if (entryType === 'workflow' && attribute === 'name') {
-      attribute = 'organization';
+      attribute = 'full_workflow_path';
     }
     let aVal = a[attribute];
     let bVal = b[attribute];

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -93,8 +93,8 @@ export class SearchService {
     direction: SortDirection,
     entryType: 'tool' | 'workflow'
   ) {
-    // For sorting tools by name, sort namespace property
-    // For sorting workflows by name, sort organization property
+    // For sorting tools by name, sort tool_path
+    // For sorting workflows by name, sort full_workflow_path
     if (entryType === 'tool' && attribute === 'name') {
       attribute = 'tool_path';
     } else if (entryType === 'workflow' && attribute === 'name') {


### PR DESCRIPTION
Fixes issue [#3014](https://github.com/dockstore/dockstore/issues/3014).

Sorting workflows by name was actually broken too, the function tried to sort by `workflow.name` which is not defined. 

Added a property in `search-entry-table.ts` to define whether the table is showing Tools or Workflows, and passes this info as a parameter to the sort function. If the table is displaying tools it will sort using `tool.tool_path` (previously sorting by `tool.name`) and if displaying workflows, it will sort by `workflow.full_workflow_path` to get the desired sort results.