### PR TITLE
Use the AWS context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,7 @@ workflows:
               only: /.*/
           context:
             - dockerhub
+            - aws
       - check_build_develop:
           requires:
             - upload_to_s3


### PR DESCRIPTION
Towards https://ucsc-cgl.atlassian.net/browse/SEAB-2852

CircleCI will use project-level environment variables first, but
once we remove them this will enable the UI to fall back on the
context.