### PR TITLE
Feature/1768/trust url security

### DIFF
--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -99,6 +99,9 @@ export class FileService {
    */
   getFileData(content: string): SafeUrl {
     if (content) {
+      // This uses the Data URI scheme, 'data;[<media type>][;base64],<data>'. For security
+      // purposes, it is important that the prefix is 'data:text/plain,' as this forces the user-input content to
+      // only be treated as plain text data. Other Data URI media types (such as text/html) could lead to potential XSS vulnerabilities.
       return this.sanitizer.bypassSecurityTrustUrl('data:text/plain,' + encodeURIComponent(content));
     } else {
       return null;

--- a/src/app/shared/file.service.ts
+++ b/src/app/shared/file.service.ts
@@ -99,7 +99,7 @@ export class FileService {
    */
   getFileData(content: string): SafeUrl {
     if (content) {
-      // This uses the Data URI scheme, 'data;[<media type>][;base64],<data>'. For security
+      // This uses the Data URI scheme, 'data:[<media type>][;base64],<data>'. For security
       // purposes, it is important that the prefix is 'data:text/plain,' as this forces the user-input content to
       // only be treated as plain text data. Other Data URI media types (such as text/html) could lead to potential XSS vulnerabilities.
       return this.sanitizer.bypassSecurityTrustUrl('data:text/plain,' + encodeURIComponent(content));


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-1768

Investigated the line in question. There do not appear to be any security vulnerabilities from trusting this code block. Added a quick description for clarity purposes. 

As long as the protocol (data:) and media type (text/plain) aren't modified, and the resulting string is used as is (not further modified) this line is safe. Details also noted on the ticket.