### PR TITLE
Use develop CIRCLECI JAR

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -50,7 +50,7 @@ export function resetDB() {
     // cy.exec('docker exec -i postgres1 psql webservice_test -U postgres < travisci/db_dump.sql');
     cy.exec('PGPASSWORD=dockstore psql -h localhost -f travisci/db_dump.sql webservice_test -U dockstore');
     cy.exec(
-      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0 travisci/web.yml'
+      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0 travisci/web.yml'
     );
   });
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.11.3"
+    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6281/workflows/466a7a14-e242-4708-be22-c0416bcdb6a5/jobs/12143/artifacts"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -8,10 +8,10 @@ GENERATOR_VERSION="4.3.0"
 
 
 
-# Uncomment this to use the actual Dockstore webservice release from the package.json
+# This to use the actual Dockstore webservice release from the package.json
 BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
-# Uncomment this to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://11390-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+# This to use the CircleCI swagger/openapi instead
+CIRCLE_CI_PATH="https://12143-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -24,11 +24,11 @@ rm -Rf src/app/shared/openapi
 
 
 # Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
+# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 # Uncomment these two lines to use the CircleCI swagger/openapi instead
-# java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-# java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 
 
 

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -14,5 +14,5 @@ psql -h localhost -c "create user dockstore with password 'dockstore' createdb;"
 psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
 psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
 psql -h localhost -f travisci/db_dump.sql webservice_test -U postgres
-java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0 travisci/web.yml
+java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0 travisci/web.yml
 

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -4,9 +4,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 # Uncomment this to use the actual Dockstore webservice from the package.json
- JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
+# JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 # Uncomment this to use the CircleCI jar
-JAR_PATH="https://11390-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.11.0-rc.1-SNAPSHOT.jar"
+JAR_PATH="https://12143-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-alpha.1-SNAPSHOT.jar"
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar


### PR DESCRIPTION
There was merge issues or something. It was using a CircleCI Jar for openapi generation but actual release jar for running the webservice

Also changing generate-openapi-script.sh to not need to comment/uncomment to first two lines