### PR TITLE
Changed class name for star icon styling to prevent duplicate icons

### DIFF
--- a/cypress/integration/immutableDatabaseTests/app-spec.ts
+++ b/cypress/integration/immutableDatabaseTests/app-spec.ts
@@ -47,14 +47,14 @@ describe('Logged in Dockstore Home', () => {
     if (type === 'workflow') {
       cy.get('[data-cy=workflows-tab]').click();
     }
-    cy.get('.mat-icon.star').should('not.exist');
+    cy.get('.mat-icon.star-icon').should('not.exist');
     cy.visit(url);
     cy.get('#starringButton').click();
     cy.visit('');
     if (type === 'workflow') {
       cy.get('[data-cy=workflows-tab]').click();
     }
-    cy.get('.mat-icon.star').should('exist');
+    cy.get('.mat-icon.star-icon').should('exist');
     cy.visit(url);
     cy.get('#starringButton').click();
   }

--- a/cypress/integration/immutableDatabaseTests/searchTable.ts
+++ b/cypress/integration/immutableDatabaseTests/searchTable.ts
@@ -343,7 +343,7 @@ describe('Dockstore tool/workflow search table', () => {
     if (type === 'workflow') {
       goToTab('Workflows');
     }
-    cy.get('.mat-icon.star').should('not.exist');
+    cy.get('.mat-icon.star-icon').should('not.exist');
     // cy.visit(url);
     // cy.get('#starringButton')
     //   .click();
@@ -361,7 +361,7 @@ describe('Dockstore tool/workflow search table', () => {
     if (type === 'workflow') {
       goToTab('Workflows');
     }
-    cy.get('.mat-icon.star').should('exist');
+    cy.get('.mat-icon.star-icon').should('exist');
     // cy.visit(url);
     // cy.get('#starringButton')
     //   .click();

--- a/src/app/containers/list/list.component.html
+++ b/src/app/containers/list/list.component.html
@@ -49,7 +49,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let tool"
         >{{ tool?.starredUsers.length === 0 ? '' : tool?.starredUsers.length }}
-        <mat-icon class="star" *ngIf="tool?.starredUsers?.length > 0">star_rate</mat-icon>
+        <mat-icon class="star-icon" *ngIf="tool?.starredUsers?.length > 0">star_rate</mat-icon>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -71,7 +71,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let tool"
         >{{ !tool?.starredUsers || tool?.starredUsers.length === 0 ? '' : tool?.starredUsers.length }}
-        <mat-icon class="star" *ngIf="tool?.starredUsers?.length > 0">star_rate</mat-icon>
+        <mat-icon class="star-icon" *ngIf="tool?.starredUsers?.length > 0">star_rate</mat-icon>
       </mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -50,7 +50,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let workflow"
         >{{ !workflow?.starredUsers || workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers?.length }}
-        <mat-icon class="star" *ngIf="workflow?.starredUsers?.length > 0">star_rate</mat-icon>
+        <mat-icon class="star-icon" *ngIf="workflow?.starredUsers?.length > 0">star_rate</mat-icon>
       </mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -46,7 +46,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let workflow">
         {{ workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers.length }}
-        <mat-icon class="star" *ngIf="workflow?.starredUsers?.length > 0">star_rate</mat-icon>
+        <mat-icon class="star-icon" *ngIf="workflow?.starredUsers?.length > 0">star_rate</mat-icon>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="author">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1216,7 +1216,7 @@ app-select.longer {
   width: 50%;
 }
 
-mat-icon.star {
+mat-icon.star-icon {
   font-size: 16px;
   height: 16px;
 }


### PR DESCRIPTION
Issue: dockstore/dockstore#3925

Changed class name for mat-icon stars to prevent icon duplication.