### PR TITLE
Feature/4179/refresh org confirmation

### DIFF
--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -288,7 +288,7 @@ describe('Dockstore my tools', () => {
       cy.get('[data-cy=imageRegistryProviderSelect]').click();
       cy.contains('Amazon ECR').click();
 
-      cy.get('#privateTool').find('input').check({force: true});
+      cy.get('#privateTool').find('input').check({ force: true });
 
       cy.get('#dockerRegistryPathInput').type('amazon.dkr.ecr.test-1.amazonaws.com');
 
@@ -470,6 +470,5 @@ describe('Dockstore my tools', () => {
   it('Refresh Namespace button should have tooltip', () => {
     cy.visit('/my-tools/quay.io/A2/a');
     cy.get('#cdk-accordion-child-4 > .mat-action-row > .pull-right > [data-cy=refreshOrganization]').trigger('mouseenter');
-    cy.get('.mat-tooltip').contains('Refresh all tools in the namespace');
   });
 });

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -466,7 +466,6 @@ describe('Dockstore my workflows', () => {
       '#cdk-accordion-child-2 > .mat-action-row.ng-star-inserted > div > :nth-child(2) > ' +
         'app-refresh-workflow-organization > [data-cy=refreshOrganization]'
     ).trigger('mouseenter');
-    cy.get('.mat-tooltip').contains('Refresh all workflows in the organization');
     cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
     cy.contains('button', 'Cancel').should('be.visible');
     cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -310,6 +310,7 @@ describe('Dockstore my workflows', () => {
     goToTab('Versions');
     cy.get('table>tbody>tr').should('have.length', 2); // 2 Versions and no warning line
     cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
+    cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
     cy.wait('@refreshWorkflow');
     goToTab('Versions');
     cy.get('table>tbody>tr').should('have.length', 1); // 2 Versions and no warning line
@@ -466,5 +467,12 @@ describe('Dockstore my workflows', () => {
         'app-refresh-workflow-organization > [data-cy=refreshOrganization]'
     ).trigger('mouseenter');
     cy.get('.mat-tooltip').contains('Refresh all workflows in the organization');
+    cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
+    cy.contains('button', 'Cancel').should('be.visible');
+    cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
+    cy.get('.error-output').should('be.visible');
+    cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
+    cy.contains('button', 'Cancel').should('be.visible').click();
+    cy.get('.error-output').should('not.be.visible');
   });
 });

--- a/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
+++ b/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
@@ -45,7 +45,6 @@ export class RefreshToolOrganizationComponent extends RefreshOrganizationCompone
   ) {
     super();
     this.buttonText = 'Refresh Namespace';
-    this.tooltipText = 'Refresh all tools in the namespace';
   }
 
   openConfirmationDialog() {

--- a/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
+++ b/src/app/container/refresh-tool-organization/refresh-tool-organization.component.ts
@@ -48,6 +48,10 @@ export class RefreshToolOrganizationComponent extends RefreshOrganizationCompone
     this.tooltipText = 'Refresh all tools in the namespace';
   }
 
+  openConfirmationDialog() {
+    this.refreshOrganization();
+  }
+
   ngOnInit() {
     this.userQuery.userId$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((userId) => (this.userId = userId));
     this.isRefreshing$ = this.alertQuery.showInfo$;

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -239,6 +239,8 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
  * @template T
  */
 export interface OrgWorkflowObject<T> extends OrgEntryObject<T> {
+  // Swagger doesn't return an enm for this. Currently, some values present are:
+  // github.com and bitbucket.org
   sourceControl: string;
   organization: string;
 }

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -239,7 +239,7 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
  * @template T
  */
 export interface OrgWorkflowObject<T> extends OrgEntryObject<T> {
-  // Swagger doesn't return an enm for this. Currently, some values present are:
+  // Swagger doesn't return an enum for this. Currently, some values present are:
   // github.com and bitbucket.org
   sourceControl: string;
   organization: string;

--- a/src/app/shared/refresh-organization/refresh-organization.component.html
+++ b/src/app/shared/refresh-organization/refresh-organization.component.html
@@ -20,7 +20,7 @@
   type="button"
   class="mr-1"
   data-cy="refreshOrganization"
-  (click)="refreshOrganization()"
+  (click)="openConfirmationDialog()"
   [disabled]="isRefreshing$ | async"
   matTooltip="{{ tooltipText }}"
 >

--- a/src/app/shared/refresh-organization/refresh-organization.component.html
+++ b/src/app/shared/refresh-organization/refresh-organization.component.html
@@ -22,7 +22,6 @@
   data-cy="refreshOrganization"
   (click)="isGitHubOrg ? openConfirmationDialog() : refreshOrganization()"
   [disabled]="isRefreshing$ | async"
-  matTooltip="{{ tooltipText }}"
 >
   {{ buttonText }}
 </button>

--- a/src/app/shared/refresh-organization/refresh-organization.component.html
+++ b/src/app/shared/refresh-organization/refresh-organization.component.html
@@ -20,7 +20,7 @@
   type="button"
   class="mr-1"
   data-cy="refreshOrganization"
-  (click)="openConfirmationDialog()"
+  (click)="isGitHubOrg ? openConfirmationDialog() : refreshOrganization()"
   [disabled]="isRefreshing$ | async"
   matTooltip="{{ tooltipText }}"
 >

--- a/src/app/shared/refresh-organization/refresh-organization.component.ts
+++ b/src/app/shared/refresh-organization/refresh-organization.component.ts
@@ -20,6 +20,7 @@ import { Base } from '../base';
 
 @Injectable()
 export abstract class RefreshOrganizationComponent extends Base {
+  public isGitHubOrg: boolean;
   protected userId: number;
   buttonText: string;
   tooltipText: string;

--- a/src/app/shared/refresh-organization/refresh-organization.component.ts
+++ b/src/app/shared/refresh-organization/refresh-organization.component.ts
@@ -23,7 +23,6 @@ export abstract class RefreshOrganizationComponent extends Base {
   public isGitHubOrg: boolean;
   protected userId: number;
   buttonText: string;
-  tooltipText: string;
   public isRefreshing$: Observable<boolean>;
   constructor() {
     super();

--- a/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.spec.ts
+++ b/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.spec.ts
@@ -16,6 +16,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -40,6 +41,7 @@ import { RefreshWorkflowOrganizationComponent } from './refresh-workflow-organiz
 describe('RefreshWorkflowOrganizationComponent', () => {
   let component: RefreshWorkflowOrganizationComponent;
   let fixture: ComponentFixture<RefreshWorkflowOrganizationComponent>;
+  const matDialogStub = jasmine.createSpyObj('MatDialog', ['closeAll']);
 
   beforeEach(
     waitForAsync(() => {
@@ -53,6 +55,7 @@ describe('RefreshWorkflowOrganizationComponent', () => {
           { provide: ExtendedDockstoreToolService, useClass: ExtendedDockstoreToolStubService },
           { provide: DateService, useClass: DateStubService },
           { provide: ProviderService, useClass: ProviderStubService },
+          { provide: MatDialog, useValue: matDialogStub },
         ],
       }).compileComponents();
     })

--- a/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
+++ b/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
@@ -14,6 +14,9 @@
  *    limitations under the License.
  */
 import { Component, Input, OnInit } from '@angular/core';
+import { ConfirmationDialogData } from 'app/confirmation-dialog/confirmation-dialog.component';
+import { ConfirmationDialogService } from 'app/confirmation-dialog/confirmation-dialog.service';
+import { bootstrap4mediumModalSize } from 'app/shared/constants';
 import { EMPTY, from } from 'rxjs';
 import { catchError, concatMap, takeUntil } from 'rxjs/operators';
 import { OrgWorkflowObject } from '../../myworkflows/my-workflow/my-workflow.component';
@@ -42,7 +45,8 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
     private workflowsService: WorkflowsService,
     private alertService: AlertService,
     protected alertQuery: AlertQuery,
-    private extendedWorkflowQuery: ExtendedWorkflowQuery
+    private extendedWorkflowQuery: ExtendedWorkflowQuery,
+    private confirmationDialogService: ConfirmationDialogService
   ) {
     super();
     this.buttonText = 'Refresh Organization';
@@ -52,6 +56,24 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
   ngOnInit() {
     this.userQuery.userId$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((userId) => (this.userId = userId));
     this.isRefreshing$ = this.alertQuery.showInfo$;
+  }
+
+  openConfirmationDialog() {
+    const confirmationDialogData: ConfirmationDialogData = {
+      title: 'Refresh Organization',
+      message: `Are you sure you wish to refresh the organization?
+                It has no effect on GitHub Apps workflows.`,
+      cancelButtonText: 'Cancel',
+      confirmationButtonText: 'Refresh',
+    };
+    this.confirmationDialogService
+      .openDialog(confirmationDialogData, bootstrap4mediumModalSize)
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((result) => {
+        if (result) {
+          this.refreshOrganization();
+        }
+      });
   }
 
   refreshOrganization(): void {

--- a/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
+++ b/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { ConfirmationDialogData } from 'app/confirmation-dialog/confirmation-dialog.component';
 import { ConfirmationDialogService } from 'app/confirmation-dialog/confirmation-dialog.service';
 import { bootstrap4mediumModalSize } from 'app/shared/constants';
@@ -36,7 +36,7 @@ import { UserQuery } from '../../shared/user/user.query';
   templateUrl: './../../shared/refresh-organization/refresh-organization.component.html',
   styleUrls: ['./../../shared/refresh-organization/refresh-organization.component.css'],
 })
-export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationComponent implements OnInit {
+export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationComponent implements OnInit, OnChanges {
   @Input() protected orgWorkflowObject: OrgWorkflowObject<Workflow>;
 
   constructor(
@@ -58,11 +58,15 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
     this.isRefreshing$ = this.alertQuery.showInfo$;
   }
 
+  ngOnChanges() {
+    this.isGitHubOrg = this.orgWorkflowObject.sourceControl === 'github.com';
+  }
+
   openConfirmationDialog() {
     const confirmationDialogData: ConfirmationDialogData = {
       title: 'Refresh Organization',
       message: `Are you sure you wish to refresh the organization?
-                It has no effect on GitHub Apps workflows.`,
+                It has no effect on workflows already being synchronized via the Dockstore GitHub App.`,
       cancelButtonText: 'Cancel',
       confirmationButtonText: 'Refresh',
     };

--- a/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
+++ b/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
@@ -64,8 +64,8 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
   openConfirmationDialog() {
     const confirmationDialogData: ConfirmationDialogData = {
       title: 'Refresh Organization',
-      message: `Are you sure you wish to refresh the workflows in the organization?
-                It has no effect on workflows already being synchronized via the Dockstore GitHub App.`,
+      message: `Are you sure you wish to refresh the organization?
+                This will sequentially refresh all workflows in the organization except for those already being synchronized via the Dockstore GitHub App.`,
       cancelButtonText: 'Cancel',
       confirmationButtonText: 'Refresh',
     };

--- a/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
+++ b/src/app/workflow/refresh-workflow-organization/refresh-workflow-organization.component.ts
@@ -50,7 +50,6 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
   ) {
     super();
     this.buttonText = 'Refresh Organization';
-    this.tooltipText = 'Refresh all workflows in the organization';
   }
 
   ngOnInit() {
@@ -65,7 +64,7 @@ export class RefreshWorkflowOrganizationComponent extends RefreshOrganizationCom
   openConfirmationDialog() {
     const confirmationDialogData: ConfirmationDialogData = {
       title: 'Refresh Organization',
-      message: `Are you sure you wish to refresh the organization?
+      message: `Are you sure you wish to refresh the workflows in the organization?
                 It has no effect on workflows already being synchronized via the Dockstore GitHub App.`,
       cancelButtonText: 'Cancel',
       confirmationButtonText: 'Refresh',


### PR DESCRIPTION
**Description**
Add a confirmation dialog before refreshing an org in my-workflows. If there's any additional text to add to the dialog, now is the time to bring it up.

**Issue**
For dockstore/dockstore#4179

