### PR TITLE
Feature/3588/remove bootstrap social

### DIFF
--- a/THIRD-PARTY-LICENSES.csv
+++ b/THIRD-PARTY-LICENSES.csv
@@ -373,7 +373,6 @@
 "bodybuilder@2.4.0","MIT","https://github.com/danpaz/bodybuilder"
 "bonjour@3.5.0","MIT","https://github.com/watson/bonjour"
 "boolbase@1.0.0","ISC","https://github.com/fb55/boolbase"
-"bootstrap-social@5.1.1","MIT","https://github.com/lipis/bootstrap-social"
 "bootstrap@3.4.1","MIT","https://github.com/twbs/bootstrap"
 "brace-expansion@1.1.8","MIT","https://github.com/juliangruber/brace-expansion"
 "braces@2.3.2","MIT","https://github.com/micromatch/braces"

--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,6 @@
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",
               "node_modules/font-awesome/css/font-awesome.css",
-              "node_modules/bootstrap-social/bootstrap-social.css",
               "src/styles.scss",
               "src/material.scss"
             ],
@@ -133,7 +132,6 @@
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",
               "node_modules/font-awesome/css/font-awesome.css",
-              "node_modules/bootstrap-social/bootstrap-social.css",
               "src/styles.scss",
               "src/material.scss"
             ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6180,15 +6180,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
-    "bootstrap-social": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-social/-/bootstrap-social-5.1.1.tgz",
-      "integrity": "sha1-dTDGeK31bPj60/qCwp1NPl0CdQE=",
-      "requires": {
-        "bootstrap": "~3",
-        "font-awesome": "~4.7"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "angular-tag-cloud-module": "^5.2.0",
     "bodybuilder": "^2.4.0",
     "bootstrap": "^3.4.1",
-    "bootstrap-social": "^5.1.1",
     "core-js": "^3.2.1",
     "cytoscape": "^3.18.2",
     "cytoscape-dagre": "^2.3.2",

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -37,12 +37,26 @@
           <mat-tab isActive="true" label="Login">
             <mat-card>
               <p>Login to your existing Dockstore account with any third party application that has been previously linked.</p>
-              <a class="btn btn-block btn-social btn-github" matTooltip="Log in with GitHub account" (click)="loginWith('github')">
-                <span class="fa fa-github"></span> Login with GitHub
-              </a>
-              <a class="btn btn-block btn-social btn-github" matTooltip="Log in with Google account" (click)="loginWith('google')">
-                <span class="fa fa-google"></span> Login with Google
-              </a>
+              <button
+                class="w-100 my-1"
+                color="accent"
+                mat-raised-button
+                matTooltip="Log in with GitHub account"
+                (click)="loginWith('github')"
+              >
+                <fa-icon [icon]="faGithub"></fa-icon> Login with GitHub
+              </button>
+              <br />
+              <button
+                class="w-100 my-1"
+                button
+                color="accent"
+                mat-raised-button
+                matTooltip="Log in with Google account"
+                (click)="loginWith('google')"
+              >
+                <fa-icon [icon]="faGoogle"></fa-icon> Login with Google
+              </button>
               <p>
                 By clicking Login with GitHub or Login with Google, you agree to Dockstore's
                 <template [ngTemplateOutlet]="PrivacyAndTOSDisclaimer"></template>
@@ -52,12 +66,26 @@
           <mat-tab label="Register">
             <mat-card>
               <p>Register a new Dockstore account with any third party application.</p>
-              <a class="btn btn-block btn-social btn-github" matTooltip="Register with GitHub account" (click)="registerWith('github')">
-                <span class="fa fa-github"></span> Register with GitHub
-              </a>
-              <a class="btn btn-block btn-social btn-github" matTooltip="Register with Google account" (click)="registerWith('google')">
-                <span class="fa fa-google"></span> Register with Google
-              </a>
+              <button
+                class="w-100 my-1"
+                color="accent"
+                mat-raised-button
+                matTooltip="Register with GitHub account"
+                (click)="registerWith('github')"
+              >
+                <fa-icon [icon]="faGithub"></fa-icon> Register with GitHub
+              </button>
+              <br />
+              <button
+                class="w-100 my-1"
+                button
+                color="accent"
+                mat-raised-button
+                matTooltip="Register with Google account"
+                (click)="registerWith('google')"
+              >
+                <fa-icon [icon]="faGoogle"></fa-icon> Register with Google
+              </button>
               <p>
                 By clicking Register with GitHub or Register with Google, you agree to Dockstore's
                 <template [ngTemplateOutlet]="PrivacyAndTOSDisclaimer"></template>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -17,6 +17,7 @@ import { Component } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
+import { faGithub, faGoogle } from '@fortawesome/free-brands-svg-icons';
 
 import { RegisterService } from '../register/register.service';
 import { TrackLoginService } from '../shared/track-login.service';
@@ -29,6 +30,8 @@ import { LoginService } from './login.service';
   styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
+  faGithub = faGithub;
+  faGoogle = faGoogle;
   constructor(
     private trackLoginService: TrackLoginService,
     private loginService: LoginService,


### PR DESCRIPTION
Remove bootstrap social, not replacing it with another library, just angular fontawesome.

Currently pretty basic replacement, others can prettify it

![image](https://user-images.githubusercontent.com/24548904/117513224-4b98ef80-af5f-11eb-80fe-5764d67514d6.png)
