### PR TITLE
Featured news update

### DIFF
--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://10918-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://11124-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -77,6 +77,7 @@ export class ConfigurationService {
 
     Dockstore.DOCUMENTATION_URL = config.documentationUrl;
     Dockstore.FEATURED_CONTENT_URL = config.featuredContentUrl;
+    Dockstore.FEATURED_NEWS_URL = config.featuredNewsUrl;
 
     Dockstore.DEPLOY_VERSION = config.deployVersion;
 

--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -34,6 +34,8 @@
         <div class="news-container">
           <app-news-updates data-cy="news-updates-container"></app-news-updates>
         </div>
+        <app-alert></app-alert>
+        <featured-news></featured-news>
       </div>
       <div class="widget-section">
         <h3>Explore Featured Content</h3>

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -236,41 +236,17 @@
     <img src="../../../assets/images/home/illustration.png" alt="illustration" fxHide.lt-md fxFlex="40" class="contain-img" />
   </div>
 
-  <!-- <div class="gray-sections pt-5 pb-5">
+  <div class="gray-sections pt-5 pb-5">
     <div class="container" fxLayout="column" fxLayoutGap="3rem" fxLayoutAlign="space-around center">
       <h3>Featured Content</h3>
       <featured-content></featured-content>
     </div>
-  </div> -->
-  <!-- remove this hr when featured content is populated -->
-  <hr class="my-5" />
+  </div>
 
   <div fxLayout="row" fxLayout.lt-md="column" class="container mt-5" fxLayoutGap="2rem">
     <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="3rem" fxFlex="33" fxFlex.lt-md="100" id="news">
       <h3>News & Events</h3>
-      <span>
-        <h4>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/github-apps/github-apps.html'"
-            >Dockstore GitHub App</a
-          >
-        </h4>
-        <span
-          >Our Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and
-          Dockstore. Check it out!</span
-        >
-      </span>
-      <span>
-        <h4>
-          <a [routerLink]="['/organizations/BroadInstitute/collections/pgs']">Viral Analysis Workflows for COVID-19</a>
-        </h4>
-        <span
-          >A collection of viral NGS workflows for analyzing COVID-19. Learn how to use them with your own data in linked Terra workspaces
-          from the Broad Viral Genomics & Data Sciences Platform.</span
-        >
-      </span>
+      <featured-news></featured-news>
     </div>
     <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="3rem" fxFlex="33" fxFlex.lt-md="100" id="resources">
       <h3>Helpful Resources</h3>

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -236,7 +236,7 @@
     <img src="../../../assets/images/home/illustration.png" alt="illustration" fxHide.lt-md fxFlex="40" class="contain-img" />
   </div>
 
-  <div class="gray-sections pt-5 pb-5">
+  <div class="gray-sections py-5">
     <div class="container" fxLayout="column" fxLayoutGap="3rem" fxLayoutAlign="space-around center">
       <h3>Featured Content</h3>
       <featured-content></featured-content>

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -18,6 +18,7 @@ import { HomePageComponent } from './home-page.component';
 import { RecentEventsComponent } from './recent-events/recent-events.component';
 import { EntriesComponent } from './widget/entries/entries.component';
 import { FeaturedContentComponent } from './widget/featured-content/featured-content.component';
+import { FeaturedNewsComponent } from './widget/featured-content/featured-news.component';
 import { GettingStartedComponent } from './widget/getting-started/getting-started.component';
 import { NewsUpdatesComponent } from './widget/news-updates/news-updates.component';
 import { OrganizationsComponent } from './widget/organizations/organizations.component';
@@ -47,6 +48,7 @@ import { RequestsComponent } from './widget/requests/requests.component';
     EntriesComponent,
     OrganizationsComponent,
     FeaturedContentComponent,
+    FeaturedNewsComponent,
     NewsUpdatesComponent,
     GettingStartedComponent,
     EntryToDisplayNamePipe,

