### PR TITLE
Fix alt images

### DIFF
--- a/src/app/sponsors/sponsors.component.html
+++ b/src/app/sponsors/sponsors.component.html
@@ -33,7 +33,7 @@
     <div fxLayout="row wrap" fxLayoutAlign="space-around stretch">
       <div *ngFor="let partner of languages" class="pb-5 px-1">
         <a [href]="partner.url" target="_blank" rel="noopener noreferrer">
-          <img [src]="partner.current" />
+          <img [src]="partner.current" [alt]="partner.url.hostname" />
         </a>
       </div>
     </div>


### PR DESCRIPTION
So close yet so far

![image](https://user-images.githubusercontent.com/24548904/98270280-b6d81980-1f5c-11eb-87c6-ba7615591176.png)

Tried for a considerably long time to get that 1%...turns out I'm bad at CSS. https://ucsc-cgl.atlassian.net/browse/SEAB-1951

Actual differences

Before:
![image](https://user-images.githubusercontent.com/24548904/98272075-a88afd00-1f5e-11eb-90ab-3f3ef3c78825.png)

After:
![image](https://user-images.githubusercontent.com/24548904/98272023-9a3ce100-1f5e-11eb-8f9c-efcf4b980b49.png)
