### PR TITLE
migrate circle ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ orbs:
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
-      - image: circleci/buildpack-deps:18.04-browsers
+      - image: cimg/base:stable-20.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
         environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
-      - image: circleci/postgres:13.3
+      - image: cimg/postgres:13.3
         command: postgres -c max_connections=200 -c jit=off
         auth:
           username: dockstoretestuser
@@ -30,7 +30,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-      - image: circleci/buildpack-deps:18.04-browsers
+      - image: cimg/base:stable-20.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -61,7 +61,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-        - image: circleci/buildpack-deps:18.04-browsers
+        - image: cimg/base:stable-20.04
           auth:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
@@ -81,7 +81,7 @@ jobs:
   lint_license_unit_test_coverage:
     working_directory: ~/repo
     docker:
-      - image: circleci/buildpack-deps:18.04-browsers
+      - image: cimg/base:stable-20.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,6 +375,8 @@ commands:
       - run:
           name: Prepare webservice
           command: bash -i -c 'npm run webservice'
+          environment:
+            PAGER: cat # prevent psql commands using less https://stackoverflow.com/questions/53055044/rails-rake-dbstructureload-times-out-on-circleci-2-0       
       - run:
           name: Install nginx
           command: sudo apt install -y nginx || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
   slack: circleci/slack@3.4.2
+  browser-tools: circleci/browser-tools@1.2.3
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
@@ -35,6 +36,7 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
+      - browser-tools/install-browser-tools
       - setup_nightly_tests
       - run:
           name: Run remote verification test against << parameters.stack >> (no auth)
@@ -66,6 +68,7 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
+      - browser-tools/install-browser-tools
       - setup_nightly_tests
       - run:
           name: Run remote verification test against << parameters.stack >> (with auth)
@@ -86,6 +89,7 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - run:
           name: Checkout merge commit (PRs only)
@@ -146,6 +150,7 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
+      - browser-tools/install-browser-tools
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -160,6 +165,7 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
+      - browser-tools/install-browser-tools
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -174,6 +180,7 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
+      - browser-tools/install-browser-tools
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -356,6 +363,7 @@ commands:
           path: cypress/screenshots
   setup_integration_test:
     steps:
+      - browser-tools/install-browser-tools      
       - get_workspace
       - install_container_dependencies
       - run:
@@ -387,6 +395,7 @@ commands:
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
     steps:
+      - browser-tools/install-browser-tools      
       - checkout
       - install_container_dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
         environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
-      - image: cimg/postgres:13.3
+      - image: circleci/postgres:13.3
         command: postgres -c max_connections=200 -c jit=off
         auth:
           username: dockstoretestuser
@@ -31,7 +31,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-      - image: cimg/base:stable-18.04
+      - image: cimg/base:stable-20.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -63,7 +63,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-        - image: cimg/base:stable-18.04
+        - image: cimg/base:stable-20.04
           auth:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
@@ -84,7 +84,7 @@ jobs:
   lint_license_unit_test_coverage:
     working_directory: ~/repo
     docker:
-      - image: cimg/base:stable-18.04
+      - image: cimg/base:stable-20.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -375,8 +375,6 @@ commands:
       - run:
           name: Prepare webservice
           command: bash -i -c 'npm run webservice'
-          environment: 
-            TERM: xterm-256color # https://github.com/fastlane/fastlane/issues/11732#issuecomment-386429867
       - run:
           name: Install nginx
           command: sudo apt install -y nginx || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,6 +375,8 @@ commands:
       - run:
           name: Prepare webservice
           command: bash -i -c 'npm run webservice'
+          environment: 
+            TERM: xterm-256color # https://github.com/fastlane/fastlane/issues/11732#issuecomment-386429867
       - run:
           name: Install nginx
           command: sudo apt install -y nginx || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
-      - image: cimg/base:stable-20.04
+      - image: cimg/base:stable-18.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -31,7 +31,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-      - image: cimg/base:stable-20.04
+      - image: cimg/base:stable-18.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -63,7 +63,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-        - image: cimg/base:stable-20.04
+        - image: cimg/base:stable-18.04
           auth:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
@@ -84,7 +84,7 @@ jobs:
   lint_license_unit_test_coverage:
     working_directory: ~/repo
     docker:
-      - image: cimg/base:stable-20.04
+      - image: cimg/base:stable-18.04
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
**Description**
Got an email from circle ci

> You're currently using a legacy image that is not optimized for performance on CircleCI on the following project(s):
> [dockstore-ui2]
> As of Dec 31, 2021, legacy images will no longer be supported on CircleCI

More info at https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/ and https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

This deals with part of  it, but not all since postgres is blocked due to the linked issue in a commit below

**Issue**
https://github.com/dockstore/dockstore/issues/4555

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
