### PR TITLE
Feature/update circle ci jar process

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.11.3",
-    "use_circle": false,
+    "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6281/workflows/466a7a14-e242-4708-be22-c0416bcdb6a5/jobs/12143/artifacts",
     "circle_build_id": "12143"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6281/workflows/466a7a14-e242-4708-be22-c0416bcdb6a5/jobs/12143/artifacts"
+    "webservice_version": "1.11.3",
+    "use_circle": false,
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6281/workflows/466a7a14-e242-4708-be22-c0416bcdb6a5/jobs/12143/artifacts",
+    "circle_build_id": "12143"
   },
   "scripts": {
     "ng": "npx ng",

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -5,13 +5,9 @@ set -o nounset
 set -o xtrace
 
 GENERATOR_VERSION="4.3.0"
-
-
-
-# This to use the actual Dockstore webservice release from the package.json
 BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
-# This to use the CircleCI swagger/openapi instead
-CIRCLE_CI_PATH="https://12143-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+CIRCLE_CI_PATH="https://""$npm_package_config_circle_build_id""-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
+
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -21,16 +17,15 @@ wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-
 rm -Rf src/app/shared/swagger
 rm -Rf src/app/shared/openapi
 
+if [ "$npm_package_config_use_circle" = true ]
+then
+        SWAGGER_PATH="${CIRCLE_CI_PATH}""/swagger.yaml"
+        OPENAPI_PATH="${CIRCLE_CI_PATH}""/openapi.yaml"
+else         
+        SWAGGER_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/swagger.yaml"
+        OPENAPI_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/openapi3/openapi.yaml"
+fi
 
-
-# Uncomment these two lines to use the actual Dockstore webservice release from the package.json
-# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-# java -jar openapi-generator-cli.jar generate -i ${BASE_PATH}/dockstore-webservice/src/main/resources/openapi3/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
-# Uncomment these two lines to use the CircleCI swagger/openapi instead
-java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/swagger.yaml -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
-java -jar openapi-generator-cli.jar generate -i ${CIRCLE_CI_PATH}/openapi.yaml -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
-
-
-
+java -jar openapi-generator-cli.jar generate -i "${SWAGGER_PATH}" -g typescript-angular -o src/app/shared/swagger -c swagger-config.json --skip-validate-spec
+java -jar openapi-generator-cli.jar generate -i "${OPENAPI_PATH}" -g typescript-angular -o src/app/shared/openapi -c swagger-config.json --skip-validate-spec
 rm openapi-generator-cli.jar
-

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -3,10 +3,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 set -o xtrace
-# Uncomment this to use the actual Dockstore webservice from the package.json
-# JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
-# Uncomment this to use the CircleCI jar
-JAR_PATH="https://12143-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-alpha.1-SNAPSHOT.jar"
+if [ "$npm_package_config_use_circle" = true ]
+then
+	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-alpha.1-SNAPSHOT.jar"
+else
+	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
+fi
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar


### PR DESCRIPTION
In light of the merge issues, I'm simplifying the process (will update docs after).

Basically the package.json now has 4 config vars:
```
"webservice_version": "1.11.3",
"use_circle": true,
"circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6281/workflows/466a7a14-e242-4708-be22-c0416bcdb6a5/jobs/12143/artifacts",
"circle_build_id": "12143"
```

If you want to use a new CircleCI JAR, change `use_circle` to true, change `circle_ci_source` with a URL that others can go to view the list of artifacts, change `circle_build_id` with the build id (should match the `#####/artifacts` of `circle_ci_source`. You mostly don't need to touch the scripts anymore

If you want to use the actual artifacts from release/tag, change `use_circle` to false and change `webservice_version` to whichever release/tag you want