### PR TITLE
Remove ES 7.10 feature

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -214,8 +214,8 @@ export class QueryBuilderService {
   private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
     return body.filter('bool', (filter) =>
       filter
-        .orFilter('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-        .orFilter('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
+        .orFilter('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*' } })
+        .orFilter('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*' } })
         .orFilter('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
         .orFilter('match_phrase', 'tags.sourceFiles.content', searchString)
         .orFilter('match_phrase', 'description', searchString)


### PR DESCRIPTION
In migrating to AWS elasticsearch, we had to go drop back to ES 7.9,
which does not support `case_insensitive`.