### PR TITLE
Fix class being overwritten by Material

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1082,7 +1082,7 @@ button.accent-1-dark-btn {
 // Applied to mat-icons to make them smaller than Material defaults. 16px was chosen based on ORCID's recommended min logo size.
 // Typically acompanied with mat-btn-sm above.
 // This is also the same size as site-icons-small
-.mat-icon-sm {
+mat-icon.mat-icon-sm {
   // These two override .mat-icon's default 24px height and width
   height: 16px;
   width: 16px;


### PR DESCRIPTION
Parts of the class were being overwritten by Material. Some options:
- This change
- Use !important
- Make the class component specific (possible duplication further down the road)

![image](https://user-images.githubusercontent.com/24548904/132392838-2244850d-22d9-4124-a56c-28a338a53378.png)
