### PR TITLE
Feature/4229/file tree

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -103,6 +103,7 @@ import { TosBannerComponent } from './tosBanner/tos-banner.component';
 import { ExporterStepComponent } from './workflow/snapshot-exporter-modal/exporter-step/exporter-step.component';
 import { SnaphotExporterModalComponent } from './workflow/snapshot-exporter-modal/snaphot-exporter-modal.component';
 import { ViewService } from './workflow/view/view.service';
+import { FileTreeComponent } from './file-tree/file-tree.component';
 
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   showDelay: 500,
@@ -153,6 +154,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     AboutComponent,
     SnaphotExporterModalComponent,
     ExporterStepComponent,
+    FileTreeComponent,
   ],
   imports: [
     environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/file-tree/file-tree.component.html
+++ b/src/app/file-tree/file-tree.component.html
@@ -1,20 +1,27 @@
 <div mat-dialog-content>
   <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
     <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
-      <button mat-icon-button disabled></button>
-      <button (click)="selectFile(node)" *ngIf="!node.child" mat-button>
+      <!-- The already selected file -->
+      <button *ngIf="!node.child && data.selectedFile.absolutePath === node.absolutePath" mat-raised-button disabled>
         <mat-icon class="mr-2" [attr.aria-label]="'file icon'">description</mat-icon>{{ node.name }}
+      </button>
+      <!-- The not-selected files -->
+      <button (click)="selectFile(node)" *ngIf="!(!node.child && data.selectedFile.absolutePath === node.absolutePath)" mat-stroked-button>
+        <mat-icon color="primary" class="mr-2" [attr.aria-label]="'file icon'">description</mat-icon>{{ node.name }}
       </button>
     </mat-tree-node>
 
     <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
       <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
-        <mat-icon class="mat-icon-rtl-mirror">
+        <mat-icon color="primary" class="mat-icon-rtl-mirror">
           {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
         </mat-icon>
       </button>
-      <mat-icon class="mr-2" [attr.aria-label]="'folder icon'"> folder </mat-icon>
+      <mat-icon color="primary" class="mr-2" [attr.aria-label]="'folder icon'"> folder </mat-icon>
       {{ node.name }}
     </mat-tree-node>
   </mat-tree>
+</div>
+<div mat-dialog-actions class="pull-right">
+  <button mat-button mat-dialog-close cdkFocusInitial>Close</button>
 </div>

--- a/src/app/file-tree/file-tree.component.html
+++ b/src/app/file-tree/file-tree.component.html
@@ -2,16 +2,9 @@
   <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
     <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
       <button mat-icon-button disabled></button>
-      <button *ngIf="!node.child" mat-button>
-        <mat-icon class="mr-2" [attr.aria-label]="'file icon'">
-          {{ node.expandable ? 'folder' : 'description' }} </mat-icon
-        >{{ node.name }}
+      <button (click)="selectFile(node)" *ngIf="!node.child" mat-button>
+        <mat-icon class="mr-2" [attr.aria-label]="'file icon'">description</mat-icon>{{ node.name }}
       </button>
-      <span *ngIf="node.child"
-        ><mat-icon class="mr-2" [attr.aria-label]="'file icon'">
-          {{ node.expandable ? 'folder' : 'description' }} </mat-icon
-        >{{ node.name }}</span
-      >
     </mat-tree-node>
 
     <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
@@ -20,9 +13,7 @@
           {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
         </mat-icon>
       </button>
-      <mat-icon class="mr-2" [attr.aria-label]="'file icon'">
-        {{ node.expandable ? 'folder' : 'description' }}
-      </mat-icon>
+      <mat-icon class="mr-2" [attr.aria-label]="'folder icon'"> folder </mat-icon>
       {{ node.name }}
     </mat-tree-node>
   </mat-tree>

--- a/src/app/file-tree/file-tree.component.html
+++ b/src/app/file-tree/file-tree.component.html
@@ -1,0 +1,29 @@
+<div mat-dialog-content>
+  <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+    <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
+      <button mat-icon-button disabled></button>
+      <button *ngIf="!node.child" mat-button>
+        <mat-icon class="mr-2" [attr.aria-label]="'file icon'">
+          {{ node.expandable ? 'folder' : 'description' }} </mat-icon
+        >{{ node.name }}
+      </button>
+      <span *ngIf="node.child"
+        ><mat-icon class="mr-2" [attr.aria-label]="'file icon'">
+          {{ node.expandable ? 'folder' : 'description' }} </mat-icon
+        >{{ node.name }}</span
+      >
+    </mat-tree-node>
+
+    <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
+      <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
+        <mat-icon class="mat-icon-rtl-mirror">
+          {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
+        </mat-icon>
+      </button>
+      <mat-icon class="mr-2" [attr.aria-label]="'file icon'">
+        {{ node.expandable ? 'folder' : 'description' }}
+      </mat-icon>
+      {{ node.name }}
+    </mat-tree-node>
+  </mat-tree>
+</div>

--- a/src/app/file-tree/file-tree.component.html
+++ b/src/app/file-tree/file-tree.component.html
@@ -1,4 +1,8 @@
 <div mat-dialog-content>
+  <mat-form-field class="w-100">
+    <mat-label>Search file...</mat-label>
+    <input type="text" matInput (input)="filter($event.target.value)" />
+  </mat-form-field>
   <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
     <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
       <!-- The already selected file -->

--- a/src/app/file-tree/file-tree.component.spec.ts
+++ b/src/app/file-tree/file-tree.component.spec.ts
@@ -3,6 +3,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTreeModule } from '@angular/material/tree';
+import { SourceFile } from 'app/shared/swagger';
 
 import { FileTreeComponent } from './file-tree.component';
 
@@ -31,5 +32,26 @@ describe('FileTreeComponent', () => {
 
   it('should compile', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should generate the nodes from sourcefiles', () => {
+    let sourcefiles: Array<SourceFile> = [];
+    let expectedNodes = [];
+    expect(component.convertSourceFilesToTree(sourcefiles)).toEqual(expectedNodes);
+    sourcefiles = [
+      { absolutePath: '/folder1/file1', path: 'file1', type: SourceFile.TypeEnum.DOCKSTOREWDL },
+      { absolutePath: '/folder1/file2', path: 'file2', type: SourceFile.TypeEnum.DOCKSTOREWDL },
+    ];
+    expectedNodes = [
+      Object({
+        name: 'folder1',
+        children: [
+          Object({ name: 'file1', children: [], absolutePath: '/folder1/file1' }),
+          Object({ name: 'file2', children: [], absolutePath: '/folder1/file2' }),
+        ],
+        absolutePath: '/folder1/file1',
+      }),
+    ];
+    expect(component.convertSourceFilesToTree(sourcefiles)).toEqual(expectedNodes);
   });
 });

--- a/src/app/file-tree/file-tree.component.spec.ts
+++ b/src/app/file-tree/file-tree.component.spec.ts
@@ -1,0 +1,30 @@
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTreeModule } from '@angular/material/tree';
+
+import { FileTreeComponent } from './file-tree.component';
+
+describe('FileTreeComponent', () => {
+  let component: FileTreeComponent;
+  let fixture: ComponentFixture<FileTreeComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [FileTreeComponent],
+        imports: [MatButtonModule, MatIconModule, MatTreeModule],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FileTreeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should compile', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/file-tree/file-tree.component.spec.ts
+++ b/src/app/file-tree/file-tree.component.spec.ts
@@ -1,5 +1,6 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTreeModule } from '@angular/material/tree';
 
@@ -13,7 +14,11 @@ describe('FileTreeComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [FileTreeComponent],
-        imports: [MatButtonModule, MatIconModule, MatTreeModule],
+        imports: [MatButtonModule, MatIconModule, MatTreeModule, MatDialogModule],
+        providers: [
+          { provide: MatDialogRef, useValue: {} },
+          { provide: MAT_DIALOG_DATA, useValue: [] },
+        ],
       }).compileComponents();
     })
   );

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -1,0 +1,94 @@
+import { Component, Inject } from '@angular/core';
+import { MatTreeFlatDataSource, MatTreeFlattener } from '@angular/material/tree';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { SourceFile } from 'app/shared/swagger';
+
+/** File node data with possible child nodes. */
+export interface FileNode {
+  name: string;
+  children?: FileNode[];
+}
+
+/**
+ * Flattened tree node that has been created from a FileNode through the flattener. Flattened
+ * nodes include level index and whether they can be expanded or not.
+ */
+export interface FlatTreeNode {
+  name: string;
+  level: number;
+  expandable: boolean;
+}
+
+@Component({
+  selector: 'app-file-tree',
+  templateUrl: './file-tree.component.html',
+})
+export class FileTreeComponent {
+  /** The TreeControl controls the expand/collapse state of tree nodes.  */
+  treeControl: FlatTreeControl<FlatTreeNode>;
+
+  /** The TreeFlattener is used to generate the flat list of items from hierarchical data. */
+  treeFlattener: MatTreeFlattener<FileNode, FlatTreeNode>;
+
+  /** The MatTreeFlatDataSource connects the control and flattener to provide data. */
+  dataSource: MatTreeFlatDataSource<FileNode, FlatTreeNode>;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: SourceFile[]) {
+    this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);
+
+    this.treeControl = new FlatTreeControl(this.getLevel, this.isExpandable);
+    this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
+    this.dataSource.data = this.convertSourceFilesToTree(data);
+  }
+
+  /** Transform the data to something the tree can read. */
+  transformer(node: FileNode, level: number): FlatTreeNode {
+    return {
+      name: node.name,
+      level,
+      expandable: !!node.children && node.children.length > 0,
+    };
+  }
+
+  /** Get the level of the node */
+  getLevel(node: FlatTreeNode): number {
+    return node.level;
+  }
+
+  /** Get whether the node is expanded or not. */
+  isExpandable(node: FlatTreeNode): boolean {
+    return node.expandable;
+  }
+
+  /** Get whether the node has children or not. */
+  hasChild(index: number, node: FlatTreeNode): boolean {
+    return node.expandable;
+  }
+
+  /** Get the children for the node. */
+  getChildren(node: FileNode): FileNode[] | null | undefined {
+    return node.children;
+  }
+
+  selectFile(node: FileNode) {
+    console.log(node.name);
+  }
+
+  private convertSourceFilesToTree(sourceFiles: SourceFile[]): FileNode[] {
+    const paths = sourceFiles.map((sourceFile) => sourceFile.absolutePath);
+    let result = [];
+    let level = { result };
+    paths.forEach((path) => {
+      path.split('/').reduce((r, name, i, a) => {
+        if (!r[name]) {
+          r[name] = { result: [] };
+          r.result.push({ name, children: r[name].result });
+        }
+
+        return r[name];
+      }, level);
+    });
+    return result;
+  }
+}

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -89,16 +89,20 @@ export class FileTreeComponent {
     this.matDialogRef.close(node.absolutePath);
   }
 
