### PR TITLE
Feature/3704/remove restub button in checker workflow

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 
-<div fxLayout="column" fxLayoutGap="4rem">
+<div fxLayout="column" fxLayoutGap="4rem" class="mb-5">
   <div fxLayout="column" class="title">
     <div
       class="container"

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -11,6 +11,7 @@
         *ngIf="(checkerWorkflowURL$ | async) && !(isRefreshing$ | async)"
         type="button"
         class="btn btn-link"
+        (click)="goToChecker()"
       >
         <mat-icon>visibility</mat-icon> View
       </a>
@@ -34,7 +35,7 @@
 </li>
 <li *ngIf="parentId$ | async">
   <form class="form-inline">
-    <div>
+    <div id="parent-exists">
       <div class="form-group"><strong matTooltip="The parent entry of this checker workflow">Parent Entry</strong>:</div>
       <span>
         <div class="btn-group" role="group">

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -11,7 +11,6 @@
         *ngIf="(checkerWorkflowURL$ | async) && !(isRefreshing$ | async)"
         type="button"
         class="btn btn-link"
-        (click)="goToChecker()"
       >
         <mat-icon>visibility</mat-icon> View
       </a>
@@ -32,10 +31,22 @@
       </span>
     </div>
   </form>
+  <div *ngIf="!(isPublic$ | async)">
+    <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ workflowMode }}
+    <button
+      class="btn btn-link push-right"
+      type="button"
+      *ngIf="workflowMode === WorkflowType.ModeEnum.FULL && !isPublished"
+      (click)="restubWorkflow()"
+      [disabled]="isRefreshing$ | async"
+    >
+      <mat-icon>clear</mat-icon> Restub
+    </button>
+  </div>
 </li>
 <li *ngIf="parentId$ | async">
   <form class="form-inline">
-    <div id="parent-exists">
+    <div>
       <div class="form-group"><strong matTooltip="The parent entry of this checker workflow">Parent Entry</strong>:</div>
       <span>
         <div class="btn-group" role="group">
@@ -45,5 +56,6 @@
         </div>
       </span>
     </div>
+    <div *ngIf="!(isPublic$ | async)"><strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ workflowMode }}</div>
   </form>
 </li>

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.spec.ts
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.spec.ts
@@ -13,11 +13,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { HttpClient, HttpHandler } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { RouterTestingModule } from '@angular/router/testing';
+import { DateService } from 'app/shared/date.service';
+import { ExtendedWorkflowsService } from 'app/shared/extended-workflows.service';
+import { ProviderService } from 'app/shared/provider.service';
 import { CheckerWorkflowStubService, RegisterCheckerWorkflowStubService } from '../../../test/service-stubs';
 import { CustomMaterialModule } from '../../modules/material.module';
 import { CheckerWorkflowService } from '../../state/checker-workflow.service';
@@ -35,6 +39,11 @@ describe('InfoTabCheckerWorkflowPathComponent', () => {
         providers: [
           { provide: CheckerWorkflowService, useClass: CheckerWorkflowStubService },
           { provide: RegisterCheckerWorkflowService, useClass: RegisterCheckerWorkflowStubService },
+          ExtendedWorkflowsService,
+          DateService,
+          ProviderService,
+          HttpClient,
+          HttpHandler,
         ],
         declarations: [InfoTabCheckerWorkflowPathComponent],
         schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.ts
@@ -13,10 +13,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Workflow } from 'app/shared/swagger';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { AlertQuery } from '../../alert/state/alert.query';
 import { Base } from '../../base';
 import { SessionQuery } from '../../session/session.query';
@@ -30,7 +31,7 @@ import { RegisterCheckerWorkflowService } from '../register-checker-workflow/reg
   templateUrl: './info-tab-checker-workflow-path.component.html',
   styleUrls: ['./info-tab-checker-workflow-path.component.scss'],
 })
