### PR TITLE
Update backend artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/5927/workflows/fa63bb79-cd13-4cf6-9c44-92fb1e90f368/jobs/10638/artifacts"
+    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6102/workflows/d2add648-1e2d-4421-8097-ae69b1c83425/jobs/11372/artifacts"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6102/workflows/d2add648-1e2d-4421-8097-ae69b1c83425/jobs/11372/artifacts"
+    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6106/workflows/c26c2a42-8bea-46c4-a91b-34fd4757f132/jobs/11390/steps WARNING: RELEASE JAR"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://11372-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://11390-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -11,7 +11,7 @@ GENERATOR_VERSION="4.3.0"
 # Uncomment this to use the actual Dockstore webservice release from the package.json
 # BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
 # Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://11124-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://11372-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 # JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar
-JAR_PATH="https://11372-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-alpha.3-SNAPSHOT.jar"
+JAR_PATH="https://11390-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-rc.1-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
 # JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar
-JAR_PATH="https://10918-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-alpha.3-SNAPSHOT.jar"
+JAR_PATH="https://11372-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-alpha.3-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar


### PR DESCRIPTION
All frontend develop builds or PRs broken because our JARs were 30 days old

Had to use the release branch's JAR (even though we're generally not supposed to) because the frontend merged the release branch's featuredNewsUrl to the frontend develop branch but the backend hasn't merged the featuredNewsUrl to the backend develop branch