### PR TITLE
Fix sample descriptor code URLs for CDN path substitution

### DIFF
--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -80,16 +80,16 @@ export class CodeEditorComponent implements AfterViewInit {
     if (!this.editorContent) {
       if (this.mode === 'cwl') {
         if (this.entryType === 'tool') {
-          sampleCodeUrl = 'assets/text/sample-tool.cwl';
+          sampleCodeUrl = '../assets/text/sample-tool.cwl';
         } else if (this.entryType === 'workflow') {
-          sampleCodeUrl = 'assets/text/sample-workflow.cwl';
+          sampleCodeUrl = '../assets/text/sample-workflow.cwl';
         }
       } else if (this.mode === 'wdl') {
-        sampleCodeUrl = 'assets/text/sample.wdl';
+        sampleCodeUrl = '../assets/text/sample.wdl';
       } else if (this.mode === 'nfl') {
-        sampleCodeUrl = 'assets/text/sample.nf';
+        sampleCodeUrl = '../assets/text/sample.nf';
       } else if (this.editorFilepath === '/nextflow.config') {
-        sampleCodeUrl = 'assets/text/nextflow.config';
+        sampleCodeUrl = '../assets/text/nextflow.config';
       }
     }
     if (sampleCodeUrl) {


### PR DESCRIPTION
Main ticket: https://github.com/dockstore/dockstore/issues/3518
Original PR: #1129

We substitute assets with the actual CDN path via substitution; my original code was not matching. I updated the URLs to fit the pattern: https://github.com/dockstore/dockstore-ui2/blob/ec8ef9efce43f6cc8365e8bed5770a6235d93df4/.circleci/config.yml#L195