### PR TITLE
styling bugs

### DIFF
--- a/src/app/organizations/collection/collection.component.scss
+++ b/src/app/organizations/collection/collection.component.scss
@@ -25,5 +25,6 @@
 
 h5 {
   word-break: break-word;
-  display: ruby;
+  display: table;
+  width: 100%;
 }

--- a/src/app/organizations/collection/collection.component.scss
+++ b/src/app/organizations/collection/collection.component.scss
@@ -22,3 +22,8 @@
 .org-name {
   color: #151c3d;
 }
+
+h5 {
+  word-break: break-word;
+  display: ruby;
+}

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -61,7 +61,8 @@
           <div class="h-100" fxLayout="column" fxLayoutAlign="space-between stretch">
             <div fxLayout="column" fxLayoutAlign="space-around">
               <div fxLayout="row wrap" fxLayoutAlign="space-between start">
-                <img class="orgLogo" [src]="org.avatarUrl" alt="org logo" />
+                <img *ngIf="org.avatarUrl; else placeholder" class="orgLogo" [src]="org.avatarUrl" alt="org logo" />
+                <ng-template #placeholder><span style="height: 50px"></span></ng-template>
                 <div *ngIf="org?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center">
                   <mat-icon class="orgStar">star</mat-icon>
                   <span>{{ org.starredUsers.length }}</span>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -39,7 +39,7 @@
       <mat-cell fxShow fxHide.lt-sm data-cy="descriptorType" *matCellDef="let workflow" fxFlex="20%">
         <div>
           <span class="nonclick-badge">{{
-            workflow?.descriptorType === 'gxformat2' ? 'Galaxy' : (workflow?.descriptorType | uppercase)
+            workflow?.descriptorType === 'gxformat2' ? galaxyShortfriendlyName : (workflow?.descriptorType | uppercase)
           }}</span>
         </div>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -38,7 +38,9 @@
       >
       <mat-cell fxShow fxHide.lt-sm data-cy="descriptorType" *matCellDef="let workflow" fxFlex="20%">
         <div>
-          <span class="nonclick-badge">{{ workflow?.descriptorType | uppercase }}</span>
+          <span class="nonclick-badge">{{
+            workflow?.descriptorType === 'gxformat2' ? 'Galaxy' : (workflow?.descriptorType | uppercase)
+          }}</span>
         </div>
       </mat-cell>
     </ng-container>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.ts
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.ts
@@ -15,6 +15,7 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
+import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { Observable } from 'rxjs';
 import { DateService } from '../../shared/date.service';
 import { Workflow } from '../../shared/swagger';
@@ -34,6 +35,9 @@ import { SearchService } from '../state/search.service';
 export class SearchWorkflowTableComponent extends SearchEntryTable implements OnInit {
   readonly entryType = 'workflow';
   public dataSource: MatTableDataSource<Workflow>;
+  public galaxyShortfriendlyName = DescriptorLanguageService.workflowDescriptorTypeEnumToShortFriendlyName(
+    Workflow.DescriptorTypeEnum.Gxformat2
+  ).split(' ')[0];
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {
     super(dateService, searchQuery, searchService);
   }


### PR DESCRIPTION
1. [dockstore/issues/4106](https://github.com/dockstore/dockstore/issues/4106)
![image](https://user-images.githubusercontent.com/57231021/111362758-92582080-8665-11eb-8d12-f87010909695.png)

2. [SEAB-2283 comment about card titles](https://ucsc-cgl.atlassian.net/browse/SEAB-2283)
The screenshot of the messed up tools and workflows line height is fixed, it seems like that only happened on Firefox. At the same time I realized on Chrome the line does not break when screen size is small. They are all fixed now.

3. [SEAB-2283 comment about organization img](https://ucsc-cgl.atlassian.net/browse/SEAB-2283)
Gave it an empty `div` when `src` is unknown, so the problem is right now some `src` are there but they are no longer valid. Wondering if anyone could give me some input on this
![image](https://user-images.githubusercontent.com/57231021/111364614-d77d5200-8667-11eb-8c07-85202317088f.png)
