### PR TITLE
Switched material icons module to a maintained version

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,8 +28,7 @@
               "node_modules/bootstrap-social/bootstrap-social.css",
               "src/styles.css",
               "src/styles.scss",
-              "src/material.scss",
-              "node_modules/material-design-icons/iconfont/material-icons.css"
+              "src/material.scss"
             ],
             "scripts": [
               "node_modules/jquery/dist/jquery.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12871,10 +12871,10 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
       "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
     },
-    "material-design-icons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-3.0.1.tgz",
-      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
+    "material-design-icons-iconfont": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.1.0.tgz",
+      "integrity": "sha512-wRJtOo1v1ch+gN8PRsj0IGJznk+kQ8mz13ds/nuhLI+Qyf/931ZlRpd92oq0IRPpZIb+bhX8pRjzIVdcPDKmiQ=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "elasticsearch-browser": "^15.0.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.1",
-    "material-design-icons": "^3.0.1",
+    "material-design-icons-iconfont": "^6.1.0",
     "ng2-ui-auth": "^10.0.1",
     "ngx-clipboard": "^13.0.1",
     "ngx-markdown": "^9.1.1",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,6 +14,9 @@
  *    limitations under the License.
  */
 
+// Must define the material icons font directory path, see https://www.npmjs.com/package/material-design-icons-iconfont
+$material-design-icons-font-directory-path: '~material-design-icons-iconfont/dist/fonts/';
+@import '~material-design-icons-iconfont/src/material-design-icons';
 @import 'ds-style-fix.scss';
 @import 'bootstrap4.scss';
 @import '~ngx-sharebuttons/themes/default/default-theme';


### PR DESCRIPTION
Original ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-1651

Using a forked and separately maintained [module](https://www.npmjs.com/package/material-design-icons-iconfont) of Google's material icons. This is due to Google's material icons module being out-of-date, see [issue](https://github.com/google/material-design-icons/issues/798).

