### PR TITLE
No Cypress retries locally

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,7 +7,7 @@
   "requestTimeout": 30000,
   "retries": {
     "runMode": 3,
-    "openMode": 3
+    "openMode": 0
   }
 }
 


### PR DESCRIPTION
**Description**
Disable Cypress retries locally.

**Issue**
Ad hoc issue. Disabling the Cypress retries locally because the idea is that:
- Non-flakey tests should not require any retries on CI or locally
- Tests that are flakey on CI but not locally will still have retries (not great but is considered acceptable for now)
- But tests that are flakey locally (and maybe the CI too) should be caught immediately and fixed. Disabling the retries would let developers immediately know that they should fix the test.

