### PR TITLE
Feature/1829/change staging prod smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
             - dockerhub
       - uptime_monitor_no_auth:
           stack: "staging"
-          smoke_testing_branch: "stagingSmokeTests"
+          smoke_testing_branch: "develop"
           context:
             - dockerhub
 #      # Add the tags filter to all jobs so they will run before upload_to_s3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,15 +247,15 @@ workflows:
   everything:
     jobs:
       - uptime_monitor_no_auth:
-        stack: "dev"
-        smoke_testing_branch: "develop"
-        context:
-          - dockerhub
-    - uptime_monitor_no_auth:
-        stack: "staging"
-        smoke_testing_branch: "stagingSmokeTests"
-        context:
-          - dockerhub
+          stack: "dev"
+          smoke_testing_branch: "develop"
+          context:
+            - dockerhub
+      - uptime_monitor_no_auth:
+          stack: "staging"
+          smoke_testing_branch: "stagingSmokeTests"
+          context:
+            - dockerhub
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
       - lint_license_unit_test_coverage:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,10 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
-          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-          webhook: $SLACK_WEBHOOK
+#      - slack/status:
+#          fail_only: true
+#          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+#          webhook: $SLACK_WEBHOOK
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
@@ -246,6 +246,16 @@ workflows:
   version: 2
   everything:
     jobs:
+      - uptime_monitor_no_auth:
+        stack: "dev"
+        smoke_testing_branch: "develop"
+        context:
+          - dockerhub
+    - uptime_monitor_no_auth:
+        stack: "staging"
+        smoke_testing_branch: "stagingSmokeTests"
+        context:
+          - dockerhub
 #      # Add the tags filter to all jobs so they will run before upload_to_s3
       - lint_license_unit_test_coverage:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     parameters:
       stack:
         type: string
-      webpage_URL:
+      smoke_testing_branch:
         type: string
     working_directory: ~/repo
     docker:
@@ -37,7 +37,7 @@ jobs:
           password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
-          webpage_URL: << parameters.webpage_URL >>
+          smoke_testing_branch: << parameters.smoke_testing_branch >>
       - run:
           name: Run remote verification test against << parameters.stack >> (no auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-no-auth'
@@ -60,7 +60,7 @@ jobs:
     parameters:
       stack:
         type: string
-      webpage_URL:
+      smoke_testing_branch:
         type: string
     working_directory: ~/repo
     docker:
@@ -70,7 +70,7 @@ jobs:
             password: $DOCKERHUB_PASSWORD
     steps:
       - setup_nightly_tests:
-          webpage_URL: << parameters.webpage_URL >>
+          smoke_testing_branch: << parameters.smoke_testing_branch >>
       - run:
           name: Run remote verification test against << parameters.stack >> (with auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-auth'
@@ -310,23 +310,23 @@ workflows:
     jobs:
       - uptime_monitor_no_auth:
           stack: "dev"
-          webpage_URL: "https://dev.dockstore.net"
+          smoke_testing_branch: "develop"
           context:
             - dockerhub
       - uptime_monitor_no_auth:
           stack: "staging"
-          webpage_URL: "https://staging.dockstore.org"
+          smoke_testing_branch: "stagingSmokeTests"
           context:
             - dockerhub
 #      - uptime_monitor_no_auth:
 #          stack: "prod"
-#          webpage_URL: "https://dockstore.org"
+#          smoke_testing_branch: "prodSmokeTests"
 #          context:
 #            - dockerhub
       # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
       - uptime_monitor_auth:
           stack: "dev"
-          webpage_URL: "https://dev.dockstore.net"
+          smoke_testing_branch: "https://dev.dockstore.net"
           context:
             - dockerhub
 
@@ -390,18 +390,13 @@ commands:
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
     parameters:
-      webpage_URL:
+      smoke_testing_branch:
         type: string
     steps:
       - checkout
       - run:
-          name: Get and checkout commit id from the current webpage.
-          command: |
-            COMMIT_ID=$(curl << parameters.webpage_URL >> | \
-                        grep -Eoi "https:\/\/gui\.dockstore\.org\/[A-Za-z0-9\.\-]+-[A-Za-z0-9]+" | \
-                        head -1 | \
-                        grep -Eoi "[A-Za-z0-9]+$")
-            git checkout $COMMIT_ID
+          name: Checkout the branch with smoke tests specifically for this stack.
+          command: git checkout << parameters.smoke_testing_branch >>
       - install_container_dependencies
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
             - dockerhub
       - uptime_monitor_no_auth:
           stack: "staging"
-          smoke_testing_branch: "develop"
+          smoke_testing_branch: "stagingSmokeTests"
           context:
             - dockerhub
 #      # Add the tags filter to all jobs so they will run before upload_to_s3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,10 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-#      - slack/status:
-#          fail_only: true
-#          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-#          webhook: $SLACK_WEBHOOK
+      - slack/status:
+          fail_only: true
+          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
@@ -246,17 +246,7 @@ workflows:
   version: 2
   everything:
     jobs:
-      - uptime_monitor_no_auth:
-          stack: "dev"
-          smoke_testing_branch: "develop"
-          context:
-            - dockerhub
-      - uptime_monitor_no_auth:
-          stack: "staging"
-          smoke_testing_branch: "stagingSmokeTests"
-          context:
-            - dockerhub
-#      # Add the tags filter to all jobs so they will run before upload_to_s3
+      # Add the tags filter to all jobs so they will run before upload_to_s3
       - lint_license_unit_test_coverage:
           filters:
             tags:
@@ -336,7 +326,7 @@ workflows:
       # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
       - uptime_monitor_auth:
           stack: "dev"
-          smoke_testing_branch: "https://dev.dockstore.net"
+          smoke_testing_branch: "develop"
           context:
             - dockerhub
 


### PR DESCRIPTION
Changes smoke tests to be pulled from a specific branch, rather than scraped from the webpage. The branches are (tentatively):
1. develop
2. stagingSmokeTests
3. prodSmokeTests

Created both the stagingSmokeTests and prodSmokeTests branches. Turning on prod smoke tests after the release seems easiest.

Also, the smoke test branches should have required PR reviews which I don't have permissions to set. Made a PR to the smoke test branch: https://github.com/dockstore/dockstore-ui2/pull/1282