### PR TITLE
Feature/1780/support elasticsearch6

### DIFF
--- a/cypress/fixtures/searchTableResponse.json
+++ b/cypress/fixtures/searchTableResponse.json
@@ -12,8 +12,8 @@
     "max_score": 1.0,
     "hits": [
       {
-        "_index": "entry",
-        "_type": "tool",
+        "_index": "tools",
+        "_type": "_doc",
         "_id": "52",
         "_score": 1.0,
         "_source": {
@@ -84,8 +84,8 @@
         }
       },
       {
-        "_index": "entry",
-        "_type": "tool",
+        "_index": "tools",
+        "_type": "_type",
         "_id": "5",
         "_score": 1.0,
         "_source": {
@@ -174,8 +174,8 @@
         }
       },
       {
-        "_index": "entry",
-        "_type": "tool",
+        "_index": "tools",
+        "_type": "_doc",
         "_id": "4",
         "_score": 1.0,
         "_source": {
@@ -264,8 +264,8 @@
         }
       },
       {
-        "_index": "entry",
-        "_type": "workflow",
+        "_index": "workflows",
+        "_type": "_doc",
         "_id": "11",
         "_score": 1.0,
         "_source": {

--- a/cypress/integration/immutableDatabaseTests/searchTable.ts
+++ b/cypress/integration/immutableDatabaseTests/searchTable.ts
@@ -37,8 +37,8 @@ describe('Dockstore tool/workflow search table', () => {
           max_score: 1.0,
           hits: [
             {
-              _index: 'entry',
-              _type: 'tool',
+              _index: 'tools',
+              _type: '_doc',
               _id: '52',
               _score: 1.0,
               _source: {
@@ -102,8 +102,8 @@ describe('Dockstore tool/workflow search table', () => {
               },
             },
             {
-              _index: 'entry',
-              _type: 'tool',
+              _index: 'tools',
+              _type: '_doc',
               _id: '5',
               _score: 1.0,
               _source: {
@@ -190,8 +190,8 @@ describe('Dockstore tool/workflow search table', () => {
               },
             },
             {
-              _index: 'entry',
-              _type: 'tool',
+              _index: 'tools',
+              _type: '_doc',
               _id: '4',
               _score: 1.0,
               _source: {
@@ -278,8 +278,8 @@ describe('Dockstore tool/workflow search table', () => {
               },
             },
             {
-              _index: 'entry',
-              _type: 'workflow',
+              _index: 'workflows',
+              _type: '_doc',
               _id: '11',
               _score: 1.0,
               _source: {

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -445,9 +445,7 @@ export class SearchComponent implements OnInit, OnDestroy {
               order: {
                 _count: 'desc',
               },
-              include: {
-                pattern: pattern,
-              },
+              include: pattern,
             },
           },
         },

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -69,7 +69,7 @@ export class SearchService {
    * @private
    * @memberof SearchService
    */
-  public exclusiveFilters = ['verified', 'private_access', '_type', 'has_checker'];
+  public exclusiveFilters = ['verified', 'private_access', '_index', 'has_checker'];
   constructor(
     private searchStore: SearchStore,
     private searchQuery: SearchQuery,

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -204,10 +204,10 @@ export class SearchService {
     hits.forEach((hit) => {
       hit['_source'] = this.providerService.setUpProvider(hit['_source']);
       if (workflowHits.length + toolHits.length < query_size - 1) {
-        if (hit['_type'] === 'tool') {
+        if (hit['_index'] === 'tools') {
           hit['_source'] = this.imageProviderService.setUpImageProvider(hit['_source']);
           toolHits.push(hit);
-        } else if (hit['_type'] === 'workflow') {
+        } else if (hit['_index'] === 'workflows') {
           workflowHits.push(hit);
         }
       }
@@ -457,7 +457,7 @@ export class SearchService {
   // Initialization Functions
   initializeCommonBucketStubs() {
     return new Map([
-      ['Entry Type', '_type'],
+      ['Entry Type', '_index'],
       ['Language', 'descriptorType'],
       ['Registry', 'registry'],
       ['Source Control', 'source_control_provider.keyword'],
@@ -477,7 +477,7 @@ export class SearchService {
 
   initializeFriendlyNames() {
     return new Map([
-      ['_type', 'Entry Type'],
+      ['_index', 'Entry Type'],
       ['descriptorType', 'Language'],
       ['registry', 'Tool: Registry'],
       ['source_control_provider.keyword', 'Workflow: Source Control'],
@@ -513,7 +513,7 @@ export class SearchService {
 
   initializeEntryOrder() {
     return new Map([
-      ['_type', new SubBucket()],
+      ['_index', new SubBucket()],
       ['descriptorType', new SubBucket()],
       ['author', new SubBucket()],
       ['registry', new SubBucket()],

--- a/src/app/test/mocked-objects.ts
+++ b/src/app/test/mocked-objects.ts
@@ -542,8 +542,8 @@ export const testSourceFiles: Array<SourceFile> = [
 
 export const elasticSearchResponse: Hit[] = [
   {
-    _index: 'entry',
-    _type: 'tool',
+    _index: 'tools',
+    _type: '_doc',
     _id: '2313',
     _score: 1,
     _source: {
@@ -623,8 +623,8 @@ export const elasticSearchResponse: Hit[] = [
     },
   },
   {
-    _index: 'entry',
-    _type: 'workflow',
+    _index: 'workflows',
+    _type: '_doc',
     _id: '2210',
     _score: 1,
     _source: {


### PR DESCRIPTION
- changes for updating to elasticsearch 6.8+ and corresponding to changes proposed in [3899](https://github.com/dockstore/dockstore/pull/3899)
- results from search come from two indices rather than one, handle them by the `index` property rather than `_type`
- slight query change for the autocomplete terms