### PR TITLE
Update staging smoke tests

### DIFF
--- a/cypress/integration/manualTests/basic-enduser.ts
+++ b/cypress/integration/manualTests/basic-enduser.ts
@@ -124,9 +124,9 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
   let launchWithTuples: any[] = [];
   if (type === 'WDL') {
     it('get the svg icons', () => {
-      cy.get('[data-cy=dnanexusLaunchWith] img').should('exist');
-      cy.get('[data-cy=terraLaunchWith] img').should('exist');
-      cy.get('[data-cy=anvilLaunchWith] img').should('exist');
+      cy.get('[data-cy=dnanexusLaunchWith] svg').should('exist');
+      cy.get('[data-cy=terraLaunchWith] svg').should('exist');
+      cy.get('[data-cy=anvilLaunchWith] svg').should('exist');
     });
   }
   if (type === 'CWL') {


### PR DESCRIPTION
Targeting stagingSmokeTests branch.

Old launch with buttons use ```<svg>```s insteads of ```<img>```s. 

Tested this alongside https://github.com/dockstore/dockstore-ui2/pull/1281, and reran the smoke tests a few times in circleCI: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2?branch=feature%2F1829%2FchangeStagingProdSmokeTests