### PR TITLE
Fix for text search

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -179,7 +179,7 @@ export class QueryBuilderService {
   appendQuery(body: any, values: string, oldAdvancedSearchObject: AdvancedSearchObject, searchTerm: boolean): any {
     const advancedSearchObject = { ...oldAdvancedSearchObject };
     if (values.toString().length > 0) {
-      this.searchEverything(body, values);
+      body = this.searchEverything(body, values);
     } else {
       body = body.query('match_all', {});
     }
@@ -207,8 +207,8 @@ export class QueryBuilderService {
    * @param body Body from the Bodybuilder package which will be mutated
    * @param searchString The string entered into the basic search bar by the user
    */
-  searchEverything(body: bodybuilder.Bodybuilder, searchString: string): void {
-    body = body
+  private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
+    return body
       .orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
       .orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
       .orQuery('wildcard', { 'workflowVersions.sourceFiles.content': { value: '*' + searchString + '*', case_insensitive: true } })

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -198,7 +198,7 @@ export class QueryBuilderService {
   /**
    * Appends search-everything filter to the query
    * Currently searches sourcefiles, description, labels, author, and path
-   * Some requiremnts:
+   * Some requirements:
    * 1. Need to be able to match substring (ex. "chicken pot pie" should match "pot")
    * 2. Need to be able to handle slashes (ex. "beef/stew" should match "beef/stew")
    * Wildcard is used for #1

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -201,21 +201,23 @@ export class QueryBuilderService {
    * Some requiremnts:
    * 1. Need to be able to match substring (ex. "chicken pot pie" should match "pot")
    * 2. Need to be able to handle slashes (ex. "beef/stew" should match "beef/stew")
-   * A query (instead of filter) is used to handle #1 because wildcard does work for filters
+   * Wildcard is used for #1
    * The paths use keyword instead of string because #2 wouldn't work otherwise
    *
    * @param body Body from the Bodybuilder package which will be mutated
    * @param searchString The string entered into the basic search bar by the user
    */
   private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
-    return body
-      .orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
-      .orQuery('match_phrase', 'tags.sourceFiles.content', searchString)
-      .orQuery('match_phrase', 'description', searchString)
-      .orQuery('match_phrase', 'labels', searchString)
-      .orQuery('match_phrase', 'author', searchString);
+    return body.filter('bool', (filter) =>
+      filter
+        .orFilter('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
+        .orFilter('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
+        .orFilter('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
+        .orFilter('match_phrase', 'tags.sourceFiles.content', searchString)
+        .orFilter('match_phrase', 'description', searchString)
+        .orFilter('match_phrase', 'labels', searchString)
+        .orFilter('match_phrase', 'author', searchString)
+    );
   }
 
   /**===============================================

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -211,11 +211,11 @@ export class QueryBuilderService {
     return body
       .orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
       .orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { 'workflowVersions.sourceFiles.content': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { 'tags.sourceFiles.content': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { description: { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { labels: { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { author: { value: '*' + searchString + '*', case_insensitive: true } });
+      .orQuery('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
+      .orQuery('match_phrase', 'tags.sourceFiles.content', searchString)
+      .orQuery('match_phrase', 'description', searchString)
+      .orQuery('match_phrase', 'labels', searchString)
+      .orQuery('match_phrase', 'author', searchString);
   }
 
   /**===============================================


### PR DESCRIPTION
Part 2 of 2 for dockstore/dockstore#3985

The code comment explains why this fix is needed and why it works. Seems the current implementation gave the illusion that search works because it's searching through a lot of other fields.  

New behaviour:
Matches when tool_path or full_workflow_path contains the search text even if the path has a prefix or suffix

Note: the results are still unordered. Sourcefile content matches have the same priority as full_workflow_path matches.


Reviewers should test it locally to be thorough.