### PR TITLE
Word break on all td elements

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -549,6 +549,13 @@ table {
   border: 1px solid #cfd1d7;
 }
 
+// Decided to not do horizontal scroll. Just wrap no matter what.
+// This is to naturally wrap breakable text. If the text is not breakable, wrap anywhere.
+// This does not affect <mat-table>
+td {
+  word-break: break-word;
+}
+
 td,
 th {
   font-weight: normal;


### PR DESCRIPTION
For partial dockstore/dockstore#3179

![Tools](https://user-images.githubusercontent.com/24548904/97755466-9e38b100-1acf-11eb-86cd-ddc3b0a65b96.PNG)
![Workflows](https://user-images.githubusercontent.com/24548904/97755467-9ed14780-1acf-11eb-9522-8b5364e4ea1f.PNG)

Global style to break on all tables. None of them should horizontal scroll ever.

It's still a mystery to me why tools and workflows behaved differently