### PR TITLE
Don't clear form prematurely

### DIFF
--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -155,11 +155,14 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
         if (this.unsavedTestWDLFile.length > 0) {
           this.addTestParameterFile(this.DescriptorType.WDL);
         }
+        const toAddCWLTestParameterFiles = this.unsavedCWLTestParameterFilePaths;
+        const toAddWDLTestParameterFiles = this.unsavedCWLTestParameterFilePaths;
+        // Question: do we really want to clear the form?
         this.initializeTag();
         // Using the string 'CWL' because this parameter only accepts 'CWL' or 'WDL' and not 'NFL'
         const addCWL: Observable<SourceFile[]> = this.containersService.addTestParameterFiles(
           id,
-          this.unsavedCWLTestParameterFilePaths,
+          toAddCWLTestParameterFiles,
           'CWL',
           tagName,
           null
@@ -167,7 +170,7 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
         // Using the string 'WDL' because this parameter only accepts 'CWL' or 'WDL' and not 'NFL'
         const addWDL: Observable<SourceFile[]> = this.containersService.addTestParameterFiles(
           id,
-          this.unsavedWDLTestParameterFilePaths,
+          toAddWDLTestParameterFiles,
           'WDL',
           tagName,
           null


### PR DESCRIPTION
**Description**
Form is cleared before trying to add the test parameter files. Not sure why. Should probably have a test if manual add tag is for long term use. 

Rough sequence of events (which is a little odd):
- Add tag request
- Clear form upon success
- Simultaneously add CWL and WDL test parameter files
- Refresh upon everything success

**Issue**
For dockstore/dockstore#4541

