### PR TITLE
Tags with a dash broke the regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ commands:
           name: Get and checkout commit id from the current webpage.
           command: |
             COMMIT_ID=$(curl << parameters.webpage_URL >> | \
-                        grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9\.]+-[A-Za-z0-9]+" | \
+                        grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9\.\-]+-[A-Za-z0-9]+" | \
                         head -1 | \
                         grep -Eoi "[A-Za-z0-9]+$")
             git checkout $COMMIT_ID


### PR DESCRIPTION
The release tag `2.8.0-rc.0` broke the regex for automated smoke testing, as it didn't consider `-` a valid character (I had only considered dots).

Now, the regex accepts `-`, `.` and `alphanumeric` characters. I don't think there should be any other characters for the regex to consider, but if there are, I can modify further.