### PR TITLE
Prevent tab change infinite loop

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -16,6 +16,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatAccordion } from '@angular/material/expansion';
+import { MatTabChangeEvent } from '@angular/material/tabs';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import {
   faAngleDoubleDown,
@@ -205,11 +206,15 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.hasFacetAutoCompleteTerms$ = this.searchQuery.hasFacetAutoCompleteTerms$;
   }
 
-  /**
+ /**
    * Only called when the tab is manually changed by the user
    */
-  saveTabIndex(tab) {
-    this.searchService.saveCurrentTabAndClear(tab.index);
+  saveTabIndex(matTabChangeEvent: MatTabChangeEvent) {
+    // This is to prevent an infinite loop. 
+    // Event is somehow triggered even though it's not the active tab
+    if (matTabChangeEvent.tab.isActive) {
+      this.searchService.saveCurrentTabAndClear(matTabChangeEvent.index);
+    }
   }
 
   /**

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -210,7 +210,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    * Only called when the tab is manually changed by the user
    */
   saveTabIndex(matTabChangeEvent: MatTabChangeEvent) {
-    // This is to prevent an infinite loop. 
+    // This is to prevent an infinite loop.
     // Event is somehow triggered even though it's not the active tab
     if (matTabChangeEvent.tab.isActive) {
       this.searchService.saveCurrentTabAndClear(matTabChangeEvent.index);


### PR DESCRIPTION
**Description**
It was shown that rapidly changing the tabs before the page has finished loading causes the infinite loop.

For some reason the event gets triggered even though it's not the active tab. Do a quick check.

Note: Rapidly changing tabs is incredibly noticeable by most users. There may be another infinite loop elsewhere that I can't find.

**Issue**
For SEAB-3548
