### PR TITLE
Wrap long search string

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-9 containers-rsb" *ngIf="advancedSearchObject$ | async as advancedSearchObject">
       <div class="hits">
-        <mat-card *ngIf="searchService.noResults(searchTerm, hits)" class="alert alert-warning">
+        <mat-card *ngIf="searchService.noResults(searchTerm, hits)" class="alert alert-warning text-break">
           Sorry, no matches found for <strong>{{ basicSearchText$ | async }}</strong
           >.
           <span *ngIf="suggestTerm$ | async"
@@ -213,7 +213,7 @@
         </mde-popover>
 
         <div *ngIf="searchService.hasSearchText(advancedSearchObject, searchTerm, hits) || searchService.hasFilters(filters)">
-          <mat-card class="alert alert-info">
+          <mat-card class="alert alert-info text-break">
             <button
               data-cy="share_button"
               mat-raised-button


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/4250

Wrapped the search string if it was super long:
![image](https://user-images.githubusercontent.com/25287123/122968019-16066500-d359-11eb-80d4-0179c919b39b.png)
