### PR TITLE
fix/3916/tagCloud

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -33,10 +33,11 @@ export class QueryBuilderService {
 
   getTagCloudQuery(type: string): string {
     const tagCloudSize = 20;
+    const index = type + 's';
     let body = bodybuilder().size(tagCloudSize);
     body = this.excludeContent(body);
-    body = body.query('match', '_type', type);
-    body = body.aggregation('significant_terms', 'description', 'tagcloud', { size: tagCloudSize });
+    body = body.query('match', '_index', index);
+    body = body.aggregation('significant_text', 'description', 'tagcloud', { size: tagCloudSize });
     const toolQuery = JSON.stringify(body.build(), null, 1);
     return toolQuery;
   }


### PR DESCRIPTION
- fix for [3916](https://github.com/dockstore/dockstore/issues/3916)
- when querying for tag cloud, use _index not _type
- use [significant_text](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-significanttext-aggregation.html) instead of significant_terms. significant_terms ends up pulling a bunch of numbers, and significant_text is supposed to be more suited for properties of the `text` type, which matches our `description` mapping
