### PR TITLE
Change links to https when there are no other side effects

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -300,7 +300,7 @@
                 >Dockstore's Getting Started With CWL</a
               >
               and
-              <a href="http://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineTool" target="_blank" rel="noopener noreferrer"
+              <a href="https://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineTool" target="_blank" rel="noopener noreferrer"
                 >commonwl.org</a
               >
               for how to define a description for this tool.

--- a/src/app/docs/docs.component.ts
+++ b/src/app/docs/docs.component.ts
@@ -58,7 +58,7 @@ export class DocsComponent implements OnInit {
   // Generate redirect link based on path
   getLink() {
     const currentPath = window.location.pathname;
-    const redirectBase = 'http://docs.dockstore.org';
+    const redirectBase = 'https://docs.dockstore.org';
 
     // Fallback path for docs that don't match existing paths
     let redirectPath = '/docs';

--- a/src/app/funding/funding.component.ts
+++ b/src/app/funding/funding.component.ts
@@ -50,7 +50,7 @@ export class FundingComponent {
   // Due to not having permission to use BD Catalyst's logo, the source here is a text generated placeholder
   BioDataCatalyst: Funder = {
     title: 'BioData Catalyst',
-    website: 'http://biodatacatalyst.nhlbi.nih.gov/',
+    website: 'https://biodatacatalyst.nhlbi.nih.gov/',
     // imageSource: '../assets/images/sponsors/bioDataCatalyst.svg',
     imageSource: '../assets/images/sponsors/BDCatalyst-text-generated.png',
     altImageText: 'BioData Catalyst Logo',

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -184,7 +184,7 @@
             <li>
               To minimizes redundancy and error prone installation, workflows and tools are described with common languages such as
               <a target="_blank" rel="noopener noreferrer" href="https://www.commonwl.org">CWL</a>,
-              <a target="_blank" rel="noopener noreferrer" href="http://openwdl.org">WDL</a>, or
+              <a target="_blank" rel="noopener noreferrer" href="https://openwdl.org">WDL</a>, or
               <a target="_blank" rel="noopener noreferrer" href="https://www.nextflow.io">Nextflow</a> and stored on
               <a target="_blank" rel="noopener noreferrer" href="https://github.com/">GitHub</a>,
               <a target="_blank" rel="noopener noreferrer" href="https://bitbucket.org/">Bitbucket</a>,

--- a/src/app/shared/user/user.service.ts
+++ b/src/app/shared/user/user.service.ts
@@ -111,7 +111,7 @@ export class UserService {
       if (defaultImg) {
         return defaultImg;
       } else {
-        return 'http://www.gravatar.com/avatar/?d=mm&s=500';
+        return 'https://www.gravatar.com/avatar/?d=mm&s=500';
       }
     }
   }

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -303,7 +303,7 @@
                     rel="noopener noreferrer"
                     >CWL Best Practices</a
                   >
-                  and <a href="http://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineTool">commonwl.org</a> for how to define a
+                  and <a href="https://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineTool">commonwl.org</a> for how to define a
                   description for this tool.
                 </span>
                 <span *ngSwitchCase="ToolDescriptor.TypeEnum.WDL">


### PR DESCRIPTION
Fixing an easy sonarcloud security hotspot. https://sonarcloud.io/project/security_hotspots?id=dockstore_dockstore-ui2&hotspots=AXbOBYtivLLK457gggR_

There are a few other places that we may be able to switch to https 