### PR TITLE
passing in the correct parameter value of descriptor type before displaying code block

### DIFF
--- a/src/app/container/launch/launch.component.html
+++ b/src/app/container/launch/launch.component.html
@@ -30,7 +30,7 @@
       <div class="row">
         <div class="col-sm-4">
           <mat-form-field class="m-2">
-            <mat-select name="toolVersions" [(value)]="currentDescriptor" (selectionChange)="reactToDescriptor($event)">
+            <mat-select name="toolVersions" [(value)]="currentDescriptor" (selectionChange)="changeDescriptor($event)">
               <mat-option *ngFor="let descriptor of filteredDescriptors" [value]="descriptor">{{ descriptor }}</mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -72,7 +72,6 @@ export class LaunchComponent extends Base implements OnInit, OnChanges {
       .subscribe((descriptors: Array<Workflow.DescriptorTypeEnum>) => {
         this.descriptors = descriptors;
         this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
-        this.reactToDescriptor();
       });
     this.published$ = this.toolQuery.toolIsPublished$;
   }
@@ -81,6 +80,7 @@ export class LaunchComponent extends Base implements OnInit, OnChanges {
     this._selectedVersion = this.selectedVersion;
     this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
     this.reactToDescriptor();
+    this.changeDescriptor();
   }
 
   // Returns an array of descriptors that are valid for the given tool version
@@ -122,12 +122,17 @@ export class LaunchComponent extends Base implements OnInit, OnChanges {
   reactToDescriptor(): void {
     const toolPath = this.path;
     const versionName = this._selectedVersion.name;
-    this.params = this.launchService.getParamsString(toolPath, versionName, this.currentDescriptor);
-    this.cli = this.launchService.getCliString(toolPath, versionName, this.currentDescriptor);
     this.cwl = this.launchService.getCwlString(toolPath, versionName, encodeURIComponent(this._selectedVersion.cwl_path));
     this.dockstoreSupportedCwlLaunch = this.launchService.getDockstoreSupportedCwlLaunchString(toolPath, versionName);
     this.dockstoreSupportedCwlMakeTemplate = this.launchService.getDockstoreSupportedCwlMakeTemplateString(toolPath, versionName);
     this.checkEntryCommand = this.launchService.getCheckToolString(toolPath, versionName);
     this.consonance = this.launchService.getConsonanceString(toolPath, versionName);
+  }
+
+  changeDescriptor() {
+    const toolPath = this.path;
+    const versionName = this._selectedVersion.name;
+    this.params = this.launchService.getParamsString(toolPath, versionName, this.currentDescriptor);
+    this.cli = this.launchService.getCliString(toolPath, versionName, this.currentDescriptor);
   }
 }

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -72,6 +72,7 @@ export class LaunchComponent extends Base implements OnInit, OnChanges {
       .subscribe((descriptors: Array<Workflow.DescriptorTypeEnum>) => {
         this.descriptors = descriptors;
         this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
+        this.changeDescriptor();
       });
     this.published$ = this.toolQuery.toolIsPublished$;
   }

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -72,14 +72,15 @@ export class LaunchComponent extends Base implements OnInit, OnChanges {
       .subscribe((descriptors: Array<Workflow.DescriptorTypeEnum>) => {
         this.descriptors = descriptors;
         this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
+        this.reactToDescriptor();
       });
     this.published$ = this.toolQuery.toolIsPublished$;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     this._selectedVersion = this.selectedVersion;
-    this.reactToDescriptor();
     this.filteredDescriptors = this.filterDescriptors(this.descriptors, this._selectedVersion, this.versionsFileTypes);
+    this.reactToDescriptor();
   }
 
   // Returns an array of descriptors that are valid for the given tool version


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3676
The problem before was when displaying the code block inside a container, _sometimes_ the correct descriptor type(for exmaple WDL) was not passed into some `launchService` functions. Thus this resulted in a missing `--descriptor wdl`

Here is after the fix:
![image](https://user-images.githubusercontent.com/57231021/114748100-925c4680-9d1f-11eb-9586-3963f6164ad6.png)

Optimization ticket: https://github.com/dockstore/dockstore/issues/4194