### PR TITLE
Feature/smoke test ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - install_cypress_dependencies
       - browser-tools/install-browser-tools
       - setup_nightly_tests
+      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (no auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-no-auth'
@@ -50,11 +50,11 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
-          channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-          webhook: $SLACK_WEBHOOK
+#      - slack/status:
+#          fail_only: true
+#          channel: $<< parameters.stack >>_id
+#          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+#          webhook: $SLACK_WEBHOOK
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
@@ -69,20 +69,21 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
-      - install_cypress_dependencies
       - browser-tools/install-browser-tools
       - setup_nightly_tests
+      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (with auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-auth'
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
-          channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> auth tests failed!
-          webhook: $SLACK_WEBHOOK
+#      - slack/status:
+#          fail_only: true
+#          channel: $<< parameters.stack >>_id
+#          failure_message: Nightly << parameters.stack >> auth tests failed!
+#          webhook: $SLACK_WEBHOOK
+
   lint_license_unit_test_coverage:
     working_directory: ~/repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - browser-tools/install-browser-tools
       - setup_nightly_tests
+      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (no auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-no-auth'
@@ -70,6 +71,7 @@ jobs:
     steps:
       - browser-tools/install-browser-tools
       - setup_nightly_tests
+      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (with auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-auth'
@@ -361,22 +363,24 @@ commands:
           path: cypress/videos
       - store_artifacts:
           path: cypress/screenshots
+  install_cypress_dependencies:
+    - run:
+        name: Install cypress dependencies
+        command: sudo apt install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
   setup_integration_test:
     steps:
-      - browser-tools/install-browser-tools      
+      - browser-tools/install-browser-tools
       - get_workspace
       - install_container_dependencies
       - run:
           name: Install postgresql client
           command: sudo apt install -y postgresql-client || true
-      - run:
-          name: Install cypress dependencies
-          command: sudo apt install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
+      - install_cypress_dependencies
       - run:
           name: Prepare webservice
           command: bash -i -c 'npm run webservice'
           environment:
-            PAGER: cat # prevent psql commands using less https://stackoverflow.com/questions/53055044/rails-rake-dbstructureload-times-out-on-circleci-2-0       
+            PAGER: cat # prevent psql commands using less https://stackoverflow.com/questions/53055044/rails-rake-dbstructureload-times-out-on-circleci-2-0
       - run:
           name: Install nginx
           command: sudo apt install -y nginx || true
@@ -397,7 +401,7 @@ commands:
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
     steps:
-      - browser-tools/install-browser-tools      
+      - browser-tools/install-browser-tools
       - checkout
       - install_container_dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,10 @@ commands:
       - store_artifacts:
           path: cypress/screenshots
   install_cypress_dependencies:
-    - run:
-        name: Install cypress dependencies
-        command: sudo apt install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
+    steps:
+      - run:
+          name: Install cypress dependencies
+          command: sudo apt install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
   setup_integration_test:
     steps:
       - browser-tools/install-browser-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,15 @@ workflows:
               only: /.*/
           context:
             - dockerhub
+      - uptime_monitor_auth:
+          stack: "dev"
+          context:
+            - dockerhub
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth-dev"
+          stack: "dev"
+          context:
+            - dockerhub
       - integration_test_1:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
+      - install_cypress_dependencies
       - browser-tools/install-browser-tools
       - setup_nightly_tests
-      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (no auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-no-auth'
@@ -69,9 +69,9 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
+      - install_cypress_dependencies
       - browser-tools/install-browser-tools
       - setup_nightly_tests
-      - install_cypress_dependencies
       - run:
           name: Run remote verification test against << parameters.stack >> (with auth)
           command: bash -i -c 'npm run test-<< parameters.stack >>-auth'
@@ -261,11 +261,15 @@ workflows:
             - dockerhub
       - uptime_monitor_auth:
           stack: "dev"
+          requires:
+            - lint_license_unit_test_coverage
           context:
             - dockerhub
       - uptime_monitor_no_auth:
           name: "uptime_monitor_no_auth-dev"
           stack: "dev"
+          requires:
+            - lint_license_unit_test_coverage
           context:
             - dockerhub
       - integration_test_1:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ commands:
     steps:
       - run:
           name: Install cypress dependencies
-          command: sudo apt install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
+          command: sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
   setup_integration_test:
     steps:
       - browser-tools/install-browser-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,11 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-#      - slack/status:
-#          fail_only: true
-#          channel: $<< parameters.stack >>_id
-#          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-#          webhook: $SLACK_WEBHOOK
+      - slack/status:
+          fail_only: true
+          channel: $<< parameters.stack >>_id
+          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
@@ -78,11 +78,11 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
-#      - slack/status:
-#          fail_only: true
-#          channel: $<< parameters.stack >>_id
-#          failure_message: Nightly << parameters.stack >> auth tests failed!
-#          webhook: $SLACK_WEBHOOK
+      - slack/status:
+          fail_only: true
+          channel: $<< parameters.stack >>_id
+          failure_message: Nightly << parameters.stack >> auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   lint_license_unit_test_coverage:
     working_directory: ~/repo
@@ -258,19 +258,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-          context:
-            - dockerhub
-      - uptime_monitor_auth:
-          stack: "dev"
-          requires:
-            - lint_license_unit_test_coverage
-          context:
-            - dockerhub
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth-dev"
-          stack: "dev"
-          requires:
-            - lint_license_unit_test_coverage
           context:
             - dockerhub
       - integration_test_1:


### PR DESCRIPTION
**Description**
Not 100% sure, but it looks like changing the CircleCI images in https://github.com/dockstore/dockstore-ui2/pull/1376 may have caused some dependency issues for the smoke test jobs. See these tests https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/6626/workflows/7786fd4e-2f45-4e6e-85e6-d60b8d6a4c5b.

This PR adds an installation step for Cypress dependencies that runs for both integration tests and smoke tests. 

CircleCi job completing: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2?branch=feature%2FsmokeTestCiImages

**Issue**
Ran into the issue in this PR while working on: https://ucsc-cgl.atlassian.net/browse/SEAB-3192

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that your code compiles by running `npm run build`
- [X] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [X] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [X] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [X] Do not use cookies, although this may change in the future
- [X] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [X] Do due diligence on new 3rd party libraries, checking for CVEs
- [X] Don't allow user-uploaded images to be served from the Dockstore domain
