### PR TITLE
Search a worse string in test

### DIFF
--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -19,8 +19,8 @@ describe('Admin UI', () => {
       cy.contains('the Entry Type is workflow').should('not.exist');
     });
     it('should be able to use basic search box and have suggestions', () => {
-      cy.get('[data-cy=basic-search]').type('dockstore_');
-      cy.contains(' Sorry, no matches found for dockstore');
+      cy.get('[data-cy=basic-search]').type('dockstore_d');
+      cy.contains(' Sorry, no matches found for dockstore_d');
       cy.contains('Do you mean: dockstore?');
       cy.url().should('include', '/search?search=dockstore_');
     });


### PR DESCRIPTION
Fix for a test due to dockstore/dockstore#3985

Whereas before, searching "dockstore_" yielded no results, the fix for dockstore/dockstore#3985, does yield results such as:

"BD2KGenomics/dockstore_workflow_cnv"

This is because path matching actually works now. You can try this on dev vs prod