### PR TITLE
Fix OpenJDK installation instructions for Mac OS X homebrew

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -91,8 +91,7 @@ exec newgrp docker
 #### Part 1a - Install Java dependencies
 We'll cover two ways to install Java 11.
 
-1. The first way is to download OpenJDK for Mac OS from [here](https://jdk.java.net/archive/), and execute
-the following commands.  First, unpack the downloaded tar archive, then move the resulting JDK directory to its standard location. Then check the Java version:
+1. The first way is to download OpenJDK for Mac OS from [here](https://jdk.java.net/archive/), and execute the following commands.  First, unpack the downloaded tar archive, then move the resulting JDK directory to its standard location. Then check the Java version:
 \`\`\`
 sudo mv jdk-11.0.2.jdk /Library/Java/JavaVirtualMachines/
 java -version

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -89,7 +89,10 @@ exec newgrp docker
 `;
     this.textDataMacOs = `
 #### Part 1 - Install dependencies
-1. We'll cover two ways to install Java 11. One way is to download the JDK for MacOS from [OpenJDK](https://jdk.java.net/archive/) and executing the following commands.  First, unpack the downloaded tar archive, then move the resulting JDK directory to its standard location and check the Java version:
+We'll cover two ways to install Java 11.
+
+1. The first way is to download OpenJDK for Mac OS from [here](https://jdk.java.net/archive/), and execute
+the following commands.  First, unpack the downloaded tar archive, then move the resulting JDK directory to its standard location. Then check the Java version:
 \`\`\`
 sudo mv jdk-11.0.2.jdk /Library/Java/JavaVirtualMachines/
 java -version
@@ -107,10 +110,20 @@ java -version
 \`\`\`
 Add the above export line to your \`.bashrc\` or \`.bash_profile\` to set \`JAVA_HOME\` properly every time you invoke a shell.
 
-2. Or to install Java 11 using Homebrew, execute the following commands:
+2. Alternatively, to install Java 11 using Homebrew, execute the following commands:
 \`\`\`
-brew tap AdoptOpenJDK/openjdk
-brew cask install adoptopenjdk11
+brew update
+brew install openjdk@11
+\`\`\`
+For the system Java wrappers to be able to use this JDK, symlink with the command:
+\`\`\`
+sudo ln -sfn $(brew --prefix)/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
+\`\`\`
+Next, set the \`JAVA_HOME\` environment variable to the correct JDK system path, and confirm the
+Java version is correct:
+\`\`\`
+unset JAVA_HOME
+export JAVA_HOME=\`/usr/libexec/java_home -v 11\`
 java -version
 \`\`\`
 

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -88,7 +88,7 @@ exec newgrp docker
 
 `;
     this.textDataMacOs = `
-#### Part 1 - Install dependencies
+#### Part 1a - Install Java dependencies
 We'll cover two ways to install Java 11.
 
 1. The first way is to download OpenJDK for Mac OS from [here](https://jdk.java.net/archive/), and execute
@@ -127,7 +127,8 @@ export JAVA_HOME=\`/usr/libexec/java_home -v 11\`
 java -version
 \`\`\`
 
-3. Install Docker following the instructions on [Docker's website](https://docs.docker.com/docker-for-mac/install/). You should have at least version 2.0.0.3 installed.
+#### Part 1b - Install Docker dependencies
+Install Docker following the instructions on [Docker's website](https://docs.docker.com/docker-for-mac/install/). You should have at least version 2.0.0.3 installed.
     `;
 
     this.textDataInstallCLI = `


### PR DESCRIPTION
**Description**

This updates the install instructions for OpenJDK on Mac using homebrew. Complements #1342 which covered Mac install instructions for the OpenJDK-provided tarball.

**Issue**
dockstore/dockstore#4486
https://ucsc-cgl.atlassian.net/browse/DOCK-1925

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization (**NOTE:** this modifies markdown contained in strings, but doesn't change how the markdown is displayed.)
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
