### PR TITLE
Feature/3942/private tool status bar text

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -80,7 +80,7 @@
       ></app-starring>
       <h3 class="pull-right">
         <div class="mr-2" *ngIf="publicPage && tool?.private_access">
-          <a mat-raised-button color="accent" [href]="requestAccessHREF"> Request Access </a>
+          <a mat-raised-button color="accent" [href]="requestAccessHREF$ | async"> Request Access </a>
         </div>
         <div class="mr-2" *ngIf="publicPage && (extendedTool$ | async)?.email && !tool?.private_access">
           <a mat-raised-button color="primary" [href]="contactAuthorHREF"> Contact Author </a>

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -59,7 +59,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   containerEditData: any;
   thisisValid = true;
   ModeEnum = DockstoreTool.ModeEnum;
-  public requestAccessHREF: string;
+  public requestAccessHREF$: Observable<string>;
   public contactAuthorHREF: string;
   public missingWarning: boolean;
   public tool: ExtendedDockstoreTool;
@@ -197,13 +197,14 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     if (tool) {
       this.tool = tool;
       this.initTool();
-      this.extendedTool$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(data => {
+      this.requestAccessHREF$ = this.extendedTool$.pipe(map(data => {
         if (Object.keys(data).length !== 0 ) {
-          this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
+          console.log(data);
+          return this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
         } else {
-          this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool, 'not-valid');
+          return this.emailService.composeRequestAccessEmail(this.tool, 'undefined');
         }
-      });
+      }));
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.updateVerifiedPlatforms(this.tool.id);

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -62,7 +62,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public requestAccessHREF$: Observable<string>;
   public contactAuthorHREF: string;
   public missingWarning: boolean;
-  public tool: ExtendedDockstoreTool;
+  public tool: DockstoreTool;
   public toolCopyBtn: string;
   public sortedVersions: Array<Tag | WorkflowVersion> = [];
   public DockstoreToolType = DockstoreTool;
