### PR TITLE
search.ts reset filters

### DIFF
--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -28,7 +28,7 @@ describe('Admin UI', () => {
     it('should reset filters', () => {
       cy.contains('Reset Filters').click();
       cy.wait(1000);
-      cy.url().should('include', '/search');
+      cy.url().should('not.include', 'search=dockstore_i');
     });
 
     it('should remember paginator setting', () => {

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -19,14 +19,15 @@ describe('Admin UI', () => {
       cy.contains('the Language is WDL').should('not.exist');
     });
     it('should be able to use basic search box and have suggestions', () => {
-      cy.get('[data-cy=basic-search]').type('dockstore_d');
-      cy.contains(' Sorry, no matches found for dockstore_d');
+      cy.get('[data-cy=basic-search]').type('dockstore_i');
+      cy.contains(' Sorry, no matches found for dockstore_i');
       cy.contains('Do you mean: dockstore?');
-      cy.url().should('include', 'search=dockstore_');
+      cy.url().should('include', 'search=dockstore_i');
     });
 
     it('should reset filters', () => {
       cy.contains('Reset Filters').click();
+      cy.wait(1000);
       cy.url().should('include', '/search');
     });
 

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -27,7 +27,6 @@ describe('Admin UI', () => {
 
     it('should reset filters', () => {
       cy.contains('Reset Filters').click();
-      cy.wait(1000);
       cy.url().should('not.include', 'search=dockstore_i');
     });
 


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/4008

Seems like I'm unable to reproduce this problem, added wait(1000) and modified assertion.
Note, right now there's a `michaelgatzen/dockstore_demo/HelloWorldWorkflow` when searching for `dockstore_d`, so I changed that to `dockstore_i`