### PR TITLE
Fixing spacing in search organizations

### DIFF
--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -43,7 +43,7 @@
           </mat-select>
         </mat-form-field>
         <mat-form-field appearance="outline" class="form-field">
-          <input matInput placeholder="Search organizations" formControlName="name" />
+          <input class="alignment" matInput placeholder="Search organizations" formControlName="name" />
         </mat-form-field>
       </form>
     </div>

--- a/src/app/organizations/organizations/organizations.component.scss
+++ b/src/app/organizations/organizations/organizations.component.scss
@@ -68,3 +68,7 @@ form {
 .mat-form-field-appearance-outline .mat-form-field-outline {
   border: black 2px solid;
 }
+
+.alignment {
+  transform: translateY(-3px);
+}


### PR DESCRIPTION
Changing the "search organizations" field to align with the "sort by" field

Reference: https://docs.google.com/document/d/1GLshBv7Ue09ceCFDSLmFvrgbEofGkY6R0jXlKxVjqHc/edit number 14 under organization