### PR TITLE
Clean up collections and stargazers page

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -151,7 +151,7 @@
       </span>
     </div>
   </div>
-  <div class="row ml-4 mr-4" *ngIf="starGazersClicked">
+  <div class="row ml-4 mr-4 mb-4" *ngIf="starGazersClicked">
     <app-stargazers></app-stargazers>
     <button mat-flat-button color="primary" id="backButton" type="button" (click)="starGazersClicked = false">
       <mat-icon>chevron_left</mat-icon>Back to details

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -22,8 +22,8 @@
       <a class="category-text" [routerLink]="['/organizations/', (organization$ | async)?.name]" fxHide.lt-sm>{{
         (organization$ | async)?.displayName
       }}</a>
-      <span fxHide.lt-sm>/</span>
-      <span fxHide.lt-sm>{{ (collection$ | async)?.displayName }}</span>
+      <span fxHide.lt-md>/</span>
+      <span fxHide.lt-md>{{ (collection$ | async)?.displayName }}</span>
     </div>
   </div>
 </app-header>

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -14,8 +14,18 @@
    limitations under the License.
 -->
 <app-header>
-  <mat-icon>people</mat-icon>
-  Collections
+  <div fxLayout="row" fxLayoutAlign="space-between stretch">
+    <div fxLayout="row" fxLayoutGap="1rem">
+      <img src="../../../assets/svg/sub-nav/organization.svg" alt="organization icon" />
+      <a class="category-text" [routerLink]="['/organizations/']">Organizations</a>
+      <span fxHide.lt-sm>/</span>
+      <a class="category-text" [routerLink]="['/organizations/', (organization$ | async)?.name]" fxHide.lt-sm>{{
+        (organization$ | async)?.displayName
+      }}</a>
+      <span fxHide.lt-sm>/</span>
+      <span fxHide.lt-sm>{{ (collection$ | async)?.displayName }}</span>
+    </div>
+  </div>
 </app-header>
 <!-- Beware of double loading bar (from page and from loading component) -->
 <app-loading [loading]="(loadingCollection$ | async) || (loadingOrganization$ | async)">

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -40,7 +40,7 @@
       <div fxFlex class="my-3">
         <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="2rem" fxLayoutAlign="start center">
           <div *ngIf="gravatarUrl$ | async" fxHide.lt-sm>
-            <img [src]="gravatarUrl$ | async" class="orgLogo" alt="organization logo" />
+            <img [src]="gravatarUrl$ | async" class="big-org-logo" alt="organization logo" />
           </div>
           <div>
             <h2>

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -92,7 +92,7 @@
                   ]"
                   class="no-underline"
                 >
-                  <div fxLayout="row" fxLayoutAlign="space-between">
+                  <div fxLayout="row" fxLayoutAlign="space-between center">
                     <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
                       <img *ngIf="entry.entryType === 'workflow'" src="../../../assets/svg/sub-nav/workflow.svg" alt="workflow icon" />
                       <img *ngIf="entry.entryType === 'tool'" src="../../../assets/svg/sub-nav/tool.svg" alt="tool icon" />

--- a/src/app/organizations/collection/collection.component.scss
+++ b/src/app/organizations/collection/collection.component.scss
@@ -1,8 +1,3 @@
-.orgLogo {
-  max-height: 100px;
-  max-width: 200px;
-}
-
 .h5:hover {
   text-decoration: underline;
 }