-  private convertSourceFilesToTree(sourceFiles: SourceFile[]): FileNode[] {
+  convertSourceFilesToTree(sourceFiles: SourceFile[]): FileNode[] {
+    if (!sourceFiles || sourceFiles.length === 0) {
+      return [];
+    }
     // Everything is assumed to be an absolute path starting with "/", removing that slash as it's not needed for path.split
     const paths = sourceFiles.map((sourceFile) => sourceFile.absolutePath.substring(1));
     let result: FileNode[] = [];
     let level = { result };
     paths.forEach((path) => {
-      path.split('/').reduce((accumulator, filename, i, a) => {
+      path.split('/').reduce((accumulator, filename) => {
+        console.log(filename);
         if (!accumulator[filename]) {
           accumulator[filename] = { result: [] };
-          accumulator.result.push({ name: filename, children: accumulator[filename].result, absolutePath: '/' + a.join('/') });
+          accumulator.result.push({ name: filename, children: accumulator[filename].result, absolutePath: '/' + path });
         }
         return accumulator[filename];
       }, level);

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -23,11 +23,12 @@ export interface FlatTreeNode {
 }
 
 /**
- * TODO: Shift the file (not folders) to the left so that it's aligned with the folders
- * TODO: Title? Dialog actions?
- * TODO: In the tree, it's not obvious to click on file to select
- * TODO: When to actually use this instead of the simpler dropdown? Over a certain amount of files?
- * TODO: What's my current selected file?
+ * TODO: Dialog title? Dialog actions?
+ * TODO: In the tree, it's not obvious to click on a file to select
+ * TODO: When to actually use this component instead of the simpler dropdown? Over a certain amount of files?
+ * TODO: Add a better indicator for currently selected file in the tree
+ * TODO: Expand the parent nodes where the selected file is a child of
+ * TODO: Truncate new file label (fix the select file button shrinking without css, add padding between the label and the button)
  * Stretch TODO: Make sure there's always more than one child node, otherwise collapse child with parent (i.e. instead of parentname => childname, it's just parentname/childname)
  */
 @Component({
@@ -44,12 +45,14 @@ export class FileTreeComponent {
   /** The MatTreeFlatDataSource connects the control and flattener to provide data. */
   dataSource: MatTreeFlatDataSource<FileNode, FlatTreeNode>;
 
-  constructor(private matDialogRef: MatDialogRef<FileTreeComponent>, @Inject(MAT_DIALOG_DATA) public data: SourceFile[]) {
+  constructor(
+    private matDialogRef: MatDialogRef<FileTreeComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { files: SourceFile[]; selectedFile: SourceFile }
+  ) {
     this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);
-
     this.treeControl = new FlatTreeControl(this.getLevel, this.isExpandable);
     this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
-    this.dataSource.data = this.convertSourceFilesToTree(data);
+    this.dataSource.data = this.convertSourceFilesToTree(data.files);
   }
 
   /** Transform the data to something the tree can read. */

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -25,8 +25,9 @@ export interface FlatTreeNode {
 /**
  * TODO: Shift the file (not folders) to the left so that it's aligned with the folders
  * TODO: Title? Dialog actions?
- * TODO: Hook up file select
- * TODO: Not obvious to click?
+ * TODO: In the tree, it's not obvious to click on file to select
+ * TODO: When to actually use this instead of the simpler dropdown? Over a certain amount of files?
+ * TODO: What's my current selected file?
  * Stretch TODO: Make sure there's always more than one child node, otherwise collapse child with parent (i.e. instead of parentname => childname, it's just parentname/childname)
  */
 @Component({

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -29,6 +29,7 @@ export interface FlatTreeNode {
  * TODO: Add a better indicator for currently selected file in the tree
  * TODO: Expand the parent nodes where the selected file is a child of
  * TODO: Truncate new file label (fix the select file button shrinking without css, add padding between the label and the button)
+ * TODO: Remove the bootstrap focus border
  * Stretch TODO: Make sure there's always more than one child node, otherwise collapse child with parent (i.e. instead of parentname => childname, it's just parentname/childname)
  */
 @Component({
@@ -44,7 +45,6 @@ export class FileTreeComponent {
 
   /** The MatTreeFlatDataSource connects the control and flattener to provide data. */
   dataSource: MatTreeFlatDataSource<FileNode, FlatTreeNode>;
-
   constructor(
     private matDialogRef: MatDialogRef<FileTreeComponent>,
     @Inject(MAT_DIALOG_DATA) public data: { files: SourceFile[]; selectedFile: SourceFile }
@@ -98,15 +98,20 @@ export class FileTreeComponent {
     let result: FileNode[] = [];
     let level = { result };
     paths.forEach((path) => {
-      path.split('/').reduce((accumulator, filename) => {
-        console.log(filename);
-        if (!accumulator[filename]) {
-          accumulator[filename] = { result: [] };
-          accumulator.result.push({ name: filename, children: accumulator[filename].result, absolutePath: '/' + path });
+      path.split('/').reduce((accumulator, pathSegment) => {
+        if (!accumulator[pathSegment]) {
+          accumulator[pathSegment] = { result: [] };
+          accumulator.result.push({ name: pathSegment, children: accumulator[pathSegment].result, absolutePath: '/' + path });
         }
-        return accumulator[filename];
+        return accumulator[pathSegment];
       }, level);
     });
     return result;
+  }
+
+  filter(filterText: string) {
+    const originalFiles = this.data.files;
+    const filteredFiles = originalFiles.filter((thing) => thing.absolutePath.includes(filterText));
+    this.dataSource.data = this.convertSourceFilesToTree(filteredFiles);
   }
 }

--- a/src/app/shared/modules/material.module.ts
+++ b/src/app/shared/modules/material.module.ts
@@ -42,6 +42,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatTreeModule } from '@angular/material/tree';
 
 const MATERIAL_MODULES = [
   DragDropModule,
@@ -71,6 +72,7 @@ const MATERIAL_MODULES = [
   MatTabsModule,
   MatToolbarModule,
   MatTooltipModule,
+  MatTreeModule,
   MatSlideToggleModule,
 ];
 

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -24,6 +24,7 @@
         <mat-toolbar color="primary">
           <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">
             <button color="accent" *ngIf="filteredFiles.length > 10" mat-raised-button (click)="openFileTree()">Select File</button>
+            <span class="ellipsis-overflow" *ngIf="filteredFiles.length > 10"> {{ currentFile.path }} </span>
             <mat-form-field *ngIf="filteredFiles.length <= 10" class="w-50">
               <mat-select [value]="currentFile" (selectionChange)="matSelectChange($event)">
                 <mat-option [value]="file" *ngFor="let file of filteredFiles"> {{ file.path }} </mat-option>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -23,6 +23,7 @@
       <ng-template matTabContent>
         <mat-toolbar color="primary">
           <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">
+            <button mat-raised-button (click)="openFileTree()">Select File</button>
             <mat-form-field class="w-50">
               <mat-select [value]="currentFile" (selectionChange)="matSelectChange($event)">
                 <mat-option [value]="file" *ngFor="let file of filteredFiles"> {{ file.path }} </mat-option>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -23,8 +23,8 @@
       <ng-template matTabContent>
         <mat-toolbar color="primary">
           <div class="w-100" fxLayout="row" fxLayoutAlign="space-between center">
-            <button mat-raised-button (click)="openFileTree()">Select File</button>
-            <mat-form-field class="w-50">
+            <button color="accent" *ngIf="filteredFiles.length > 10" mat-raised-button (click)="openFileTree()">Select File</button>
+            <mat-form-field *ngIf="filteredFiles.length <= 10" class="w-50">
               <mat-select [value]="currentFile" (selectionChange)="matSelectChange($event)">
                 <mat-option [value]="file" *ngFor="let file of filteredFiles"> {{ file.path }} </mat-option>
               </mat-select>

--- a/src/app/source-file-tabs/source-file-tabs.component.spec.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.spec.ts
@@ -7,6 +7,7 @@ import { FileService } from 'app/shared/file.service';
 import { FileStubService, SourceFileTabsStubService } from 'app/test/service-stubs';
 import { SourceFileTabsComponent } from './source-file-tabs.component';
 import { SourceFileTabsService } from './source-file-tabs.service';
+import { MatDialogModule } from '@angular/material/dialog';
 
 describe('SourceFileTabsComponent', () => {
   let component: SourceFileTabsComponent;
@@ -16,7 +17,7 @@ describe('SourceFileTabsComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [SourceFileTabsComponent, MapFriendlyValuesPipe],
-        imports: [HttpClientTestingModule],
+        imports: [HttpClientTestingModule, MatDialogModule],
         providers: [
           { provide: SourceFileTabsService, useClass: SourceFileTabsStubService },
           { provide: FileService, useClass: FileStubService },

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -119,6 +119,14 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   openFileTree() {
-    this.matDialog.open(FileTreeComponent, { width: bootstrap4largeModalSize, data: this.files });
+    this.matDialog
+      .open(FileTreeComponent, { width: bootstrap4largeModalSize, data: this.filteredFiles })
+      .afterClosed()
+      .subscribe((absoluteFilePath) => {
+        const foundFile = this.filteredFiles.find((file) => file.absolutePath === absoluteFilePath);
+        if (foundFile) {
+          this.selectFile(foundFile);
+        }
+      });
   }
 }

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -120,7 +120,7 @@ export class SourceFileTabsComponent implements OnChanges {
 
   openFileTree() {
     this.matDialog
-      .open(FileTreeComponent, { width: bootstrap4largeModalSize, data: this.filteredFiles })
+      .open(FileTreeComponent, { width: bootstrap4largeModalSize, data: { files: this.filteredFiles, selectedFile: this.currentFile } })
       .afterClosed()
       .subscribe((absoluteFilePath) => {
         const foundFile = this.filteredFiles.find((file) => file.absolutePath === absoluteFilePath);

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,7 +1,10 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSelectChange } from '@angular/material/select';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { SafeUrl } from '@angular/platform-browser';
+import { FileTreeComponent } from 'app/file-tree/file-tree.component';
+import { bootstrap4largeModalSize } from 'app/shared/constants';
 import { FileService } from 'app/shared/file.service';
 import { SourceFile, ToolDescriptor, WorkflowVersion } from 'app/shared/openapi';
 import { Validation } from 'app/shared/swagger';
@@ -14,7 +17,7 @@ import { SourceFileTabsService } from './source-file-tabs.service';
   styleUrls: ['./source-file-tabs.component.scss'],
 })
 export class SourceFileTabsComponent implements OnChanges {
-  constructor(private fileService: FileService, private sourceFileTabsService: SourceFileTabsService) {}
+  constructor(private fileService: FileService, private sourceFileTabsService: SourceFileTabsService, private matDialog: MatDialog) {}
   @Input() workflowId: number;
   @Input() descriptorType: ToolDescriptor.TypeEnum;
   // Version is strictly non-null because everything that uses this component has a truthy-check guard
@@ -113,5 +116,9 @@ export class SourceFileTabsComponent implements OnChanges {
 
   matSelectChange(event: MatSelectChange) {
     this.selectFile(event.value);
+  }
+
+  openFileTree() {
+    this.matDialog.open(FileTreeComponent, { width: bootstrap4largeModalSize, data: this.files });
   }
 }


### PR DESCRIPTION
For dockstore/dockstore#4229

Currently set to only appear for files > 10

Before clicking button
![image](https://user-images.githubusercontent.com/24548904/121418220-bbbcdb80-c938-11eb-8656-9824b1b8030f.png)

Dialog appears once clicked:

![image](https://user-images.githubusercontent.com/24548904/121418319-d2fbc900-c938-11eb-9b4d-2a697646f0cc.png)

After file selected:

![image](https://user-images.githubusercontent.com/24548904/121418407-ed35a700-c938-11eb-9bb2-c21816b1f176.png)


0 css, many TODOs, needs a follow up ticket


Anyone got any low hanging fruit fixes/changes?

