### PR TITLE
Allow public and private Amazon ECR tools to be registered

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
       - image: circleci/postgres:13.3
+        command: postgres -c max_connections=200 -c jit=off
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
         environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
-      - image: circleci/postgres:11.6-alpine-ram
+      - image: circleci/postgres:13.3
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD

--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -143,7 +143,7 @@ describe('Dockstore my tools', () => {
     });
   });
 
-  describe('manually register an Amazon ECR tool', () => {
+  describe('Manually register a public Amazon ECR tool', () => {
     it('register tool', () => {
       const toolObject = {
         id: 40000,
@@ -169,11 +169,11 @@ describe('Dockstore my tools', () => {
         defaultWDLTestParameterFile: '/test.wdl.json',
         default_cwl_path: '/Dockstore.cwl',
         default_wdl_path: '/Dockstore.wdl',
-        tool_maintainer_email: 'test@email.com',
-        private_access: true,
-        path: 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname',
-        tool_path: 'amazon.dkr.ecr.test.amazonaws.com/testnamespace/testname',
-        custom_docker_registry_path: 'amazon.dkr.ecr.test.amazonaws.com',
+        tool_maintainer_email: null,
+        private_access: false,
+        path: 'public.ecr.aws/testnamespace/testname',
+        tool_path: 'public.ecr.aws/testnamespace/testname',
+        custom_docker_registry_path: 'public.ecr.aws',
       };
       cy.server()
         .route({
@@ -212,7 +212,84 @@ describe('Dockstore my tools', () => {
       cy.get('[data-cy=imageRegistryProviderSelect]').click();
       cy.contains('Amazon ECR').click();
 
-      cy.get('#dockerRegistryPathInput').type('amazon.dkr.ecr.test.amazonaws.com');
+      cy.get('#imageRegistryInput').type('testnamespace/testname');
+
+      cy.get('#submitButton').click();
+    });
+  });
+
+  describe('Manually register a private Amazon ECR tool', () => {
+    it('register tool', () => {
+      const toolObject = {
+        id: 40000,
+        author: null,
+        description: null,
+        labels: [],
+        users: [{ id: 1, username: 'user_A', isAdmin: false, name: 'user_A' }],
+        email: null,
+        defaultVersion: null,
+        lastUpdated: 1482334377743,
+        gitUrl: 'git@github.com:testnamespace/testname.git',
+        mode: 'MANUAL_IMAGE_PATH',
+        name: 'testname',
+        toolname: '',
+        namespace: 'testnamespace',
+        registry: 'AMAZON_ECR',
+        lastBuild: null,
+        tags: [],
+        is_published: false,
+        last_modified: null,
+        default_dockerfile_path: '/Dockerfile',
+        defaultCWLTestParameterFile: '/test.cwl.json',
+        defaultWDLTestParameterFile: '/test.wdl.json',
+        default_cwl_path: '/Dockstore.cwl',
+        default_wdl_path: '/Dockstore.wdl',
+        tool_maintainer_email: 'test@email.com',
+        private_access: true,
+        path: 'amazon.dkr.ecr.test-1.amazonaws.com/testnamespace/testname',
+        tool_path: 'amazon.dkr.ecr.test-1.amazonaws.com/testnamespace/testname',
+        custom_docker_registry_path: 'amazon.dkr.ecr.test-1.amazonaws.com',
+      };
+      cy.server()
+        .route({
+          method: 'GET',
+          url: /refresh/,
+          response: toolObject,
+        })
+        .route({
+          method: 'GET',
+          url: 'containers/40000',
+          response: toolObject,
+        })
+        .route({
+          method: 'GET',
+          url: /dockerfile/,
+          response: { content: 'FROM ubuntu:16.10' },
+        })
+        .route({
+          method: 'GET',
+          url: /cwl/,
+          response: {
+            content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
+            path: '/Dockstore.cwl',
+          },
+        });
+      // Make sure page is loaded first
+      cy.get('#tool-path').should('be.visible');
+      cy.get('#register_tool_button').click();
+      // TODO: Fix this.  When 'Next' is clicked too fast, the next step is empty
+      cy.wait(1000);
+      cy.get('mat-radio-button').eq(1).click();
+      cy.get('.modal-footer').contains('Next').first().click();
+
+      cy.get('#sourceCodeRepositoryInput').type('testnamespace/testname').wait(1000);
+
+      cy.get('[data-cy=imageRegistryProviderSelect]').click();
+      cy.contains('Amazon ECR').click();
+
+      cy.get('#privateTool').check();
+
+      cy.get('#dockerRegistryPathInput').type('amazon.dkr.ecr.test-1.amazonaws.com');
 
       cy.get('#toolMaintainerEmailInput').type('test@email.com');
 
@@ -275,7 +352,7 @@ describe('Dockstore my tools', () => {
         name: 'testname',
         toolname: '',
         namespace: 'testnamespace',
-        registry: 'AMAZON_ECR',
+        registry: 'SEVEN_BRIDGES',
         lastBuild: null,
         tags: [],
         is_published: false,

--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -288,13 +288,13 @@ describe('Dockstore my tools', () => {
       cy.get('[data-cy=imageRegistryProviderSelect]').click();
       cy.contains('Amazon ECR').click();
 
-      cy.get('#privateTool').check();
+      cy.get('#privateTool').find('input').check({force: true});
 
       cy.get('#dockerRegistryPathInput').type('amazon.dkr.ecr.test-1.amazonaws.com');
 
       cy.get('#toolMaintainerEmailInput').type('test@email.com');
 
-      cy.get('#imageRegistryInput').type('testnamespace/testname');
+      cy.get('#imageRegistryInput').type('_/testname');
 
       cy.get('#submitButton').click();
 

--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -13,6 +13,7 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+import { DockstoreTool } from '../../../src/app/shared/openapi';
 import { goToTab, resetDB, setTokenUserViewPort } from '../../support/commands';
 
 describe('Dockstore my tools', () => {
@@ -145,14 +146,14 @@ describe('Dockstore my tools', () => {
 
   describe('Manually register a public Amazon ECR tool', () => {
     it('register tool', () => {
-      const toolObject = {
+      const toolObject: DockstoreTool = {
         id: 40000,
-        author: null,
-        description: null,
+        author: undefined,
+        description: undefined,
         labels: [],
         users: [{ id: 1, username: 'user_A', isAdmin: false, name: 'user_A' }],
-        email: null,
-        defaultVersion: null,
+        email: undefined,
+        defaultVersion: undefined,
         lastUpdated: 1482334377743,
         gitUrl: 'git@github.com:testnamespace/testname.git',
         mode: 'MANUAL_IMAGE_PATH',
@@ -160,16 +161,16 @@ describe('Dockstore my tools', () => {
         toolname: '',
         namespace: 'testnamespace',
         registry: 'AMAZON_ECR',
-        lastBuild: null,
+        lastBuild: undefined,
         tags: [],
         is_published: false,
-        last_modified: null,
+        last_modified: undefined,
         default_dockerfile_path: '/Dockerfile',
         defaultCWLTestParameterFile: '/test.cwl.json',
         defaultWDLTestParameterFile: '/test.wdl.json',
         default_cwl_path: '/Dockstore.cwl',
         default_wdl_path: '/Dockstore.wdl',
-        tool_maintainer_email: null,
+        tool_maintainer_email: undefined,
         private_access: false,
         path: 'public.ecr.aws/testnamespace/testname',
         tool_path: 'public.ecr.aws/testnamespace/testname',
@@ -220,14 +221,14 @@ describe('Dockstore my tools', () => {
 
   describe('Manually register a private Amazon ECR tool', () => {
     it('register tool', () => {
-      const toolObject = {
+      const toolObject: DockstoreTool = {
         id: 40000,
-        author: null,
-        description: null,
+        author: undefined,
+        description: undefined,
         labels: [],
         users: [{ id: 1, username: 'user_A', isAdmin: false, name: 'user_A' }],
-        email: null,
-        defaultVersion: null,
+        email: undefined,
+        defaultVersion: undefined,
         lastUpdated: 1482334377743,
         gitUrl: 'git@github.com:testnamespace/testname.git',
         mode: 'MANUAL_IMAGE_PATH',
@@ -235,10 +236,10 @@ describe('Dockstore my tools', () => {
         toolname: '',
         namespace: 'testnamespace',
         registry: 'AMAZON_ECR',
-        lastBuild: null,
+        lastBuild: undefined,
         tags: [],
         is_published: false,
-        last_modified: null,
+        last_modified: undefined,
         default_dockerfile_path: '/Dockerfile',
         defaultCWLTestParameterFile: '/test.cwl.json',
         defaultWDLTestParameterFile: '/test.wdl.json',

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.3",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6388/workflows/34b3c871-e880-41c8-b1b8-53e36bf57ed6/jobs/12712/artifacts",
-    "circle_build_id": "12712"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6490/workflows/eb5e2eaa-f39a-4e52-b706-ac29d6e5e819/jobs/13276/artifacts",
+    "circle_build_id": "13276"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.3",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6490/workflows/eb5e2eaa-f39a-4e52-b706-ac29d6e5e819/jobs/13276/artifacts",
-    "circle_build_id": "13276"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6525/workflows/25ed5900-2d24-4127-a093-db4b40c87256/jobs/13454/artifacts",
+    "circle_build_id": "13454"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -39,11 +39,11 @@
           </li>
           <li *ngIf="tool?.imgProviderUrl">
             <strong matTooltip="Docker registry for the associated Docker images">Docker Image</strong>:
-            <a id="imageRegistry" [href]="tool?.imgProviderUrl" *ngIf="!privateOnlyRegistry">
-              {{ tool?.imgProviderUrl | urlDeconstruct }}
+            <a id="imageRegistry" [href]="tool?.imgProviderUrl" *ngIf="!tool?.private_access">
+              {{ tool?.path }}
             </a>
-            <span *ngIf="privateOnlyRegistry">
-              {{ tool?.imgProviderUrl }}
+            <span *ngIf="tool?.private_access">
+              {{ tool?.path }}
             </span>
           </li>
           <span *ngIf="isPublic && isValidVersion">

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -204,20 +204,38 @@
           <div class="form-group form-group-sm">
             <label class="col-sm-3 control-label"> Image Registry: </label>
             <div class="col-sm-9">
-              <input
-                id="imageRegistryInput"
-                type="text"
-                class="form-control"
-                name="imagePath"
-                [(ngModel)]="tool.imagePath"
-                minlength="3"
-                maxlength="128"
-                [pattern]="validationPatterns.imagePath"
-                required
-                matTooltip="Docker Image Registry path."
-                placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
-              />
-              <div *ngIf="formErrors.imagePath" class="alert alert-danger">{{ formErrors.imagePath }}</div>
+              <span *ngIf="tool.irProvider === 'Amazon ECR'">
+                <input
+                  id="imageRegistryInput"
+                  type="text"
+                  class="form-control"
+                  name="repoNameWithSlashesImagePath"
+                  [(ngModel)]="tool.imagePath"
+                  minlength="3"
+                  maxlength="128"
+                  [pattern]="validationPatterns.repoNameWithSlashesImagePath"
+                  required
+                  matTooltip="Docker Image Registry path."
+                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
+                />
+                <div *ngIf="formErrors.repoNameWithSlashesImagePath" class="alert alert-danger">{{ formErrors.repoNameWithSlashesImagePath }}</div>
+              </span>
+              <span *ngIf="tool.irProvider !== 'Amazon ECR'">
+                <input
+                  id="imageRegistryInput"
+                  type="text"
+                  class="form-control"
+                  name="imagePath"
+                  [(ngModel)]="tool.imagePath"
+                  minlength="3"
+                  maxlength="128"
+                  [pattern]="validationPatterns.imagePath"
+                  required
+                  matTooltip="Docker Image Registry path."
+                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
+                />
+                <div *ngIf="formErrors.imagePath" class="alert alert-danger">{{ formErrors.imagePath }}</div>
+              </span>
             </div>
           </div>
           <div class="form-group form-group-sm">
@@ -378,14 +396,15 @@
                   [(ngModel)]="hostedTool.path"
                   minlength="3"
                   maxlength="128"
-                  [pattern]="validationPatterns.imagePath"
+                  [pattern]="hostedTool.registryProvider === 'Amazon ECR' ? validationPatterns.repoNameWithSlashesImagePath : validationPatterns.imagePath"
                   required
                   matTooltip="Docker Image Registry path."
                   placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
                 />
               </div>
               <div *ngIf="hostedImagePath?.errors?.pattern" class="alert alert-danger">
-                The namespace and name of the image repository, separated by a '/'. Use '_' for an empty namespace.
+                <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">{{ validationMessages.repoNameWithSlashesImagePath.pattern }}</span>
+                <span *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">{{ validationMessages.imagePath.pattern }}</span>
               </div>
             </div>
           </div>

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -251,7 +251,7 @@
                     maxlength="256"
                     matTooltip="Custom Docker registry path"
                     placeholder="e.g. *.dkr.ecr.*.amazonaws.com"
-                    [pattern]="validationPatterns.amazonDockerRegistryPath"
+                    [pattern]="validationPatterns.privateAmazonDockerRegistryPath"
                   />
                   <div *ngIf="formErrors.amazonDockerRegistryPath" class="alert alert-danger">
                     {{ formErrors.amazonDockerRegistryPath }}
@@ -294,6 +294,7 @@
                   [disabled]="disablePrivateCheckbox"
                   name="tool.private_access"
                   [(ngModel)]="tool.private_access"
+                  (change)="togglePrivateAccess()"
                   matTooltip="Image registry entry is private."
                   id="privateTool"
                 />
@@ -419,13 +420,14 @@
                     name="amazonDockerRegistryPath"
                     #amazonDockerRegistryPath="ngModel"
                     [(ngModel)]="hostedTool.registry"
+                    required
                     maxlength="256"
                     matTooltip="Custom Docker registry path"
-                    placeholder="e.g. *.dkr.ecr.*.amazonaws.com"
+                    placeholder="e.g. public.ecr.aws or *.dkr.ecr.*.amazonaws.com"
                     [pattern]="validationPatterns.amazonDockerRegistryPath"
                   />
                   <div *ngIf="amazonDockerRegistryPath?.errors?.pattern" class="alert alert-danger">
-                    Must be of the form *.dkr.ecr.*.amazonaws.com, where * can be any alphanumeric character.
+                    {{ validationMessages.amazonDockerRegistryPath.pattern }}
                   </div>
                 </span>
                 <span *ngIf="hostedTool.registryProvider === 'Seven Bridges'">
@@ -441,7 +443,7 @@
                     [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
                   />
                   <div *ngIf="sevenBridgesDockerRegistryPath?.errors?.pattern" class="alert alert-danger">
-                    Must be of the form *-images.sbgenomics.com or images.sbgenomics.com, where * can be any alphanumeric character.
+                    {{ validationMessages.sevenBridgesDockerRegistryPath.pattern }}
                   </div>
                 </span>
               </span>
@@ -464,13 +466,14 @@
                 type="text"
                 class="form-control"
                 name="toolName"
+                #toolName="ngModel"
                 [(ngModel)]="hostedTool.entryName"
                 maxlength="256"
                 [pattern]="validationPatterns.toolName"
                 matTooltip="Name to distinguish between multiple tools within the same repository"
                 placeholder="e.g. liftover-fast (optional)"
               />
-              <div *ngIf="formErrors.toolName" class="alert alert-danger">{{ formErrors.toolName }}</div>
+              <div *ngIf="toolName?.errors?.pattern" class="alert alert-danger">{{ validationMessages.toolName.pattern }}</div>
             </div>
           </div>
           <div *ngIf="hostedTool.path">Final tool path: {{hostedTool.registry}}/{{hostedTool.path}}{{hostedTool.entryName ? '/' + hostedTool.entryName : ''}}</div>

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -59,280 +59,274 @@
         (submit)="registerTool()"
         novalidate
       >
-        <div class="modal-body">
+        <div fxLayout="column" fxLayoutAlign="start stretch">
           <p>
             Manually register a tool with a custom Docker image and Git repository pairing. Use the optional tool name field to handle
             multiple tools with the same Docker image.
           </p>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Source Code Repository: </label>
-            <div class="col-sm-9">
-              <div class="input-group">
-                <div class="input-group-btn">
-                  <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                    {{ tool.scrProvider }}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li *ngFor="let repository of friendlyRepositoryKeys()">
-                      <a class="dropdown-item" (click)="tool.scrProvider = repository">
-                        {{ repository }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-                <input
-                  id="sourceCodeRepositoryInput"
-                  type="text"
-                  class="form-control"
-                  name="gitPath"
-                  [(ngModel)]="tool.gitPath"
-                  minlength="3"
-                  maxlength="128"
-                  [pattern]="validationPatterns.gitPath"
-                  required
-                  matTooltip="Git Repository path."
-                  placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"
-                />
-              </div>
-              <div *ngIf="formErrors.gitPath" class="alert alert-danger">{{ formErrors.gitPath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Dockerfile Path: </label>
-            <div class="col-sm-9">
+          <mat-form-field>
+            <mat-select placeholder="Source Code Provider" [(value)]="tool.scrProvider">
+              <mat-option *ngFor="let repository of friendlyRepositoryKeys()" [value]="repository">
+                {{ repository }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Source Code Repository</mat-label>
+            <input
+              matInput
+              id="sourceCodeRepositoryInput"
+              type="text"
+              name="gitPath"
+              [(ngModel)]="tool.gitPath"
+              minlength="3"
+              maxlength="128"
+              [pattern]="validationPatterns.gitPath"
+              required
+              matTooltip="Git Repository path"
+              placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"
+            />
+            <mat-error *ngIf="formErrors.gitPath">{{ formErrors.gitPath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Dockerfile Path</mat-label>
+            <input
+              matInput
+              type="text"
+              name="dockerfilePath"
+              [(ngModel)]="tool.default_dockerfile_path"
+              minlength="3"
+              maxlength="1000"
+              [pattern]="validationPatterns.dockerfilePath"
+              required
+              matTooltip="Default relative path to the Dockerfile in the Git repository"
+              placeholder="e.g. /Dockerfile"
+            />
+            <mat-error *ngIf="formErrors.dockerfilePath">{{ formErrors.dockerfilePath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>CWL Descriptor Path</mat-label>
+            <input
+              matInput
+              type="text"
+              name="cwlPath"
+              [(ngModel)]="tool.default_cwl_path"
+              minlength="3"
+              maxlength="1000"
+              [pattern]="validationPatterns.cwlPath"
+              [required]="!tool.default_wdl_path.length"
+              matTooltip="Default relative path to the CWL Descriptor in the Git repository"
+              placeholder="e.g. /Dockstore.cwl"
+            />
+            <mat-error *ngIf="formErrors.cwlPath">{{ formErrors.cwlPath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>WDL Descriptor Path</mat-label>
+            <input
+              matInput
+              type="text"
+              name="wdlPath"
+              [(ngModel)]="tool.default_wdl_path"
+              minlength="3"
+              maxlength="1000"
+              [pattern]="validationPatterns.wdlPath"
+              [required]="!tool.default_cwl_path.length"
+              matTooltip="Default relative path to the WDL Descriptor in the Git repository"
+              placeholder="e.g. /Dockstore.wdl"
+            />
+            <mat-error *ngIf="formErrors.wdlPath">{{ formErrors.wdlPath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>CWL Test Parameter File</mat-label>
+            <input
+              matInput
+              type="text"
+              name="cwlTestParameterFilePath"
+              [(ngModel)]="tool.default_cwl_test_parameter_file"
+              minlength="3"
+              maxlength="1000"
+              [pattern]="validationPatterns.testFilePath"
+              matTooltip="Relative path to a CWL Test Parameter File in the Git repository"
+              placeholder="e.g. /test.cwl.json"
+            />
+            <mat-error *ngIf="formErrors.cwlTestParameterFilePath">{{ formErrors.cwlTestParameterFilePath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>WDL Test Parameter File</mat-label>
+            <input
+              matInput
+              type="text"
+              name="wdlTestParameterFilePath"
+              [(ngModel)]="tool.default_wdl_test_parameter_file"
+              minlength="3"
+              maxlength="1000"
+              [pattern]="validationPatterns.testFilePath"
+              matTooltip="Relative path to a WDL Test Parameter File in the Git repository"
+              placeholder="e.g. /test.wdl.json"
+            />
+            <mat-error *ngIf="formErrors.wdlTestParameterFilePath">{{ formErrors.wdlTestParameterFilePath }}</mat-error>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Image Registry Provider</mat-label>
+            <mat-select [(value)]="tool.irProvider" data-cy="imageRegistryProviderSelect">
+              <mat-option
+                *ngFor="let registry of friendlyRegistryKeys()"
+                value="{{ registry }}"
+                (click)="tool.irProvider = registry; checkForSpecialDockerRegistry()"
+                >{{ registry }}</mat-option
+              >
+            </mat-select>
+          </mat-form-field>
+
+          <!-- Image Repository -->
+          <ng-container *ngIf="tool.irProvider === 'Amazon ECR'">
+            <mat-form-field *ngIf="tool.private_access">
+              <mat-label>Image Repository</mat-label>
               <input
+                matInput
+                id="imageRegistryInput"
                 type="text"
-                class="form-control"
-                name="dockerfilePath"
-                [(ngModel)]="tool.default_dockerfile_path"
+                name="privateAmazonImagePath"
+                [(ngModel)]="tool.imagePath"
                 minlength="3"
-                maxlength="1000"
-                [pattern]="validationPatterns.dockerfilePath"
+                maxlength="128"
+                [pattern]="validationPatterns.privateAmazonImagePath"
                 required
-                matTooltip="Default relative path to the Dockerfile in the Git repository."
-                placeholder="e.g. /Dockerfile"
+                matTooltip="Docker Image Registry path."
+                placeholder="e.g. _/dockstore-tool-liftover"
               />
-              <div *ngIf="formErrors.dockerfilePath" class="alert alert-danger">{{ formErrors.dockerfilePath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> CWL Descriptor Path: </label>
-            <div class="col-sm-9">
+              <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;. The &lt;namespace&gt; must be empty, represented by a '_'.</mat-hint>
+              <mat-error *ngIf="formErrors.privateAmazonImagePath">{{ formErrors.privateAmazonImagePath }}</mat-error>
+            </mat-form-field>
+            <mat-form-field *ngIf="!tool.private_access">
+              <mat-label>Image Repository</mat-label>
               <input
+                matInput
+                id="imageRegistryInput"
                 type="text"
-                class="form-control"
-                name="cwlPath"
-                [(ngModel)]="tool.default_cwl_path"
+                name="repoNameWithSlashesImagePath"
+                [(ngModel)]="tool.imagePath"
                 minlength="3"
-                maxlength="1000"
-                [pattern]="validationPatterns.cwlPath"
-                [required]="!tool.default_wdl_path.length"
-                matTooltip="Default relative path to the CWL Descriptor in the Git repository."
-                placeholder="e.g. /Dockstore.cwl"
+                maxlength="128"
+                [pattern]="validationPatterns.repoNameWithSlashesImagePath"
+                required
+                matTooltip="Docker Image Registry path."
+                placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
               />
-              <div *ngIf="formErrors.cwlPath" class="alert alert-danger">{{ formErrors.cwlPath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> WDL Descriptor Path: </label>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                class="form-control"
-                name="wdlPath"
-                [(ngModel)]="tool.default_wdl_path"
-                minlength="3"
-                maxlength="1000"
-                [pattern]="validationPatterns.wdlPath"
-                [required]="!tool.default_cwl_path.length"
-                matTooltip="Default relative path to the WDL Descriptor in the Git repository."
-                placeholder="e.g. /Dockstore.wdl"
-              />
-              <div *ngIf="formErrors.wdlPath" class="alert alert-danger">{{ formErrors.wdlPath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> CWL Test Parameter File: </label>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                class="form-control"
-                name="cwlTestParameterFilePath"
-                [(ngModel)]="tool.default_cwl_test_parameter_file"
-                minlength="3"
-                maxlength="1000"
-                [pattern]="validationPatterns.testFilePath"
-                matTooltip="Relative path to a CWL Test Parameter File in the Git repository."
-                placeholder="e.g. /test.cwl.json"
-              />
-              <div *ngIf="formErrors.cwlTestParameterFilePath" class="alert alert-danger">{{ formErrors.cwlTestParameterFilePath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> WDL Test Parameter File: </label>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                class="form-control"
-                name="wdlTestParameterFilePath"
-                [(ngModel)]="tool.default_wdl_test_parameter_file"
-                minlength="3"
-                maxlength="1000"
-                [pattern]="validationPatterns.testFilePath"
-                matTooltip="Relative path to a WDL Test Parameter File in the Git repository."
-                placeholder="e.g. /test.wdl.json"
-              />
-              <div *ngIf="formErrors.wdlTestParameterFilePath" class="alert alert-danger">{{ formErrors.wdlTestParameterFilePath }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Image Registry Provider: </label>
-            <div class="col-sm-9">
-              <mat-form-field class="w-100">
-                <mat-select [(value)]="tool.irProvider" data-cy="imageRegistryProviderSelect">
-                  <mat-option
-                    *ngFor="let registry of friendlyRegistryKeys()"
-                    value="{{ registry }}"
-                    (click)="tool.irProvider = registry; checkForSpecialDockerRegistry()"
-                    >{{ registry }}</mat-option
-                  >
-                </mat-select>
-              </mat-form-field>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Image Registry: </label>
-            <div class="col-sm-9">
-              <span *ngIf="tool.irProvider === 'Amazon ECR'">
-                <input
-                  id="imageRegistryInput"
-                  type="text"
-                  class="form-control"
-                  name="repoNameWithSlashesImagePath"
-                  [(ngModel)]="tool.imagePath"
-                  minlength="3"
-                  maxlength="128"
-                  [pattern]="validationPatterns.repoNameWithSlashesImagePath"
-                  required
-                  matTooltip="Docker Image Registry path."
-                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
-                />
-                <div *ngIf="formErrors.repoNameWithSlashesImagePath" class="alert alert-danger">{{ formErrors.repoNameWithSlashesImagePath }}</div>
-              </span>
-              <span *ngIf="tool.irProvider !== 'Amazon ECR'">
-                <input
-                  id="imageRegistryInput"
-                  type="text"
-                  class="form-control"
-                  name="imagePath"
-                  [(ngModel)]="tool.imagePath"
-                  minlength="3"
-                  maxlength="128"
-                  [pattern]="validationPatterns.imagePath"
-                  required
-                  matTooltip="Docker Image Registry path."
-                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
-                />
-                <div *ngIf="formErrors.imagePath" class="alert alert-danger">{{ formErrors.imagePath }}</div>
-              </span>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Docker Registry Path: </label>
-            <div class="col-sm-9">
-              <span *ngIf="showCustomDockerRegistryPath">
-                <span *ngIf="tool.irProvider === 'Amazon ECR'">
-                  <input
-                    id="dockerRegistryPathInput"
-                    class="form-control"
-                    name="amazonDockerRegistryPath"
-                    [(ngModel)]="customDockerRegistryPath"
-                    maxlength="256"
-                    matTooltip="Custom Docker registry path"
-                    placeholder="e.g. *.dkr.ecr.*.amazonaws.com"
-                    [pattern]="validationPatterns.privateAmazonDockerRegistryPath"
-                  />
-                  <div *ngIf="formErrors.amazonDockerRegistryPath" class="alert alert-danger">
-                    {{ formErrors.amazonDockerRegistryPath }}
-                  </div>
-                </span>
-                <span *ngIf="tool.irProvider === 'Seven Bridges'">
-                  <input
-                    id="dockerRegistryPathInput"
-                    class="form-control"
-                    name="sevenBridgesDockerRegistryPath"
-                    [(ngModel)]="customDockerRegistryPath"
-                    maxlength="256"
-                    matTooltip="Custom Docker registry path"
-                    placeholder="e.g. *-images.sbgenomics.com"
-                    [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
-                  />
-                  <div *ngIf="formErrors.sevenBridgesDockerRegistryPath" class="alert alert-danger">
-                    {{ formErrors.sevenBridgesDockerRegistryPath }}
-                  </div>
-                </span>
-              </span>
-              <input
-                *ngIf="!showCustomDockerRegistryPath"
+              <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
+              <mat-error *ngIf="formErrors.repoNameWithSlashesImagePath">{{ formErrors.repoNameWithSlashesImagePath }}</mat-error>
+            </mat-form-field>
+          </ng-container>
+          <mat-form-field *ngIf="tool.irProvider !== 'Amazon ECR'">
+            <mat-label>Image Repository</mat-label>
+            <input
+              matInput
+              id="imageRegistryInput"
+              type="text"
+              name="imagePath"
+              [(ngModel)]="tool.imagePath"
+              minlength="3"
+              maxlength="128"
+              [pattern]="validationPatterns.imagePath"
+              required
+              matTooltip="Docker Image Registry path."
+              placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
+            />
+            <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
+            <mat-error *ngIf="formErrors.imagePath">{{ formErrors.imagePath }}</mat-error>
+          </mat-form-field>
+
+          <!-- Docker Registry Path -->
+          <ng-container *ngIf="showCustomDockerRegistryPath">
+            <mat-form-field *ngIf="tool.irProvider === 'Amazon ECR'">
+              <mat-label>Docker Registry Path</mat-label>
+              <input 
+                matInput
                 id="dockerRegistryPathInput"
-                class="form-control"
-                name="customDockerRegistryPath"
+                name="amazonDockerRegistryPath"
                 [(ngModel)]="customDockerRegistryPath"
+                required
                 maxlength="256"
                 matTooltip="Custom Docker registry path"
-                disabled
+                placeholder="e.g. 000123456789.dkr.ecr.us-east-1.amazonaws.com"
+                [pattern]="validationPatterns.privateAmazonDockerRegistryPath"
               />
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Private Image: </label>
-            <div class="col-sm-9">
-              <label>
-                <input
-                  type="checkbox"
-                  [disabled]="disablePrivateCheckbox"
-                  name="tool.private_access"
-                  [(ngModel)]="tool.private_access"
-                  (change)="togglePrivateAccess()"
-                  matTooltip="Image registry entry is private."
-                  id="privateTool"
-                />
-              </label>
-            </div>
-          </div>
-          <div class="form-group form-group-sm" *ngIf="tool.private_access">
-            <label class="col-sm-3 control-label"> Tool Maintainer Email: </label>
-            <div class="col-sm-9">
-              <input
-                id="toolMaintainerEmailInput"
-                type="email"
-                class="form-control"
-                name="toolmaintaineremail"
-                [(ngModel)]="tool.tool_maintainer_email"
+              <mat-hint>Has the form &lt;aws-account-id&gt;.dkr.ecr.&lt;region&gt;.amazonaws.com</mat-hint>
+              <mat-error *ngIf="formErrors.amazonDockerRegistryPath">{{ formErrors.amazonDockerRegistryPath }}</mat-error>
+            </mat-form-field>
+            <mat-form-field *ngIf="tool.irProvider === 'Seven Bridges'">
+              <mat-label>Docker Registry Path</mat-label>
+              <input 
+                matInput
+                id="dockerRegistryPathInput"
+                name="sevenBridgesDockerRegistryPath"
+                [(ngModel)]="customDockerRegistryPath"
+                required
                 maxlength="256"
-                matTooltip="Email of the tool maintainer."
-                placeholder="e.g. example@domain.com"
+                matTooltip="Custom Docker registry path"
+                placeholder="e.g. *-images.sbgenomics.com"
+                [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
               />
-              <div *ngIf="formErrors.email" class="alert alert-danger">{{ formErrors.email }}</div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Tool Name: </label>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                class="form-control"
-                name="toolName"
-                [(ngModel)]="tool.toolname"
-                maxlength="256"
-                [pattern]="validationPatterns.toolName"
-                matTooltip="Dockstore Image path toolname suffix."
-                placeholder="e.g. liftover-fast (optional)"
-              />
-              <div *ngIf="formErrors.toolName" class="alert alert-danger">{{ formErrors.toolName }}</div>
-            </div>
-          </div>
+              <mat-hint>Has the form *-images.sbgenomics.com</mat-hint>
+              <mat-error *ngIf="formErrors.sevenBridgesDockerRegistryPath">{{ formErrors.sevenBridgesDockerRegistryPath }}</mat-error>
+            </mat-form-field>
+          </ng-container>
+          <mat-form-field *ngIf="!showCustomDockerRegistryPath">
+            <input
+              matInput
+              id="dockerRegistryPathInput"
+              name="customDockerRegistryPath"
+              [(ngModel)]="customDockerRegistryPath"
+              maxlength="256"
+              matTooltip="Docker registry path"
+              required
+              readonly
+            />
+            <mat-hint>Read-only</mat-hint>
+          </mat-form-field>
+
+          <mat-checkbox 
+            class="mb-2"
+            [disabled]="disablePrivateCheckbox"
+            name="tool.private_access"
+            [(ngModel)]="tool.private_access"
+            (change)="togglePrivateAccess()"
+            matTooltip="Image registry entry is private."
+            labelPosition="before"
+            id="privateTool"
+          > Private Image:</mat-checkbox>
+          <mat-form-field *ngIf="tool.private_access">
+            <mat-label>Tool Maintainer Email</mat-label>
+            <input
+              matInput
+              id="toolMaintainerEmailInput"
+              type="email"
+              name="email"
+              [(ngModel)]="tool.tool_maintainer_email"
+              required
+              maxlength="256"
+              matTooltip="Email of the tool maintainer"
+              placeholder="e.g. example@domain.com"
+            />
+            <mat-error *ngIf="formErrors.email">{{ formErrors.email }}</mat-error>
+            <mat-hint>Email of the person responsible for giving users access to your tool on external sites</mat-hint>
+          </mat-form-field>
+          
+          <mat-form-field>
+            <mat-label>Tool Name</mat-label>
+            <input
+              matInput
+              type="text"
+              name="toolName"
+              [(ngModel)]="tool.toolname"
+              maxlength="256"
+              [pattern]="validationPatterns.toolName"
+              matTooltip="Optional Dockstore tool path suffix"
+              placeholder="e.g. liftover-fast (optional)"
+            />
+            <mat-error *ngIf="formErrors.toolName">{{ formErrors.toolName }}</mat-error>
+            <mat-hint>Name to distinguish between multiple tools within the same repository</mat-hint>
+          </mat-form-field>
         </div>
         <div mat-dialog-actions class="pull-right">
           <button mat-button type="button" color="secondary" data-dismiss="modal" (click)="hideModal()">Close</button>
@@ -357,127 +351,114 @@
         (ngSubmit)="registerHostedTool()"
         novalidate
       >
-        <mat-dialog-content>
+        <div fxLayout="column" fxLayoutAlign="start stretch">
           <p>
             Create a tool with all descriptor files stored and edited on Dockstore.org. Docker images are stored on sites like Quay.io and
             DockerHub.
           </p>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Image Registry: </label>
-            <div class="col-sm-9">
-              <div class="input-group">
-                <div class="input-group-btn">
-                  <button
-                    id="hostedImageRegistrySpinner"
-                    type="button"
-                    class="btn btn-default btn-sm dropdown-toggle"
-                    data-toggle="dropdown"
-                  >
-                    {{ hostedTool.registryProvider }}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li *ngFor="let registry of friendlyRegistryKeys()">
-                      <a
-                        [attr.id]="'hostedImageRegistrySpinner' + registry"
-                        class="dropdown-item"
-                        (click)="hostedTool.registryProvider = registry; hostedTool.registry = getToolRegistry(registry, null)"
-                      >
-                        {{ registry }}
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-                <input
-                  id="hostedImagePath"
-                  type="text"
-                  class="form-control"
-                  name="hostedImagePath"
-                  #hostedImagePath="ngModel"
-                  [(ngModel)]="hostedTool.path"
-                  minlength="3"
-                  maxlength="128"
-                  [pattern]="hostedTool.registryProvider === 'Amazon ECR' ? validationPatterns.repoNameWithSlashesImagePath : validationPatterns.imagePath"
-                  required
-                  matTooltip="Docker Image Registry path."
-                  placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
-                />
-              </div>
-              <div *ngIf="hostedImagePath?.errors?.pattern" class="alert alert-danger">
-                <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">{{ validationMessages.repoNameWithSlashesImagePath.pattern }}</span>
-                <span *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">{{ validationMessages.imagePath.pattern }}</span>
-              </div>
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Docker Registry Path: </label>
-            <div class="col-sm-9">
-              <span *ngIf="hostedTool.registryProvider === 'Seven Bridges' || hostedTool.registryProvider === 'Amazon ECR'">
-                <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">
-                  <input
-                    id="hostedDockerRegistryPathInput"
-                    class="form-control"
-                    name="amazonDockerRegistryPath"
-                    #amazonDockerRegistryPath="ngModel"
-                    [(ngModel)]="hostedTool.registry"
-                    required
-                    maxlength="256"
-                    matTooltip="Custom Docker registry path"
-                    placeholder="e.g. public.ecr.aws or *.dkr.ecr.*.amazonaws.com"
-                    [pattern]="validationPatterns.amazonDockerRegistryPath"
-                  />
-                  <div *ngIf="amazonDockerRegistryPath?.errors?.pattern" class="alert alert-danger">
-                    {{ validationMessages.amazonDockerRegistryPath.pattern }}
-                  </div>
-                </span>
-                <span *ngIf="hostedTool.registryProvider === 'Seven Bridges'">
-                  <input
-                    id="hostedDockerRegistryPathInput"
-                    class="form-control"
-                    name="sevenBridgesDockerRegistryPath"
-                    #sevenBridgesDockerRegistryPath="ngModel"
-                    [(ngModel)]="hostedTool.registry"
-                    maxlength="256"
-                    matTooltip="Custom Docker registry path"
-                    placeholder="e.g. *-images.sbgenomics.com"
-                    [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
-                  />
-                  <div *ngIf="sevenBridgesDockerRegistryPath?.errors?.pattern" class="alert alert-danger">
-                    {{ validationMessages.sevenBridgesDockerRegistryPath.pattern }}
-                  </div>
-                </span>
-              </span>
-              <input
-                *ngIf="hostedTool.registryProvider !== 'Seven Bridges' && hostedTool.registryProvider !== 'Amazon ECR'"
-                id="dockerRegistryPathInput"
-                class="form-control"
-                name="customDockerRegistryPath"
-                [(ngModel)]="hostedTool.registry"
-                maxlength="256"
-                matTooltip="Custom Docker registry path"
-                disabled
-              />
-            </div>
-          </div>
-          <div class="form-group form-group-sm">
-            <label class="col-sm-3 control-label"> Tool Name: </label>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                class="form-control"
-                name="toolName"
-                #toolName="ngModel"
-                [(ngModel)]="hostedTool.entryName"
-                maxlength="256"
-                [pattern]="validationPatterns.toolName"
-                matTooltip="Name to distinguish between multiple tools within the same repository"
-                placeholder="e.g. liftover-fast (optional)"
-              />
-              <div *ngIf="toolName?.errors?.pattern" class="alert alert-danger">{{ validationMessages.toolName.pattern }}</div>
-            </div>
-          </div>
+          <mat-form-field>
+            <mat-label>Docker Image Registry</mat-label>
+            <mat-select [(value)]="hostedTool.registryProvider" id="hostedImageRegistrySpinner">
+              <mat-option
+                *ngFor="let registry of friendlyRegistryKeys()"
+                value="{{ registry }}"
+                (click)="hostedTool.registryProvider = registry; hostedTool.registry = getToolRegistry(registry, null);"
+                >{{ registry }}</mat-option
+              >
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Image Repository</mat-label>
+            <input
+              matInput
+              id="hostedImagePath"
+              type="text"
+              name="hostedImagePath"
+              #hostedImagePath="ngModel"
+              [(ngModel)]="hostedTool.path"
+              minlength="3"
+              maxlength="128"
+              [pattern]="hostedTool.registryProvider === 'Amazon ECR' ? validationPatterns.repoNameWithSlashesImagePath : validationPatterns.imagePath"
+              required
+              placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
+              matTooltip="Docker Image Repository"
+            />
+            <mat-hint *ngIf="hostedTool.registryProvider === 'Amazon ECR'">Has the form &lt;namespace&gt;/&lt;name&gt;. An empty namespace, represented by '_', must be used if the registry is private.</mat-hint>
+            <mat-hint *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
+            <mat-error *ngIf="hostedImagePath?.errors?.required">{{ validationMessages.imagePath.required }}</mat-error>
+            <mat-error *ngIf="hostedImagePath?.errors?.pattern">
+              <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">{{ validationMessages.repoNameWithSlashesImagePath.pattern }}</span>
+              <span *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">{{ validationMessages.imagePath.pattern }}</span>
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field *ngIf="hostedTool.registryProvider === 'Amazon ECR'">
+            <mat-label>Docker Registry Path</mat-label>
+            <input
+              matInput
+              id="hostedDockerRegistryPathInput"
+              name="amazonDockerRegistryPath"
+              #amazonDockerRegistryPath="ngModel"
+              [(ngModel)]="hostedTool.registry"
+              required
+              maxlength="256"
+              matTooltip="Custom Docker registry path"
+              placeholder="e.g. public.ecr.aws or *.dkr.ecr.*.amazonaws.com"
+              [pattern]="validationPatterns.amazonDockerRegistryPath"
+            />
+            <mat-hint>Use public.ecr.aws for a public registry or *.dkr.ecr.*.amazonaws.com for a private registry</mat-hint>
+            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.required">{{ validationMessages.amazonDockerRegistryPath.required }}</mat-error>
+            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.pattern">{{ validationMessages.amazonDockerRegistryPath.pattern }}</mat-error>
+          </mat-form-field>
+          <mat-form-field *ngIf="hostedTool.registryProvider === 'Seven Bridges'">
+            <mat-label>Docker Registry Path</mat-label>
+            <input
+              matInput
+              id="hostedDockerRegistryPathInput"
+              name="sevenBridgesDockerRegistryPath"
+              #sevenBridgesDockerRegistryPath="ngModel"
+              [(ngModel)]="hostedTool.registry"
+              required
+              maxlength="256"
+              matTooltip="Custom Docker registry path"
+              placeholder="e.g. *-images.sbgenomics.com"
+              [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
+            />
+            <mat-hint>Has the form *-images.sbgenomics.com</mat-hint>
+            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.required">{{ validationMessages.sevenBridgesDockerRegistryPath.required }}</mat-error>
+            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.pattern">{{ validationMessages.sevenBridgesDockerRegistryPath.pattern }}</mat-error>
+          </mat-form-field>
+          <mat-form-field *ngIf="hostedTool.registryProvider !== 'Amazon ECR' && hostedTool.registryProvider !== 'Seven Bridges'">
+            <mat-label>Docker Registry Path</mat-label>
+            <input
+              matInput
+              id="dockerRegistryPathInput"
+              name="customDockerRegistryPath"
+              [(ngModel)]="hostedTool.registry"
+              required
+              maxlength="256"
+              matTooltip="Docker registry path"
+              readonly
+            />
+            <mat-hint>Read-only</mat-hint>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Tool Name</mat-label>
+            <input
+              matInput
+              type="text"
+              name="toolName"
+              #toolName="ngModel"
+              [(ngModel)]="hostedTool.entryName"
+              maxlength="256"
+              [pattern]="validationPatterns.toolName"
+              matTooltip="Optional Dockstore tool path suffix"
+              placeholder="e.g. liftover-fast (optional)"
+            />
+            <mat-hint>Name to distinguish between multiple tools within the same repository</mat-hint>
+            <mat-error *ngIf="toolName?.errors?.pattern">{{ validationMessages.toolName.pattern }}</mat-error>
+          </mat-form-field>
           <div *ngIf="hostedTool.path">Final tool path: {{hostedTool.registry}}/{{hostedTool.path}}{{hostedTool.entryName ? '/' + hostedTool.entryName : ''}}</div>
-        </mat-dialog-content>
+        </div>
         <div mat-dialog-actions class="pull-right">
           <button mat-button type="button" color="secondary" (click)="hideModal()">Close</button>
           <button id="submitButton" type="submit" mat-raised-button color="primary" [disabled]="!registerHostedToolForm.form.valid">

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -71,6 +71,7 @@
               </mat-option>
             </mat-select>
           </mat-form-field>
+
           <mat-form-field>
             <mat-label>Source Code Repository</mat-label>
             <input
@@ -166,6 +167,7 @@
             />
             <mat-error *ngIf="formErrors.wdlTestParameterFilePath">{{ formErrors.wdlTestParameterFilePath }}</mat-error>
           </mat-form-field>
+
           <mat-form-field>
             <mat-label>Image Registry Provider</mat-label>
             <mat-select [(value)]="tool.irProvider" data-cy="imageRegistryProviderSelect">
@@ -192,10 +194,10 @@
                 maxlength="128"
                 [pattern]="validationPatterns.privateAmazonImagePath"
                 required
-                matTooltip="Docker Image Registry path."
+                matTooltip="Docker Image Registry path"
                 placeholder="e.g. _/dockstore-tool-liftover"
               />
-              <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;. The &lt;namespace&gt; must be empty, represented by a '_'.</mat-hint>
+              <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;. The &lt;namespace&gt; must be empty (use '_').</mat-hint>
               <mat-error *ngIf="formErrors.privateAmazonImagePath">{{ formErrors.privateAmazonImagePath }}</mat-error>
             </mat-form-field>
             <mat-form-field *ngIf="!tool.private_access">
@@ -213,7 +215,6 @@
                 matTooltip="Docker Image Registry path."
                 placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
               />
-              <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
               <mat-error *ngIf="formErrors.repoNameWithSlashesImagePath">{{ formErrors.repoNameWithSlashesImagePath }}</mat-error>
             </mat-form-field>
           </ng-container>
@@ -232,7 +233,6 @@
               matTooltip="Docker Image Registry path."
               placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
             />
-            <mat-hint>Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
             <mat-error *ngIf="formErrors.imagePath">{{ formErrors.imagePath }}</mat-error>
           </mat-form-field>
 
@@ -240,10 +240,10 @@
           <ng-container *ngIf="showCustomDockerRegistryPath">
             <mat-form-field *ngIf="tool.irProvider === 'Amazon ECR'">
               <mat-label>Docker Registry Path</mat-label>
-              <input 
+              <input
                 matInput
                 id="dockerRegistryPathInput"
-                name="amazonDockerRegistryPath"
+                name="privateAmazonDockerRegistryPath"
                 [(ngModel)]="customDockerRegistryPath"
                 required
                 maxlength="256"
@@ -252,11 +252,11 @@
                 [pattern]="validationPatterns.privateAmazonDockerRegistryPath"
               />
               <mat-hint>Has the form &lt;aws-account-id&gt;.dkr.ecr.&lt;region&gt;.amazonaws.com</mat-hint>
-              <mat-error *ngIf="formErrors.amazonDockerRegistryPath">{{ formErrors.amazonDockerRegistryPath }}</mat-error>
+              <mat-error *ngIf="formErrors.privateAmazonDockerRegistryPath">{{ formErrors.privateAmazonDockerRegistryPath }}</mat-error>
             </mat-form-field>
             <mat-form-field *ngIf="tool.irProvider === 'Seven Bridges'">
               <mat-label>Docker Registry Path</mat-label>
-              <input 
+              <input
                 matInput
                 id="dockerRegistryPathInput"
                 name="sevenBridgesDockerRegistryPath"
@@ -272,6 +272,7 @@
             </mat-form-field>
           </ng-container>
           <mat-form-field *ngIf="!showCustomDockerRegistryPath">
+            <mat-label>Docker Registry Path</mat-label>
             <input
               matInput
               id="dockerRegistryPathInput"
@@ -285,8 +286,8 @@
             <mat-hint>Read-only</mat-hint>
           </mat-form-field>
 
-          <mat-checkbox 
-            class="mb-2"
+          <mat-checkbox
+            class="mt-4 mb-2"
             [disabled]="disablePrivateCheckbox"
             name="tool.private_access"
             [(ngModel)]="tool.private_access"
@@ -294,7 +295,9 @@
             matTooltip="Image registry entry is private."
             labelPosition="before"
             id="privateTool"
-          > Private Image:</mat-checkbox>
+          >
+            Private Image:</mat-checkbox
+          >
           <mat-form-field *ngIf="tool.private_access">
             <mat-label>Tool Maintainer Email</mat-label>
             <input
@@ -311,7 +314,7 @@
             <mat-error *ngIf="formErrors.email">{{ formErrors.email }}</mat-error>
             <mat-hint>Email of the person responsible for giving users access to your tool on external sites</mat-hint>
           </mat-form-field>
-          
+
           <mat-form-field>
             <mat-label>Tool Name</mat-label>
             <input
@@ -335,9 +338,7 @@
             type="submit"
             mat-raised-button
             color="primary"
-            [disabled]="
-              !registerToolForm.form.valid || savingActive || (isRefreshing$ | async) || isInvalidCustomRegistry() || isInvalidPrivateTool()
-            "
+            [disabled]="!registerToolForm.form.valid || (isRefreshing$ | async) || isInvalidCustomRegistry() || isInvalidPrivateTool()"
           >
             Add Tool
           </button>
@@ -362,7 +363,7 @@
               <mat-option
                 *ngFor="let registry of friendlyRegistryKeys()"
                 value="{{ registry }}"
-                (click)="hostedTool.registryProvider = registry; hostedTool.registry = getToolRegistry(registry, null);"
+                (click)="hostedTool.registryProvider = registry; hostedTool.registry = getToolRegistry(registry, null)"
                 >{{ registry }}</mat-option
               >
             </mat-select>
@@ -378,16 +379,23 @@
               [(ngModel)]="hostedTool.path"
               minlength="3"
               maxlength="128"
-              [pattern]="hostedTool.registryProvider === 'Amazon ECR' ? validationPatterns.repoNameWithSlashesImagePath : validationPatterns.imagePath"
+              [pattern]="
+                hostedTool.registryProvider === 'Amazon ECR'
+                  ? validationPatterns.repoNameWithSlashesImagePath
+                  : validationPatterns.imagePath
+              "
               required
               placeholder="e.g. cancercollaboratory/dockstore-tool-liftover"
               matTooltip="Docker Image Repository"
             />
-            <mat-hint *ngIf="hostedTool.registryProvider === 'Amazon ECR'">Has the form &lt;namespace&gt;/&lt;name&gt;. An empty namespace, represented by '_', must be used if the registry is private.</mat-hint>
-            <mat-hint *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">Has the form &lt;namespace&gt;/&lt;name&gt;</mat-hint>
+            <mat-hint *ngIf="hostedTool.registryProvider === 'Amazon ECR'"
+              >Has the form &lt;namespace&gt;/&lt;name&gt;. If the registry is private, use '_' as the namespace.</mat-hint
+            >
             <mat-error *ngIf="hostedImagePath?.errors?.required">{{ validationMessages.imagePath.required }}</mat-error>
             <mat-error *ngIf="hostedImagePath?.errors?.pattern">
-              <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">{{ validationMessages.repoNameWithSlashesImagePath.pattern }}</span>
+              <span *ngIf="hostedTool.registryProvider === 'Amazon ECR'">{{
+                validationMessages.repoNameWithSlashesImagePath.pattern
+              }}</span>
               <span *ngIf="hostedTool.registryProvider !== 'Amazon ECR'">{{ validationMessages.imagePath.pattern }}</span>
             </mat-error>
           </mat-form-field>
@@ -406,8 +414,12 @@
               [pattern]="validationPatterns.amazonDockerRegistryPath"
             />
             <mat-hint>Use public.ecr.aws for a public registry or *.dkr.ecr.*.amazonaws.com for a private registry</mat-hint>
-            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.required">{{ validationMessages.amazonDockerRegistryPath.required }}</mat-error>
-            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.pattern">{{ validationMessages.amazonDockerRegistryPath.pattern }}</mat-error>
+            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.required">{{
+              validationMessages.amazonDockerRegistryPath.required
+            }}</mat-error>
+            <mat-error *ngIf="amazonDockerRegistryPath?.errors?.pattern">{{
+              validationMessages.amazonDockerRegistryPath.pattern
+            }}</mat-error>
           </mat-form-field>
           <mat-form-field *ngIf="hostedTool.registryProvider === 'Seven Bridges'">
             <mat-label>Docker Registry Path</mat-label>
@@ -424,8 +436,12 @@
               [pattern]="validationPatterns.sevenBridgesDockerRegistryPath"
             />
             <mat-hint>Has the form *-images.sbgenomics.com</mat-hint>
-            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.required">{{ validationMessages.sevenBridgesDockerRegistryPath.required }}</mat-error>
-            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.pattern">{{ validationMessages.sevenBridgesDockerRegistryPath.pattern }}</mat-error>
+            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.required">{{
+              validationMessages.sevenBridgesDockerRegistryPath.required
+            }}</mat-error>
+            <mat-error *ngIf="sevenBridgesDockerRegistryPath?.errors?.pattern">{{
+              validationMessages.sevenBridgesDockerRegistryPath.pattern
+            }}</mat-error>
           </mat-form-field>
           <mat-form-field *ngIf="hostedTool.registryProvider !== 'Amazon ECR' && hostedTool.registryProvider !== 'Seven Bridges'">
             <mat-label>Docker Registry Path</mat-label>
@@ -457,7 +473,9 @@
             <mat-hint>Name to distinguish between multiple tools within the same repository</mat-hint>
             <mat-error *ngIf="toolName?.errors?.pattern">{{ validationMessages.toolName.pattern }}</mat-error>
           </mat-form-field>
-          <div *ngIf="hostedTool.path">Final tool path: {{hostedTool.registry}}/{{hostedTool.path}}{{hostedTool.entryName ? '/' + hostedTool.entryName : ''}}</div>
+          <div *ngIf="hostedTool.path" class="mt-4">
+            Final tool path: {{ hostedTool.registry }}/{{ hostedTool.path }}{{ hostedTool.entryName ? '/' + hostedTool.entryName : '' }}
+          </div>
         </div>
         <div mat-dialog-actions class="pull-right">
           <button mat-button type="button" color="secondary" (click)="hideModal()">Close</button>

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -133,7 +133,7 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
         this.registerToolService.setCustomDockerRegistryPath(null);
       } else {
         this.registerToolService.setCustomDockerRegistryPath(this.registerToolService.getImageRegistryPath(this.tool.irProvider));
-      }      
+      }
     }
   }
 
@@ -177,6 +177,8 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
         .subscribe((data) => this.onValueChanged(data));
     }
   }
+
+  // Shows one form error at a time
   onValueChanged(data?: any) {
     if (!this.registerToolForm) {
       return;
@@ -191,7 +193,7 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
           const messages = validationMessages[field];
           for (const key in control.errors) {
             if (control.errors.hasOwnProperty(key)) {
-              formErrors[field] += messages[key] + ' ';
+              formErrors[field] = messages[key];
             }
           }
         }

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -123,6 +123,20 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
     this.disablePrivateCheckbox = this.registerToolService.disabledPrivateCheckbox;
   }
 
+  togglePrivateAccess() {
+    // Amazon ECR is a public and private registry, but it has custom docker paths for its private registries.
+    // If tool is private, allow the docker registry path to be edited.
+    // If tool is public, disable the docker registry path input field and set it to the public docker registry path (public.ecr.aws)
+    if (this.tool.irProvider === 'Amazon ECR') {
+      this.registerToolService.setShowCustomDockerRegistryPath(this.tool.private_access);
+      if (this.tool.private_access) {
+        this.registerToolService.setCustomDockerRegistryPath(null);
+      } else {
+        this.registerToolService.setCustomDockerRegistryPath(this.registerToolService.getImageRegistryPath(this.tool.irProvider));
+      }      
+    }
+  }
+
   hideModal() {
     this.registerToolService.setIsModalShown(false);
     this.alertService.clearEverything();

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -41,6 +41,7 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
   public tool: any;
   public formErrors = formErrors;
   public validationPatterns = validationDescriptorPatterns;
+  public validationMessages = validationMessages;
   public customDockerRegistryPath: string;
   public showCustomDockerRegistryPath: boolean;
   public isModalShown: boolean;

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -239,7 +239,16 @@ export class RegisterToolService {
           this.disabledPrivateCheckbox = false;
         }
 
-        if (registry.customDockerPath === 'true') {
+        if (registry.friendlyName === 'Amazon ECR') {
+          // Amazon ECR is a special case where it's a public and private registry but it has custom docker paths for its private repositories
+          if (toolObj.private_access) {
+            this.setShowCustomDockerRegistryPath(true);
+            this.setCustomDockerRegistryPath(null);
+          } else {
+            this.setShowCustomDockerRegistryPath(false);
+            this.setCustomDockerRegistryPath(this.getImageRegistryPath(toolObj.irProvider));
+          }
+        } else if (registry.customDockerPath === 'true') {
           this.setShowCustomDockerRegistryPath(true);
           this.setCustomDockerRegistryPath(null);
         } else {

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -134,7 +134,7 @@ export class RegisterToolService {
   registerHostedTool(hostedTool: any): void {
     const splitPath = hostedTool.path.split('/');
     const namespace = splitPath[0];
-    const name = splitPath[1];
+    const name = splitPath.slice(1, splitPath.length).join("/");
     this.alertService.start('Registering tool');
     this.hostedService
       .createHostedTool(name, hostedTool.registry, undefined, namespace, hostedTool.entryName ? hostedTool.entryName : undefined)
@@ -191,7 +191,7 @@ export class RegisterToolService {
   getImagePath(imagePath: string, part: string) {
     /** Defines the regex that an image path (namespace/name) must match.
          Group 1 = namespace, Group 2 = name*/
-    const imagePathRegexp = /^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)\/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$/i;
+    const imagePathRegexp = /^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)\/([a-zA-Z0-9]+([-_./][a-zA-Z0-9]+)*)$/i;
     const matchObj = imagePath.match(imagePathRegexp);
     let imageName = '';
     if (matchObj && matchObj.length > 2) {

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -90,7 +90,7 @@ describe('SearchService', () => {
           privateOnly: 'false',
           url: 'https://gitlab.com/',
         },
-        { customDockerPath: 'true', dockerPath: null, enum: 'AMAZON_ECR', friendlyName: 'Amazon ECR', privateOnly: 'true', url: null },
+        { customDockerPath: 'true', dockerPath: 'public.ecr.aws', enum: 'AMAZON_ECR', friendlyName: 'Amazon ECR', privateOnly: 'false', url: "https://gallery.ecr.aws/" },
         {
           customDockerPath: 'true',
           dockerPath: null,

--- a/src/app/shared/image-provider.service.spec.ts
+++ b/src/app/shared/image-provider.service.spec.ts
@@ -61,9 +61,15 @@ describe('ImageProviderService', () => {
     };
     expect(service.checkPrivateOnlyRegistry(tool)).toBeFalsy();
     const tool2 = tool;
+    tool2.registry_string = 'test-images.sbgenomics.com';
+    tool2.registry = DockstoreTool.RegistryEnum.SEVENBRIDGES;
+    expect(service.checkPrivateOnlyRegistry(tool2)).toBeTruthy();
     tool2.registry_string = 'amazon.dkr.ecr.test.amazonaws.com';
     tool2.registry = DockstoreTool.RegistryEnum.AMAZONECR;
-    expect(service.checkPrivateOnlyRegistry(tool2)).toBeTruthy();
+    expect(service.checkPrivateOnlyRegistry(tool2)).toBeFalsy();
+    tool2.registry_string = 'public.ecr.aws';
+    tool2.registry = DockstoreTool.RegistryEnum.AMAZONECR;
+    expect(service.checkPrivateOnlyRegistry(tool2)).toBeFalsy();
     tool2.registry_string = null;
     tool2.registry = null;
     expect(service.checkPrivateOnlyRegistry(tool)).toBeFalsy();
@@ -100,6 +106,9 @@ describe('ImageProviderService', () => {
     expect(service.setUpImageProvider(tool).imgProviderUrl).toEqual(
       'https://gitlab.com/dockstore-testing/dockstore-tool-bamstats/container_registry'
     );
+    tool.registry_string = 'public.ecr.aws';
+    tool.registry = DockstoreTool.RegistryEnum.AMAZONECR;
+    expect(service.setUpImageProvider(tool).imgProviderUrl).toEqual('https://gallery.ecr.aws/dockstore-testing/dockstore-tool-bamstats');
   }));
   it('should display appropriate icons for imgProviders', inject([ImageProviderService], (service: ImageProviderService) => {
     const tool: ExtendedDockstoreTool = validTool;

--- a/src/app/shared/image-provider.service.ts
+++ b/src/app/shared/image-provider.service.ts
@@ -51,7 +51,7 @@ export class ImageProviderService {
     const friendlyRegistryName = registry ? registry.friendlyName : null;
     tool.imgProvider = friendlyRegistryName;
     if (registry) {
-      tool.imgProviderUrl = this.getImageProviderUrl(tool.path, registry);
+      tool.imgProviderUrl = this.getImageProviderUrl(tool.path, registry, tool.private_access);
       tool.imgProviderIcon = this.getImageProviderIcon(tool.registry);
     }
     return tool;
@@ -86,7 +86,7 @@ export class ImageProviderService {
     }
   }
 
-  private getImageProviderUrl(path: string, registry) {
+  private getImageProviderUrl(path: string, registry, private_access: boolean) {
     if (path) {
       const imageRegExp = /^([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_./]+)$/;
       const match = imageRegExp.exec(path);
@@ -102,7 +102,7 @@ export class ImageProviderService {
           suffix = '/container_registry';
         }
 
-        if (containerRegistry === 'AMAZON_ECR' || containerRegistry === 'SEVEN_BRIDGES') {
+        if (containerRegistry === 'SEVEN_BRIDGES' || (containerRegistry === 'AMAZON_ECR' && private_access)) {
           url = match[1] + '/';
         }
 

--- a/src/app/shared/image-provider.service.ts
+++ b/src/app/shared/image-provider.service.ts
@@ -88,7 +88,7 @@ export class ImageProviderService {
 
   private getImageProviderUrl(path: string, registry) {
     if (path) {
-      const imageRegExp = /^(.*)\/(.*)\/(.*)\/?$/i;
+      const imageRegExp = /^([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_.]+)\/([a-zA-Z0-9-_./]+)$/;
       const match = imageRegExp.exec(path);
 
       if (match) {

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -33,6 +33,7 @@ interface FormErrors {
   workflow_path: string;
   workflowName: string;
   amazonDockerRegistryPath: string;
+  privateAmazonDockerRegistryPath: string;
   sevenBridgesDockerRegistryPath: string;
 }
 
@@ -55,6 +56,7 @@ export const formErrors: FormErrors = {
   workflow_path: '',
   workflowName: '',
   amazonDockerRegistryPath: '',
+  privateAmazonDockerRegistryPath: '',
   sevenBridgesDockerRegistryPath: '',
 };
 
@@ -95,33 +97,31 @@ export const validationMessages = {
     required: 'This field cannot be empty.',
     minlength: 'Descriptor Path is too short (minimum 3 characters).',
     maxlength: 'Descriptor Path is too long (max 1000 characters).',
-    pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', or '*.yaml'.`,
+    pattern: `Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', or '*.yaml'.`,
   },
   wdlPath: {
     required: 'This field cannot be empty.',
     minlength: 'Descriptor Path is too short (minimum 3 characters).',
     maxlength: 'Descriptor Path is too long (max 1000 characters).',
-    pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.wdl'.`,
+    pattern: `Descriptor Path must begin with '/' and end with '*.wdl'.`,
   },
   nflPath: {
     required: 'This field cannot be empty.',
     minlength: 'Descriptor Path is too short (minimum 3 characters).',
     maxlength: 'Descriptor Path is too long (max 1000 characters).',
-    pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.config'.`,
+    pattern: `Descriptor Path must begin with '/' and end with '*.config'.`,
   },
   galaxyPath: {
     required: 'This field cannot be empty.',
     minlength: 'Descriptor Path is too short (minimum 3 characters).',
     maxlength: 'Descriptor Path is too long (max 1000 characters).',
-    pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.ga', '*.yml', or '*.yaml'.`,
+    pattern: `Descriptor Path must begin with '/' and end with '*.ga', '*.yml', or '*.yaml'.`,
   },
   dockerfilePath: {
     required: 'This field cannot be empty.',
     minlength: 'Dockerfile Path is too short (minimum 3 characters).',
     maxlength: 'Dockerfile Path is too long (max 1000 characters).',
-    pattern:
-      `Must begin with '/' and end with 'Dockerfile'. ` +
-      `Optionally you can use a string as a prefix or a suffix to 'Dockerfile', as long as they are separated by a '.'.`,
+    pattern: `Must have the form /Dockerfile, /<prefix>.Dockerfile, or /Dockerfile.<suffix>`,
   },
   gitPath: {
     required: 'This field cannot be empty.',
@@ -133,19 +133,19 @@ export const validationMessages = {
     required: 'This field cannot be empty.',
     minlength: 'Image Path is too short (minimum 3 characters).',
     maxlength: 'Image Path is too long (max 128 characters).',
-    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository cannot contain additional '/'.`,
+    pattern: `Must have the form <namespace>/<name>. The <name> cannot contain additional '/'.`,
   },
   repoNameWithSlashesImagePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Image Path is too short (minimum 3 characters). ',
+    minlength: 'Image path is too short (minimum 3 characters).',
     maxlength: 'Image Path is too long (max 128 characters).',
-    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository may contain additional '/'.`,
+    pattern: `Must have the form <namespace>/<name>. The <name> may contain additional '/'.`,
   },
   privateAmazonImagePath: {
     required: 'This field cannot be empty.',
     minlength: 'Image Path is too short (minimum 3 characters).',
     maxlength: 'Image Path is too long (max 128 characters).',
-    pattern: `The namespace and name of the image repository, separated by a '/'. The namespace must be empty (use '_'). The name of the image repository may contain additional '/'.`,
+    pattern: `Must have the form <namespace>/<name>. The namespace must be empty (use '_').`,
   },
   label: {
     maxlength: 'Labels string is too long (max 512 characters).',
@@ -171,7 +171,7 @@ export const validationMessages = {
   },
   toolName: {
     maxlength: 'Tool Name is too long (max 256 characters).',
-    pattern: 'A Tool Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
+    pattern: 'May only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   email: {
     required: 'This field cannot be empty.',
@@ -196,22 +196,25 @@ export const validationMessages = {
   },
   repository: {
     maxlength: 'Repository Name is too long (max 256 characters).',
-    pattern: 'A Repository may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
+    pattern: 'May only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   workflowName: {
     maxlength: 'Workflow Name is too long (max 256 characters).',
-    pattern: 'A Workflow Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
+    pattern: 'May only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   amazonDockerRegistryPath: {
     required: 'This field cannot be empty.',
     maxlength: 'Custom docker registry path is too long (max 256 characters).',
-    pattern:
-      'Must be of the form *.dkr.ecr.*.amazonaws.com or public.ecr.aws, where * can be any alphanumeric character,' +
-      ' internal underscores, and internal hyphens.',
+    pattern: 'Must be of the form <aws-account-id>.dkr.ecr.<region>.amazonaws.com or public.ecr.aws.',
+  },
+  privateAmazonDockerRegistryPath: {
+    required: 'This field cannot be empty.',
+    maxlength: 'Custom docker registry path is too long (max 256 characters).',
+    pattern: 'Must be of the form <aws-account-id>.dkr.ecr.<region>.amazonaws.com.',
   },
   sevenBridgesDockerRegistryPath: {
     required: 'This field cannot be empty.',
     maxlength: 'Custom docker registry path is too long (max 256 characters).',
-    pattern: 'Must be of the form *-images.sbgenomics.com or images.sbgenomics.com, where * can be any alphanumeric character.',
+    pattern: 'Must be of the form *-images.sbgenomics.com or images.sbgenomics.com.',
   },
 };

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -145,7 +145,7 @@ export const validationMessages = {
     required: 'This field cannot be empty.',
     minlength: 'Image Path is too short (minimum 3 characters).',
     maxlength: 'Image Path is too long (max 128 characters).',
-    pattern: `Must have the form <namespace>/<name>. The namespace must be empty (use '_').`,
+    pattern: `Must have the form _/<name> because the Amazon ECR registry is private.`,
   },
   label: {
     maxlength: 'Labels string is too long (max 512 characters).',

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -20,6 +20,7 @@ interface FormErrors {
   dockerfilePath: string;
   gitPath: string;
   imagePath: string;
+  repoNameWithSlashesImagePath: string;
   label: string;
   cwlTestParameterFilePath: string;
   wdlTestParameterFilePath: string;
@@ -40,6 +41,7 @@ export const formErrors: FormErrors = {
   dockerfilePath: '',
   gitPath: '',
   imagePath: '',
+  repoNameWithSlashesImagePath: '',
   label: '',
   cwlTestParameterFilePath: '',
   wdlTestParameterFilePath: '',
@@ -68,6 +70,7 @@ export const validationDescriptorPatterns = {
   dockerfilePath: '^/([^/?:*|<>]+/)*(([a-zA-Z]+[.])?Dockerfile|Dockerfile([.][a-zA-Z]+)?)$',
   testFilePath: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(json|yml|yaml)$',
   imagePath: '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$',
+  repoNameWithSlashesImagePath: '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_./][a-zA-Z0-9]+)*)$',
   toolName: '^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$',
   label: '^(| *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)( *, *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))* *)$',
   versionTag: '^[a-zA-Z0-9]+([-_.]*[a-zA-Z0-9]+)*$',
@@ -127,6 +130,12 @@ export const validationMessages = {
     minlength: 'Image Path is too short. (Minimum 3 characters)',
     maxlength: 'Image Path is too long. (Max 128 characters)',
     pattern: `The namespace and name of the image repository, separated by a '/'. ` + `Use '_' for an empty namespace.`,
+  },
+  repoNameWithSlashesImagePath: {
+    required: 'This field cannot be empty.',
+    minlength: 'Image Path is too short. (Minimum 3 characters)',
+    maxlength: 'Image Path is too long. (Max 128 characters)',
+    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository may contain additional '/'. ` + `Use '_' for an empty namespace.`,
   },
   label: {
     maxlength: 'Labels string is too long. (Max 512 characters)',

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -21,6 +21,7 @@ interface FormErrors {
   gitPath: string;
   imagePath: string;
   repoNameWithSlashesImagePath: string;
+  privateAmazonImagePath: string;
   label: string;
   cwlTestParameterFilePath: string;
   wdlTestParameterFilePath: string;
@@ -42,6 +43,7 @@ export const formErrors: FormErrors = {
   gitPath: '',
   imagePath: '',
   repoNameWithSlashesImagePath: '',
+  privateAmazonImagePath: '',
   label: '',
   cwlTestParameterFilePath: '',
   wdlTestParameterFilePath: '',
@@ -71,6 +73,7 @@ export const validationDescriptorPatterns = {
   testFilePath: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(json|yml|yaml)$',
   imagePath: '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)$',
   repoNameWithSlashesImagePath: '^(([a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)|_)/([a-zA-Z0-9]+([-_./][a-zA-Z0-9]+)*)$',
+  privateAmazonImagePath: '^_/([a-zA-Z0-9]+([-_./][a-zA-Z0-9]+)*)$', // Has an empty namespace. Allows for slashes in repo name
   toolName: '^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$',
   label: '^(| *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)( *, *([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))* *)$',
   versionTag: '^[a-zA-Z0-9]+([-_.]*[a-zA-Z0-9]+)*$',
@@ -90,116 +93,125 @@ export const validationDescriptorPatterns = {
 export const validationMessages = {
   cwlPath: {
     required: 'This field cannot be empty.',
-    minlength: 'Descriptor Path is too short. (Minimum 3 characters)',
-    maxlength: 'Descriptor Path is too long. (Max 1000 characters)',
+    minlength: 'Descriptor Path is too short (minimum 3 characters).',
+    maxlength: 'Descriptor Path is too long (max 1000 characters).',
     pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', or '*.yaml'.`,
   },
   wdlPath: {
     required: 'This field cannot be empty.',
-    minlength: 'Descriptor Path is too short. (Minimum 3 characters)',
-    maxlength: 'Descriptor Path is too long. (Max 1000 characters)',
+    minlength: 'Descriptor Path is too short (minimum 3 characters).',
+    maxlength: 'Descriptor Path is too long (max 1000 characters).',
     pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.wdl'.`,
   },
   nflPath: {
     required: 'This field cannot be empty.',
-    minlength: 'Descriptor Path is too short. (Minimum 3 characters)',
-    maxlength: 'Descriptor Path is too long. (Max 1000 characters)',
+    minlength: 'Descriptor Path is too short (minimum 3 characters).',
+    maxlength: 'Descriptor Path is too long (max 1000 characters).',
     pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.config'.`,
   },
   galaxyPath: {
     required: 'This field cannot be empty.',
-    minlength: 'Descriptor Path is too short. (Minimum 3 characters)',
-    maxlength: 'Descriptor Path is too long. (Max 1000 characters)',
+    minlength: 'Descriptor Path is too short (minimum 3 characters).',
+    maxlength: 'Descriptor Path is too long (max 1000 characters).',
     pattern: `Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.ga', '*.yml', or '*.yaml'.`,
   },
   dockerfilePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Dockerfile Path is too short. (Minimum 3 characters)',
-    maxlength: 'Dockerfile Path is too long. (Max 1000 characters)',
+    minlength: 'Dockerfile Path is too short (minimum 3 characters).',
+    maxlength: 'Dockerfile Path is too long (max 1000 characters).',
     pattern:
       `Must begin with '/' and end with 'Dockerfile'. ` +
       `Optionally you can use a string as a prefix or a suffix to 'Dockerfile', as long as they are separated by a '.'.`,
   },
   gitPath: {
     required: 'This field cannot be empty.',
-    minlength: 'Source Code Repository Path is too short. (Minimum 3 characters)',
-    maxlength: 'Source Code Repository Path is too long. (Max 128 characters)',
+    minlength: 'Source Code Repository Path is too short (minimum 3 characters).',
+    maxlength: 'Source Code Repository Path is too long (max 128 characters).',
     pattern: `The namespace and name of the Git repository, separated by a '/'. `,
   },
   imagePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Image Path is too short. (Minimum 3 characters)',
-    maxlength: 'Image Path is too long. (Max 128 characters)',
-    pattern: `The namespace and name of the image repository, separated by a '/'. ` + `Use '_' for an empty namespace.`,
+    minlength: 'Image Path is too short (minimum 3 characters).',
+    maxlength: 'Image Path is too long (max 128 characters).',
+    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository cannot contain additional '/'.`,
   },
   repoNameWithSlashesImagePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Image Path is too short. (Minimum 3 characters)',
-    maxlength: 'Image Path is too long. (Max 128 characters)',
-    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository may contain additional '/'. ` + `Use '_' for an empty namespace.`,
+    minlength: 'Image Path is too short (minimum 3 characters). ',
+    maxlength: 'Image Path is too long (max 128 characters).',
+    pattern: `The namespace and name of the image repository, separated by a '/'. The name of the image repository may contain additional '/'.`,
+  },
+  privateAmazonImagePath: {
+    required: 'This field cannot be empty.',
+    minlength: 'Image Path is too short (minimum 3 characters).',
+    maxlength: 'Image Path is too long (max 128 characters).',
+    pattern: `The namespace and name of the image repository, separated by a '/'. The namespace must be empty (use '_'). The name of the image repository may contain additional '/'.`,
   },
   label: {
-    maxlength: 'Labels string is too long. (Max 512 characters)',
+    maxlength: 'Labels string is too long (max 512 characters).',
     pattern: 'Labels are comma-delimited, and may only consist of alphanumerical characters and internal hyphens.',
   },
   cwlTestParameterFilePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Test parameter file path is too short. (Minimum 3 characters)',
-    maxlength: 'Test parameter file path is too long. (Max 1000 characters)',
+    minlength: 'Test parameter file path is too short (minimum 3 characters).',
+    maxlength: 'Test parameter file path is too long (max 1000 characters).',
     pattern: `Must begin with '/' and end with '*.json', '*.yml', or '*.yaml'.`,
   },
   wdlTestParameterFilePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Test parameter file path is too short. (Minimum 3 characters)',
-    maxlength: 'Test parameter file path is too long. (Max 1000 characters)',
+    minlength: 'Test parameter file path is too short (minimum 3 characters).',
+    maxlength: 'Test parameter file path is too long (max 1000 characters).',
     pattern: `Must begin with '/' and end with '*.json', '*.yml', or '*.yaml'.`,
   },
   testParameterFilePath: {
     required: 'This field cannot be empty.',
-    minlength: 'Test parameter file path is too short. (Minimum 3 characters)',
-    maxlength: 'Test parameter file path is too long. (Max 1000 characters)',
+    minlength: 'Test parameter file path is too short (minimum 3 characters).',
+    maxlength: 'Test parameter file path is too long (max 1000 characters).',
     pattern: `Must begin with '/' and end with '*.json', '*.yml', or '*.yaml'.`,
   },
   toolName: {
-    maxlength: 'Tool Name is too long. (Max 256 characters)',
+    maxlength: 'Tool Name is too long (max 256 characters).',
     pattern: 'A Tool Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   email: {
-    maxlength: 'Email is too long. (Max 256 characters)',
+    required: 'This field cannot be empty.',
+    maxlength: 'Email is too long (max 256 characters).',
   },
   reference: {
     required: 'This field cannot be empty.',
-    minlength: 'Git reference is too short. (Minimum 3 characters)',
-    maxlength: 'Git reference is too long. (Max 128 characters)',
+    minlength: 'Git reference is too short (minimum 3 characters).',
+    maxlength: 'Git reference is too long (max 128 characters).',
     pattern: `May only consist of alphanumeric characters, '-' and '_', with interior '/' and '.' separators.`,
   },
   versionTag: {
     required: 'This field cannot be empty.',
-    maxlength: 'Version Tag is too long. (Max 128 characters)',
+    maxlength: 'Version Tag is too long (max 128 characters).',
     pattern: 'A Version Tag may only consist of alphanumeric characters, internal underscores, internal hyphens, and internal periods.',
   },
   workflow_path: {
     required: 'This field cannot be empty.',
-    minlength: 'Workflow Path is too short. (Minimum 3 characters)',
-    maxlength: 'Workflow Path is too long. (Max 1000 characters)',
+    minlength: 'Workflow Path is too short (minimum 3 characters).',
+    maxlength: 'Workflow Path is too long (max 1000 characters).',
     pattern: `Must begin with '/' and end with '*.cwl', '*.yml', '*.yaml', '*.config', or'*.wdl' ` + 'depending on the descriptor type.',
   },
   repository: {
-    maxlength: 'Repository Name is too long. (Max 256 characters)',
+    maxlength: 'Repository Name is too long (max 256 characters).',
     pattern: 'A Repository may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   workflowName: {
-    maxlength: 'Workflow Name is too long. (Max 256 characters)',
+    maxlength: 'Workflow Name is too long (max 256 characters).',
     pattern: 'A Workflow Name may only consist of alphanumeric characters, internal underscores, and internal hyphens.',
   },
   amazonDockerRegistryPath: {
-    maxlength: 'Custom docker registry path is too long. (Max 256 characters)',
+    required: 'This field cannot be empty.',
+    maxlength: 'Custom docker registry path is too long (max 256 characters).',
     pattern:
       'Must be of the form *.dkr.ecr.*.amazonaws.com or public.ecr.aws, where * can be any alphanumeric character,' +
       ' internal underscores, and internal hyphens.',
   },
   sevenBridgesDockerRegistryPath: {
-    maxlength: 'Custom docker registry path is too long. (Max 256 characters)',
+    required: 'This field cannot be empty.',
+    maxlength: 'Custom docker registry path is too long (max 256 characters).',
     pattern: 'Must be of the form *-images.sbgenomics.com or images.sbgenomics.com, where * can be any alphanumeric character.',
   },
 };

--- a/src/app/shared/validationMessages.model.ts
+++ b/src/app/shared/validationMessages.model.ts
@@ -82,7 +82,8 @@ export const validationDescriptorPatterns = {
   testParameterFilePath: '^/([^/?:*|<>]+/)*[^/?:*|<>]+.(json|yml|yaml)$',
   // This should be used for all validation patterns that are alphanumeric with internal underscores, hyphens, and periods.
   alphanumericInternalUHP: '^[a-zA-Z0-9]+([-_.]*[a-zA-Z0-9]+)*$',
-  amazonDockerRegistryPath: '^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.dkr.ecr.[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.amazonaws.com',
+  amazonDockerRegistryPath: '(^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.dkr.ecr.[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.amazonaws.com)|(public.ecr.aws)', // public and private path
+  privateAmazonDockerRegistryPath: '^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.dkr.ecr.[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*.amazonaws.com',
   sevenBridgesDockerRegistryPath: '^([a-zA-Z0-9]+-)?images.sbgenomics.com',
 };
 
@@ -194,7 +195,7 @@ export const validationMessages = {
   amazonDockerRegistryPath: {
     maxlength: 'Custom docker registry path is too long. (Max 256 characters)',
     pattern:
-      'Must be of the form *.dkr.ecr.*.amazonaws.com, where * can be any alphanumeric character,' +
+      'Must be of the form *.dkr.ecr.*.amazonaws.com or public.ecr.aws, where * can be any alphanumeric character,' +
       ' internal underscores, and internal hyphens.',
   },
   sevenBridgesDockerRegistryPath: {

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -447,12 +447,12 @@ export class MetadataStubService {
       url: 'https://gitlab.com/',
     },
     {
-      dockerPath: null,
+      dockerPath: 'public.ecr.aws',
       customDockerPath: 'true',
-      privateOnly: 'true',
+      privateOnly: 'false',
       enum: 'AMAZON_ECR',
       friendlyName: 'Amazon ECR',
-      url: null,
+      url: 'https://gallery.ecr.aws/',
     },
     {
       dockerPath: null,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1098,3 +1098,14 @@ hr {
 .mat-checkbox.text-wrap > label.mat-checkbox-layout {
   white-space: normal;
 }
+
+// The material form field hints and errors are absolute by default, so if the hint/error is multi-line, it will overlap the elements below it.
+// This style prevents multi-line hints/errors from overlapping the elements below it.
+mat-form-field .mat-form-field {
+  &-underline {
+    position: static;
+  }
+  &-subscript-wrapper {
+    position: static;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1064,7 +1064,7 @@ button.accent-1-dark-btn {
   font-size: 12px;
 }
 
-// Applied to buttons to make them smaller than Material defaults. 
+// Applied to buttons to make them smaller than Material defaults.
 // Use whenever the developer thinks a more compact button is more suitable
 .mat-btn-sm {
   // This overrides .mat-raised-button's 36px line-height
@@ -1125,15 +1125,4 @@ button.accent-1-dark-btn {
 // The material checkbox overflows text by default so this style wraps the text instead.
 .mat-checkbox.text-wrap > label.mat-checkbox-layout {
   white-space: normal;
-}
-
-// The material form field hints and errors are absolute by default, so if the hint/error is multi-line, it will overlap the elements below it.
-// This style prevents multi-line hints/errors from overlapping the elements below it.
-mat-form-field .mat-form-field {
-  &-underline {
-    position: static;
-  }
-  &-subscript-wrapper {
-    position: static;
-  }
 }


### PR DESCRIPTION
For https://github.com/dockstore/dockstore/issues/4331
Corresponding webservice PR: https://github.com/dockstore/dockstore/pull/4420

Registering a public Amazon ECR tool: [public.ecr.aws/x5g7o3i3/appropriate/curl](https://gallery.ecr.aws/x5g7o3i3/appropriate/curl)
- Docker registry path is pre-filled and disabled
- `x5g7o3i3` is what Amazon calls a registry alias. For our use, it's a namespace. 
  - Side note: Amazon allows you to request a custom alias that's more readable. For example, for the repository: [public.ecr.aws/ubuntu/ubuntu](https://gallery.ecr.aws/ubuntu/ubuntu), the first `ubuntu` is a custom registry alias
- `appropriate/curl` is the repository name (this one has slashes in it)

![Screenshot 2021-08-24 at 08-39-25 Dockstore My Tools](https://user-images.githubusercontent.com/25287123/130619160-d28f5357-af4e-4712-8ecb-a83b3e5d7b00.png)

Registering a private Amazon ECR tool: `467982390456.dkr.ecr.us-east-1.amazonaws.com/kathy-test`
- Docker registry path can be edited if the Private Image checkbox is checked
- Private images don't have a registry alias (because it's already uniquely identified by the account id), so in our case, the namespace should always be `_`. 
  - Any thoughts on whether this should this be enforced in the UI? It previously wasn't.
  - EDIT: We specify in the docs that "Amazon ECR images are treated in Dockstore as a custom Docker registry path and an empty namespace": https://docs.dockstore.org/en/develop/advanced-topics/docker-registries.html?highlight=amazon%20ecr#amazon-ecr-tools
- `kathy-test` is the repository name (private repository names can also have slashes)

![Screenshot 2021-08-24 at 08-41-27 Dockstore My Tools](https://user-images.githubusercontent.com/25287123/130619203-db42df0a-a1e7-44c0-a637-6eb6fdaa8acc.png)

Registering a hosted Amazon ECR tool:
![Screenshot 2021-08-24 at 08-42-44 Dockstore My Tools](https://user-images.githubusercontent.com/25287123/130619555-e19e9716-4501-418d-a4e1-dad999d4b4e8.png)