--- a/src/app/organizations/collection/collection.component.scss
+++ b/src/app/organizations/collection/collection.component.scss
@@ -1,4 +1,4 @@
-.h5:hover {
+h5:hover {
   text-decoration: underline;
 }
 

--- a/src/app/organizations/organization/organization-starring/organization-starring.module.ts
+++ b/src/app/organizations/organization/organization-starring/organization-starring.module.ts
@@ -16,13 +16,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { StarOrganizationService } from '../../../shared/star-organization.service';
 import { OrganizationStarringComponent } from './organization-starring.component';
 import { OrganizationStarringService } from './organization-starring.service';
 
 @NgModule({
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatIconModule, MatTooltipModule],
   declarations: [OrganizationStarringComponent],
   exports: [OrganizationStarringComponent],
   providers: [OrganizationStarringService, StarOrganizationService],

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -62,7 +62,7 @@
           </div>
           <div>
             <h2 class="name">{{ org.displayName }}</h2>
-            <span>{{ org.topic }}</span>
+            <span style="word-break: break-word">{{ org.topic }}</span>
           </div>
         </div>
         <div fxFlex>
@@ -152,7 +152,7 @@
               </span>
               <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
                 <mat-icon class="side-icons">location_on</mat-icon>
-                <span>{{ org.location }}</span>
+                <span style="word-break: break-word">{{ org.location }}</span>
               </span>
             </div>
             <markdown-wrapper *ngIf="org.description" fxFlex [data]="org.description"></markdown-wrapper>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -62,7 +62,7 @@
           </div>
           <div>
             <h2 class="name">{{ org.displayName }}</h2>
-            <span style="word-break: break-word">{{ org.topic }}</span>
+            <span class="text-break">{{ org.topic }}</span>
           </div>
         </div>
         <div fxFlex>
@@ -140,7 +140,7 @@
               </button>
             </div>
             <div *ngIf="!org.description" fxFlex>
-              <div *ngIf="canEdit$ | async" class="text-muted">Select edit to add a markdown description</div>
+              <div *ngIf="canEdit$ | async" class="text-muted">Click edit to add a markdown description</div>
               <div *ngIf="!(canEdit$ | async)" class="text-muted">This organization does not have a description</div>
             </div>
             <div fxLayout="column" fxLayoutGap="10px" class="px-4 py-1">
@@ -152,7 +152,7 @@
               </span>
               <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
                 <mat-icon class="side-icons">location_on</mat-icon>
-                <span style="word-break: break-word">{{ org.location }}</span>
+                <span class="text-break">{{ org.location }}</span>
               </span>
             </div>
             <markdown-wrapper *ngIf="org.description" fxFlex [data]="org.description"></markdown-wrapper>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -19,7 +19,16 @@
       <img src="../../../assets/svg/sub-nav/organization.svg" alt="organization icon" />
       <a class="category-text" [routerLink]="['/organizations/']">Organizations</a>
       <span fxHide.lt-sm>/</span>
-      <span fxHide.lt-sm>{{ (organization$ | async)?.displayName }}</span>
+      <div fxHide.lt-sm *ngIf="organizationStarGazersClicked; else organizationName" fxLayoutGap="1rem">
+        <a class="category-text" [routerLink]="['./']" (click)="organizationStarGazersChange()">{{
+          (organization$ | async)?.displayName
+        }}</a>
+        <span>/</span>
+        <span>Stargazers</span>
+      </div>
+      <ng-template #organizationName>
+        <span fxHide.lt-sm>{{ (organization$ | async)?.displayName }}</span>
+      </ng-template>
     </div>
   </div>
 </app-header>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -152,7 +152,7 @@
               </span>
               <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
                 <mat-icon class="side-icons">location_on</mat-icon>
-                <span class="ellipsis-lines">{{ org.location }}</span>
+                <span>{{ org.location }}</span>
               </span>
             </div>
             <markdown-wrapper *ngIf="org.description" fxFlex [data]="org.description"></markdown-wrapper>

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -34,31 +34,9 @@
 </app-header>
 <app-loading [loading]="loading$ | async">
   <div class="container" *ngIf="!(organization$ | async)">Organization not found</div>
-  <div class="container" *ngIf="organizationStarGazersClicked && (organization$ | async) as org">
-    <div fxLayout="row">
-      <div fxFlex="70">
-        <h3>{{ org.displayName }}</h3>
-      </div>
-      <div fxFlex>
-        <app-organization-starring
-          *ngIf="org?.status === approved"
-          [organization]="org"
-          class="pull-right starring-button"
-          (change)="organizationStarGazersChange()"
-        ></app-organization-starring>
-      </div>
-    </div>
-    <p class="update">
-      <span [matTooltip]="org?.dbUpdateDate | date: 'medium'">Last updated: {{ org?.dbUpdateDate | timeAgoMessage }}</span>
-    </p>
-    <app-organization-stargazers></app-organization-stargazers>
-    <button mat-flat-button color="primary" id="backButton" type="button" (click)="organizationStarGazersClicked = false">
-      <mat-icon>chevron_left</mat-icon>Back to details
-    </button>
-  </div>
   <!-- Organization header -->
-  <div class="container mb-5" *ngIf="!organizationStarGazersClicked && (organization$ | async) as org" fxLayout="column" fxLayoutGap="10px">
-    <ngx-json-ld [json]="schema$ | async"></ngx-json-ld>
+  <div class="container mb-5" *ngIf="organization$ | async as org" fxLayout="column" fxLayoutGap="10px">
+    <ngx-json-ld [json]="schema$ | async" class="m-0"></ngx-json-ld>
     <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'PENDING'">
       <mat-icon>info</mat-icon> This organization is pending approval by a Dockstore curator.
       <span *ngIf="(isAdmin$ | async) || (isCurator$ | async); else notAdminOrCurator">
@@ -80,7 +58,7 @@
       <div fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="space-between">
         <div fxFlex="90" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="2rem">
           <div *ngIf="gravatarUrl$ | async">
-            <img [src]="gravatarUrl$ | async" class="orgLogo" alt="avatar" />
+            <img [src]="gravatarUrl$ | async" class="big-org-logo" alt="avatar" />
           </div>
           <div>
             <h2 class="name">{{ org.displayName }}</h2>
@@ -96,82 +74,91 @@
           ></app-organization-starring>
         </div>
       </div>
-      <mat-card-actions *ngIf="canEdit$ | async" fxLayoutAlign="flex-end">
+      <mat-card-actions *ngIf="(canEdit$ | async) && !organizationStarGazersClicked" fxLayoutAlign="flex-end">
         <button mat-button (click)="editOrganization()" id="editOrgInfo" matTooltip="Edit the organization">
           <mat-icon>edit</mat-icon>
         </button>
       </mat-card-actions>
     </div>
 
+    <div *ngIf="organizationStarGazersClicked; else tabsAndDescription">
+      <app-organization-stargazers></app-organization-stargazers>
+      <button mat-flat-button color="primary" id="backButton" type="button" (click)="organizationStarGazersClicked = false">
+        <mat-icon>chevron_left</mat-icon>Back to details
+      </button>
+    </div>
+
     <!-- Tabs and description -->
-    <div fxLayout="row" fxLayout.lt-md="column" fxLayoutGap="2rem" class="my-3" data-cy="organizationDetails">
-      <div fxFlex fxGrow="1" fxFlex.lt-md="100%">
-        <mat-tab-group class="purple-tab-group">
-          <mat-tab>
-            <ng-template mat-tab-label>
-              <div fxLayoutGap="0.5rem">
-                <img src="../../../assets/svg/sub-nav/collections.svg" alt="collections icon" />
-                <span>Collections</span>
-                <span class="tab-display">{{ collectionsLength$ | async }}</span>
-              </div>
-            </ng-template>
-            <collections [organizationID]="org.id" [organizationName]="org.name"></collections>
-          </mat-tab>
-          <mat-tab>
-            <ng-template mat-tab-label>
-              <div fxLayoutGap="0.5rem">
-                <mat-icon class="tab-icons">people</mat-icon>
-                <span>Members</span>
-                <span class="tab-display">{{ (organizationMembersQuery.sortedOrganizationMembers$ | async).length }}</span>
-              </div>
-            </ng-template>
-            <organization-members></organization-members>
-          </mat-tab>
-          <mat-tab>
-            <ng-template mat-tab-label>
-              <div fxLayoutGap="0.5rem">
-                <mat-icon class="tab-icons">update</mat-icon>
-                <span>Updates</span>
-                <span class="tab-display">{{ (eventsQuery.organizationEvents$ | async).length }}</span>
-              </div>
-            </ng-template>
-            <events [organizationID]="org.id"></events>
-          </mat-tab>
-        </mat-tab-group>
-      </div>
-      <div fxFlex fxGrow="1" fxFlex.lt-md="100%">
-        <div fxLayout="column" fxLayoutGap="15px" class="my-3">
-          <div fxLayout="row" fxLayoutAlign="space-between">
-            <h4>About the Organization</h4>
-            <button
-              mat-button
-              *ngIf="canEdit$ | async"
-              (click)="updateDescription()"
-              id="editOrgDescription"
-              matTooltip="Edit the description"
-            >
-              <mat-icon>edit</mat-icon>
-            </button>
-          </div>
-          <div *ngIf="!org.description" fxFlex>
-            <div *ngIf="canEdit$ | async" class="text-muted">Select edit to add a markdown description</div>
-            <div *ngIf="!(canEdit$ | async)" class="text-muted">This organization does not have a description</div>
-          </div>
-          <div fxLayout="column" fxLayoutGap="10px" class="px-4 py-1">
-            <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.link">
-              <mat-icon class="side-icons">link</mat-icon>
-              <span
-                ><a [href]="org.link" target="_blank" rel="noopener">{{ org?.link }}</a></span
+    <ng-template #tabsAndDescription>
+      <div fxLayout="row" fxLayout.lt-md="column" fxLayoutGap="2rem" class="my-3" data-cy="organizationDetails">
+        <div fxFlex fxGrow="1" fxFlex.lt-md="100%">
+          <mat-tab-group class="purple-tab-group">
+            <mat-tab>
+              <ng-template mat-tab-label>
+                <div fxLayoutGap="0.5rem">
+                  <img src="../../../assets/svg/sub-nav/collections.svg" alt="collections icon" />
+                  <span>Collections</span>
+                  <span class="tab-display">{{ collectionsLength$ | async }}</span>
+                </div>
+              </ng-template>
+              <collections [organizationID]="org.id" [organizationName]="org.name"></collections>
+            </mat-tab>
+            <mat-tab>
+              <ng-template mat-tab-label>
+                <div fxLayoutGap="0.5rem">
+                  <mat-icon class="tab-icons">people</mat-icon>
+                  <span>Members</span>
+                  <span class="tab-display">{{ (organizationMembersQuery.sortedOrganizationMembers$ | async).length }}</span>
+                </div>
+              </ng-template>
+              <organization-members></organization-members>
+            </mat-tab>
+            <mat-tab>
+              <ng-template mat-tab-label>
+                <div fxLayoutGap="0.5rem">
+                  <mat-icon class="tab-icons">update</mat-icon>
+                  <span>Updates</span>
+                  <span class="tab-display">{{ (eventsQuery.organizationEvents$ | async).length }}</span>
+                </div>
+              </ng-template>
+              <events [organizationID]="org.id"></events>
+            </mat-tab>
+          </mat-tab-group>
+        </div>
+        <div fxFlex fxGrow="1" fxFlex.lt-md="100%">
+          <div fxLayout="column" fxLayoutGap="15px" class="my-3">
+            <div fxLayout="row" fxLayoutAlign="space-between">
+              <h4>About the Organization</h4>
+              <button
+                mat-button
+                *ngIf="canEdit$ | async"
+                (click)="updateDescription()"
+                id="editOrgDescription"
+                matTooltip="Edit the description"
               >
-            </span>
-            <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
-              <mat-icon class="side-icons">location_on</mat-icon>
-              <span class="ellipsis-lines">{{ org.location }}</span>
-            </span>
+                <mat-icon>edit</mat-icon>
+              </button>
+            </div>
+            <div *ngIf="!org.description" fxFlex>
+              <div *ngIf="canEdit$ | async" class="text-muted">Select edit to add a markdown description</div>
+              <div *ngIf="!(canEdit$ | async)" class="text-muted">This organization does not have a description</div>
+            </div>
+            <div fxLayout="column" fxLayoutGap="10px" class="px-4 py-1">
+              <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.link">
+                <mat-icon class="side-icons">link</mat-icon>
+                <span
+                  ><a [href]="org.link" target="_blank" rel="noopener">{{ org?.link }}</a></span
+                >
+              </span>
+              <span fxLayout="row" fxLayoutGap="10px" *ngIf="org?.location">
+                <mat-icon class="side-icons">location_on</mat-icon>
+                <span class="ellipsis-lines">{{ org.location }}</span>
+              </span>
+            </div>
+            <markdown-wrapper *ngIf="org.description" fxFlex [data]="org.description"></markdown-wrapper>
           </div>
-          <markdown-wrapper *ngIf="org.description" fxFlex [data]="org.description"></markdown-wrapper>
         </div>
       </div>
-    </div>
+    </ng-template>
   </div>
 </app-loading>

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -59,7 +59,7 @@
           fxFlex.lt-md="100"
         >
           <div class="h-100" fxLayout="column" fxLayoutAlign="space-between stretch">
-            <div class="overflow-scroll" fxLayout="column" fxLayoutAlign="space-between stretch" fxLayoutGap="1rem">
+            <div fxLayout="column" fxLayoutGap="2rem">
               <a [routerLink]="org.name" class="no-underline" target="_self">
                 <div fxLayout="column" fxLayoutAlign="space-around">
                   <div fxLayout="row wrap" fxLayoutAlign="space-between start">
@@ -80,17 +80,17 @@
                 <div fxLayout="column" fxLayoutAlign="space-between start" class="info">
                   <span fxLayout="row" fxLayoutAlign="start center" *ngIf="org?.link">
                     <mat-icon class="info-icon">link</mat-icon>
-                    <span
+                    <span class="info-overflow"
                       ><a [href]="org.link" target="_blank" rel="noopener noreferrer">{{ org.link }}</a></span
                     >
                   </span>
                   <span fxLayout="row" fxLayoutAlign="start center" *ngIf="org?.location">
                     <mat-icon class="info-icon">location_on</mat-icon>
-                    <span>{{ org.location }}</span>
+                    <span class="info-overflow">{{ org.location }}</span>
                   </span>
                   <span fxLayout="row" fxLayoutAlign="start center" *ngIf="org?.email">
                     <mat-icon class="info-icon">email</mat-icon>
-                    <span
+                    <span class="info-overflow"
                       ><a [href]="'mailto:' + org.email" target="_top">{{ org.email }}</a></span
                     >
                   </span>

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -63,7 +63,7 @@
               <a [routerLink]="org.name" class="no-underline" target="_self">
                 <div fxLayout="column" fxLayoutAlign="space-around">
                   <div fxLayout="row wrap" fxLayoutAlign="space-between start">
-                    <img *ngIf="org.avatarUrl; else placeholder" class="orgLogo" [src]="org.avatarUrl" alt="org logo" />
+                    <img *ngIf="org.avatarUrl; else placeholder" class="small-org-logo" [src]="org.avatarUrl" alt="org logo" />
                     <ng-template #placeholder><span style="height: 50px"></span></ng-template>
                     <div *ngIf="org?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center">
                       <mat-icon class="orgStar">star</mat-icon>

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -71,7 +71,7 @@
                     </div>
                   </div>
                   <div data-cy="orgName">
-                    <h5>{{ org.displayName }}</h5>
+                    <h5 class="text-break">{{ org.displayName }}</h5>
                     <span class="org-topic">{{ org.topic }}</span>
                   </div>
                 </div>

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -20,6 +20,7 @@
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 
 .orgStar {
@@ -53,6 +54,7 @@
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 
 form {

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -13,6 +13,13 @@
 .org-topic {
   line-height: 1.5;
   color: mat-color($dockstore-app-gray, darker);
+  // Hide overflow if longer than 3 lines
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: initial;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
 }
 
 .orgStar {
@@ -36,6 +43,16 @@
 .info {
   font-size: 12px;
   line-height: 2rem;
+}
+
+.info-overflow {
+  // Hide overflow if longer than 1 line
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: initial;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 }
 
 form {

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -13,7 +13,7 @@
 .org-topic {
   line-height: 1.5;
   color: mat-color($dockstore-app-gray, darker);
-  // Hide overflow if longer than 3 lines
+  // Hide overflow if longer than 4 lines
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: initial;

--- a/src/app/stargazers/stargazers.component.css
+++ b/src/app/stargazers/stargazers.component.css
@@ -15,7 +15,7 @@
  */
 
 .stargazer-img {
-  width: 15rem;
-  height: 15rem;
+  width: 17rem;
+  height: 17rem;
   border-radius: 0.5rem;
 }

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -39,7 +39,7 @@
       >
         <div class="h-100" fxLayout="column" fxLayoutAlign="start center">
           <img src="{{ stargazer.avatarUrl }}" class="stargazer-img" alt="{{ altAvatarImg }}" />
-          <div fxLayout="column" fxLayoutAlign="space-between center" style="word-break: break-word">
+          <div class="text-break" fxLayout="column" fxLayoutAlign="space-between center">
             <h5>{{ stargazer.username }}</h5>
             <h6 *ngIf="stargazer.orcid">
               ORCID <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo" />

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -28,19 +28,26 @@
     <mat-card-header>
       <mat-card-title>Stargazers</mat-card-title>
     </mat-card-header>
-    <div fxLayout="row wrap">
-      <div *ngFor="let stargazer of starGazers">
-        <div fxFlex="90%" class="mx-3 text-center">
+    <div fxLayoutAlign="space-between" fxLayout="row wrap" fxLayoutGap="1rem">
+      <mat-card
+        style="height: 280px"
+        *ngFor="let stargazer of starGazers"
+        class="my-2 mat-elevation-z3 mx-0"
+        fxFlex="19"
+        fxFlex.lt-lg="30"
+        fxFlex.lt-md="100"
+      >
+        <div class="h-100" fxLayout="column" fxLayoutAlign="start center">
           <img src="{{ stargazer.avatarUrl }}" class="stargazer-img" alt="{{ altAvatarImg }}" />
-          <div style="width: 15rem">
-            <h5 class="text-center">{{ stargazer.username }}</h5>
+          <div fxLayout="column" fxLayoutAlign="space-between center" style="word-break: break-word">
+            <h5>{{ stargazer.username }}</h5>
             <h6 *ngIf="stargazer.orcid">
               ORCID <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo" />
               <a href="https://orcid.org/{{ stargazer.orcid }}" style="font-size: 0.8em">{{ stargazer.orcid }}</a>
             </h6>
           </div>
         </div>
-      </div>
+      </mat-card>
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/starring/starring.component.html
+++ b/src/app/starring/starring.component.html
@@ -24,7 +24,9 @@
     [ngClass]="rate ? 'btn btn-default active' : 'btn btn-default'"
   >
     <mat-icon id="unstarringButtonIcon" *ngIf="rate">star</mat-icon>
-    <mat-icon id="starringButtonIcon" *ngIf="!rate">star_border</mat-icon>
+    <mat-icon id="starringButtonIcon" *ngIf="!rate" matTooltip="Login to star this page" [matTooltipDisabled]="isLoggedIn"
+      >star_border</mat-icon
+    >
   </button>
   <button id="starCountButton" (click)="getStargazers()" style="height: 38px" class="btn btn-default">{{ total_stars }}</button>
 </div>

--- a/src/app/starring/starring.module.ts
+++ b/src/app/starring/starring.module.ts
@@ -16,13 +16,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { StarentryService } from '../shared/starentry.service';
 import { StarringComponent } from './starring.component';
 import { StarringService } from './starring.service';
 
 @NgModule({
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatIconModule, MatTooltipModule],
   declarations: [StarringComponent],
   exports: [StarringComponent],
   providers: [StarringService, StarentryService],

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -154,7 +154,7 @@
       </span>
     </div>
   </div>
-  <div class="row ml-4 mr-4" *ngIf="starGazersClicked">
+  <div class="row ml-4 mr-4 mb-4" *ngIf="starGazersClicked">
     <app-stargazers></app-stargazers>
     <button id="backButton" type="button" (click)="starGazersClicked = false" mat-flat-button color="primary">
       <mat-icon>chevron_left</mat-icon>Back to details

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1235,12 +1235,6 @@ div.tabs > div:target > div,
   color: #808080;
 }
 
-.ellipsis-lines {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
 .test_parameter_input {
   width: 90%;
   float: left;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1462,7 +1462,13 @@ hr {
   vertical-align: sub;
 }
 
-.orgLogo {
+.small-org-logo {
   height: 50px;
   object-fit: scale-down;
+}
+
+.big-org-logo {
+  max-height: 100px;
+  max-width: 200px;
+  margin-top: 1.5rem;
 }


### PR DESCRIPTION
For [SEAB-2849](https://ucsc-cgl.atlassian.net/browse/SEAB-2849)

Did 17, 19 - 22 from the [Dockstore UI review doc](https://docs.google.com/document/d/1GLshBv7Ue09ceCFDSLmFvrgbEofGkY6R0jXlKxVjqHc/edit)

- **Collection page breadcrumb**
![Collection breadcrumb](https://user-images.githubusercontent.com/25287123/118273484-ffcfd400-b491-11eb-8ead-6e8ee5e92e32.png)

- **Consistent logo location**
    - Stargazer page has the same header as the organization page so the logo and org title location is the same
![Organization header](https://user-images.githubusercontent.com/25287123/118274756-8933d600-b493-11eb-94f0-b64a1571f7d3.png)
Also note the stargazers breadcrumb
![Stargazers header](https://user-images.githubusercontent.com/25287123/118274764-8c2ec680-b493-11eb-9006-52b83e970aa1.png)
    - For the most part, the logo location from the organization page to the collection page is the same
![Screenshot_2021-05-14 Dockstore Organization](https://user-images.githubusercontent.com/25287123/118278055-83d88a80-b497-11eb-954e-bca78a2c34fc.png)
![Screenshot_2021-05-14 Dockstore Collection](https://user-images.githubusercontent.com/25287123/118278061-85a24e00-b497-11eb-8773-62f6c0f3d789.png)
The logo location may be a little different if the description of the organization is longer than the collection (i.e. 2 line org description vs 1 line collection description). I couldn't really find a way to make it consistent with different length descriptions unless I put the logo at the top of the container, but that makes the logo look unbalanced with the title.



- **Stargazer member cards**
I did a grid of 5 boxes, instead of 6 like the UI review doc suggests so that I could get the Orcid ID on one line

    - Normal view:
![Stargazers normal size](https://user-images.githubusercontent.com/25287123/118274998-d87a0680-b493-11eb-9a92-3319d014d562.png)
    - Medium view:
![Stargazers medium](https://user-images.githubusercontent.com/25287123/118275076-f182b780-b493-11eb-88aa-103e1044ed59.png)
    - Small view:
![stargazers small](https://user-images.githubusercontent.com/25287123/118275106-fb0c1f80-b493-11eb-953f-277a39ad8440.png)

- **Tooltip for disabled starring button**
![Tooltip to login and star](https://user-images.githubusercontent.com/25287123/118275610-a6b56f80-b494-11eb-844d-750f162273ed.png)

- **Hide overflow in organization cards**
Removed the overflow scrolling bar and just hid the overflow with "..."
![Organization card overflow](https://user-images.githubusercontent.com/25287123/118275745-d19fc380-b494-11eb-879e-9c2ef9e035a3.png)
If there's enough room (ex: small screen so the cards are big), then the full content is shown
![Organization card no overflow](https://user-images.githubusercontent.com/25287123/118275816-ea0fde00-b494-11eb-8956-70baab1ccaff.png)