--- a/src/app/home-page/widget/featured-content/featured-content.component.ts
+++ b/src/app/home-page/widget/featured-content/featured-content.component.ts
@@ -8,7 +8,7 @@ import { Dockstore } from '../../../shared/dockstore.model';
   template: ` <div [innerHTML]="myExternalHTML"></div> `,
 })
 export class FeaturedContentComponent implements OnInit {
-  public myExternalHTML: any = '';
+  public myExternalHTML = '';
 
   constructor(private http: HttpClient, private alertService: AlertService) {}
   ngOnInit() {

--- a/src/app/home-page/widget/featured-content/featured-content.component.ts
+++ b/src/app/home-page/widget/featured-content/featured-content.component.ts
@@ -12,7 +12,7 @@ export class FeaturedContentComponent implements OnInit {
 
   constructor(private http: HttpClient, private alertService: AlertService) {}
   ngOnInit() {
-    this.alertService.start('Retrieve featured content');
+    this.alertService.start('Retrieving featured content');
     this.http
       .get(
         Dockstore.FEATURED_CONTENT_URL,

--- a/src/app/home-page/widget/featured-content/featured-news.component.ts
+++ b/src/app/home-page/widget/featured-content/featured-news.component.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, OnInit } from '@angular/core';
+import { AlertService } from '../../../shared/alert/state/alert.service';
+import { Dockstore } from '../../../shared/dockstore.model';
+
+@Component({
+  selector: 'featured-news',
+  template: ` <div [innerHTML]="myExternalHTML"></div> `,
+})
+export class FeaturedNewsComponent implements OnInit {
+  // TODO should parameterize FeaturedContentComponent or something
+  public myExternalHTML: any = '';
+
+  constructor(private http: HttpClient, private alertService: AlertService) {}
+  ngOnInit() {
+    this.alertService.start('Retrieve featured content');
+    this.http
+      .get(
+        Dockstore.FEATURED_NEWS_URL,
+        // set authorization header to empty, prevents ng2-ui interceptor from adding dockstore bearer token
+        { headers: { Authorization: '' }, responseType: 'text' }
+      )
+      .subscribe(
+        (data) => {
+          this.myExternalHTML = data;
+          this.alertService.simpleSuccess();
+        },
+        () => {
+          this.alertService.simpleError();
+        }
+      );
+  }
+}

--- a/src/app/home-page/widget/featured-content/featured-news.component.ts
+++ b/src/app/home-page/widget/featured-content/featured-news.component.ts
@@ -9,7 +9,7 @@ import { Dockstore } from '../../../shared/dockstore.model';
 })
 export class FeaturedNewsComponent implements OnInit {
   // TODO should parameterize FeaturedContentComponent or something
-  public myExternalHTML: any = '';
+  public myExternalHTML = '';
 
   constructor(private http: HttpClient, private alertService: AlertService) {}
   ngOnInit() {

--- a/src/app/home-page/widget/featured-content/featured-news.component.ts
+++ b/src/app/home-page/widget/featured-content/featured-news.component.ts
@@ -13,7 +13,7 @@ export class FeaturedNewsComponent implements OnInit {
 
   constructor(private http: HttpClient, private alertService: AlertService) {}
   ngOnInit() {
-    this.alertService.start('Retrieve featured content');
+    this.alertService.start('Retrieving featured news');
     this.http
       .get(
         Dockstore.FEATURED_NEWS_URL,

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -85,6 +85,7 @@ export class Dockstore {
   static DOCKSTORE_REPO = 'https://github.com/dockstore/dockstore';
   static DOCUMENTATION_URL = 'https://docs.dockstore.org';
   static FEATURED_CONTENT_URL = 'will be filled in by configuration.service';
+  static FEATURED_NEWS_URL = 'will be filled in by configuration.service';
 
   static DEPLOY_VERSION = '';
   static COMPOSE_SETUP_VERSION = '';


### PR DESCRIPTION
* makes featured news pull from cloudfront just like featured content
* probably need help styling and reusing the featured component

Relies on https://github.com/dockstore/extra-content/pull/23 to provide content (split up news and content, plus remove styles on news to match mock-ups) and https://github.com/dockstore/dockstore/pull/4269 for a back-end change

Eventually should make it to https://projects.invisionapp.com/share/VNZ92Z0T2B3#/screens/434510663
Currently looks like 

Logged off homepage
![Screenshot from 2021-06-01 19-02-49](https://user-images.githubusercontent.com/1730679/120400992-00c78900-c30d-11eb-96be-8c7493d61012.png)

Logged in (will be very different in 1.12)
![Screenshot from 2021-06-01 19-02-43](https://user-images.githubusercontent.com/1730679/120400987-fefdc580-c30c-11eb-934a-dd6dcfd5fa82.png)
