### PR TITLE
Null check orcid authors

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -105,7 +105,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       this.downloadZipLink = Dockstore.API_URI + '/workflows/' + this.workflow.id + '/zip/' + this.currentVersion.id;
       this.authors = this.selectedVersion.authors;
       if (this.selectedVersion.orcidAuthors) {
-        this.authors.concat(this.selectedVersion.orcidAuthors);
+        this.authors = this.authors.concat(this.selectedVersion.orcidAuthors);
       }
     } else {
       this.isValidVersion = false;


### PR DESCRIPTION
**Description**
Noticed that the console was showing `ERROR TypeError: this.selectedVersion.orcidAuthors is null` when publishing/unpublishing a workflow or refreshing a workflow because the workflow returned from those actions don't have orcid authors initialized.

**Issue**
Technically part of dockstore/dockstore#4295

