### PR TITLE
Remove Preview from GitHub apps

### DIFF
--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -38,8 +38,5 @@ export const currentTOSVersion: User.TosversionEnum = User.TosversionEnum.TOSVER
 export const currentPrivacyPolicyVersion: User.PrivacyPolicyVersionEnum = User.PrivacyPolicyVersionEnum.PRIVACYPOLICYVERSION25;
 export const dismissedLatestTOS = 'dismissedLatestTOS';
 export const dismissedLatestPrivacyPolicy = 'dismissedLatestPrivacyPolicy';
-// This is used to toggle whether GitHub apps are recommended or not.
-// If it's to be recommended permanently, it's better to revert this commit instead.
-export const recommendGitHubApps = false;
 // There is a search term length limit of 500 on the backend, but two extra characters, '.*', get counted in the backend.
 export const searchTermLengthLimit = 498;

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -19,8 +19,7 @@
     *ngIf="
       !isPublic &&
       workflow?.source_control_provider === 'GITHUB' &&
-      (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB) &&
-      this.recommendGitHubApps
+      (workflow?.mode === WorkflowType.ModeEnum.FULL || workflow?.mode === WorkflowType.ModeEnum.STUB)
     "
   >
     Keep your workflow automatically in sync with GitHub with our new registration process. Click

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -20,7 +20,6 @@ import { EntryType } from 'app/shared/enum/entry-type';
 import { Observable } from 'rxjs';
 import { shareReplay, takeUntil } from 'rxjs/operators';
 import { AlertQuery } from '../../shared/alert/state/alert.query';
-import { recommendGitHubApps } from '../../shared/constants';
 import { Dockstore } from '../../shared/dockstore.model';
 import { EntryTab } from '../../shared/entry/entry-tab';
 import { ExtendedWorkflowsService } from '../../shared/extended-workflows.service';
@@ -68,7 +67,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   ToolDescriptor = ToolDescriptor;
   public entryType$: Observable<EntryType>;
   public isRefreshing$: Observable<boolean>;
-  public recommendGitHubApps = recommendGitHubApps;
   modeTooltipContent = `STUB: Basic metadata pulled from source control.
   FULL: Full content synced from source control.
   HOSTED: Workflow metadata and files hosted on Dockstore.`;

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -31,7 +31,6 @@
           <mat-radio-button *ngFor="let option of options" [value]="option" [id]="option.value + '-register-workflow-option'">
             <span class="text-wrap">
               {{ option.label }}
-              <div *ngIf="option.value === 0 && !this.recommendGitHubApps" class="beta-label">preview</div>
               <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">
                 {{ selectedOption.extendedLabel }}
               </div>

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
@@ -22,7 +22,7 @@ import { SessionQuery } from 'app/shared/session/session.query';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { AlertQuery } from '../../shared/alert/state/alert.query';
-import { formInputDebounceTime, recommendGitHubApps } from '../../shared/constants';
+import { formInputDebounceTime } from '../../shared/constants';
 import { Dockstore } from '../../shared/dockstore.model';
 import { BioWorkflow, Service, ToolDescriptor, Workflow } from '../../shared/swagger';
 import { Tooltip } from '../../shared/tooltip';
@@ -60,7 +60,6 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
   public Tooltip = Tooltip;
   public workflowPathPlaceholder: string;
   public gitHubAppInstallationLink$: Observable<string>;
-  public recommendGitHubApps = recommendGitHubApps;
   public hostedWorkflow = {
     repository: '',
     descriptorType: Workflow.DescriptorTypeEnum.CWL,
@@ -84,11 +83,11 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
     },
   ];
   private githubAppOption = {
-    label: 'Register using GitHub Apps' + (this.recommendGitHubApps ? ' (Recommended)' : ''),
+    label: 'Register using GitHub Apps (Recommended)',
     extendedLabel: 'Install our GitHub App on your repository/organization to automatically sync workflows with GitHub.',
     value: 0,
   };
-  public options = this.recommendGitHubApps ? [this.githubAppOption, ...this.baseOptions] : [...this.baseOptions, this.githubAppOption];
+  public options = [this.githubAppOption, ...this.baseOptions];
 
   public selectedOption = this.options[0];
 


### PR DESCRIPTION
dockstore/dockstore#4282

I'm proposing getting this in for 1.11. Seems like the feature has been around long enough and it's working.

I'll re-target for develop if we think it's too soon.
