### PR TITLE
Test the 1.11 rc release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "dockstore-ui2",
-  "version": "2.3.0",
+  "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/5927/workflows/fa63bb79-cd13-4cf6-9c44-92fb1e90f368/jobs/10638/artifacts"
+    "webservice_version": "1.11.0-rc.0"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -9,9 +9,9 @@ GENERATOR_VERSION="4.3.0"
 
 
 # Uncomment this to use the actual Dockstore webservice release from the package.json
-# BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
+BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://11124-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+# CIRCLE_CI_PATH="https://11124-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -24,11 +24,11 @@ rm -Rf src/app/shared/openapi
 
 
 # Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 # Uncomment these two lines to use the CircleCI swagger/openapi instead
-java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
+# java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+# java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 
 
 

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -4,9 +4,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
-# JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
+JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar
-JAR_PATH="https://10918-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-alpha.3-SNAPSHOT.jar"
+# JAR_PATH="https://10918-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-alpha.3-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar


### PR DESCRIPTION
Probably need to give this a shot before the final release and the swagger/openapi should be frozen now