### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -37,13 +37,7 @@
             </div>
             <div *ngIf="canEdit$ | async">
               <mat-card-content fxLayout="row" fxLayoutGap="10px" class="m-0">
-                <button
-                  color="basic"
-                  mat-icon-button
-                  (click)="editCollection(collection)"
-                  id="editCollection"
-                  matTooltip="Edit the collection"
-                >
+                <button mat-icon-button (click)="editCollection(collection)" id="editCollection" matTooltip="Edit the collection">
                   <mat-icon>edit</mat-icon>
                 </button>
               </mat-card-content>

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -32,7 +32,14 @@
                 <span class="role-display">{{ organizationUser.role | titlecase }}</span>
               </div>
               <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row wrap">
-                 <div>ORCID <img src="../../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo site-icons-small mr-3" /></div>
+                <div>
+                  ORCID
+                  <img
+                    src="../../../assets/images/account-logos/orcid.svg"
+                    alt="ORCID iD logo"
+                    class="orcid-id-logo site-icons-small mr-3"
+                  />
+                </div>
                 <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
               </span>
             </div>
@@ -40,7 +47,6 @@
           <div fxFlex fxGrow="1" fxLayoutAlign="end center" *ngIf="canEditMembership$ | async">
             <mat-card-content fxLayout="row" fxLayoutGap="10px" class="m-0">
               <button
-                color="basic"
                 mat-icon-button
                 matTooltip="Edit user's role in organization"
                 [id]="'edit-user-role-' + index"
@@ -50,7 +56,6 @@
                 <mat-icon>edit</mat-icon>
               </button>
               <button
-                color="basic"
                 mat-icon-button
                 matTooltip="Remove user from organization"
                 [id]="'remove-user-' + index"

--- a/src/app/shared/entry-actions/tool-actions.component.html
+++ b/src/app/shared/entry-actions/tool-actions.component.html
@@ -4,7 +4,6 @@
     [routerLink]="['/tools/', tool.tool_path]"
     id="viewPublicToolButton"
     mat-button
-    color="basic"
     [disabled]="isRefreshing$ | async"
     [matTooltip]="viewPublicMessage"
   >

--- a/src/app/shared/entry-actions/workflow-actions.component.html
+++ b/src/app/shared/entry-actions/workflow-actions.component.html
@@ -4,7 +4,6 @@
     [routerLink]="['/' + entryType + 's/', workflow.full_workflow_path]"
     id="viewPublicWorkflowButton"
     mat-button
-    color="basic"
     [disabled]="isRefreshing$ | async"
     [matTooltip]="viewPublicMessage"
   >


### PR DESCRIPTION
**Description**
Remove `color="basic"` throughout the codebase

**Issue**
Ad hoc issue. Noticed we had `color="basic"` applied to material components. The only known options that do anything are primary, accent, warn, etc. Removing it so this isn't perpetuated through new components added.

