### PR TITLE
Feature/3361/logout incorrect user

### DIFF
--- a/src/app/myworkflows/my-workflow/my-workflow.component.spec.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.spec.ts
@@ -19,6 +19,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TrackLoginService } from 'app/shared/track-login.service';
 import { AuthService } from 'ng2-ui-auth';
 import { AccountsService } from '../../loginComponents/accounts/external/accounts.service';
 import { CustomMaterialModule } from '../../shared/modules/material.module';
@@ -39,6 +40,7 @@ import {
   ConfigurationStub,
   RefreshStubService,
   RegisterWorkflowModalStubService,
+  TrackLoginStubService,
   UrlResolverStubService,
   UsersStubService,
   WorkflowsStubService,
@@ -75,6 +77,7 @@ describe('MyWorkflowsComponent', () => {
           { provide: AccountsService, useClass: AccountsStubService },
           { provide: WorkflowsService, useClass: WorkflowsStubService },
           { provide: UrlResolverService, useClass: UrlResolverStubService },
+          { provide: TrackLoginService, useClass: TrackLoginStubService},
           {
             provide: MatDialogRef,
             useValue: {

--- a/src/app/shared/logout.service.ts
+++ b/src/app/shared/logout.service.ts
@@ -14,28 +14,16 @@
  *    limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import { AuthService } from 'ng2-ui-auth';
 
-import { TrackLoginService } from './track-login.service';
 import { UserService } from './user/user.service';
 
 @Injectable()
 export class LogoutService {
   constructor(
-    private trackLoginService: TrackLoginService,
-    private router: Router,
     private userService: UserService,
-    private auth: AuthService
   ) {}
 
   logout(routeChange?: string) {
-    this.auth.logout().subscribe({
-      complete: () => {
-        this.userService.remove();
-        this.trackLoginService.switchState(false);
-        routeChange ? this.router.navigate([routeChange]) : this.router.navigate(['/logout']);
-      },
-    });
+    this.userService.logout(routeChange);
   }
 }

--- a/src/app/shared/user/user.service.ts
+++ b/src/app/shared/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
-import { Router } from 'app/test';
+import { Router } from '@angular/router';
 import { AuthService } from 'ng2-ui-auth';
 import { Md5 } from 'ts-md5/dist/md5';
 import { AlertService } from '../alert/state/alert.service';

--- a/src/app/shared/user/user.service.ts
+++ b/src/app/shared/user/user.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
+import { Router } from 'app/test';
 import { AuthService } from 'ng2-ui-auth';
 import { Md5 } from 'ts-md5/dist/md5';
 import { AlertService } from '../alert/state/alert.service';
 import { TokenService } from '../state/token.service';
 import { WorkflowService } from '../state/workflow.service';
 import { Configuration, ExtendedUserData, User, UsersService, Workflow } from '../swagger';
+import { TrackLoginService } from '../track-login.service';
 import { UserStore } from './user.store';
 
 @Injectable({ providedIn: 'root' })
@@ -17,7 +19,9 @@ export class UserService {
     private configuration: Configuration,
     private tokenService: TokenService,
     private alertService: AlertService,
-    private workflowService: WorkflowService
+    private workflowService: WorkflowService,
+    private trackLoginService: TrackLoginService,
+    private router: Router
   ) {
     this.getUser();
   }
@@ -89,12 +93,23 @@ export class UserService {
         (error) => {
           this.updateUser(null);
           this.tokenService.removeAll();
+          this.logout();
         }
       );
     } else {
       this.updateUser(null);
       this.tokenService.removeAll();
     }
+  }
+
+  logout(routeChange?: string) {
+    this.authService.logout().subscribe({
+      complete: () => {
+        this.remove();
+        this.trackLoginService.switchState(false);
+        routeChange ? this.router.navigate([routeChange]) : this.router.navigate(['/logout']);
+      },
+    });
   }
 
   @transaction()


### PR DESCRIPTION
For dockstore/dockstore#3361

Simply logout if there's any issues grabbing the user.

Had to move some code around because:

logout.service.ts imports user.service.ts, we grab users in the user.service.ts (which makes sense), but logging out requires logout.service.ts function which results in a circular dependency.

logout.service.ts is now mostly useless and should probably be merged with user.service sometime

So the previous behavior where the top right shows a dropdown with no username should never happen. The user would be instantly redirected to the logout page.