### PR TITLE
Feature/dock 1795/use sandbox orcid on dev

### DIFF
--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -83,7 +83,7 @@
                 <strong>Username: {{ row.source | getTokenUsername: tokens }} </strong>
                 <span *ngIf="row.name === 'ORCID'">
                   <img src="../../assets/images/account-logos/{{ row.logo }}" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
-                  <a href="{{ this.accountsService.getRoot(Dockstore.ORCID_AUTH_URL) }}/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
+                  <a href="{{ orcidRootUrl }}/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
                 </span>
               </mat-card-subtitle>
               <ng-template #placeholder><br /></ng-template>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -83,7 +83,7 @@
                 <strong>Username: {{ row.source | getTokenUsername: tokens }} </strong>
                 <span *ngIf="row.name === 'ORCID'">
                   <img src="../../assets/images/account-logos/{{ row.logo }}" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
-                  <a href="https://orcid.org/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
+                  <a href="{{ getRoot(Dockstore.ORCID_AUTH_URL) }}/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
                 </span>
               </mat-card-subtitle>
               <ng-template #placeholder><br /></ng-template>

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -83,7 +83,7 @@
                 <strong>Username: {{ row.source | getTokenUsername: tokens }} </strong>
                 <span *ngIf="row.name === 'ORCID'">
                   <img src="../../assets/images/account-logos/{{ row.logo }}" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
-                  <a href="{{ getRoot(Dockstore.ORCID_AUTH_URL) }}/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
+                  <a href="{{ this.accountsService.getRoot(Dockstore.ORCID_AUTH_URL) }}/{{ orcidId$ | async }}"> {{ orcidId$ | async }}</a>
                 </span>
               </mat-card-subtitle>
               <ng-template #placeholder><br /></ng-template>

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -222,6 +222,12 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     return this.authService.getToken();
   }
 
+  // Compute the root portion of a URL.  Adapted from:
+  // https://stackoverflow.com/questions/1368264/how-to-extract-the-hostname-portion-of-a-url-in-javascript
+  getRoot(url: string) {
+    return (url.replace(/^(.*\/\/[^\/?#]*).*$/,"$1"));
+  }
+
   ngOnInit() {
     this.dsServerURI = Dockstore.API_URI;
     this.tokenQuery.tokens$.subscribe((tokens: TokenUser[]) => {

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -137,6 +137,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<{}> = new Subject();
   public show: false;
   public dockstoreToken: string;
+  public orcidRootUrl: string;
   constructor(
     private trackLoginService: TrackLoginService,
     private tokenService: TokenService,
@@ -154,6 +155,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
       }
     });
     this.dockstoreToken = this.getDockstoreToken();
+    this.orcidRootUrl = this.accountsService.getRoot(Dockstore.ORCID_AUTH_URL);
   }
 
   // Delete token by id

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -222,12 +222,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
     return this.authService.getToken();
   }
 
-  // Compute the root portion of a URL.  Adapted from:
-  // https://stackoverflow.com/questions/1368264/how-to-extract-the-hostname-portion-of-a-url-in-javascript
-  getRoot(url: string): string {
-    return (url.replace(/^(.*\/\/[^\/?#]*).*$/,"$1"));
-  }
-
   ngOnInit() {
     this.dsServerURI = Dockstore.API_URI;
     this.tokenQuery.tokens$.subscribe((tokens: TokenUser[]) => {

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -224,7 +224,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
 
   // Compute the root portion of a URL.  Adapted from:
   // https://stackoverflow.com/questions/1368264/how-to-extract-the-hostname-portion-of-a-url-in-javascript
-  getRoot(url: string) {
+  getRoot(url: string): string {
     return (url.replace(/^(.*\/\/[^\/?#]*).*$/,"$1"));
   }
 

--- a/src/app/loginComponents/accounts/external/accounts.service.spec.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.spec.ts
@@ -21,4 +21,9 @@ describe('Service: Accounts', () => {
   it('should ...', inject([AccountsService], (service: AccountsService) => {
     expect(service).toBeTruthy();
   }));
+
+  it('should compute correct root urls', inject([AccountsService], (service: AccountsService) => {
+    expect(service.getRoot('https://sandbox.orcid.org/oauth/authorize')).toBe('https://sandbox.orcid.org');
+    expect(service.getRoot('https://orcid.org/oauth/authorize')).toBe('https://orcid.org');
+  }));
 });

--- a/src/app/loginComponents/accounts/external/accounts.service.ts
+++ b/src/app/loginComponents/accounts/external/accounts.service.ts
@@ -76,4 +76,12 @@ export class AccountsService {
         break;
     }
   }
+
+  /**
+   * Compute the root portion of a URL.  Adapted from:
+   * {@link https://stackoverflow.com/questions/1368264/how-to-extract-the-hostname-portion-of-a-url-in-javascript}
+   */
+  getRoot(url: string): string {
+    return url.replace(/^(.*\/\/[^\/?#]*).*$/,"$1");
+  }
 }


### PR DESCRIPTION
Changed the ORCID accounts box to use the root of Dockstore.ORCID_AUTH_URL to create the link to the user's ORCID.
https://github.com/dockstore/dockstore/issues/4253
https://ucsc-cgl.atlassian.net/browse/DOCK-1795

This was hard to test: the better testing methods would consume much more effort to implement than the fix itself.  Gary suggested that user testing on dev might be easiest, and, in lieu of that, Charles suggested I move the helper function getRoot() into AccountsService and write some tests for it since it contained a regexp, and submit a PR.  And here we are.  I tested the modified clause in the HTML template by copying it elsewhere in the template, where it rendered successfully, so I'm 98%+ sure it'll work whenever we deploy it on dev/staging.  Someone will need to check.

I found the core of getRoot() while checking if Javascript had a quick way to get the root of a URL.  I've noted the source in the code comments.  I might have ended up with the exact same code after writing it myself.  If the sourcing is not kosher, let me know and I'll replace it with another method. 

An aside: since getRoot() is a generic helper function, it really should be defined in a central place where it can be reused.  However, I did a quick Internet survey of Angularland regarding helper functions and best practices to manage them, and found two basic recommendations.  One was "helper functions wut?!" and the other was "create a HelperService and put them there".  The latter seemed pretty heavyweight compared to this tiny little bug fix, so I did not.