### PR TITLE
Add container classes

### DIFF
--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -103,7 +103,6 @@ describe('Dockstore Workflow Details', () => {
 
   describe('Change tab to dag', () => {
     it('Change to fullscreen and back', () => {
-      cy.get('.mat-tab-header-pagination-after').click();
       goToTab('DAG');
       goToTab('DAG');
       cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=dag');

--- a/src/bootstrap4.scss
+++ b/src/bootstrap4.scss
@@ -390,3 +390,59 @@ $overflows: scroll, hidden, auto, inherit, initial, unset, visible;
   word-break: break-word !important; // Deprecated, but avoids issues with flex containers
   word-wrap: break-word !important; // Used instead of `overflow-wrap` for IE & Edge Legacy
 }
+
+// These are actually from bootstrap 5 (pretty similar to our existing bootstrap 3 except it has an additional style for 1400px+ screens
+.container,
+.container-fluid,
+.container-xxl,
+.container-xl,
+.container-lg,
+.container-md,
+.container-sm {
+  width: 100%;
+  padding-right: var(--bs-gutter-x, 0.75rem);
+  padding-left: var(--bs-gutter-x, 0.75rem);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media (min-width: 576px) {
+  .container-sm,
+  .container {
+    max-width: 540px;
+  }
+}
+@media (min-width: 768px) {
+  .container-md,
+  .container-sm,
+  .container {
+    max-width: 720px;
+  }
+}
+@media (min-width: 992px) {
+  .container-lg,
+  .container-md,
+  .container-sm,
+  .container {
+    max-width: 960px;
+  }
+}
+@media (min-width: 1200px) {
+  .container-xl,
+  .container-lg,
+  .container-md,
+  .container-sm,
+  .container {
+    max-width: 1140px;
+  }
+}
+@media (min-width: 1400px) {
+  .container-xxl,
+  .container-xl,
+  .container-lg,
+  .container-md,
+  .container-sm,
+  .container {
+    max-width: 1320px;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -355,18 +355,6 @@ h3.available-containers {
   line-height: 55px;
 }
 
-@media (min-width: 992px) {
-  .container {
-    width: 970px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .container {
-    width: 1200px;
-  }
-}
-
 #container-header {
   box-shadow: 0px 3px 6px #cfd1d7;
   position: relative;


### PR DESCRIPTION
**Description**
In order to remove bootstrap, the main hurdles left are the grid and container class usages. The idea of us removing our container usage throughout the site seems...unlikely. Copying the container classes instead (at least until after we actually remove bootstrap 3). Might need to do the same for grid.  Notable differences: 
for 1200px <= screen size width < 1400px, it's now 60px smaller.  
for screen width >= 1400px, it's now 120px wider (1320px, this is what i see on my desktop monitors which should be the same for most users/developers). This is in fact even larger than the search mockup (1275px)

So temporarily, most of the classes added are redundent until we actually remove bootstrap 3.

You may want to check this out and see for yourself. Most of our pages (search, organizations, about, logged out homepage) is wider and have less white space.  In particular, the search table is less cramped and workflow tabs aren't paginated (see test changes) because there's enough room.

**Issue**
Adhoc issue. Though kind of related to https://github.com/dockstore/dockstore/issues/1899
