### PR TITLE
Feature/smoke test suggestions

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,7 +6,7 @@
   "defaultCommandTimeout": 30000,
   "requestTimeout": 30000,
   "retries": {
-    "runMode": 1,
+    "runMode": 3,
     "openMode": 3
   }
 }

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -19,10 +19,10 @@ describe('Admin UI', () => {
       cy.contains('the Language is WDL').should('not.exist');
     });
     it('should be able to use basic search box and have suggestions', () => {
-      const search_str = 'dockstore_I_am_an_unlikely_text_search';
-      cy.get('[data-cy=basic-search]').type(search_str);
-      cy.contains(' Sorry, no matches found for ' + search_str);
-      cy.url().should('include', 'search=' + search_str);
+      cy.get('[data-cy=basic-search]').type('dockstore_i');
+      cy.contains(' Sorry, no matches found for dockstore_i');
+      cy.contains(/Do[ ]you[ ]mean:[ ].+/);
+      cy.url().should('include', 'search=dockstore_i');
     });
 
     it('should reset filters', () => {

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -22,7 +22,7 @@ describe('Admin UI', () => {
       const search_str = 'dockstore_I_am_an_unlikely_text_search';
       cy.get('[data-cy=basic-search]').type(search_str);
       cy.contains(' Sorry, no matches found for ' + search_str);
-      cy.url().should('include', search_str);
+      cy.url().should('include', 'search=' + search_str);
     });
 
     it('should reset filters', () => {

--- a/cypress/integration/manualTests/search.ts
+++ b/cypress/integration/manualTests/search.ts
@@ -19,10 +19,10 @@ describe('Admin UI', () => {
       cy.contains('the Language is WDL').should('not.exist');
     });
     it('should be able to use basic search box and have suggestions', () => {
-      cy.get('[data-cy=basic-search]').type('dockstore_i');
-      cy.contains(' Sorry, no matches found for dockstore_i');
-      cy.contains('Do you mean: dockstore\'s?');
-      cy.url().should('include', 'search=dockstore_i');
+      const search_str = 'dockstore_I_am_an_unlikely_text_search';
+      cy.get('[data-cy=basic-search]').type(search_str);
+      cy.contains(' Sorry, no matches found for ' + search_str);
+      cy.url().should('include', search_str);
     });
 
     it('should reset filters', () => {


### PR DESCRIPTION
In response to nightly dev/staging smoke test failures.

I'm suggesting two changes to improve smoke test reliability:
1. Match the suggested text by regex rather than a specific string, should make the test more reliable regardless of what database a Dockstore stack is using.
2. Added more retries to test runs. I noticed some smoke tests are a little flaky, so this should alleviate some false-positives for test failures.