### PR TITLE
Use one command

### DIFF
--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -229,7 +229,6 @@ describe('Test search page functionality', () => {
     // Fragile assertion that depends on the below workflow to be in the first table results, but not the 2nd
     cy.contains('nf-core/exoseq').should('not.exist');
     cy.get('[data-cy=verificationStatus]').each(($el, index, $list) => {
-      console.log($el);
       cy.wrap($el).contains('done');
     });
   });

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -112,24 +112,19 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   });
 
   it('DAG tab works', () => {
+    /// New material have to click twice
+    cy.contains('.mat-tab-label', 'DAG').click();
     cy.contains('.mat-tab-label', 'DAG').click();
     cy.url().should('contain', '?tab=dag');
-    cy.get('[data-cy=dag-holder]')
-      .children().should('have.length.of.at.least', 1);
+    cy.get('[data-cy=dag-holder]').children().should('have.length.of.at.least', 1);
   });
 
   let launchWithTuples: any[] = [];
   if (type === 'WDL') {
     it('get the svg icons', () => {
-      cy.get('[data-cy=dnanexusLaunchWith]').within(() => {
-        cy.get('img').should('exist');
-      });
-      cy.get('[data-cy=terraLaunchWith]').within(() => {
-        cy.get('img').should('exist');
-      });
-      cy.get('[data-cy=anvilLaunchWith]').within(() => {
-        cy.get('img').should('exist');
-      });
+      cy.get('[data-cy=dnanexusLaunchWith] img').should('exist');
+      cy.get('[data-cy=terraLaunchWith] img').should('exist');
+      cy.get('[data-cy=anvilLaunchWith] img').should('exist');
     });
   }
   if (type === 'CWL') {

--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -10,6 +10,8 @@ describe('run stochastic smoke test', () => {
 function testEntry(tab: string) {
   beforeEach('get random entry on first page', () => {
     cy.visit('/search');
+    // Fragile assertion that depends on the below workflow to be in the first table results, but not the 2nd
+    cy.contains('DataBiosphere/topmed-workflows/UM_variant_caller_wdl');
     goToTab(tab);
     const linkName = tab === 'Workflows' ? 'workflowColumn' : 'toolNames';
     // select a random entry on the first page and navigate to it
@@ -224,6 +226,8 @@ describe('Test search page functionality', () => {
     cy.visit('/search');
     cy.contains('mat-checkbox', /^[ ]*verified/).click();
     cy.url().should('contain', 'verified=1');
+    // Fragile assertion that depends on the below workflow to be in the first table results, but not the 2nd
+    cy.contains('nf-core/exoseq').should('not.exist');
     cy.get('[data-cy=verificationStatus]').each(($el, index, $list) => {
       console.log($el);
       cy.wrap($el).contains('done');


### PR DESCRIPTION
Collapse the two commands into one so that Cypress does not see 

![image](https://user-images.githubusercontent.com/24548904/121711995-34db4080-caa9-11eb-8975-d0de1ebe4618.png)

and keep trying to find an img in it

Also doubled up on the DAG tab clicking...the new material does weird things