### PR TITLE
made some minor changes to the detailed success message

### DIFF
--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -119,7 +119,7 @@ export class ToolFileEditorComponent extends FileEditing {
               updatedVersion.name +
               ' of hosted tool ' +
               editedDockstoreTool.name +
-              (editedDockstoreTool.toolname ? '/' + editedDockstoreTool.toolname : null)
+              (editedDockstoreTool.toolname ? '/' + editedDockstoreTool.toolname : '')
           );
         } else {
           // Probably encountered a 204

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -114,7 +114,13 @@ export class ToolFileEditorComponent extends FileEditing {
           this.toggleEdit();
           this.containerService.setTool(editedDockstoreTool);
           const updatedVersion = this.getNewestVersion(editedDockstoreTool.workflowVersions);
-          this.alertService.detailedSuccess('Saved version ' + updatedVersion.name + ' of hosted tool ' + editedDockstoreTool.toolname);
+          this.alertService.detailedSuccess(
+            'Saved version ' +
+              updatedVersion.name +
+              ' of hosted tool ' +
+              editedDockstoreTool.name +
+              (editedDockstoreTool.toolname ? '/' + editedDockstoreTool.toolname : null)
+          );
         } else {
           // Probably encountered a 204
           this.handleNoContentResponse();

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -114,7 +114,7 @@ export class ToolFileEditorComponent extends FileEditing {
           this.toggleEdit();
           this.containerService.setTool(editedDockstoreTool);
           const updatedVersion = this.getNewestVersion(editedDockstoreTool.workflowVersions);
-          this.alertService.detailedSuccess('Saved version ' + updatedVersion.name + ' of hosted entry ' + editedDockstoreTool.toolname);
+          this.alertService.detailedSuccess('Saved version ' + updatedVersion.name + ' of hosted tool ' + editedDockstoreTool.toolname);
         } else {
           // Probably encountered a 204
           this.handleNoContentResponse();

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -114,7 +114,7 @@ export class ToolFileEditorComponent extends FileEditing {
           this.toggleEdit();
           this.containerService.setTool(editedDockstoreTool);
           const updatedVersion = this.getNewestVersion(editedDockstoreTool.workflowVersions);
-          this.alertService.detailedSuccess('Saved version ' + updatedVersion.name + ' of hosted entry ' + editedDockstoreTool.namespace);
+          this.alertService.detailedSuccess('Saved version ' + updatedVersion.name + ' of hosted entry ' + editedDockstoreTool.toolname);
         } else {
           // Probably encountered a 204
           this.handleNoContentResponse();


### PR DESCRIPTION
switched from "hosted entry" to "hosted tool" as suggested, and replaced the namespace var with name to get the hosted tool's name instead of it's namespace. The namespace and my hosted tool's names were similar, I think, so that was why I didn't catch it.