### PR TITLE
Overhauled Quick-Start MacOS Java installation instructions

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -89,19 +89,25 @@ exec newgrp docker
 `;
     this.textDataMacOs = `
 #### Part 1 - Install dependencies
-1. We'll cover two ways to install Java 11. One way is to download the JDK for MacOS from [OpenJDK](https://jdk.java.net/archive/) and executing the following commands.
+1. We'll cover two ways to install Java 11. One way is to download the JDK for MacOS from [OpenJDK](https://jdk.java.net/archive/) and executing the following commands.  First, unpack the downloaded tar archive, then move the resulting JDK directory to its standard location and check the Java version:
 \`\`\`
-// put the JDK in its standard location
-sudo mv jdk-11.0.2.jdk /Library/Java/JavaVirtualMachines/ \n\n // List the JDKs that are installed; you should see version 11
-/usr/libexec/java_home -V \n\n // If you need to switch to Java 11, run the following
-/usr/libexec/java_home -v 11.0.2 \n\n // Check that if $JAVA_HOME is set to the correct JDK. Should look similar to /Library/Java/JavaVirtualMachines/jdk-11.0.2.jdk/Contents/Home/
-echo $JAVA_HOME/ \n \n // If it is not check your .bashrc or .bash_profile to find out where it is being set. Fix it and/or source the correct one.
-/usr/libexec/java_home \n\n // Use the output from the above command and run
-export JAVA_HOME={OUTPUT FROM ABOVE COMMAND} \n\n // Check that the default version is JDK 11
+sudo mv jdk-11.0.2.jdk /Library/Java/JavaVirtualMachines/
 java -version
 \`\`\`
+If the reported version is JDK 11, you've correctly installed Java!  If not, check the list of the JDKs that are installed; you should see version 11:
+\`\`\`
+/usr/libexec/java_home -V
+\`\`\`
+Next, set the \`JAVA_HOME\` environment variable to the correct JDK system path
+and confirm the Java version:
+\`\`\`
+unset JAVA_HOME
+export JAVA_HOME=\`/usr/libexec/java_home -v 11\`
+java -version
+\`\`\`
+Add the above export line to your \`.bashrc\` or \`.bash_profile\` to set \`JAVA_HOME\` properly every time you invoke a shell.
 
-2. Or to install using Homebrew, execute the following commands:
+2. Or to install Java 11 using Homebrew, execute the following commands:
 \`\`\`
 brew tap AdoptOpenJDK/openjdk
 brew cask install adoptopenjdk11


### PR DESCRIPTION
Whilst fixing the formatting issues in the quick-start MacOS Java installation section, I discovered that some of the instructions were incorrect ("/usr/libexec/java_home -v (version)" prints the path to the specified Java version, but doesn't set anything).  So, I decided to overhaul the section that discusses the non-Brew Java install to improve clarity and prioritize the common success case.  The "unset JAVA_HOME" line before exporting JAVA_HOME is a workaround for a purported Big Sur bug (https://developer.apple.com/forums/thread/666681) which I'm unable to confirm because I'm running Mojave.  I tested all the commands, but I am a Mac n00b so please scrutinize xtra.
https://ucsc-cgl.atlassian.net/browse/DOCK-1888
https://github.com/dockstore/dockstore/issues/4417
Screenshot of modified portion of instructions.
<img width="957" alt="Screen Shot 2021-08-31 at 6 48 22 PM" src="https://user-images.githubusercontent.com/88108675/131598545-b81723c7-6eac-42ed-8ddd-d2f0e046fdef.png">

