### PR TITLE
Feature/2937/run smoke tests against staging and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - upload_nightly_artifacts
       - slack/status:
         fail_only: true
-        failure_message: Nightly << parameters.stack >> non-auth tests failed!
+        failure_message: "Nightly << parameters.stack >> non-auth tests failed!"
         webhook: $SLACK_WEBHOOK
 
   # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ jobs:
       - run:
           name: Get commit id.
           command: |
-            git checkout
-            $(curl https://dev.dockstore.net | \
+            git checkout $(curl https://dev.dockstore.net | \
             grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9]+-[A-Za-z0-9]+" | \
             head -1 | \
             grep -Eoi "[A-Za-z0-9]+$")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,8 @@ workflows:
                 - develop
     jobs:
       - uptime_monitor_no_auth:
+          stack: "dev"
+          webpage_URL: "https://dev.dockstore.net"
           context:
             - dockerhub
       - uptime_monitor_auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-#      - slack/status:
-#        fail_only: true
-#        failure_message: Nightly << parameters.stack >> non-auth tests failed!
-#        webhook: $SLACK_WEBHOOK
+      - slack/status:
+        fail_only: true
+        failure_message: Nightly << parameters.stack >> non-auth tests failed!
+        webhook: $SLACK_WEBHOOK
 
   # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
   uptime_monitor_auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,26 +21,6 @@ executors:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
 jobs:
-  nightly_staging_smoke_tests:
-    steps:
-      - checkout
-      - run:
-          name: Get commit id.
-          command: |
-            git checkout $(curl https://dev.dockstore.net | \
-            grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9]+-[A-Za-z0-9]+" | \
-            head -1 | \
-            grep -Eoi "[A-Za-z0-9]+$")
-      - install_container_dependencies
-      - run:
-          name: Execute staging no-auth smoke tests
-          command: |
-            bash -i -c 'npm run test-staging-no-auth'
-      - run:
-          name: Execute prod no-auth smoke tests
-          command: |
-            bash -i -c 'npm run test-prod-no-auth'
-
   uptime_monitor_no_auth:
     working_directory: ~/repo
     docker:
@@ -49,7 +29,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - setup_nightly_tests
+      - setup_nightly_tests:
+          webpage_URL: "https://dev.dockstore.net"
       - run:
           name: Run remote verification test against dev (no auth)
           command: bash -i -c 'npm run test-dev-no-auth'
@@ -73,7 +54,8 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
-      - setup_nightly_tests
+      - setup_nightly_tests:
+          webpage_URL: "https://dev.dockstore.net"
       - run:
           name: Run remote verification test against dev (with auth)
           command: bash -i -c 'npm run test-dev-auth'
@@ -250,6 +232,9 @@ workflows:
   everything:
     jobs:
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
+      - uptime_monitor_no_auth:
+          context:
+            - dockerhub
       - lint_license_unit_test_coverage:
           filters:
             tags:
@@ -377,8 +362,19 @@ commands:
           name: Wait for services
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
+    parameters:
+      webpage_URL:
+        type: string
     steps:
       - checkout
+      - run:
+          name: Get and checkout commit id from the current webpage.
+          command: |
+            COMMIT_ID=$(curl << parameters.webpage_URL >> | \
+                        grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9\.]+-[A-Za-z0-9]+" | \
+                        head -1 | \
+                        grep -Eoi "[A-Za-z0-9]+$")
+            git checkout $COMMIT_ID
       - install_container_dependencies
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,72 +21,37 @@ executors:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
 jobs:
-  # TODO: Add auth tests once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done
-  uptime_monitor_staging_no_auth:
-    working_directory: ~/repo
-    docker:
-      - image: circleci/buildpack-deps:18.04-browsers
-    steps:
-      - setup_nightly_tests:
-          webpage_URL: "https://staging.dockstore.org"
-      - run:
-          name: Run remote verification test against staging (no auth)
-          command: bash -i -c 'npm run test-staging-no-auth'
-          environment:
-            MOCHA_FILE: nightly-test-results/junit/test-staging-no-auth-[hash].xml
-      - run:
-          name: Run remote verification of WAF against staging
-          command: bash -i -c 'npm run test-staging-waf'
-          environment:
-            MOCHA_FILE: nightly-test-results/junit/test-staging-waf-[hash].xml
-
-  # TODO: Add auth tests once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done
-  uptime_monitor_prod_no_auth:
-    working_directory: ~/repo
-    docker:
-      - image: circleci/buildpack-deps:18.04-browsers
-        auth:
-          username: dockstoretestuser
-          password: $DOCKERHUB_PASSWORD
-    steps:
-      - setup_nightly_tests:
-          webpage_URL: "https://dockstore.org"
-      - run:
-          name: Run remote verification test against prod (no auth)
-          command: bash -i -c 'npm run test-prod-no-auth'
-          environment:
-            MOCHA_FILE: nightly-test-results/junit/test-prod-no-auth-[hash].xml
-      - run:
-          name: Run remote verification of WAF against staging
-          command: bash -i -c 'npm run test-prod-waf'
-          environment:
-            MOCHA_FILE: nightly-test-results/junit/test-prod-waf-[hash].xml
-
+  # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
+  # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
   uptime_monitor_no_auth:
+    parameters:
+      stack:
+        type: string
+      webpage_URL:
+        type: string
     working_directory: ~/repo
     docker:
       - image: circleci/buildpack-deps:18.04-browsers
-        auth:
-          username: dockstoretestuser
-          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
-          webpage_URL: "https://dev.dockstore.net"
+          webpage_URL: << parameters.webpage_URL >>
       - run:
-          name: Run remote verification test against dev (no auth)
-          command: bash -i -c 'npm run test-dev-no-auth'
+          name: Run remote verification test against << parameters.stack >> (no auth)
+          command: bash -i -c 'npm run test-<< parameters.stack >>-no-auth'
           environment:
-            MOCHA_FILE: nightly-test-results/junit/test-dev-no-auth-[hash].xml
+            MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-no-auth-[hash].xml
       - run:
-          name: Run remote verification of WAF against dev
-          command: bash -i -c 'npm run test-dev-waf'
+          name: Run remote verification of WAF against << parameters.stack >>
+          command: bash -i -c 'npm run test-<< parameters.stack >>-waf'
           environment:
-            MOCHA_FILE: nightly-test-results/junit/test-dev-waf-[hash].xml
+            MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
-          failure_message: Nightly non-auth tests failed!
-          webhook: $SLACK_WEBHOOK
+#      - slack/status:
+#        fail_only: true
+#        failure_message: Nightly << parameters.stack >> non-auth tests failed!
+#        webhook: $SLACK_WEBHOOK
+
+  # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
   uptime_monitor_auth:
     working_directory: ~/repo
     docker:
@@ -273,7 +238,9 @@ workflows:
   everything:
     jobs:
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
-      - uptime_monitor_staging_no_auth:
+      - uptime_monitor_no_auth:
+          stack: "staging"
+          webpage_URL: "https://staging.dockstore.org"
           context:
             - dockerhub
       - lint_license_unit_test_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,11 +318,11 @@ workflows:
           webpage_URL: "https://staging.dockstore.org"
           context:
             - dockerhub
-      - uptime_monitor_no_auth:
-          stack: "prod"
-          webpage_URL: "https://dockstore.org"
-          context:
-            - dockerhub
+#      - uptime_monitor_no_auth:
+#          stack: "prod"
+#          webpage_URL: "https://dockstore.org"
+#          context:
+#            - dockerhub
       # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
       - uptime_monitor_auth:
           stack: "dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,9 @@ jobs:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
-        fail_only: true
-        failure_message: "Nightly << parameters.stack >> non-auth tests failed!"
-        webhook: $SLACK_WEBHOOK
+          fail_only: true
+          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
   uptime_monitor_auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,11 @@ executors:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
 jobs:
+  # TODO: Add auth tests once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done
   uptime_monitor_staging_no_auth:
     working_directory: ~/repo
     docker:
       - image: circleci/buildpack-deps:18.04-browsers
-        auth:
-          username: dockstoretestuser
-          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
           webpage_URL: "https://staging.dockstore.org"
@@ -41,6 +39,29 @@ jobs:
           command: bash -i -c 'npm run test-staging-waf'
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-staging-waf-[hash].xml
+
+  # TODO: Add auth tests once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done
+  uptime_monitor_prod_no_auth:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/buildpack-deps:18.04-browsers
+        auth:
+          username: dockstoretestuser
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - setup_nightly_tests:
+          webpage_URL: "https://dockstore.org"
+      - run:
+          name: Run remote verification test against prod (no auth)
+          command: bash -i -c 'npm run test-prod-no-auth'
+          environment:
+            MOCHA_FILE: nightly-test-results/junit/test-prod-no-auth-[hash].xml
+      - run:
+          name: Run remote verification of WAF against staging
+          command: bash -i -c 'npm run test-prod-waf'
+          environment:
+            MOCHA_FILE: nightly-test-results/junit/test-prod-waf-[hash].xml
+
   uptime_monitor_no_auth:
     working_directory: ~/repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: circleci/buildpack-deps:18.04-browsers
+        auth:
+          username: dockstoretestuser
+          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
           webpage_URL: << parameters.webpage_URL >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,26 @@ executors:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
 jobs:
+  nightly_staging_smoke_tests:
+    steps:
+      - checkout
+      - run:
+          name: Get commit id.
+          command: |
+            git checkout
+            $(curl https://dev.dockstore.net | \
+            grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9]+-[A-Za-z0-9]+" | \
+            head -1 | \
+            grep -Eoi "[A-Za-z0-9]+$")
+      - install_container_dependencies
+      - run:
+          name: Execute staging no-auth smoke tests
+          command: |
+            bash -i -c 'npm run test-staging-no-auth'
+      - run:
+          name: Execute prod no-auth smoke tests
+          command: |
+            bash -i -c 'npm run test-prod-no-auth'
 
   uptime_monitor_no_auth:
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,26 @@ executors:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
 jobs:
+  uptime_monitor_staging_no_auth:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/buildpack-deps:18.04-browsers
+        auth:
+          username: dockstoretestuser
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - setup_nightly_tests:
+          webpage_URL: "https://staging.dockstore.org"
+      - run:
+          name: Run remote verification test against staging (no auth)
+          command: bash -i -c 'npm run test-staging-no-auth'
+          environment:
+            MOCHA_FILE: nightly-test-results/junit/test-staging-no-auth-[hash].xml
+      - run:
+          name: Run remote verification of WAF against staging
+          command: bash -i -c 'npm run test-staging-waf'
+          environment:
+            MOCHA_FILE: nightly-test-results/junit/test-staging-waf-[hash].xml
   uptime_monitor_no_auth:
     working_directory: ~/repo
     docker:
@@ -232,7 +252,7 @@ workflows:
   everything:
     jobs:
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
-      - uptime_monitor_no_auth:
+      - uptime_monitor_staging_no_auth:
           context:
             - dockerhub
       - lint_license_unit_test_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,14 @@ jobs:
           failure_message: Nightly << parameters.stack >> non-auth tests failed!
           webhook: $SLACK_WEBHOOK
 
-  # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
+  # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
+  # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
   uptime_monitor_auth:
+    parameters:
+      stack:
+        type: string
+      webpage_URL:
+        type: string
     working_directory: ~/repo
     docker:
         - image: circleci/buildpack-deps:18.04-browsers
@@ -61,16 +67,16 @@ jobs:
             password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
-          webpage_URL: "https://dev.dockstore.net"
+          webpage_URL: << parameters.webpage_URL >>
       - run:
-          name: Run remote verification test against dev (with auth)
-          command: bash -i -c 'npm run test-dev-auth'
+          name: Run remote verification test against << parameters.stack >> (with auth)
+          command: bash -i -c 'npm run test-<< parameters.stack >>-auth'
           environment:
-            MOCHA_FILE: nightly-test-results/junit/test-dev-auth-[hash].xml
+            MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
           fail_only: true
-          failure_message: Nightly auth tests failed!
+          failure_message: Nightly << parameters.stack >> auth tests failed!
           webhook: $SLACK_WEBHOOK
   lint_license_unit_test_coverage:
     working_directory: ~/repo
@@ -238,11 +244,6 @@ workflows:
   everything:
     jobs:
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
-      - uptime_monitor_no_auth:
-          stack: "staging"
-          webpage_URL: "https://staging.dockstore.org"
-          context:
-            - dockerhub
       - lint_license_unit_test_coverage:
           filters:
             tags:
@@ -309,7 +310,20 @@ workflows:
           webpage_URL: "https://dev.dockstore.net"
           context:
             - dockerhub
+      - uptime_monitor_no_auth:
+          stack: "staging"
+          webpage_URL: "https://staging.dockstore.org"
+          context:
+            - dockerhub
+      - uptime_monitor_no_auth:
+          stack: "prod"
+          webpage_URL: "https://dockstore.org"
+          context:
+            - dockerhub
+      # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
       - uptime_monitor_auth:
+          stack: "dev"
+          webpage_URL: "https://dev.dockstore.net"
           context:
             - dockerhub
 

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -151,17 +151,17 @@ describe('Test workflow page functionality', () => {
 });
 
 // pairs of [workflow URL without version number, verified version number, another verified version number, workflow.trsUrl]
-// TODO re add this after https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done: [
-//     'github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl',
-//     '1.32.0',
-//     'develop',
-//     window.location.origin +
-//       '/api' +
-//       ga4ghPath +
-//       '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
-//     'WDL',
-//   ],
 const workflowVersionTuples = [
+  [
+    'github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl',
+    '1.32.0',
+    'develop',
+    window.location.origin +
+      '/api' +
+      ga4ghPath +
+      '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
+    'WDL',
+  ],
   [
     'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
     'dev',

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -151,17 +151,17 @@ describe('Test workflow page functionality', () => {
 });
 
 // pairs of [workflow URL without version number, verified version number, another verified version number, workflow.trsUrl]
+// TODO re add this after https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done: [
+//     'github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl',
+//     '1.32.0',
+//     'develop',
+//     window.location.origin +
+//       '/api' +
+//       ga4ghPath +
+//       '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
+//     'WDL',
+//   ],
 const workflowVersionTuples = [
-  [
-    'github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl',
-    '1.32.0',
-    'develop',
-    window.location.origin +
-      '/api' +
-      ga4ghPath +
-      '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
-    'WDL',
-  ],
   [
     'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
     'dev',


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-2937

Runs the staging no-auth smoke tests during the nightly testing. Since the auth testing user is not currently setup on staging and prod, the auth tests will need to wait until: https://ucsc-cgl.atlassian.net/browse/SEAB-1871 is finished.

To get the correct set of tests to run:
1. Scrape the current webpage for the commit id
2. Checkout the branch with the commit id
3. Run smoke tests
(Note: This PR also changes the dev nightly tests to use the above strategy)

There is currently one smoke test that is known to be broken: https://ucsc-cgl.atlassian.net/browse/SEAB-2071. 

I've removed the breaking input so that the tests wont fail in the upcoming release (they will until then, though). 
We can see the smoke test failing (correctly) in staging: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/5775/workflows/691f3f94-8109-4c8c-af04-ec4709bb5be2/jobs/18891.