### PR TITLE
Feature/seab 2850/about page cleanup

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -246,7 +246,7 @@
         <hr />
         <div class="w-100" fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
           <div fxLayout="column" fxHide.lt-md fxFlex="10">
-            <h3 style="word-wrap: break-word">Integration Partners</h3>
+            <h3 class="text-break">Integration Partners</h3>
           </div>
           <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="4rem" fxFlex>
             <a *ngFor="let partner of partners" [href]="partner.url" target="_blank" rel="noopener noreferrer">

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -214,7 +214,7 @@
         tools.
       </p>
       <div fxLayout="column" fxLayoutAlign="space-between start" fxLayoutGap="1rem">
-        <div fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
+        <div class="w-100" fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
           <div fxLayout="column" fxHide.lt-md fxFlex="10">
             <h3>Funders</h3>
             <span>
@@ -229,8 +229,8 @@
           </div>
         </div>
         <hr />
-        <div fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
-          <div fxLayout="column" fxHide.lt-md>
+        <div class="w-100" fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
+          <div fxLayout="column" fxHide.lt-md fxFlex="10">
             <h3>Contributors</h3>
             <!-- <span>
               Meet the Team
@@ -244,10 +244,9 @@
           </div>
         </div>
         <hr />
-        <div fxLayout="row" fxLayoutGap="4rem" fxFlex fxLayoutAlign="start center">
-          <div fxLayout="column" fxHide.lt-md fxLayoutAlign="start start" fxLayoutGap="0">
-            <h3>Integration</h3>
-            <h3>Partners</h3>
+        <div class="w-100" fxLayout="row" fxLayoutGap="4rem" fxLayoutAlign="start center">
+          <div fxLayout="column" fxHide.lt-md fxFlex="10">
+            <h3 style="word-wrap: break-word">Integration Partners</h3>
           </div>
           <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="4rem" fxFlex>
             <a *ngFor="let partner of partners" [href]="partner.url" target="_blank" rel="noopener noreferrer">

--- a/src/bootstrap4.scss
+++ b/src/bootstrap4.scss
@@ -385,3 +385,8 @@ $overflows: scroll, hidden, auto, inherit, initial, unset, visible;
     overflow: $value !important;
   }
 }
+
+.text-break {
+  word-break: break-word !important; // Deprecated, but avoids issues with flex containers
+  word-wrap: break-word !important; // Used instead of `overflow-wrap` for IE & Edge Legacy
+}

--- a/src/material.scss
+++ b/src/material.scss
@@ -90,16 +90,16 @@ $my-teal: (
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue. Available color palettes: https://www.google.com/design/spec/style/color.html
-$candy-app-primary: mat-palette($my-blue, 900, 200, A100);
-$candy-app-accent: mat-palette($my-teal, 800, 200, A100);
+$dockstore-app-primary: mat-palette($my-blue, 900, 200, A100);
+$dockstore-app-accent: mat-palette($my-teal, 800, 200, A100);
 
 // The warn palette is optional (defaults to red).
-$candy-app-warn: mat-palette($mat-red);
+$dockstore-app-warn: mat-palette($mat-red);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent, $candy-app-warn);
+$dockstore-app-theme: mat-light-theme($dockstore-app-primary, $dockstore-app-accent, $dockstore-app-warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
-@include angular-material-theme($candy-app-theme);
+@include angular-material-theme($dockstore-app-theme);


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2850

The headings are now an arbitrary 10% of the width of the subcomponent

![image](https://user-images.githubusercontent.com/24548904/116602234-7056ec80-a8f9-11eb-8e79-7c9a0d8aca77.png)


Renamed candy because why not.
