### PR TITLE
Update cytoscape and use Stylesheet type

### DIFF
--- a/THIRD-PARTY-LICENSES.csv
+++ b/THIRD-PARTY-LICENSES.csv
@@ -525,7 +525,7 @@
 "cypress@5.0.0","MIT","https://github.com/cypress-io/cypress"
 "cytoscape-dagre@2.3.2","MIT","https://github.com/cytoscape/cytoscape.js-dagre"
 "cytoscape-popper@1.0.4","MIT","https://github.com/cytoscape/cytoscape.js-popper"
-"cytoscape@3.10.1","MIT","https://github.com/cytoscape/cytoscape.js"
+"cytoscape@3.18.2","MIT","https://github.com/cytoscape/cytoscape.js"
 "d@1.0.1","ISC","https://github.com/medikoo/d"
 "dagre@0.8.5","MIT","https://github.com/dagrejs/dagre"
 "damerau-levenshtein@1.0.6","BSD-2-Clause","https://github.com/tad-lispy/node-damerau-levenshtein"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8200,9 +8200,9 @@
       }
     },
     "cytoscape": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.10.1.tgz",
-      "integrity": "sha512-uNId+LR2YlqrM6BuNMI44gA1iGg6NHGoSzYufIN5XkaeJCVNB5iDodYcqguDsTrEW30ckuchZl1axoUbrUfGTg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.18.2.tgz",
+      "integrity": "sha512-NRY3JTrUzx0fSn44LyMlPqC8/zuuOo8kbr2hFlfjiObRmtir+lnxVg08f8wUA4X/P80df9vSThKDASl39yH+Iw==",
       "requires": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"
@@ -20029,7 +20029,8 @@
     "y18n": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "bootstrap": "^3.4.1",
     "bootstrap-social": "^5.1.1",
     "core-js": "^3.2.1",
-    "cytoscape": "^3.10.1",
+    "cytoscape": "^3.18.2",
     "cytoscape-dagre": "^2.3.2",
     "cytoscape-popper": "^1.0.4",
     "dompurify": "^2.2.7",

--- a/src/app/workflow/dag/state/dag.service.ts
+++ b/src/app/workflow/dag/state/dag.service.ts
@@ -29,12 +29,12 @@ import { DagStore } from './dag.store';
 
 @Injectable()
 export class DagService {
-  readonly style = [
+  readonly style: cytoscape.Stylesheet[] = [
     {
       selector: 'node',
       style: {
         content: 'data(name)',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#7a88a9',
@@ -56,7 +56,7 @@ export class DagService {
       selector: 'node[id = "UniqueBeginKey"]',
       style: {
         content: 'Start',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#4caf50',
@@ -67,7 +67,7 @@ export class DagService {
       selector: 'node[id = "UniqueEndKey"]',
       style: {
         content: 'End',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#f44336',
@@ -78,7 +78,7 @@ export class DagService {
       selector: 'node[type = "workflow"]',
       style: {
         content: 'data(name)',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#4ab4a9',
@@ -89,7 +89,7 @@ export class DagService {
       selector: 'node[type = "tool"]',
       style: {
         content: 'data(name)',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#51aad8',
@@ -100,7 +100,7 @@ export class DagService {
       selector: 'node[type = "expressionTool"]',
       style: {
         content: 'data(name)',
-        'font-size': '16px',
+        'font-size': 16,
         'text-valign': 'center',
         'text-halign': 'center',
         'background-color': '#9966FF',
@@ -110,7 +110,7 @@ export class DagService {
     {
       selector: 'edge.notselected',
       style: {
-        opacity: '0.4',
+        opacity: 0.4,
       },
     },
   ];


### PR DESCRIPTION
* update cytoscape version
* Use @types/cytoscape for stylesheet section
* Change font-size and opacity definitions

I was a bit confused the string representation of the font-size `16px` wouldn't build so I removed the `px` and quotes and it builds as expected.

![image](https://user-images.githubusercontent.com/3795586/114911027-72865a80-9dd3-11eb-947f-6f2b231a8fe5.png)

https://github.com/dockstore/dockstore/issues/4005