-export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit, OnDestroy {
+export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit, OnDestroy, AfterViewInit {
   isPublic$: Observable<boolean>;
   isStub$: Observable<boolean>;
   parentId$: Observable<number>;
@@ -43,6 +44,8 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
   @Input() canRead: boolean;
   @Input() canWrite: boolean;
   @Input() isOwner: boolean;
+  isChecker: boolean;
+  @Output() changeType: EventEmitter<boolean> = new EventEmitter<boolean>();
   constructor(
     private checkerWorkflowService: CheckerWorkflowService,
     private checkerWorkflowQuery: CheckerWorkflowQuery,
@@ -68,6 +71,11 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
     this.canAdd$ = this.checkerWorkflowService.canAdd(this.checkerId$, this.parentId$, this.isStub$);
   }
 
+  ngAfterViewInit() {
+    this.isChecker = document.getElementById('parent-exists') == null ? false : true;
+    this.changeChecker();
+  }
+
   add(): void {
     this.registerCheckerWorkflowService.add();
     this.matDialog.open(RegisterCheckerWorkflowComponent, { width: '600px' });
@@ -84,5 +92,16 @@ export class InfoTabCheckerWorkflowPathComponent extends Base implements OnInit,
    */
   viewParentEntry(): void {
     this.checkerWorkflowService.goToParentEntry();
+    this.isChecker = false;
+    this.changeChecker();
+  }
+
+  goToChecker(): void {
+    this.isChecker = true;
+    this.changeChecker();
+  }
+
+  changeChecker(): void {
+    this.changeType.emit(this.isChecker);
   }
 }

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -17,7 +17,7 @@
   <mat-card
     class="alert alert-info"
     *ngIf="
-      !isPublic &&
+      !(isPublic$ | async) &&
       workflow?.source_control_provider === 'GITHUB' &&
       (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB) &&
       this.recommendGitHubApps
@@ -42,8 +42,11 @@
         <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
             <strong matTooltip="Git repository for the associated descriptors">Source Code</strong>:
-            <a id="sourceRepository" [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')">
-              {{ workflow?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.name : '') }}
+            <a
+              id="sourceRepository"
+              [href]="workflow?.providerUrl | versionProviderUrl: ((isPublic$ | async) ? selectedVersion?.name : '')"
+            >
+              {{ workflow?.providerUrl | urlDeconstruct: ((isPublic$ | async) ? selectedVersion?.name : '') }}
             </a>
           </li>
         </span>
@@ -51,7 +54,7 @@
           <strong matTooltip="The source code for this workflow is stored on Dockstore.org">Source Code</strong>:
           <i>The source code for this workflow is stored on Dockstore.org</i>
         </li>
-        <li *ngIf="isPublic && isValidVersion">
+        <li *ngIf="(isPublic$ | async) && isValidVersion">
           <strong matTooltip="TRS link to the main descriptor for the selected workflow version">TRS</strong>:
           <a [href]="trsLink"> #{{ entryType$ | async }}/{{ workflow?.full_workflow_path }} </a>
           <button mat-icon-button color="secondary" matTooltip="Copy TRS ID" [cdkCopyToClipboard]="displayTextForButton" appSnackbar>
@@ -60,7 +63,7 @@
         </li>
         <div *ngIf="(entryType$ | async) === EntryType.BioWorkflow">
           <span>
-            <li *ngIf="workflow?.workflow_path || !isPublic">
+            <li *ngIf="workflow?.workflow_path || !(isPublic$ | async)">
               <form
                 #editWorkflowPathForm="ngForm"
                 class="form-inline"
@@ -85,11 +88,11 @@
                   />
                 </div>
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
-                  <button *ngIf="!isPublic && workflowPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                  <button *ngIf="!(isPublic$ | async) && workflowPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
-                    *ngIf="!isPublic"
+                    *ngIf="!(isPublic$ | async)"
                     type="button"
                     [disabled]="
                       defaultTestFilePathEditing ||
@@ -130,11 +133,16 @@
                   />
                 </div>
                 <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
-                  <button *ngIf="!isPublic && defaultTestFilePathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                  <button
+                    *ngIf="!(isPublic$ | async) && defaultTestFilePathEditing"
+                    type="button"
+                    class="btn btn-link"
+                    (click)="cancelEditing()"
+                  >
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
-                    *ngIf="!isPublic"
+                    *ngIf="!(isPublic$ | async)"
                     type="button"
                     [disabled]="
                       workflowPathEditing ||
@@ -173,11 +181,11 @@
                   />
                 </div>
                 <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
-                  <button *ngIf="!isPublic && forumUrlEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                  <button *ngIf="!(isPublic$ | async) && forumUrlEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
-                    *ngIf="!isPublic && !workflow?.forumUrl && !forumUrlEditing"
+                    *ngIf="!(isPublic$ | async) && !workflow?.forumUrl && !forumUrlEditing"
                     [disabled]="workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async)"
                     type="button"
                     class="btn btn-link"
@@ -186,7 +194,7 @@
                     <mat-icon>add</mat-icon> Add
                   </button>
                   <button
-                    *ngIf="!isPublic && (workflow?.forumUrl || forumUrlEditing)"
+                    *ngIf="!(isPublic$ | async) && (workflow?.forumUrl || forumUrlEditing)"
                     type="button"
                     class="btn btn-link"
                     (click)="toggleEditForumUrl()"
@@ -276,12 +284,12 @@
         <a [href]="downloadZipLink" *ngIf="workflow?.is_published" mat-raised-button>Export as ZIP</a>
       </span>
       <div>
-        <div *ngIf="selectedVersion?.description || !isPublic">
+        <div *ngIf="selectedVersion?.description || !(isPublic$ | async)">
           <label matTooltip="Description of workflow obtained from workflow descriptor"> Description </label>:
           <div *ngIf="selectedVersion?.description" class="well well-sm">
             <markdown-wrapper [data]="selectedVersion?.description"></markdown-wrapper>
           </div>
-          <div *ngIf="!selectedVersion?.description && !isPublic" class="well well-sm">
+          <div *ngIf="!selectedVersion?.description && !(isPublic$ | async)" class="well well-sm">
             <mat-icon>warning</mat-icon>
             <span ng-show="!containerObj.description">
               No description associated with this {{ entryType$ | async }}.

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -204,24 +204,14 @@
             [canRead]="canRead"
             [canWrite]="canWrite"
             [isOwner]="isOwner"
-            (changeType)="checkworkflowPathHandler($event)"
+            [isPublished]="workflow?.is_published"
+            [workflowMode]="workflow?.mode"
+            [workflowId]="workflow.id"
           ></app-info-tab-checker-workflow-path>
           <!-- TODO: Remove once hosted workflows and Nextflow support checker workflows -->
           <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED || (isNFL$ | async)">
             <strong matTooltip="Currently disabled for Hosted Workflows and Nextflow Workflows">Checker Workflow</strong>: n/a
           </div>
-          <li *ngIf="!isPublic">
-            <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ workflow?.mode }}
-            <button
-              class="btn btn-link push-right"
-              type="button"
-              *ngIf="workflow?.mode === WorkflowType.ModeEnum.FULL && !workflow?.is_published && !currentlyIsChecker"
-              (click)="restubWorkflow()"
-              [disabled]="isRefreshing$ | async"
-            >
-              <mat-icon>clear</mat-icon> Restub
-            </button>
-          </li>
           <li>
             <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.STUB" class="form-inline">
               <Strong matTooltip="Type of descriptor language used">Descriptor Type</Strong>:

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -220,6 +220,9 @@
           <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED || (isNFL$ | async)">
             <strong matTooltip="Currently disabled for Hosted Workflows and Nextflow Workflows">Checker Workflow</strong>: n/a
           </div>
