### PR TITLE
Hotfix URL

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -24,7 +24,7 @@
   >
     Keep your workflow automatically in sync with GitHub with our new registration process. Click
     <a
-      [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#why-should-i-migrate-my-existing-workflow-to-use-github-apps-and-a-dockstore-yml'"
+      [href]="Dockstore.DOCUMENTATION_URL + '/getting-started/github-apps/github-apps.html#why-have-a-dockstore-github-app'"
       target="_blank"
       rel="noopener noreferrer"
       class="link-with-underline"


### PR DESCRIPTION
Although what's live does resolve to the FAQ page successfully, the FAQ page does not have anything about the github app on it -- it probably got removed and the relevant section given its own page. I replaced it with a link that resolves on stable and develop to a header in the github app docs page instead.