### PR TITLE
Checker link: No more social distancing

### DIFF
--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -1,6 +1,6 @@
 <li *ngIf="((checkerId$ | async) || (canAdd$ | async)) && !(isRefreshing$ | async)">
   <form #editCheckerWorkflowPathForm="ngForm" class="form-inline">
-    <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
+    <div class="form-group" fxFlex="nogrow" fxLayout fxLayoutAlign=" center">
       <strong matTooltip="Checker workflow of this tool/workflow that tests it">Checker Workflow</strong>:
     </div>
     <span *ngIf="!(checkerId$ | async) && ((isPublic$ | async) || (canRead && !canWrite))"> n/a</span>


### PR DESCRIPTION
Random fix. 

Computed difference is `flex: 1 0 auto` -> `flex: 0 1 auto`. Prevents the container from filling as much space as possible.

**Before:**
<img width="792" alt="Screen Shot 2021-06-04 at 11 41 34 AM" src="https://user-images.githubusercontent.com/36607471/120828134-2aa9c700-c52a-11eb-9b96-97b63d2a2806.png">

**After:**
<img width="812" alt="Screen Shot 2021-06-04 at 11 41 06 AM" src="https://user-images.githubusercontent.com/36607471/120828157-31383e80-c52a-11eb-9df7-b3010fdf60c5.png">