+          <li *ngIf="!(isPublic$ | async) && (workflow?.mode === WorkflowType.ModeEnum.HOSTED || (isNFL$ | async))">
+            <strong>Mode</strong>: {{ workflow?.mode }}
+          </li>
           <li>
             <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.STUB" class="form-inline">
               <Strong matTooltip="Type of descriptor language used">Descriptor Type</Strong>:

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -204,6 +204,7 @@
             [canRead]="canRead"
             [canWrite]="canWrite"
             [isOwner]="isOwner"
+            (changeType)="checkworkflowPathHandler($event)"
           ></app-info-tab-checker-workflow-path>
           <!-- TODO: Remove once hosted workflows and Nextflow support checker workflows -->
           <div *ngIf="workflow?.mode === WorkflowType.ModeEnum.HOSTED || (isNFL$ | async)">
@@ -214,7 +215,7 @@
             <button
               class="btn btn-link push-right"
               type="button"
-              *ngIf="workflow?.mode === WorkflowType.ModeEnum.FULL && !workflow?.is_published"
+              *ngIf="workflow?.mode === WorkflowType.ModeEnum.FULL && !workflow?.is_published && !currentlyIsChecker"
               (click)="restubWorkflow()"
               [disabled]="isRefreshing$ | async"
             >

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -58,7 +58,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   descriptorLanguages$: Observable<Array<Workflow.DescriptorTypeEnum>>;
   defaultTestFilePathEditing: boolean;
   forumUrlEditing: boolean;
