### PR TITLE
Fix missing SRI for CSS styles inside noscript tags

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -63,7 +63,12 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.prod.ts"
                 }
-              ]
+              ],
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              }
             },
             "development": {
               "buildOptimizer": false,


### PR DESCRIPTION
This fixes the missing subresource integrity attribute on the CSS styles inside noscript tags generated by Angular.

This is necessary because the `inlineCritical` setting changed its default value from false (Angular 11) to true (Angular 12).

See [SEAB-3225](https://ucsc-cgl.atlassian.net/browse/SEAB-3225) and #1325 (this pull request replaces 1325).