### PR TITLE
Feature/4009/copy snackbar

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { ListContainersModule } from './shared/modules/list-containers.module';
 import { ListWorkflowsModule } from './shared/modules/list-workflows.module';
 import { CustomMaterialModule } from './shared/modules/material.module';
 import { OrderByModule } from './shared/modules/orderby.module';
+import { SnackbarModule } from './shared/modules/snackbar.module';
 import { ApiModule as ApiModule2 } from './shared/openapi/api.module';
 import { GA4GHV20Service } from './shared/openapi/api/gA4GHV20.service';
 import { PagenumberService } from './shared/pagenumber.service';
@@ -178,6 +179,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     RequestsModule,
     HomePageModule,
     HttpClientModule,
+    SnackbarModule,
   ],
   providers: [
     AccountsService,

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -290,6 +290,7 @@
                 type="button"
                 [cdkCopyToClipboard]="dockerPullCmd"
                 (cbOnSuccess)="toolCopyBtnClick('docker_pull_command')"
+                appSnackbar
               >
                 <mat-icon>file_copy</mat-icon>
               </button>

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -80,7 +80,7 @@
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>
-              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content">
+              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content" appSnackbar>
                 <mat-icon>file_copy</mat-icon>
               </button>
             </div>

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -51,7 +51,7 @@
               <a [href]="trsLinkCWL">
                 {{ tool?.tool_path }}
               </a>
-              <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID">
+              <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID" appSnackbar>
                 <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
               </button>
             </li>
@@ -60,7 +60,7 @@
               <a [href]="trsLinkWDL">
                 {{ tool?.tool_path }}
               </a>
-              <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID">
+              <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID" appSnackbar>
                 <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
               </button>
             </li>

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -82,7 +82,7 @@
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>
-              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content">
+              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content" appSnackbar>
                 <mat-icon>file_copy</mat-icon>
               </button>
             </div>

--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -393,7 +393,7 @@
                   disabled
                 />
                 <span class="input-group-btn" id="clipboard">
-                  <button class="btn btn-default btn-sm form-sm-button" type="button" [cdkCopyToClipboard]="inputTarget">
+                  <button class="btn btn-default btn-sm form-sm-button" type="button" [cdkCopyToClipboard]="inputTarget" appSnackbar>
                     <mat-icon id="file_copy">file_copy</mat-icon>
                   </button>
                 </span>

--- a/src/app/entry/entry-file-tab/entry-file-tab.component.html
+++ b/src/app/entry/entry-file-tab/entry-file-tab.component.html
@@ -48,7 +48,7 @@
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>
-              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="fileContents$ | async">
+              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="fileContents$ | async" appSnackbar>
                 <mat-icon>file_copy</mat-icon>
               </button>
             </span>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -96,7 +96,7 @@
               </a>
             </li>
             <li class="m-0">
-              <button mat-stroked-button [cdkCopyToClipboard]="content" (click)="openSnackBar()">
+              <button mat-stroked-button [cdkCopyToClipboard]="content" appSnackbar>
                 <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
                 <small>&nbsp;Copy Build Info</small>
               </button>

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -15,7 +15,6 @@
  */
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { takeUntil } from 'rxjs/operators';
 
 import { MetadataService } from '../metadata/metadata.service';
@@ -29,7 +28,7 @@ import { versions } from './versions';
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.css']
+  styleUrls: ['./footer.component.css'],
 })
 export class FooterComponent extends Base implements OnInit {
   version: string;
@@ -58,15 +57,8 @@ export class FooterComponent extends Base implements OnInit {
    */
   private readonly WEBSERVICE_DOWN_STATUS_CODES = [0, 404, 502, 504];
 
-  constructor(private metadataService: MetadataService, private footerService: FooterService, private matSnackBar: MatSnackBar) {
+  constructor(private metadataService: MetadataService, private footerService: FooterService) {
     super();
-  }
-
-  openSnackBar() {
-    this.matSnackBar.open('Copied!', '', {
-      duration: 500,
-      panelClass: 'custom_copy_snack_bar',
-    });
   }
 
   ngOnInit() {

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -38,6 +38,7 @@
           [cdkCopyToClipboard]="dockstoreToken"
           (cbOnSuccess)="isCopied1 = true"
           matTooltip="Copy Token"
+          appSnackbar
         >
           <mat-icon>file_copy</mat-icon>
         </button>
@@ -83,6 +84,7 @@
           color="secondary"
           [cdkCopyToClipboard]="row.source | getTokenContent: tokens"
           (cbOnSuccess)="isCopied1 = true"
+          appSnackbar
         >
           <mat-icon>file_copy</mat-icon>
         </button>

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.html
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.html
@@ -27,6 +27,7 @@ token: {{ dsToken }}&#13;&#10;server-url: {{ dsServerURI }}</textarea
       type="button"
       [cdkCopyToClipboard]="inputTarget"
       (cbOnSuccess)="isCopied2 = true"
+      appSnackbar
     >
       <mat-icon>file_copy</mat-icon>
     </button>

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -173,6 +173,7 @@
                   type="button"
                   [cdkCopyToClipboard]="shortUrl$ | async"
                   (cbOnSuccess)="isCopied = true"
+                  appSnackbar
                 >
                   <mat-icon>file_copy</mat-icon>
                 </button>

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -27,6 +27,7 @@ import { TagCloudModule } from 'angular-tag-cloud-module';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HeaderModule } from '../shared/modules/header.module';
 import { CustomMaterialModule } from '../shared/modules/material.module';
+import { SnackbarModule } from '../shared/modules/snackbar.module';
 import { PipeModule } from '../shared/pipe/pipe.module';
 import { PrivateIconModule } from '../shared/private-icon/private-icon.module';
 import { AdvancedSearchComponent } from './advancedsearch/advancedsearch.component';
@@ -65,6 +66,7 @@ import { SearchService } from './state/search.service';
     RefreshAlertModule,
     FlexLayoutModule,
     MdePopoverModule,
+    SnackbarModule,
   ],
   providers: [SearchService, QueryBuilderService],
   exports: [SearchComponent],

--- a/src/app/shared/code-editor-list/code-editor-list.component.html
+++ b/src/app/shared/code-editor-list/code-editor-list.component.html
@@ -67,6 +67,7 @@
                 class="mr-2"
                 matTooltip="Copy to clipboard"
                 [cdkCopyToClipboard]="sourcefile?.content"
+                appSnackbar
               >
                 <mat-icon>file_copy</mat-icon>
               </button>

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -31,6 +31,7 @@ import { CodeEditorComponent } from '../code-editor/code-editor.component';
 import { EntryActionsService } from '../entry-actions/entry-actions.service';
 import { PublicFileDownloadPipe } from '../entry/public-file-download.pipe';
 import { CustomMaterialModule } from '../modules/material.module';
+import { SnackbarModule } from '../modules/snackbar.module';
 import { CommitUrlPipe } from './commit-url.pipe';
 import { InfoTabCheckerWorkflowPathComponent } from './info-tab-checker-workflow-path/info-tab-checker-workflow-path.component';
 import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch-checker-workflow.component';
@@ -55,6 +56,7 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     RouterModule,
     ReactiveFormsModule,
     RefreshAlertModule,
+    SnackbarModule,
   ],
   declarations: [
     InfoTabCheckerWorkflowPathComponent,

--- a/src/app/shared/modules/container.module.ts
+++ b/src/app/shared/modules/container.module.ts
@@ -56,6 +56,7 @@ import { HeaderModule } from './header.module';
 import { ListContainersModule } from './list-containers.module';
 import { MarkdownWrapperModule } from './markdown-wrapper.module';
 import { SelectModule } from './select.module';
+import { SnackbarModule } from './snackbar.module';
 
 @NgModule({
   declarations: [
@@ -91,6 +92,7 @@ import { SelectModule } from './select.module';
     FlexLayoutModule,
     MarkdownModule,
     MarkdownWrapperModule,
+    SnackbarModule,
   ],
   providers: [
     EmailService,

--- a/src/app/shared/modules/snackbar.module.ts
+++ b/src/app/shared/modules/snackbar.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { SnackbarDirective } from '../snackbar.directive';
+
+@NgModule({
+  declarations: [SnackbarDirective],
+  exports: [SnackbarDirective],
+})
+export class SnackbarModule {}

--- a/src/app/shared/modules/workflow.module.ts
+++ b/src/app/shared/modules/workflow.module.ts
@@ -58,6 +58,7 @@ import { EntryModule } from './../entry/entry.module';
 import { CustomMaterialModule } from './../modules/material.module';
 import { RefreshService } from './../refresh.service';
 import { MarkdownWrapperModule } from './markdown-wrapper.module';
+import { SnackbarModule } from './snackbar.module';
 
 @NgModule({
   declarations: [
@@ -97,6 +98,7 @@ import { MarkdownWrapperModule } from './markdown-wrapper.module';
     MarkdownModule,
     RefreshAlertModule,
     MarkdownWrapperModule,
+    SnackbarModule,
   ],
   providers: [
     DateService,

--- a/src/app/shared/snackbar.directive.ts
+++ b/src/app/shared/snackbar.directive.ts
@@ -13,6 +13,5 @@ export class SnackbarDirective {
       duration: 1000,
       panelClass: 'custom_copy_snack_bar',
     });
-    console.log('hi');
   }
 }

--- a/src/app/shared/snackbar.directive.ts
+++ b/src/app/shared/snackbar.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, HostListener } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Directive({
+  selector: '[appSnackbar]',
+})
+export class SnackbarDirective {
+  constructor(private matSnackBar: MatSnackBar) {}
+
+  @HostListener('click')
+  onClick() {
+    this.matSnackBar.open('Copied!', '', {
+      duration: 1000,
+      panelClass: 'custom_copy_snack_bar',
+    });
+    console.log('hi');
+  }
+}

--- a/src/app/workflow/descriptors/descriptors.component.html
+++ b/src/app/workflow/descriptors/descriptors.component.html
@@ -56,7 +56,7 @@
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>
-              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content">
+              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content" appSnackbar>
                 <mat-icon>file_copy</mat-icon>
               </button>
             </div>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -54,7 +54,7 @@
         <li *ngIf="isPublic && isValidVersion">
           <strong matTooltip="TRS link to the main descriptor for the selected workflow version">TRS</strong>:
           <a [href]="trsLink"> #{{ entryType$ | async }}/{{ workflow?.full_workflow_path }} </a>
-          <button mat-icon-button color="secondary" matTooltip="Copy TRS ID" [cdkCopyToClipboard]="displayTextForButton">
+          <button mat-icon-button color="secondary" matTooltip="Copy TRS ID" [cdkCopyToClipboard]="displayTextForButton" appSnackbar>
             <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
           </button>
         </li>

--- a/src/app/workflow/paramfiles/paramfiles.component.html
+++ b/src/app/workflow/paramfiles/paramfiles.component.html
@@ -64,7 +64,7 @@
                   <mat-icon>save_alt</mat-icon>
                 </a>
               </ng-template>
-              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content">
+              <button mat-icon-button color="secondary" type="button" [cdkCopyToClipboard]="content" appSnackbar>
                 <mat-icon>file_copy</mat-icon>
               </button>
             </div>


### PR DESCRIPTION
[DOCK-1692 dockstore#4009](https://github.com/dockstore/dockstore/issues/4009)
![image](https://user-images.githubusercontent.com/57231021/108372467-db36c980-71cc-11eb-82c9-e0e1cbb9f3e5.png)
Created a directive and a module for this custom snackbar.
The reason for the presence of the new module is due to the fact that snackbar directive is needed to be included in the declarations of multiple modules, but we are unable to directly do so with the directive. The way to go about it is to create a module dedicated for snackbar. (Although it seems redundant)
Both of them are in the shared folder.

I believe the duplicate lines were there before, not sure if I could do anything about it?