### PR TITLE
Discourse URL Slash

### DIFF
--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -26,8 +26,8 @@ export class Dockstore {
   // All the following properties will get updated by configuration.service.ts. You do not
   // need to update them here. Set them in your dockstore.yml for the web service.
 
-  // Discourse URL MUST end with a slash (/)
-  static DISCOURSE_URL = 'http://localhost/';
+  // Discourse URL should not end with a slash (/) but will work fine with one
+  static DISCOURSE_URL = 'http://localhost';
 
   static DNASTACK_IMPORT_URL = 'https://app.dnastack.com/#/app/workflow/import/dockstore';
   static DNANEXUS_IMPORT_URL = 'https://platform.dnanexus.com/panx/tools/import-workflow';

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -454,14 +454,14 @@ export abstract class Entry implements OnInit, OnDestroy {
       element.remove();
     }
     (<any>window).DiscourseEmbed = {
-      discourseUrl: Dockstore.DISCOURSE_URL,
+      discourseUrl: Dockstore.DISCOURSE_URL + '/',
       topicId: topicId,
     };
     (function () {
       const d = document.createElement('script');
       d.type = 'text/javascript';
       d.async = true;
-      d.src = (<any>window).DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+      d.src = (<any>window).DiscourseEmbed.discourseUrl + '/javascripts/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
     })();
   }


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-2162

Add slash so that Discourse URL shouldn't require one but will work either way.