### PR TITLE
Remove duplicate secondary color

### DIFF
--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -1,3 +1,5 @@
+@import '/src/materialColorScheme.scss';
+
 .about-dockstore {
   margin-top: 6rem;
   background-image: url(../../assets/images/about-page/city.png);
@@ -16,7 +18,7 @@
 }
 
 button {
-  background-color: #397a84;
+  background-color: mat-color($dockstore-app-accent);
   color: white;
   padding: 1rem;
   text-decoration: none;

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -10,7 +10,7 @@ import { Sponsor } from '../sponsors/sponsor.model';
 @Component({
   selector: 'app-about',
   templateUrl: './about.component.html',
-  styleUrls: ['./about.component.css'],
+  styleUrls: ['./about.component.scss'],
   providers: [FundingComponent],
 })
 export class AboutComponent implements OnInit {

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -44,7 +44,7 @@ ul {
 }
 
 hr {
-  border: 1px solid #596684;
+  border: 1px solid mat-color($dockstore-app-primary, 3);
 }
 
 @media only screen and (min-width: 80rem) {

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -13,10 +13,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+@import 'materialColorScheme.scss';
 
 .container-fluid,
 a {
-  background-color: #21335b;
+  background-color: mat-color($dockstore-app-primary);
   color: #e8eaf6;
 }
 

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -28,7 +28,7 @@ import { versions } from './versions';
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.css'],
+  styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent extends Base implements OnInit {
   version: string;

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -145,14 +145,14 @@
           </div>
           <div fxFlex>
             <pre>
-              <span class="code" style="color: #596684">## Make a runtime JSON template and fill in desired inputs, outputs, and</span>
-              <span class="code" style="color: #596684">## other parameters</span>
-              <span class="code"><span style="color: #3f51b5">dockstore</span> <span style="color: #0277bd">workflow convert entry2json --entry </span><span style="color: #c14747">github.com/dockstore/bcc2020-training/HelloWorld:master > Dockstore.json</span></span>
-              <span class="code"><span style="color: #3f51b5">vim</span> <span style="color: #c14747">Dockstore.json</span></span>
-              <span class="code" style="color: #596684">## or grab one that the workflow author has provided (if applicable)</span>
-              <span class="code"><span style="color: #3f51b5">wget --header=</span><span style="color: #0277bd">'Accept: text/plain' </span><span style="color: #c14747">https://dockstore.org/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fdockstore%2Fbcc2020-training%2FHelloWorld/versions/master/PLAIN_WDL/descriptor/..%2F..%2Ftest.json -O Dockstore.json</span></span>
-              <span class="code" style="color: #596684">## Run locally with the Dockstore CLI</span>
-              <span class="code"><span style="color: #3f51b5">dockstore</span><span style="color: #0277bd">' workflow launch --entry </span><span style="color: #c14747">github.com/dockstore/bcc2020-training/HelloWorld:master --json Dockstore.json</span></span>
+              <span class="code primary-3">## Make a runtime JSON template and fill in desired inputs, outputs, and</span>
+              <span class="code primary-3">## other parameters</span>
+              <span class="code"><span style="color: #3f51b5">dockstore</span> <span style="color: #0277bd">workflow convert entry2json --entry </span><span class="warn-1">github.com/dockstore/bcc2020-training/HelloWorld:master > Dockstore.json</span></span>
+              <span class="code"><span style="color: #3f51b5">vim</span> <span class="warn-1">Dockstore.json</span></span>
+              <span class="code primary-3">## or grab one that the workflow author has provided (if applicable)</span>
+              <span class="code"><span style="color: #3f51b5">wget --header=</span><span style="color: #0277bd">'Accept: text/plain' </span><span class="warn-1">https://dockstore.org/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fdockstore%2Fbcc2020-training%2FHelloWorld/versions/master/PLAIN_WDL/descriptor/..%2F..%2Ftest.json -O Dockstore.json</span></span>
+              <span class="code primary-3">## Run locally with the Dockstore CLI</span>
+              <span class="code"><span style="color: #3f51b5">dockstore</span><span style="color: #0277bd">' workflow launch --entry </span><span class="warn-1">github.com/dockstore/bcc2020-training/HelloWorld:master --json Dockstore.json</span></span>
             </pre>
           </div>
         </div>

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -14,6 +14,8 @@
  *    limitations under the License.
  */
 
+@import 'materialColorScheme.scss';
+
 .title {
   background-image: url(../../../assets/images//home/banner-docker-containers.jpg);
   color: white;
@@ -26,7 +28,7 @@
 }
 
 button {
-  background-color: #397a84;
+  background-color: mat-color($dockstore-app-accent);
   color: white;
   padding: 1rem;
   text-decoration: none;
@@ -111,7 +113,7 @@ h3 {
 }
 
 .search-background {
-  background: #397a84;
+  background: mat-color($dockstore-app-accent);
   padding: 2rem;
   border-radius: 1rem;
 }

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -117,3 +117,11 @@ h3 {
   padding: 2rem;
   border-radius: 1rem;
 }
+
+.primary-3 {
+  color: mat-color($dockstore-app-primary, 3);
+}
+
+.warn-1 {
+  color: mat-color($dockstore-app-warn, darker);
+}

--- a/src/app/home-page/widget/getting-started/getting-started.component.scss
+++ b/src/app/home-page/widget/getting-started/getting-started.component.scss
@@ -1,3 +1,5 @@
+@import 'materialColorScheme.scss';
+
 .tutorial-section-card {
   border-radius: 0.5rem;
   min-width: 20rem;
@@ -11,5 +13,5 @@
 }
 
 .tutorial-title {
-  color: #21335b;
+  color: mat-color($dockstore-app-primary);
 }

--- a/src/app/organizations/organization/organization.component.scss
+++ b/src/app/organizations/organization/organization.component.scss
@@ -1,5 +1,7 @@
+@import 'materialColorScheme.scss';
+
 .side-icons {
-  color: #397a84;
+  color: mat-color($dockstore-app-accent);
 }
 
 .tab-icons {

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -1,4 +1,5 @@
 @import 'bootstrap4.scss';
+@import '/src/materialColorScheme.scss';
 
 .mat-icon {
   @extend .pr-5;
@@ -28,7 +29,7 @@
 .info-icon {
   font-size: 1.5rem;
   height: auto;
-  color: #397a84;
+  color: mat-color($dockstore-app-accent);
   padding: 0 !important;
 }
 

--- a/src/material.scss
+++ b/src/material.scss
@@ -14,75 +14,13 @@
  *     limitations under the License.
  */
 @import '~@angular/material/theming';
+@import 'materialColorScheme.scss';
 // Plus imports for other components in your app.
 
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 @include mat-core();
-
-// The below is new from Kim's new color scheme: https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc699d068c46f17551f745b.
-// Note: By default, material uses 3 shades of each color (mainly just one). The other shades can be used by manually overriding the default material components.
-// The contrast is not specified in Kim's design. It is chosen from either black or white depending on
-// what's legible in both normal and large text when using https://material.io/resources/color/#!/?view.left=1&view.right=1&primary.color=21335b&secondary.color=487980
-// Accent 1 to 4, warning, grayscale and border is not covered.
-$kim-primary: (
-  1: #121d34,
-  2: #21335b,
-  3: #596684,
-  4: #a6adbd,
-  5: #ced2db,
-  6: #e8eaee,
-  contrast: (
-    1: white,
-    2: white,
-    3: white,
-    4: black,
-    5: black,
-    6: black,
-  ),
-);
-
-$kim-secondary: (
-  1: #295a62,
-  2: #397a84,
-  3: #75a4ab,
-  4: #b0cbcf,
-  5: #ebf2f3,
-  contrast: (
-    1: white,
-    2: white,
-    3: black,
-    4: black,
-    5: black,
-  ),
-);
-
-// Using kim's error instead (material doesn't differentiate between error and warn, kim's error seems more suitable)
-$kim-warn: (
-  1: #c14747,
-  2: #e64a46,
-  3: #e96f6c,
-  4: #f5b7b5,
-  5: #fcecec,
-  contrast: (
-    1: white,
-    2: black,
-    3: black,
-    4: black,
-    5: black,
-  ),
-);
-
-// main color is assumed to be 2 based on prevalence of it on the home page (buttons). It's also called default in zeplin
-// 1 is the darker version of it because it's the only one that's darker
-// 4 was arbitarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
-$dockstore-app-primary: mat-palette($kim-primary, 2, 4, 1);
-$dockstore-app-accent: mat-palette($kim-secondary, 2, 4, 1);
-$dockstore-app-warn: mat-palette($kim-warn, 2, 4, 1);
-
-// Create the theme object (a Sass map containing all of the palettes).
-$dockstore-app-theme: mat-light-theme($dockstore-app-primary, $dockstore-app-accent, $dockstore-app-warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -1,0 +1,79 @@
+/*
+ *     Copyright 2018 OICR
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+@import '~@angular/material/theming';
+
+// The below is new from Kim's new color scheme: https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc699d068c46f17551f745b.
+// Note: By default, material uses 3 shades of each color (mainly just one). The other shades can be used by manually overriding the default material components.
+// The contrast is not specified in Kim's design. It is chosen from either black or white depending on
+// what's legible in both normal and large text when using https://material.io/resources/color/#!/?view.left=1&view.right=1&primary.color=21335b&secondary.color=487980
+// Accent 1 to 4, warning, grayscale and border is not covered.
+$kim-primary: (
+  1: #121d34,
+  2: #21335b,
+  3: #596684,
+  4: #a6adbd,
+  5: #ced2db,
+  6: #e8eaee,
+  contrast: (
+    1: white,
+    2: white,
+    3: white,
+    4: black,
+    5: black,
+    6: black,
+  ),
+);
+
+$kim-secondary: (
+  1: #295a62,
+  2: #397a84,
+  3: #75a4ab,
+  4: #b0cbcf,
+  5: #ebf2f3,
+  contrast: (
+    1: white,
+    2: white,
+    3: black,
+    4: black,
+    5: black,
+  ),
+);
+
+// Using kim's error instead (material doesn't differentiate between error and warn, kim's error seems more suitable)
+$kim-warn: (
+  1: #c14747,
+  2: #e64a46,
+  3: #e96f6c,
+  4: #f5b7b5,
+  5: #fcecec,
+  contrast: (
+    1: white,
+    2: black,
+    3: black,
+    4: black,
+    5: black,
+  ),
+);
+
+// main color is assumed to be 2 based on prevalence of it on the home page (buttons). It's also called default in zeplin
+// 1 is the darker version of it because it's the only one that's darker
+// 4 was arbitarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
+$dockstore-app-primary: mat-palette($kim-primary, 2, 4, 1);
+$dockstore-app-accent: mat-palette($kim-secondary, 2, 4, 1);
+$dockstore-app-warn: mat-palette($kim-warn, 2, 4, 1);
+
+// Create the theme object (a Sass map containing all of the palettes).
+$dockstore-app-theme: mat-light-theme($dockstore-app-primary, $dockstore-app-accent, $dockstore-app-warn);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,7 @@ $material-design-icons-font-directory-path: '~material-design-icons-iconfont/dis
 @import 'bootstrap4.scss';
 @import '~ngx-sharebuttons/themes/default/default-theme';
 @import 'featured-content.scss';
+@import '/src/materialColorScheme.scss';
 /*@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,600);*/
 
 /* #487980 GREEN */
@@ -1331,7 +1332,7 @@ mat-tab-group.no-pagination {
 }
 
 .view-button {
-  background: #397a84;
+  background: mat-color($dockstore-app-accent);
   color: white;
   font-size: 12px;
   padding: 0.5rem 1rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -163,12 +163,12 @@ body {
 }
 
 .main-menu {
-  background-color: #21335b;
+  background-color: mat-color($dockstore-app-primary);
   position: relative;
 }
 
 .header {
-  background-color: #21335b;
+  background-color: mat-color($dockstore-app-primary);
   position: relative;
   img#ship,
   img#truck {
@@ -290,13 +290,13 @@ h2.title.caption {
 
 h3 {
   font-size: 20px;
-  color: #21335b;
+  color: mat-color($dockstore-app-primary);
   font-weight: normal;
 }
 
 h3.available-containers {
   font-size: 20px;
-  color: #21335b;
+  color: mat-color($dockstore-app-primary);
   font-weight: normal;
   margin: 20px 0px 15px 0px;
   display: inline;
@@ -650,7 +650,7 @@ ul.our-sponsors li img {
 }
 
 #footer {
-  background-color: #21335b;
+  background-color: mat-color($dockstore-app-primary);
   /*width: 100%;*/
   /*padding: 0px 100px;*/
   /*position: relative;*/
@@ -793,7 +793,7 @@ div.side-block td {
 div.side-block h3 {
   font-size: 16px;
   margin: 0px;
-  color: #21335b;
+  color: mat-color($dockstore-app-primary);
 }
 
 div.side-block a {


### PR DESCRIPTION
PR just to remove duplicate 397a84

Demonstrates how not to repeat colors

Split material.scss to a different file because:

https://material.angular.io/guide/theming#defining-a-custom-theme
"Your custom theme file should not be imported into other SCSS files. This will duplicate styles in your CSS output. If you want to consume your theme definition object (e.g., $candy-app-theme) in other SCSS files, then the definition of the theme object should be broken into its own file, separate from the inclusion of the mat-core and angular-material-theme mixins."