-  isPublic: boolean;
+  isPublic$: Observable<boolean>;
   trsLink: string;
   displayTextForButton: string;
   EntryType = EntryType;
@@ -108,7 +108,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
     this.descriptorType$ = this.workflowQuery.descriptorType$;
     this.isNFL$ = this.workflowQuery.isNFL$;
     this.isRefreshing$ = this.alertQuery.showInfo$;
-    this.sessionQuery.isPublic$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isPublic) => (this.isPublic = isPublic));
+    this.isPublic$ = this.sessionQuery.isPublic$;
     this.infoTabService.workflowPathEditing$
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((editing) => (this.workflowPathEditing = editing));

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -27,7 +27,6 @@ import { ExtendedWorkflowsService } from '../../shared/extended-workflows.servic
 import { ExtendedWorkflow } from '../../shared/models/ExtendedWorkflow';
 import { SessionQuery } from '../../shared/session/session.query';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { WorkflowService } from '../../shared/state/workflow.service';
 import { ToolDescriptor } from '../../shared/swagger';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
@@ -44,7 +43,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   @Input() validVersions;
   @Input() defaultVersion;
   @Input() extendedWorkflow: ExtendedWorkflow;
-  currentlyIsChecker: boolean;
   public workflow: Workflow;
   currentVersion: WorkflowVersion;
   downloadZipLink: string;
@@ -70,12 +68,8 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   public entryType$: Observable<EntryType>;
   public isRefreshing$: Observable<boolean>;
   public recommendGitHubApps = recommendGitHubApps;
-  modeTooltipContent = `STUB: Basic metadata pulled from source control.
-  FULL: Full content synced from source control.
-  HOSTED: Workflow metadata and files hosted on Dockstore.`;
   Dockstore = Dockstore;
   constructor(
-    private workflowService: WorkflowService,
     private workflowsService: ExtendedWorkflowsService,
     private sessionQuery: SessionQuery,
     private infoTabService: InfoTabService,
@@ -126,18 +120,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .subscribe((entryType) => (this.displayTextForButton = '#' + entryType + '/' + this.workflow?.full_workflow_path));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
   }
-  /**
-   * Handle restubbing a workflow
-   * TODO: Handle restub error
-   *
-   * @memberof InfoTabComponent
-   */
-  restubWorkflow() {
-    this.workflowsService.restub(this.workflow.id).subscribe((restubbedWorkflow: Workflow) => {
-      this.workflowService.setWorkflow(restubbedWorkflow);
-      this.workflowService.upsertWorkflowToWorkflow(restubbedWorkflow);
-    });
-  }
 
   downloadZip() {
     this.workflowsService.getWorkflowZip(this.workflow.id, this.currentVersion.id, 'response').subscribe((data: HttpResponse<any>) => {
@@ -187,9 +169,5 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
-  }
-
-  checkworkflowPathHandler(value: boolean) {
-    this.currentlyIsChecker = value;
   }
 }

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -44,6 +44,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   @Input() validVersions;
   @Input() defaultVersion;
   @Input() extendedWorkflow: ExtendedWorkflow;
+  currentlyIsChecker: boolean;
   public workflow: Workflow;
   currentVersion: WorkflowVersion;
   downloadZipLink: string;
@@ -186,5 +187,9 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
+  }
+
+  checkworkflowPathHandler(value: boolean) {
+    this.currentlyIsChecker = value;
   }
 }


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3704
Inside my workflows, there used to be a "restub" button on workflows and checker workflows. But now we would like to remove that button on checker workflows, this PR addresses this.

(Currently the restub button is broken even outside of checker workflow, already created a ticket on this: https://github.com/dockstore/dockstore/issues/4193)