@@ -198,12 +198,8 @@ export class ContainerComponent extends Entry implements AfterViewInit {
       this.tool = tool;
       this.initTool();
       this.requestAccessHREF$ = this.extendedTool$.pipe(
-        map((data) => {
-          if (data.imgProvider) {
-            return this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
-          } else {
-            return this.emailService.composeRequestAccessEmail(this.tool, 'undefined');
-          }
+        map((extendedTool) => {
+          return this.emailService.composeRequestAccessEmail(extendedTool);
         })
       );
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -197,14 +197,15 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     if (tool) {
       this.tool = tool;
       this.initTool();
-      this.requestAccessHREF$ = this.extendedTool$.pipe(map(data => {
-        if (Object.keys(data).length !== 0 ) {
-          console.log(data);
-          return this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
-        } else {
-          return this.emailService.composeRequestAccessEmail(this.tool, 'undefined');
-        }
-      }));
+      this.requestAccessHREF$ = this.extendedTool$.pipe(
+        map((data) => {
+          if (data.imgProvider) {
+            return this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
+          } else {
+            return this.emailService.composeRequestAccessEmail(this.tool, 'undefined');
+          }
+        })
+      );
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.updateVerifiedPlatforms(this.tool.id);

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -21,7 +21,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { Observable } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 import { ListContainersService } from '../containers/list/list.service';
 import { AlertQuery } from '../shared/alert/state/alert.query';
 import { BioschemaService, BioschemaTool } from '../shared/bioschema.service';
@@ -62,7 +62,7 @@ export class ContainerComponent extends Entry implements AfterViewInit {
   public requestAccessHREF: string;
   public contactAuthorHREF: string;
   public missingWarning: boolean;
-  public tool: DockstoreTool;
+  public tool: ExtendedDockstoreTool;
   public toolCopyBtn: string;
   public sortedVersions: Array<Tag | WorkflowVersion> = [];
   public DockstoreToolType = DockstoreTool;
@@ -197,8 +197,14 @@ export class ContainerComponent extends Entry implements AfterViewInit {
     if (tool) {
       this.tool = tool;
       this.initTool();
+      this.extendedTool$.pipe(takeUntil(this.ngUnsubscribe)).subscribe(data => {
+        if (Object.keys(data).length !== 0 ) {
+          this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool, data.imgProvider);
+        } else {
+          this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool, 'not-valid');
+        }
+      });
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
-      this.requestAccessHREF = this.emailService.composeRequestAccessEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.updateVerifiedPlatforms(this.tool.id);
     }

--- a/src/app/container/email.service.spec.ts
+++ b/src/app/container/email.service.spec.ts
@@ -25,7 +25,7 @@ describe('Service: Email', () => {
 
   it('should get the right request access email href', inject([EmailService], (service: EmailService) => {
     expect(service).toBeTruthy();
-    expect(service.composeRequestAccessEmail(tool)).toEqual(
+    expect(service.composeRequestAccessEmail(tool, tool.imgProvider)).toEqual(
       'mailto:fake@maintainer.email.ca' +
         '?subject=Dockstore%20Request%20for%20Access%20to%20registry.hub.docker.com/postgres/postgres' +
         '&body=I%20would%20like%20to%20request%20access%20to%20your%20Docker%20image%20registry.hub.docker.com/postgres/postgres.%20' +

--- a/src/app/container/email.service.spec.ts
+++ b/src/app/container/email.service.spec.ts
@@ -29,7 +29,7 @@ describe('Service: Email', () => {
       'mailto:fake@maintainer.email.ca' +
         '?subject=Dockstore%20Request%20for%20Access%20to%20registry.hub.docker.com/postgres/postgres' +
         '&body=I%20would%20like%20to%20request%20access%20to%20your%20Docker%20image%20registry.hub.docker.com/postgres/postgres.%20' +
-        'My%20user%20name%20on%20Docker%20Hub%20is%20%3Cput%20your%20Docker%20Hub/quay.io%20username%20here%3E'
+        'My%20username%20on%20Docker%20Hub%20is%20%3Cinput%20username%20here%3E'
     );
   }));
 

--- a/src/app/container/email.service.spec.ts
+++ b/src/app/container/email.service.spec.ts
@@ -29,7 +29,7 @@ describe('Service: Email', () => {
       'mailto:fake@maintainer.email.ca' +
         '?subject=Dockstore%20Request%20for%20Access%20to%20registry.hub.docker.com/postgres/postgres' +
         '&body=I%20would%20like%20to%20request%20access%20to%20your%20Docker%20image%20registry.hub.docker.com/postgres/postgres.%20' +
-        'My%20user%20name%20on%20Docker%20Hub%20is%20%3Cusername%3E'
+        'My%20user%20name%20on%20Docker%20Hub%20is%20%3Cput%20your%20Docker%20Hub/quay.io%20username%20here%3E'
     );
   }));
 

--- a/src/app/container/email.service.spec.ts
+++ b/src/app/container/email.service.spec.ts
@@ -25,7 +25,7 @@ describe('Service: Email', () => {
 
   it('should get the right request access email href', inject([EmailService], (service: EmailService) => {
     expect(service).toBeTruthy();
-    expect(service.composeRequestAccessEmail(tool, tool.imgProvider)).toEqual(
+    expect(service.composeRequestAccessEmail(tool)).toEqual(
       'mailto:fake@maintainer.email.ca' +
         '?subject=Dockstore%20Request%20for%20Access%20to%20registry.hub.docker.com/postgres/postgres' +
         '&body=I%20would%20like%20to%20request%20access%20to%20your%20Docker%20image%20registry.hub.docker.com/postgres/postgres.%20' +

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { DockstoreTool } from '../shared/swagger/model/dockstoreTool';
 import { DockstoreService } from './../shared/dockstore.service';
 import { ExtendedDockstoreTool } from './../shared/models/ExtendedDockstoreTool';
 
@@ -29,7 +30,11 @@ export class EmailService {
    * @param toolRegistry The tool registry (Quay.io, GitLab, etc) of the tool whose access is being requested
    */
   private static getRequestEmailBody(path: string, toolRegistry: string): string {
-    return encodeURI(`I would like to request access to your Docker image ${path}. ` + `My user name on ${toolRegistry} is <username>`);
+    const imgProvider: string = toolRegistry ? toolRegistry : 'undefined';
+    return encodeURI(
+      `I would like to request access to your Docker image ${path}. ` +
+        `My user name on ${imgProvider} is <put your Docker Hub/quay.io username here>`
+    );
   }
 
   // Contact Author button methods
@@ -62,10 +67,10 @@ export class EmailService {
    * Composes the href for the Request Access email
    * @param tool The tool to request access for
    */
-  public composeRequestAccessEmail(tool: ExtendedDockstoreTool, imgProvider: string): string {
+  public composeRequestAccessEmail(tool: ExtendedDockstoreTool): string {
     const email = this.getRequestEmailMailTo(tool.tool_maintainer_email, tool.email);
     const subject = EmailService.getRequestEmailSubject(tool.tool_path);
-    const body = EmailService.getRequestEmailBody(tool.tool_path, imgProvider);
+    const body = EmailService.getRequestEmailBody(tool.tool_path, tool.imgProvider);
     return EmailService.composeEmail(email, subject, body);
   }
 
@@ -73,7 +78,7 @@ export class EmailService {
    * Composes the href for the Contact Author email
    * @param tool The tool to contact author for
    */
-  public composeContactAuthorEmail(tool: ExtendedDockstoreTool): string {
+  public composeContactAuthorEmail(tool: DockstoreTool): string {
     const email = EmailService.getInquiryEmailMailTo(tool.email);
     const subject = EmailService.getInquiryEmailSubject(tool.tool_path);
     const body = EmailService.getInquiryEmailBody();

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -11,8 +11,51 @@ export class EmailService {
    * @param subject The subject of the email
    * @param body The body of the the email
    */
-  private composeEmail(email: string, subject: string, body: string): string {
+  private static composeEmail(email: string, subject: string, body: string): string {
     return `mailto:${email}?subject=${subject}&body=${body}`;
+  }
+
+  /**
+   * This gets the email subject when the Request Access button is clicked
+   * @param path The path of the tool whose access is being requested
+   */
+  private static getRequestEmailSubject(path: string): string {
+    return encodeURI(`Dockstore Request for Access to ${path}`);
+  }
+
+  /**
+   * This gets the email body when the Request Access button is clicked
+   * @param path The path of the tool whose access is being requested
+   * @param toolRegistry The tool registry (Quay.io, GitLab, etc) of the tool whose access is being requested
+   */
+  private static getRequestEmailBody(path: string, toolRegistry: string): string {
+    return encodeURI(`I would like to request access to your Docker image ${path}. ` + `My user name on ${toolRegistry} is <username>`);
+  }
+
+  // Contact Author button methods
+  /**
+   * This gets the mailto address when the Contact Author button is clicked.    console.log(tool);
+   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
+   * @param email The tool author's email address
+   */
+  private static getInquiryEmailMailTo(email: string): string {
+    return email;
+  }
+
+  /**
+   * This gets the email subject when the Contact Author button is clicked
+   * @param path The path of the tool whose access is being requested
+   */
+  private static getInquiryEmailSubject(path: string): string {
+    return encodeURI(`Dockstore ${path} inquiry`);
+  }
+
+  /**
+   * This gets the email body when the Contact Author button is clicked
+   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
+   */
+  private static getInquiryEmailBody(): string {
+    return '';
   }
 
   /**
@@ -21,9 +64,9 @@ export class EmailService {
    */
   public composeRequestAccessEmail(tool: ExtendedDockstoreTool, imgProvider: string): string {
     const email = this.getRequestEmailMailTo(tool.tool_maintainer_email, tool.email);
-    const subject = this.getRequestEmailSubject(tool.tool_path);
-    const body = this.getRequestEmailBody(tool.tool_path, imgProvider, tool.users ? tool.users[0].username : 'not-logged-in');
-    return this.composeEmail(email, subject, body);
+    const subject = EmailService.getRequestEmailSubject(tool.tool_path);
+    const body = EmailService.getRequestEmailBody(tool.tool_path, imgProvider);
+    return EmailService.composeEmail(email, subject, body);
   }
 
   /**
@@ -31,10 +74,10 @@ export class EmailService {
    * @param tool The tool to contact author for
    */
   public composeContactAuthorEmail(tool: ExtendedDockstoreTool): string {
-    const email = this.getInquiryEmailMailTo(tool.email);
-    const subject = this.getInquiryEmailSubject(tool.tool_path);
-    const body = this.getInquiryEmailBody();
-    return this.composeEmail(email, subject, body);
+    const email = EmailService.getInquiryEmailMailTo(tool.email);
+    const subject = EmailService.getInquiryEmailSubject(tool.tool_path);
+    const body = EmailService.getInquiryEmailBody();
+    return EmailService.composeEmail(email, subject, body);
   }
 
   // Request Access button methods
@@ -45,48 +88,5 @@ export class EmailService {
    */
   private getRequestEmailMailTo(maintainerEmail: string, email: string): string {
     return this.dockstoreService.getRequestAccessEmail(maintainerEmail, email);
-  }
-
-  /**
-   * This gets the email subject when the Request Access button is clicked
-   * @param path The path of the tool whose access is being requested
-   */
-  private getRequestEmailSubject(path: string): string {
-    return encodeURI(`Dockstore Request for Access to ${path}`);
-  }
-
-  /**
-   * This gets the email body when the Request Access button is clicked
-   * @param path The path of the tool whose access is being requested
-   * @param toolRegistry The tool registry (Quay.io, GitLab, etc) of the tool whose access is being requested
-   */
-  private getRequestEmailBody(path: string, toolRegistry: string, username: string): string {
-    return encodeURI(`I would like to request access to your Docker image ${path}. ` + `My user name on ${toolRegistry} is ${username}`);
-  }
-
-  // Contact Author button methods
-  /**
-   * This gets the mailto address when the Contact Author button is clicked.    console.log(tool);
-   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
-   * @param email The tool author's email address
-   */
-  private getInquiryEmailMailTo(email: string): string {
-    return email;
-  }
-
-  /**
-   * This gets the email subject when the Contact Author button is clicked
-   * @param path The path of the tool whose access is being requested
-   */
-  private getInquiryEmailSubject(path: string): string {
-    return encodeURI(`Dockstore ${path} inquiry`);
-  }
-
-  /**
-   * This gets the email body when the Contact Author button is clicked
-   * This method is mostly redundant, but keeping it to mirror the Request Access button methods and in case modifications are needed
-   */
-  private getInquiryEmailBody(): string {
-    return '';
   }
 }

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -31,9 +31,7 @@ export class EmailService {
    */
   private static getRequestEmailBody(path: string, toolRegistry: string): string {
     const imgProvider: string = toolRegistry ? toolRegistry : 'undefined';
-    return encodeURI(
-      `I would like to request access to your Docker image ${path}. ` + `My username on ${imgProvider} is <input username here>`
-    );
+    return encodeURI(`I would like to request access to your Docker image ${path}. My username on ${imgProvider} is <input username here>`);
   }
 
   // Contact Author button methods

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -32,8 +32,7 @@ export class EmailService {
   private static getRequestEmailBody(path: string, toolRegistry: string): string {
     const imgProvider: string = toolRegistry ? toolRegistry : 'undefined';
     return encodeURI(
-      `I would like to request access to your Docker image ${path}. ` +
-        `My user name on ${imgProvider} is <put your Docker Hub/quay.io username here>`
+      `I would like to request access to your Docker image ${path}. ` + `My username on ${imgProvider} is <input username here>`
     );
   }
 

--- a/src/app/container/email.service.ts
+++ b/src/app/container/email.service.ts
@@ -19,10 +19,10 @@ export class EmailService {
    * Composes the href for the Request Access email
    * @param tool The tool to request access for
    */
-  public composeRequestAccessEmail(tool: ExtendedDockstoreTool): string {
+  public composeRequestAccessEmail(tool: ExtendedDockstoreTool, imgProvider: string): string {
     const email = this.getRequestEmailMailTo(tool.tool_maintainer_email, tool.email);
     const subject = this.getRequestEmailSubject(tool.tool_path);
-    const body = this.getRequestEmailBody(tool.tool_path, tool.imgProvider);
+    const body = this.getRequestEmailBody(tool.tool_path, imgProvider, tool.users ? tool.users[0].username : 'not-logged-in');
     return this.composeEmail(email, subject, body);
   }
 
@@ -60,8 +60,8 @@ export class EmailService {
    * @param path The path of the tool whose access is being requested
    * @param toolRegistry The tool registry (Quay.io, GitLab, etc) of the tool whose access is being requested
    */
-  private getRequestEmailBody(path: string, toolRegistry: string): string {
-    return encodeURI(`I would like to request access to your Docker image ${path}. ` + `My user name on ${toolRegistry} is <username>`);
+  private getRequestEmailBody(path: string, toolRegistry: string, username: string): string {
+    return encodeURI(`I would like to request access to your Docker image ${path}. ` + `My user name on ${toolRegistry} is ${username}`);
   }
 
   // Contact Author button methods


### PR DESCRIPTION
[dockstore/dockstore#3942](https://github.com/dockstore/dockstore/issues/3942)
This feature fixes a part of the issue. It takes care of displaying registry name properly when hovered over the "Request Access" button. The rest of the solution to this issue please refer to the [other PR](https://github.com/dockstore/dockstore-ui2/pull/1135)