### PR TITLE
Hide display of non-Dockstore tokens

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -74,21 +74,6 @@
       </div>
 
       <span fxLayout="row" fxLayoutAlign="start center" *ngIf="row.isLinked">
-        <strong>Token</strong>
-        <button mat-icon-button color="secondary" (click)="row.show = !row.show">
-          <mat-icon *ngIf="row.show">visibility_off</mat-icon>
-          <mat-icon *ngIf="!row.show">visibility</mat-icon>
-        </button>
-        <button
-          mat-icon-button
-          color="secondary"
-          [cdkCopyToClipboard]="row.source | getTokenContent: tokens"
-          (cbOnSuccess)="isCopied1 = true"
-          appSnackbar
-        >
-          <mat-icon>file_copy</mat-icon>
-        </button>
-        <span *ngIf="row.show" style="overflow: auto">{{ row.source | getTokenContent: tokens }}</span>
         <span *ngIf="row.isLinked" class="pull-right">
           <span class="mx-2">
             <strong>Username: </strong>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -75,10 +75,8 @@
 
       <span fxLayout="row" fxLayoutAlign="start center" *ngIf="row.isLinked">
         <span *ngIf="row.isLinked" class="pull-right">
-          <span class="mx-2">
-            <strong>Username: </strong>
-            {{ row.source | getTokenUsername: tokens }}
-          </span>
+          <strong>Username: </strong>
+          {{ row.source | getTokenUsername: tokens }}
         </span>
       </span>
     </div>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -73,11 +73,9 @@
         {{ row.bold }}
       </div>
 
-      <span fxLayout="row" fxLayoutAlign="start center" *ngIf="row.isLinked">
-        <span *ngIf="row.isLinked" class="pull-right">
-          <strong>Username: </strong>
-          {{ row.source | getTokenUsername: tokens }}
-        </span>
+      <span *ngIf="row.isLinked">
+        <strong>Username: </strong>
+        {{ row.source | getTokenUsername: tokens }}
       </span>
     </div>
     <div fxLayout="column" fxLayoutAlign="end" style="margin-left: auto">


### PR DESCRIPTION
First part of [SEAB-1713](https://ucsc-cgl.atlassian.net/browse/SEAB-1713)

Hid the show token button and copy token button for non-Dockstore tokens so users can't access it. Looks like the following:

![Hide tokens](https://user-images.githubusercontent.com/25287123/115081898-02f79480-9ed3-11eb-9b83-954051a6e545.png)

