### PR TITLE
Feature/angular cli settings

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,8 +5,10 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
 Firefox ESR
-not dead
-IE 9-11 
+IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.

--- a/angular.json
+++ b/angular.json
@@ -46,13 +46,7 @@
               "node_modules/ace-builds/src-min-noconflict/theme-idle_fingers.js",
               "node_modules/ace-builds/src-min-noconflict/ext-searchbox.js",
               "node_modules/bootstrap/dist/js/bootstrap.js"
-            ],
-            "vendorChunk": true,
-            "extractLicenses": false,
-            "buildOptimizer": false,
-            "sourceMap": true,
-            "optimization": false,
-            "namedChunks": true
+            ]
           },
           "configurations": {
             "production": {
@@ -62,13 +56,8 @@
                   "maximumWarning": "6kb"
                 }
               ],
-              "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
+	      "subresourceIntegrity": true,
+	      "outputHashing": "all",
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
@@ -76,36 +65,28 @@
                 }
               ]
             },
-            "staging": {
-              "budgets": [
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb"
-                }
-              ],
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.staging.ts"
-                }
-              ]
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "production"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "browserTarget": "dockstore-ui2:build"
-          },
           "configurations": {
             "production": {
               "browserTarget": "dockstore-ui2:build:production"
             },
-            "staging": {
-              "browserTarget": "dockstore-ui2:build:staging"
+            "development": {
+              "browserTarget": "dockstore-ui2:build:development"
             }
-          }
+          },
+	  "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "webservice": "./scripts/run-webservice-script.sh",
     "prebuild": "ts-node -O '{\"module\":\"commonjs\"}' git.version.ts && ./scripts/generate-openapi-script.sh",
     "prebuild.prod": "npm run prebuild",
-    "build.prod": "npx ng build --prod --subresource-integrity",
+    "build.prod": "npx ng build",
     "build": "npx ng build",
     "watch": "ng build --watch --configuration development",
     "license": "license-checker --excludePackages dockstore-ui2@$npm_package_version --csv > THIRD-PARTY-LICENSES.csv",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "ts-node -O '{\"module\":\"commonjs\"}' git.version.ts && ./scripts/generate-openapi-script.sh",
     "prebuild.prod": "npm run prebuild",
     "build.prod": "npx ng build --prod --subresource-integrity",
-    "build": "npx ng build --subresource-integrity",
+    "build": "npx ng build",
     "license": "license-checker --excludePackages dockstore-ui2@$npm_package_version --csv > THIRD-PARTY-LICENSES.csv",
     "circle-ci-license-test-file": "license-checker --excludePackages dockstore-ui2@$npm_package_version --csv > CIRCLE-THIRD-PARTY-LICENSES.csv",
     "compodoc": "npx compodoc -p src/tsconfig.compodoc.json --output docs",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prebuild.prod": "npm run prebuild",
     "build.prod": "npx ng build --prod --subresource-integrity",
     "build": "npx ng build",
+    "watch": "ng build --watch --configuration development",
     "license": "license-checker --excludePackages dockstore-ui2@$npm_package_version --csv > THIRD-PARTY-LICENSES.csv",
     "circle-ci-license-test-file": "license-checker --excludePackages dockstore-ui2@$npm_package_version --csv > CIRCLE-THIRD-PARTY-LICENSES.csv",
     "compodoc": "npx compodoc -p src/tsconfig.compodoc.json --output docs",


### PR DESCRIPTION
Should've been done during the Angular 12 CLI.

Essentially copied the default angular.json, package.json, and .browserslistrc

After the first commit (but before actually committing), the hash code for `npm run build` is the same as develop's `npm run build.prod`

I've officially dropped support for IE9 and 10...not like it was working before

More details on what changed:
prod build is now done by default, staging builds are removed