### PR TITLE
Feature/2855/automate smoke tests rebased

### DIFF
--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -63,7 +63,7 @@ const workflowVersionTuples = [
   ],
   ['github.com/nf-core/vipr', 'dev', 'master', '', 'NFL'],
 ];
-describe('Monitor workflows', () => {
+describe.only('Monitor workflows', () => {
   workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
 });
 function testWorkflow(url: string, version1: string, version2: string, trsUrl: string, type: string) {
@@ -132,20 +132,21 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   if (type === 'CWL') {
     launchWithTuples = [
       // pairs of [launch button text, expected href]
-      ['CGC', '?trs=' + trsUrl],
-      ['NHLBI BioData Catalyst', '?trs=' + trsUrl],
+      ['cgcLaunchWith', '?trs=' + trsUrl],
+      ['nhlbiLaunchWith', '?trs=' + trsUrl],
+      ['cavaticaLaunchWith', '?trs=' + trsUrl],
     ];
   } else if (type === 'WDL') {
     launchWithTuples = [
       // pairs of [launch button text, expected href]
-      ['DNAstack', '?descriptorType=wdl&path=' + url],
-      ['DNAnexus', '?source=' + trsUrl],
-      ['Terra', url + ':' + version2],
-      ['AnVIL', url + ':' + version2],
-      ['NHLBI BioData Catalyst', url + ':' + version2],
+      ['dnastackLaunchWith', '?descriptorType=wdl&path=' + url],
+      ['dnanexusLaunchWith', '?source=' + trsUrl],
+      ['terraLaunchWith', url + ':' + version2],
+      ['anvilLaunchWith', url + ':' + version2],
+      ['nhlbiLaunchWith', url + ':' + version2],
     ];
   } else if (type === 'NFL') {
-    launchWithTuples = [['Nextflow Tower', url + '&revision=' + version2]];
+    launchWithTuples = [['nextflowtowerLaunchWith', url + '&revision=' + version2]];
   } else {
     launchWithTuples = [];
   }
@@ -153,7 +154,7 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   // click on each launch button and confirm the url changes
   launchWithTuples.forEach((t) => {
     it('launch with buttons go to external site', () => {
-      cy.contains('a', t[0]).should(($el) => {
+      cy.get('[data-cy=' + t[0] + ']').should(($el) => {
         // @ts-ignore
         expect($el.attr('href')).to.contain(t[1]);
       });

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -82,14 +82,6 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     goToTab('Launch');
     cy.url().should('contain', '?tab=launch');
     cy.contains('mat-card-header', 'Workflow Information');
-
-    // test export to zip button
-    goToTab('Info');
-    cy.get('[data-cy=downloadZip]')
-      .contains('a')
-      .then((el) => {
-        cy.request(el.prop('href')).its('status').should('eq', 200);
-      });
   });
 
   it('versions tab works', () => {

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -75,6 +75,8 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
       ['AnVIL', url + ':' + version2],
       ['NHLBI BioData Catalyst', url + ':' + version2],
     ];
+  } else if (type === 'NFL') {
+    launchWithTuples = [['Nextflow Tower', url + '&revision=' + version2]];
   } else {
     launchWithTuples = [];
   }
@@ -132,7 +134,7 @@ describe('Test search page functionality', () => {
     cy.url().should('not.contain', 'descriptorType=NF');
     cy.url().should('contain', 'searchMode=files');
   });
-  it.only('boolean facet filters', () => {
+  it('boolean facet filters', () => {
     cy.visit('/search');
     cy.contains('mat-checkbox', /^[ ]*verified/).click();
     cy.url().should('contain', 'verified=1');
@@ -183,7 +185,7 @@ const workflowVersionTuples = [
 
 const organizations = [['Broad Institute']];
 
-describe('Monitor workflows', () => {
+describe.only('Monitor workflows', () => {
   workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
 });
 

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -114,7 +114,8 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   it('DAG tab works', () => {
     cy.contains('.mat-tab-label', 'DAG').click();
     cy.url().should('contain', '?tab=dag');
-    cy.get('[data-cy=dag-holder]');
+    cy.get('[data-cy=dag-holder]')
+      .children().should('have.length.of.at.least', 1);
   });
 
   let launchWithTuples: any[] = [];

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -8,7 +8,16 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     goToTab('Launch');
     cy.url().should('contain', '?tab=launch');
     cy.contains('mat-card-header', 'Workflow Information');
-    // test export to zip button?
+
+    // test export to zip button
+    goToTab('Info');
+    cy.get('[data-cy=downloadZip]')
+      .contains('a')
+      .then(el => {
+        cy.request(el.prop('href'))
+          .its('status')
+          .should('eq', 200);
+      });
   });
 
   it('versions tab works', () => {
@@ -185,7 +194,7 @@ const workflowVersionTuples = [
 
 const organizations = [['Broad Institute']];
 
-describe.only('Monitor workflows', () => {
+describe('Monitor workflows', () => {
   workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
 });
 

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -2,6 +2,70 @@ import { ga4ghPath } from '../../../src/app/shared/constants';
 import { Dockstore } from '../../../src/app/shared/dockstore.model';
 import { goToTab } from '../../support/commands';
 
+// Test an entry, these should be ambiguous between tools and workflows.
+describe('run stochastic smoke test', () => {
+  testEntry('Tools');
+  testEntry('Workflows');
+});
+function testEntry(tab: string) {
+  beforeEach('get random entry on first page', () => {
+    cy.visit('/search');
+    goToTab(tab);
+    const linkName = tab === 'Workflows' ? 'workflowColumn' : 'toolNames';
+    // select a random entry on the first page and navigate to it
+    let chosen_index = 0;
+    cy.get('[data-cy=' + linkName + ']')
+      .then(($list) => {
+        chosen_index = Math.floor(Math.random() * $list.length);
+      })
+      .eq(chosen_index)
+      .within(() => {
+        cy.get('a').then((el) => {
+          cy.log(el.prop('href')); // log the href in case a test fails
+          cy.visit(el.prop('href'));
+        });
+      });
+  });
+
+  it('check info tab', () => {
+    // test export to zip button
+    goToTab('Info');
+
+    cy.get('[data-cy=downloadZip]').within(() => {
+      cy.get('a').then((el) => {
+        cy.request(el.prop('href')).its('status').should('eq', 200);
+      });
+    });
+    cy.get('[data-cy=sourceRepository]').should('have.attr', 'href');
+  });
+
+  it('files tab works', () => {
+    goToTab('Files');
+    cy.url().should('contain', '?tab=files');
+    cy.contains('Descriptor Files');
+  });
+
+  it('versions tab works', () => {
+    goToTab('Versions');
+    cy.url().should('contain', '?tab=versions');
+    cy.get('[data-cy=versionRow]').should('have.length.of.at.least', 1);
+  });
+}
+
+// pairs of [workflow URL without version number, verified version number, another verified version number, workflow.trsUrl]
+const workflowVersionTuples = [
+  [
+    'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
+    'dev',
+    'master',
+    window.location.origin + '/api' + ga4ghPath + '/tools/%23workflow%2Fgithub.com%2FNCI-GDC%2Fgdc-dnaseq-cwl%2FGDC_DNASeq/versions/master',
+    'CWL',
+  ],
+  ['github.com/nf-core/vipr', 'dev', 'master', '', 'NFL'],
+];
+describe('Monitor workflows', () => {
+  workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
+});
 function testWorkflow(url: string, version1: string, version2: string, trsUrl: string, type: string) {
   it('info tab works', () => {
     cy.visit('/workflows/' + url + ':' + version1);
@@ -13,10 +77,8 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     goToTab('Info');
     cy.get('[data-cy=downloadZip]')
       .contains('a')
-      .then(el => {
-        cy.request(el.prop('href'))
-          .its('status')
-          .should('eq', 200);
+      .then((el) => {
+        cy.request(el.prop('href')).its('status').should('eq', 200);
       });
   });
 
@@ -101,6 +163,25 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   });
 }
 
+const organizations = [['Broad Institute']];
+describe('Check organizations page', () => {
+  it('has multiple organizations', () => {
+    cy.contains('a', 'Organizations').click();
+    cy.url().should('contain', '/organizations');
+    cy.get('[data-cy=orgName]').should('have.length.of.at.least', 2);
+  });
+
+  organizations.forEach((t) => {
+    it('organization page and collections work', () => {
+      cy.contains('[data-cy=orgName]', t[0]).click();
+      cy.get('[data-cy=collectionName').should('have.length.of.at.least', 1);
+      cy.get('[data-cy=collectionName').first().click();
+      cy.url().should('contain', 'collections');
+      cy.get('[data-cy=collectionEntry]').should('have.length.of.at.least', 1);
+    });
+  });
+});
+
 describe('Test logged out home page', () => {
   it('find buttons', () => {
     cy.visit('/');
@@ -167,52 +248,6 @@ describe('Test workflow page functionality', () => {
       .within(() => {
         cy.get('a').click(); // click on the link to the first workflow
       });
-  });
-});
-
-// pairs of [workflow URL without version number, verified version number, another verified version number, workflow.trsUrl]
-// TODO re add this after https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done: [
-//     'github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl',
-//     '1.32.0',
-//     'develop',
-//     window.location.origin +
-//       '/api' +
-//       ga4ghPath +
-//       '/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/develop',
-//     'WDL',
-//   ],
-const workflowVersionTuples = [
-  [
-    'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
-    'dev',
-    'master',
-    window.location.origin + '/api' + ga4ghPath + '/tools/%23workflow%2Fgithub.com%2FNCI-GDC%2Fgdc-dnaseq-cwl%2FGDC_DNASeq/versions/master',
-    'CWL',
-  ],
-  ['github.com/nf-core/vipr', 'dev', 'master', '', 'NFL'],
-];
-
-const organizations = [['Broad Institute']];
-
-describe('Monitor workflows', () => {
-  workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
-});
-
-describe('Check organizations page', () => {
-  it('has multiple organizations', () => {
-    cy.contains('a', 'Organizations').click();
-    cy.url().should('contain', '/organizations');
-    cy.get('[data-cy=orgName]').should('have.length.of.at.least', 2);
-  });
-
-  organizations.forEach((t) => {
-    it('organization page and collections work', () => {
-      cy.contains('[data-cy=orgName]', t[0]).click();
-      cy.get('[data-cy=collectionName').should('have.length.of.at.least', 1);
-      cy.get('[data-cy=collectionName').first().click();
-      cy.url().should('contain', 'collections');
-      cy.get('[data-cy=collectionEntry]').should('have.length.of.at.least', 1);
-    });
   });
 });
 

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -21,7 +21,7 @@ function testEntry(tab: string) {
       .eq(chosen_index)
       .within(() => {
         cy.get('a').then((el) => {
-          cy.log(el.prop('href')); // log the href in case a test fails
+          cy.task('log', el.prop('href')); // log the href in case a test fails
           cy.visit(el.prop('href'));
         });
       });
@@ -39,13 +39,13 @@ function testEntry(tab: string) {
     cy.get('[data-cy=sourceRepository]').should('have.attr', 'href');
   });
 
-  it('files tab works', () => {
+  it('check files tab', () => {
     goToTab('Files');
     cy.url().should('contain', '?tab=files');
     cy.contains('Descriptor Files');
   });
 
-  it('versions tab works', () => {
+  it('check versions tab', () => {
     goToTab('Versions');
     cy.url().should('contain', '?tab=versions');
     cy.get('[data-cy=versionRow]').should('have.length.of.at.least', 1);
@@ -109,13 +109,11 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     cy.url().should('contain', '?tab=tools');
   });
 
-  // This tends to be flaky so we are leaving it out for now
-  //
-  // it('DAG tab works', () => {
-  //   goToTab('DAG');
-  //   cy.url().should('contain', '?tab=dag');
-  //   cy.get('[data-cy=dag-holder]');
-  // });
+  it('DAG tab works', () => {
+    cy.contains('.mat-tab-label', 'DAG').click();
+    cy.url().should('contain', '?tab=dag');
+    cy.get('[data-cy=dag-holder]');
+  });
 
   let launchWithTuples: any[] = [];
   if (type === 'WDL') {

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -132,6 +132,15 @@ describe('Test search page functionality', () => {
     cy.url().should('not.contain', 'descriptorType=NF');
     cy.url().should('contain', 'searchMode=files');
   });
+  it.only('boolean facet filters', () => {
+    cy.visit('/search');
+    cy.contains('mat-checkbox', /^[ ]*verified/).click();
+    cy.url().should('contain', 'verified=1');
+    cy.get('[data-cy=verificationStatus]').each(($el, index, $list) => {
+      console.log($el);
+      cy.wrap($el).contains('done');
+    });
+  });
 });
 
 describe('Test workflow page functionality', () => {

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -21,7 +21,7 @@ function testEntry(tab: string) {
       .eq(chosen_index)
       .within(() => {
         cy.get('a').then((el) => {
-          cy.task('log', el.prop('href')); // log the href in case a test fails
+          cy.log(el.prop('href')); // log the href in case a test fails
           cy.visit(el.prop('href'));
         });
       });
@@ -55,6 +55,16 @@ function testEntry(tab: string) {
 // pairs of [workflow URL without version number, verified version number, another verified version number, workflow.trsUrl]
 const workflowVersionTuples = [
   [
+    'github.com/briandoconnor/dockstore-workflow-md5sum/dockstore-wdl-workflow-md5sum',
+    '1.4.0',
+    'develop',
+    window.location.origin +
+      '/api' +
+      ga4ghPath +
+      '/tools/%23workflow%2Fgithub.com%2Fbriandoconnor%2Fdockstore-workflow-md5sum%2Fdockstore-wdl-workflow-md5sum/versions/develop',
+    'WDL',
+  ],
+  [
     'github.com/NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq',
     'dev',
     'master',
@@ -63,7 +73,7 @@ const workflowVersionTuples = [
   ],
   ['github.com/nf-core/vipr', 'dev', 'master', '', 'NFL'],
 ];
-describe.only('Monitor workflows', () => {
+describe('Monitor workflows', () => {
   workflowVersionTuples.forEach((t) => testWorkflow(t[0], t[1], t[2], t[3], t[4]));
 });
 function testWorkflow(url: string, version1: string, version2: string, trsUrl: string, type: string) {
@@ -118,14 +128,14 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   let launchWithTuples: any[] = [];
   if (type === 'WDL') {
     it('get the svg icons', () => {
-      cy.get('[data-cy=dnanexusIcon]').within(() => {
-        cy.get('svg').should('exist');
+      cy.get('[data-cy=dnanexusLaunchWith]').within(() => {
+        cy.get('img').should('exist');
       });
-      cy.get('[data-cy=terraIcon]').within(() => {
-        cy.get('svg').should('exist');
+      cy.get('[data-cy=terraLaunchWith]').within(() => {
+        cy.get('img').should('exist');
       });
-      cy.get('[data-cy=anvilIcon]').within(() => {
-        cy.get('svg').should('exist');
+      cy.get('[data-cy=anvilLaunchWith]').within(() => {
+        cy.get('img').should('exist');
       });
     });
   }
@@ -139,7 +149,6 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   } else if (type === 'WDL') {
     launchWithTuples = [
       // pairs of [launch button text, expected href]
-      ['dnastackLaunchWith', '?descriptorType=wdl&path=' + url],
       ['dnanexusLaunchWith', '?source=' + trsUrl],
       ['terraLaunchWith', url + ':' + version2],
       ['anvilLaunchWith', url + ':' + version2],

--- a/cypress/integration/manualTests/monitor.ts
+++ b/cypress/integration/manualTests/monitor.ts
@@ -22,7 +22,7 @@ function aboutPageExternalLink(selector: string, url: string): void {
 }
 
 const selectorLinkTuples = [
-  ['[data-cy=register-button]', '/login'],
+  ['[data-cy=register-button]', '/register'],
   ['[data-cy=footer-about-link]', '/about'],
   ['[data-cy=homepage-organizations-button]', '/organizations'],
   ['[data-cy=footer-organizations-link]', '/organizations'],

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -21,7 +21,7 @@ describe('Admin UI', () => {
     it('should be able to use basic search box and have suggestions', () => {
       cy.get('[data-cy=basic-search]').type('dockstore_i');
       cy.contains(' Sorry, no matches found for dockstore_i');
-      cy.contains('Do you mean: dockstore?');
+      cy.contains('Do you mean: dockstore\'s?');
       cy.url().should('include', 'search=dockstore_i');
     });
 

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -27,6 +27,7 @@
             <a
               *ngIf="tool?.providerUrl"
               id="sourceRepository"
+              data-cy="sourceRepository"
               [href]="tool?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')"
             >
               {{ tool?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.name : '') }}

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -281,7 +281,7 @@
           </a>
           <span *ngIf="!selectedVersion?.email"> n/a </span>
         </div>
-        <span *ngIf="isValidVersion" id="downloadZipButton">
+        <span *ngIf="isValidVersion" id="downloadZipButton" data-cy="downloadZip">
           <button *ngIf="!tool?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
           <a [href]="downloadZipLink" *ngIf="tool?.is_published" mat-raised-button>Export as ZIP</a>
         </span>

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -123,6 +123,7 @@
       [ngClass]="{ highlight: version.name === selectedTag.name }"
       mat-row
       *matRowDef="let row; columns: displayedColumns; let version"
+      data-cy="versionRow"
     ></tr>
   </table>
 </div>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -22,7 +22,7 @@
     </ng-container>
     <ng-container matColumnDef="verified">
       <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let workflow">
+      <mat-cell data-cy="verificationStatus" fxShow fxHide.lt-md *matCellDef="let workflow">
         <a *ngIf="workflow.verified" [href]="verifiedLink">
           <mat-icon matTooltip="Verified">done</mat-icon>
         </a>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -42,7 +42,11 @@
         <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
             <strong matTooltip="Git repository for the associated descriptors">Source Code</strong>:
-            <a id="sourceRepository" [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')">
+            <a
+              id="sourceRepository"
+              data-cy="sourceRepository"
+              [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')"
+            >
               {{ workflow?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.name : '') }}
             </a>
           </li>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -280,7 +280,7 @@
         </a>
         <span *ngIf="!selectedVersion?.email"> n/a </span>
       </div>
-      <span *ngIf="isValidVersion" id="downloadZipButton">
+      <span *ngIf="isValidVersion" id="downloadZipButton" data-cy="downloadZip">
         <button *ngIf="!workflow?.is_published" mat-raised-button (click)="downloadZip()">Export as ZIP</button>
         <a [href]="downloadZipLink" *ngIf="workflow?.is_published" mat-raised-button>Export as ZIP</a>
       </span>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -50,6 +50,7 @@
               rel="noopener"
               [attr.href]="config.DNANEXUS_IMPORT_URL + '?source=' + trsUrl"
               [disabled]="!(hasContent$ | async)"
+              data-cy="dnanexusLaunchWith"
               ><img class="partner-launch" src="../assets/images/thirdparty/dnanexus.png" alt="DNAnexus launch with logo"
             /></a>
             <a
@@ -60,6 +61,7 @@
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
+              data-cy="terraLaunchWith"
               ><img class="partner-launch" src="../assets/images/thirdparty/terra.png" alt="Terra launch with logo"
             /></a>
             <a
@@ -70,6 +72,7 @@
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.ANVIL_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
+              data-cy="anvilLaunchWith"
               ><img class="partner-launch" src="../assets/images/thirdparty/anvil.png" alt="AnVIL launch with logo"
             /></a>
             <a
@@ -80,7 +83,7 @@
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.BD_CATALYST_TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
-              data-cy="nhlbiWdlButton"
+              data-cy="nhlbiLaunchWith"
               ><span class="partner-name">NHLBI BioData Catalyst</span></a
             >
           </div>
@@ -95,8 +98,8 @@
                 [attr.href]="config.DNASTACK_IMPORT_URL + '?descriptorType=wdl&path=' + workflowPathAsQueryValue"
                 [disabled]="!(hasContent$ | async)"
                 color="primary"
-                ><img class="partner-icon" data-cy="dnastackIcon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" />
-                DNAstack &raquo;</a
+                data-cy="dnastackLaunchWith"
+                ><img class="partner-icon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" /> DNAstack &raquo;</a
               >
               <a
                 mat-raised-button
@@ -107,7 +110,8 @@
                 [attr.href]="config.DNANEXUS_IMPORT_URL + '?source=' + trsUrl"
                 [disabled]="!(hasContent$ | async)"
                 color="primary"
-                ><mat-icon svgIcon="dnanexus" data-cy="dnanexusIcon"></mat-icon> DNAnexus &raquo;</a
+                data-cy="dnanexusLaunchWith"
+                ><mat-icon svgIcon="dnanexus"></mat-icon> DNAnexus &raquo;</a
               >
               <a
                 mat-raised-button
@@ -118,7 +122,8 @@
                 [disabled]="disableTerraPlatform$ | async"
                 [attr.href]="config.TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
                 color="primary"
-                ><mat-icon svgIcon="terra" data-cy="terraIcon"></mat-icon> Terra &raquo;</a
+                data-cy="terraLaunchWith"
+                ><mat-icon svgIcon="terra"></mat-icon> Terra &raquo;</a
               >
               <a
                 mat-raised-button
@@ -129,7 +134,8 @@
                 [disabled]="disableTerraPlatform$ | async"
                 [attr.href]="config.ANVIL_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
                 color="primary"
-                ><mat-icon class="anvil-icon" svgIcon="anvil" data-cy="anvilIcon"></mat-icon> AnVIL &raquo;</a
+                data-cy="anvilLaunchWith"
+                ><mat-icon class="anvil-icon" svgIcon="anvil"></mat-icon> AnVIL &raquo;</a
               >
               <a
                 mat-raised-button
@@ -140,7 +146,7 @@
                 [disabled]="disableTerraPlatform$ | async"
                 [attr.href]="config.BD_CATALYST_TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
                 color="primary"
-                data-cy="nhlbiWdlButton"
+                data-cy="nhlbiLaunchWith"
                 >NHLBI BioData Catalyst</a
               >
             </div>
@@ -161,6 +167,7 @@
             [attr.href]="config.CGC_IMPORT_URL + '?trs=' + trsUrl"
             [disabled]="disableSevenBridgesPlatform$ | async"
             color="primary"
+            data-cy="cgcLaunchWith"
             ><img class="partner-icon" src="../assets/images/thirdparty/cgc.png" alt="CGC icon" /> CGC
           </a>
           <a
@@ -172,6 +179,7 @@
             [attr.href]="config.BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL + '?trs=' + trsUrl"
             [disabled]="disableSevenBridgesPlatform$ | async"
             color="primary"
+            data-cy="nhlbiLaunchWith"
             >NHLBI BioData Catalyst
           </a>
           <a
@@ -183,6 +191,7 @@
             [attr.href]="config.CAVATICA_IMPORT_URL + '?trs=' + trsUrl"
             [disabled]="disableSevenBridgesPlatform$ | async"
             color="primary"
+            data-cy="cavaticaLaunchWith"
             ><img class="partner-icon" src="../assets/images/thirdparty/cavatica.png" alt="Cavatica icon" /> Cavatica
           </a>
         </div>
@@ -219,6 +228,7 @@
             "
             [disabled]="!(hasContent$ | async)"
             color="primary"
+            data-cy="nextflowtowerLaunchWith"
           >
             <img class="partner-icon" src="../assets/images/thirdparty/nextflow-icon.png" alt="Nextflow icon" /> Nextflow Tower
           </a>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -181,6 +181,7 @@
       [ngClass]="{ highlight: version.name === _selectedVersion.name }"
       mat-row
       *matRowDef="let row; columns: displayedColumns; let version"
+      data-cy="versionRow"
     ></tr>
   </table>
 </div>


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-2855
Smoke test doc: https://docs.google.com/document/d/1CShy6nHne-defoJlA4jXIBJG-TG4g07lZcOZn7t7lU4/edit

I covered a majority of the manual smoke tests, there were a few I'm leaving behind for the moment (services/discourse) as they require a little more tinkering to get right.

Passing tests against release/2.8:
<img width="709" alt="Screen Shot 2021-06-03 at 2 39 33 PM" src="https://user-images.githubusercontent.com/36607471/120695925-eced6580-c479-11eb-9097-04a740a9032f.png">

There is a draft PR that is targeted at develop, https://github.com/dockstore/dockstore-ui2/pull/1255, instead of the release/2.8 branch, if we decide that is a better route (it also has some more details on the smoke tests that were changed/added).