### PR TITLE
specific channels for smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - upload_nightly_artifacts
       - slack/status:
           fail_only: true
+          channel: << parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> non-auth tests failed!
           webhook: $SLACK_WEBHOOK
 
@@ -74,6 +75,7 @@ jobs:
       - upload_nightly_artifacts
       - slack/status:
           fail_only: true
+          channel: << parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> auth tests failed!
           webhook: $SLACK_WEBHOOK
   lint_license_unit_test_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,13 @@ workflows:
               only: /.*/
           context:
             - dockerhub
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth-dev"
+          stack: "dev"
+          requires:
+            - lint_license_unit_test_coverage
+          context:
+            - dockerhub            
       - integration_test_1:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ workflows:
             tags:
               only: /.*/
           context:
-            - dockerhub        
+            - dockerhub
       - integration_test_1:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
-          fail_only: false
+          fail_only: true
           channel: $<< parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> non-auth tests failed!
           webhook: $SLACK_WEBHOOK
@@ -74,7 +74,7 @@ jobs:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
-          fail_only: false
+          fail_only: true
           channel: $<< parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> auth tests failed!
           webhook: $SLACK_WEBHOOK
@@ -249,14 +249,7 @@ workflows:
             tags:
               only: /.*/
           context:
-            - dockerhub
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth-dev"
-          stack: "dev"
-          requires:
-            - lint_license_unit_test_coverage
-          context:
-            - dockerhub            
+            - dockerhub        
       - integration_test_1:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - upload_nightly_artifacts
       - slack/status:
           fail_only: false
-          channel: << parameters.stack >>_id
+          channel: $<< parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> non-auth tests failed!
           webhook: $SLACK_WEBHOOK
 
@@ -75,7 +75,7 @@ jobs:
       - upload_nightly_artifacts
       - slack/status:
           fail_only: false
-          channel: << parameters.stack >>_id
+          channel: $<< parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> auth tests failed!
           webhook: $SLACK_WEBHOOK
   lint_license_unit_test_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
-          fail_only: true
+          fail_only: false
           channel: << parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> non-auth tests failed!
           webhook: $SLACK_WEBHOOK
@@ -74,7 +74,7 @@ jobs:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
       - slack/status:
-          fail_only: true
+          fail_only: false
           channel: << parameters.stack >>_id
           failure_message: Nightly << parameters.stack >> auth tests failed!
           webhook: $SLACK_WEBHOOK


### PR DESCRIPTION
- consequence of the channel re-ordering, we want smoke tests to go into channels that reflect what server got tested
- would use 4.4.4 of the Slack orb but it requires switching to context immediately
- can look at sample output at https://app.slack.com/archives/CTAGGL7G9/p1631139351010900