### PR TITLE
Disable public set default version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.8",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6525/workflows/25ed5900-2d24-4127-a093-db4b40c87256/jobs/13454/artifacts",
-    "circle_build_id": "13454"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6679/workflows/60161515-ff06-465a-b2a1-aa0cad3e4562/jobs/14219/artifacts",
+    "circle_build_id": "14219"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/container/view/view.component.html
+++ b/src/app/container/view/view.component.html
@@ -18,31 +18,22 @@
 <button data-cy="actionsButton" mat-button [matMenuTriggerFor]="menu">Actions<mat-icon>arrow_drop_down</mat-icon></button>
 <mat-menu #menu="matMenu">
   <button type="button" mat-menu-item color="accent" *ngIf="isPublic$ | async" (click)="setMode(TagEditorMode.View); (false)">View</button>
-  <button
-    data-cy="editTagButton"
-    type="button"
-    mat-menu-item
-    color="accent"
-    *ngIf="(isPublic$ | async) === false"
-    (click)="setMode(TagEditorMode.Edit); (false)"
-  >
-    Edit
-  </button>
-  <button type="button" mat-menu-item color="warn" *ngIf="(isPublic$ | async) === false && isManualTool" (click)="deleteTag(); (false)">
-    Delete
-  </button>
-  <button
-    type="button"
-    mat-menu-item
-    color="warn"
-    class="deleteVersionButton"
-    *ngIf="(isPublic$ | async) === false && tool?.mode === DockstoreToolType.ModeEnum.HOSTED"
-    (click)="deleteHostedTag(); (false)"
-  >
-    Delete
-  </button>
-  <button mat-menu-item [disabled]="(isRefreshing$ | async) || version.name === tool.defaultVersion" (click)="updateDefaultVersion()">
-    Set as Default Version
-  </button>
+  <ng-container *ngIf="(isPublic$ | async) === false">
+    <button data-cy="editTagButton" type="button" mat-menu-item color="accent" (click)="setMode(TagEditorMode.Edit); (false)">Edit</button>
+    <button type="button" mat-menu-item color="warn" *ngIf="isManualTool" (click)="deleteTag(); (false)">Delete</button>
+    <button
+      type="button"
+      mat-menu-item
+      color="warn"
+      class="deleteVersionButton"
+      *ngIf="tool?.mode === DockstoreToolType.ModeEnum.HOSTED"
+      (click)="deleteHostedTag(); (false)"
+    >
+      Delete
+    </button>
+    <button mat-menu-item [disabled]="(isRefreshing$ | async) || version.name === tool.defaultVersion" (click)="updateDefaultVersion()">
+      Set as Default Version
+    </button>
+  </ng-container>
   <!-- Modal -->
 </mat-menu>


### PR DESCRIPTION
For https://github.com/dockstore/dockstore/issues/4325

Removed a few asyncs and wrapped the non-public buttons in an ng-container (just like how workflow does it)