### PR TITLE
Feature/potato

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -47,7 +47,7 @@
           </button>
         </div>
       </div>
-      <div class="search-holder" fxFlex>
+      <div fxFlex>
         <div class="search-background">
           <mat-form-field appearance="none" class="home-field fully-rounded landing-search w-100">
             <input matInput id="searchBar" aria-label="Search" #search placeholder="Search..." (keyup.enter)="goToSearch(search.value)" />

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -49,11 +49,12 @@
       </div>
       <div fxFlex>
         <div class="search-background">
-          <mat-form-field appearance="none" class="home-field fully-rounded landing-search w-100">
-            <input matInput id="searchBar" aria-label="Search" #search placeholder="Search..." (keyup.enter)="goToSearch(search.value)" />
+          <mat-form-field appearance="outline" class="w-100 landing-search fully-rounded">
+            <mat-icon matPrefix>search</mat-icon>
+            <input #search matInput placeholder="Search...">
             <button mat-button *ngIf="search.value" matSuffix mat-icon-button (click)="search.value = ''">
-              <mat-icon inline="true">close</mat-icon>
-            </button>
+              <mat-icon>close</mat-icon>
+          </button>
           </mat-form-field>
         </div>
       </div>

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -121,25 +121,19 @@ h3 {
 }
 
 // Style home search mat-form-field which is vastly different from all other form fields on the site due to the accented border on a non-white background
-// Make mat-form-field match home search bar, could look into more solutions
-::ng-deep .mat-form-field-wrapper {
-  // Removing the padding because we don't need hint
-  padding-bottom: 0;
-  // Material expects to have some extra space from the form field with `margin: .25em 0;`
-  // However, we have none because of the accent border surrounding the form field
-  margin: 0;
-}
-
-::ng-deep .landing-search .mat-form-field-infix {
-  padding: 0.5em 0;
-}
-
-::ng-deep .mat-form-field-appearance-outline .mat-form-field-wrapper {
-  margin: 0 !important;
-}
-
-.landing-search {
+::ng-deep .search-background .landing-search {
   max-width: 600px;
   background: white;
   color: black;
+  .mat-form-field-wrapper {
+    // Removing the padding because we don't need hint
+    padding-bottom: 0;
+    // Material expects to have some extra space from the form field with `margin: .25em 0;`
+    // However, we have none because of the accent border surrounding the form field
+    margin: 0;
+  }
+  .mat-form-field-infix {
+    // Overriding the default `padding: 1em 0 1em 0;` and making it smaller to align with mocks
+    padding: 0.5em 0;
+  }
 }

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -120,12 +120,26 @@ h3 {
   color: mat.get-color-from-palette($dockstore-app-warn, darker);
 }
 
-// Style home search mat-form-field
+// Style home search mat-form-field which is vastly different from all other form fields on the site due to the accented border on a non-white background
 // Make mat-form-field match home search bar, could look into more solutions
-::ng-deep .home-field .mat-form-field-wrapper {
+::ng-deep .mat-form-field-wrapper {
+  // Removing the padding because we don't need hint
   padding-bottom: 0;
+  // Material expects to have some extra space from the form field with `margin: .25em 0;`
+  // However, we have none because of the accent border surrounding the form field
+  margin: 0;
 }
-::ng-deep .home-field .mat-form-field-infix {
-  padding: 0.8em 0 0.8em 0;
-  border-top: 0em;
+
+::ng-deep .landing-search .mat-form-field-infix {
+  padding: 0.5em 0;
+}
+
+::ng-deep .mat-form-field-appearance-outline .mat-form-field-wrapper {
+  margin: 0 !important;
+}
+
+.landing-search {
+  max-width: 600px;
+  background: white;
+  color: black;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -446,7 +446,6 @@ img.contain-img {
   -webkit-border-radius: 8px;
   -moz-border-radius: 8px;
   border-radius: 8px;
-  margin-top: 8px;
 }
 
 .button.login p {
@@ -947,7 +946,7 @@ mat-icon.star-icon {
 }
 
 .landing-search {
-  width: 60%;
+  margin-top: 8px;
   max-width: 600px;
   padding-left: 30px;
   padding-top: 3px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -945,20 +945,6 @@ mat-icon.star-icon {
   height: 16px;
 }
 
-.landing-search {
-  margin-top: 8px;
-  max-width: 600px;
-  padding-left: 30px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  border: none;
-  line-height: 2em;
-  background: white url(../images/search-button.png) left center no-repeat;
-  background-position: 5px;
-  outline: none;
-  color: black;
-}
-
 .ellipsis-overflow {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
@e34lin to test out

The search image was replaced with mat-icon, not sure of the downsides (if there's something wrong with the material icon for some reason). Change the color of the mat-icon and remove the image if it's not needed.

Few improvements are:
- the vertical size is now closer to https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602197fe5ca1a163b9ae735b (mock is 36px, this is 37.31px, previously it's 43.81px)
- the outline now appears (though it's still missing the mat-label that goes to the top left after focus)


One main downside is that the input text has shifted slightly down, but considering that most appearances for the default material  form-fields also do that, it's probably not too bad