### PR TITLE
fix/3961/filterSearchResults

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -368,7 +368,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       this.filters,
       this.sortModeMap
     );
-    if (!values) {
+    if (!values && this.filters.size === 0) {
       const toolsQuery = this.queryBuilderService.getResultSingleIndexQuery(this.query_size, 'tools');
       const workflowsQuery = this.queryBuilderService.getResultSingleIndexQuery(this.query_size, 'workflows');
       this.resetEntryOrder();


### PR DESCRIPTION
- fix for [3961](https://github.com/dockstore/dockstore/issues/3961)
- if a facet was selected but there was no search term, the wrong query was called
- added condition so that query is only called when there are no search terms and no filters, and the correct query is called to update the results table