### PR TITLE
Feature/dock 1765/entry page category buttons

### DIFF
--- a/cypress/integration/group2/categories.ts
+++ b/cypress/integration/group2/categories.ts
@@ -88,6 +88,11 @@ describe('Dockstore Categories', () => {
       cy.visit('/organizations/dockstore/collections/' + categoryName);
       cy.get('app-category-button').contains(categoryDisplayName);
     });
+    it('appear in tool page', () => {
+      cy.visit(toolPath);
+      cy.wait(1000); // give categories time to load
+      cy.get('app-category-button').contains(categoryDisplayName);
+    });
     it('appear in logged-out home page', () => {
       cy.clearLocalStorage();
       cy.visit('/');

--- a/cypress/integration/group2/categories.ts
+++ b/cypress/integration/group2/categories.ts
@@ -21,6 +21,7 @@ describe('Dockstore Categories', () => {
   const categoryTopic = 'some topic';
   const toolPath = '/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8?tab=info';
   const toolSnippet = 'cgpmap-cramOut';
+  const workflowPath = '/workflows/github.com/A/l:master?tab=info';
 
   resetDB();
   setTokenUserViewPort();
@@ -47,6 +48,20 @@ describe('Dockstore Categories', () => {
   describe('Should be able to add a tool to a category', () => {
     it('be able to add tool to category', () => {
       cy.visit(toolPath);
+      cy.get('#addToolToCollectionButton').should('be.visible').click();
+      cy.get('#addEntryToCollectionButton').should('be.disabled');
+      cy.get('#selectOrganization').click();
+      cy.get('mat-option').contains('Dockstore').click();
+      cy.get('#addEntryToCollectionButton').should('be.disabled');
+      cy.get('#selectCollection').click();
+      cy.get('mat-option').contains(categoryDisplayName).click();
+      cy.get('#addEntryToCollectionButton').should('not.be.disabled').click();
+    });
+  });
+
+  describe('Should be able to add a workflow to a category', () => {
+    it('be able to add workflow to category', () => {
+      cy.visit(workflowPath);
       cy.get('#addToolToCollectionButton').should('be.visible').click();
       cy.get('#addEntryToCollectionButton').should('be.disabled');
       cy.get('#selectOrganization').click();
@@ -90,6 +105,11 @@ describe('Dockstore Categories', () => {
     });
     it('appear in tool page', () => {
       cy.visit(toolPath);
+      cy.wait(1000); // give categories time to load
+      cy.get('app-category-button').contains(categoryDisplayName);
+    });
+    it('appear in workflow page', () => {
+      cy.visit(workflowPath);
       cy.wait(1000); // give categories time to load
       cy.get('app-category-button').contains(categoryDisplayName);
     });

--- a/cypress/integration/group2/categories.ts
+++ b/cypress/integration/group2/categories.ts
@@ -105,12 +105,10 @@ describe('Dockstore Categories', () => {
     });
     it('appear in tool page', () => {
       cy.visit(toolPath);
-      cy.wait(1000); // give categories time to load
       cy.get('app-category-button').contains(categoryDisplayName);
     });
     it('appear in workflow page', () => {
       cy.visit(workflowPath);
-      cy.wait(1000); // give categories time to load
       cy.get('app-category-button').contains(categoryDisplayName);
     });
     it('appear in logged-out home page', () => {

--- a/src/app/categories/button/category-button.component.scss
+++ b/src/app/categories/button/category-button.component.scss
@@ -1,9 +1,9 @@
 // A category button is an anchor mat-button.
-// Override the default button styling and inherit various properties to maintain consistency with our mockups and any adjacent "label"-type elements.
+// Override the default button styling and inherit various properties to maintain consistency with our mockups.
 // Specific to the above.
 a, a:hover, a:focus, a:active, a:link, a:visited {
   color: black;
-  font-weight: inherit;
+  font-weight: 500;
   font-size: inherit;
   line-height: inherit;
   border: none;

--- a/src/app/categories/state/entry-categories.query.ts
+++ b/src/app/categories/state/entry-categories.query.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { QueryEntity } from '@datorama/akita';
+import { Category } from '../../shared/openapi';
+import { EntryCategoriesState, EntryCategoriesStore } from './entry-categories.store';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EntryCategoriesQuery extends QueryEntity<EntryCategoriesState, Category> {
+  constructor(protected store: EntryCategoriesStore) {
+    super(store);
+  }
+}

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -35,11 +35,12 @@ export class EntryCategoriesService {
   }
 
   /**
-   * Updates the list of categories.
+   * Updates the list of categories for the specified entry.
    */
   updateEntryCategories(id: number) {
     this.entryCategoriesStore.setLoading(true);
     this.entryCategoriesStore.setError(false);
+    this.entryCategoriesStore.set([]);
     this.entriesService
       .entryCategories(id)
       .subscribe(

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Category, EntriesService } from '../../shared/openapi';
+import { EntryCategoriesStore } from './entry-categories.store';
+import { EntryCategoriesQuery } from './entry-categories.query';
+
+@Injectable({ providedIn: 'root' })
+export class EntryCategoriesService {
+  public categories$: Observable<Array<Category>>;
+
+  constructor(
+    private entryCategoriesStore: EntryCategoriesStore,
+    private entryCategoriesQuery: EntryCategoriesQuery,
+    private entriesService: EntriesService,
+  ) {
+    /**
+     * An observable list of the categories for a given entry.
+     */
+    this.categories$ = this.entryCategoriesQuery.selectAll();
+  }
+
+  /**
+   * Updates the list of categories.
+   */
+  updateEntryCategories(id: number) {
+    this.entryCategoriesStore.setLoading(true);
+    this.entryCategoriesStore.setError(false);
+    this.entriesService
+      .entryCategories(id)
+      .subscribe(
+        (categories: Array<Category>) => {
+          this.entryCategoriesStore.setLoading(false);
+          this.entryCategoriesStore.setError(false);
+          this.entryCategoriesStore.set(categories);
+        },
+        () => {
+          this.entryCategoriesStore.setLoading(false);
+          this.entryCategoriesStore.setError(true);
+        }
+      );
+  }
+}

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { Category, EntriesService } from '../../shared/openapi';
 import { EntryCategoriesStore } from './entry-categories.store';
 import { EntryCategoriesQuery } from './entry-categories.query';
@@ -35,33 +35,29 @@ export class EntryCategoriesService {
   }
 
   /**
-   * Current entry category update sequence number.
+   * Current entry category update subscription.
    */
-  private updateNumber: number = 0;
+  private currentSubscription: Subscription = null;
 
   /**
    * Updates the list of categories for the specified entry.
    */
   updateEntryCategories(entryId: number) {
-    const myUpdateNumber = ++this.updateNumber;
     this.entryCategoriesStore.setLoading(true);
     this.entryCategoriesStore.setError(false);
     this.entryCategoriesStore.remove();
-    this.entriesService
+    this.currentSubscription?.unsubscribe();
+    this.currentSubscription = this.entriesService
       .entryCategories(entryId)
       .subscribe(
         (categories: Array<Category>) => {
-          if (myUpdateNumber === this.updateNumber) {
-            this.entryCategoriesStore.setLoading(false);
-            this.entryCategoriesStore.setError(false);
-            this.entryCategoriesStore.set(categories);
-          }
+          this.entryCategoriesStore.setLoading(false);
+          this.entryCategoriesStore.setError(false);
+          this.entryCategoriesStore.set(categories);
         },
         () => {
-          if (myUpdateNumber === this.updateNumber) {
-            this.entryCategoriesStore.setLoading(false);
-            this.entryCategoriesStore.setError(true);
-          }
+          this.entryCategoriesStore.setLoading(false);
+          this.entryCategoriesStore.setError(true);
         }
       );
   }

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -35,23 +35,33 @@ export class EntryCategoriesService {
   }
 
   /**
+   * Current entry category update sequence number.
+   */
+  private updateNumber: number = 0;
+
+  /**
    * Updates the list of categories for the specified entry.
    */
-  updateEntryCategories(id: number) {
+  updateEntryCategories(entryId: number) {
+    const myUpdateNumber = ++this.updateNumber;
     this.entryCategoriesStore.setLoading(true);
     this.entryCategoriesStore.setError(false);
-    this.entryCategoriesStore.set([]);
+    this.entryCategoriesStore.remove();
     this.entriesService
-      .entryCategories(id)
+      .entryCategories(entryId)
       .subscribe(
         (categories: Array<Category>) => {
-          this.entryCategoriesStore.setLoading(false);
-          this.entryCategoriesStore.setError(false);
-          this.entryCategoriesStore.set(categories);
+          if (myUpdateNumber === this.updateNumber) {
+            this.entryCategoriesStore.setLoading(false);
+            this.entryCategoriesStore.setError(false);
+            this.entryCategoriesStore.set(categories);
+          }
         },
         () => {
-          this.entryCategoriesStore.setLoading(false);
-          this.entryCategoriesStore.setError(true);
+          if (myUpdateNumber === this.updateNumber) {
+            this.entryCategoriesStore.setLoading(false);
+            this.entryCategoriesStore.setError(true);
+          }
         }
       );
   }

--- a/src/app/categories/state/entry-categories.store.ts
+++ b/src/app/categories/state/entry-categories.store.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { EntityState, EntityStore, StoreConfig } from '@datorama/akita';
+import { Category } from '../../shared/openapi';
+
+export interface EntryCategoriesState extends EntityState<Category> {}
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'entry-categories' })
+export class EntryCategoriesStore extends EntityStore<EntryCategoriesState, Category> {
+  constructor() {
+    super();
+  }
+}

--- a/src/app/container/container.component.css
+++ b/src/app/container/container.component.css
@@ -1,0 +1,9 @@
+/* Force the label mat-chips to be the same height as the adjacent category buttons. */
+.labels * {
+  min-height: 28px;
+}
+
+/* Set a consistent spacing between each label mat-chip and category button that matches the mockup. */
+.labels mat-chip, app-category-button {
+  margin-right: 0.6rem !important;
+}

--- a/src/app/container/container.component.css
+++ b/src/app/container/container.component.css
@@ -5,5 +5,5 @@
 
 /* Set a consistent spacing between each label mat-chip and category button that matches the mockup. */
 .labels mat-chip, app-category-button {
-  margin-right: 0.6rem !important;
+  margin-right: 0 0.7rem 0 0 !important;
 }

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -104,14 +104,14 @@
     </div>
   </div>
   <div class="row m-1">
-    <div *ngIf="tool" class="size-12">
-      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-4 mt-1 mb-1">
-        <span class="mr-2">Categories</span>
+    <div *ngIf="tool">
+      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
+        <span class="size-12 mr-2">Categories</span>
         <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool" class="weight-500"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
+        <span *ngIf="containerEditData?.labels.length > 0" class="size-12 mr-2">Labels</span>
         <mat-chip-list class="labels">
-          <span *ngIf="containerEditData?.labels.length > 0" class="mr-2">Labels</span>
           <mat-chip class="container-label-tag" *ngFor="let label of containerEditData?.labels" (click)="goToSearch(label)">{{
             label
           }}</mat-chip>

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -106,11 +106,11 @@
   <div class="row m-1">
     <div *ngIf="tool">
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
-        <span class="size-12 mr-2">Categories</span>
+        <span class="size-small mr-2">Categories</span>
         <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool" class="weight-500"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
-        <span *ngIf="containerEditData?.labels.length > 0" class="size-12 mr-2">Labels</span>
+        <span *ngIf="containerEditData?.labels.length > 0" class="size-small mr-2">Labels</span>
         <mat-chip-list class="labels">
           <mat-chip class="container-label-tag" *ngFor="let label of containerEditData?.labels" (click)="goToSearch(label)">{{
             label

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -104,9 +104,14 @@
     </div>
   </div>
   <div class="row m-1">
-    <div *ngIf="tool" class="col-sm-12" style="margin-bottom: 5px">
-      <span *ngIf="!labelsEditMode && !starGazersClicked">
-        <mat-chip-list>
+    <div *ngIf="tool" class="size-12">
+      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-4 mt-1 mb-1">
+        <span class="mr-2">Categories</span>
+        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool" class="weight-500"></app-category-button>
+      </span>
+      <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
+        <mat-chip-list class="labels">
+          <span *ngIf="containerEditData?.labels.length > 0" class="mr-2">Labels</span>
           <mat-chip class="container-label-tag" *ngFor="let label of containerEditData?.labels" (click)="goToSearch(label)">{{
             label
           }}</mat-chip>
@@ -117,7 +122,7 @@
       </span>
 
       <span *ngIf="labelsEditMode && !isToolPublic">
-        <mat-form-field style="width: 100%">
+        <mat-form-field class="mt-3" style="width: 100%">
           <mat-chip-list #chipList>
             <mat-chip *ngFor="let label of containerEditData?.labels" [removable]="true" (removed)="removeLabel(label)">
               {{ label }}

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -107,7 +107,7 @@
     <div *ngIf="tool">
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
         <span class="size-small mr-2">Categories</span>
-        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool" class="weight-500"></app-category-button>
+        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
         <span *ngIf="containerEditData?.labels.length > 0" class="size-small mr-2">Labels</span>

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -49,6 +49,7 @@ import { DockstoreTool } from './../shared/swagger/model/dockstoreTool';
 import { UrlResolverService } from './../shared/url-resolver.service';
 import { AddTagComponent } from './add-tag/add-tag.component';
 import { EmailService } from './email.service';
+import { EntryCategoriesService } from '../categories/state/entry-categories.service';
 
 @Component({
   selector: 'app-container',
@@ -99,7 +100,8 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
     private toolService: ToolService,
     alertService: AlertService,
     entryService: EntriesService,
-    private titleService: Title
+    private titleService: Title,
+    protected entryCategoriesService: EntryCategoriesService,
   ) {
     super(
       trackLoginService,
@@ -114,7 +116,8 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
       sessionQuery,
       gA4GHFilesService,
       alertService,
-      entryService
+      entryService,
+      entryCategoriesService
     );
     this.isRefreshing$ = this.alertQuery.showInfo$;
     this.extendedTool$ = this.extendedDockstoreToolQuery.extendedDockstoreTool$;
@@ -215,6 +218,7 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.updateVerifiedPlatforms(this.tool.id);
+      this.updateCategories(this.tool.id);
     }
   }
 

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -54,6 +54,7 @@ import { EntryCategoriesService } from '../categories/state/entry-categories.ser
 @Component({
   selector: 'app-container',
   templateUrl: './container.component.html',
+  styleUrls: ['./container.component.css'],
 })
 export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
   dockerPullCmd: string;

--- a/src/app/organizations/collection/state/add-entry.service.ts
+++ b/src/app/organizations/collection/state/add-entry.service.ts
@@ -5,6 +5,7 @@ import { CurrentCollectionsService } from '../../../entry/state/current-collecti
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { Collection, OrganizationsService, OrganizationUser, UsersService } from '../../../shared/swagger';
 import { AddEntryState, AddEntryStore } from './add-entry.store';
+import { EntryCategoriesService } from '../../../categories/state/entry-categories.service';
 
 @Injectable({ providedIn: 'root' })
 export class AddEntryService {
@@ -13,7 +14,8 @@ export class AddEntryService {
     private organizationsService: OrganizationsService,
     private usersService: UsersService,
     private alertService: AlertService,
-    private currentCollectionsService: CurrentCollectionsService
+    private currentCollectionsService: CurrentCollectionsService,
+    private entryCategoriesService: EntryCategoriesService
   ) {}
 
   /**
@@ -104,6 +106,8 @@ export class AddEntryService {
         (collection: Collection) => {
           this.alertService.detailedSuccess();
           this.currentCollectionsService.get(entryId);
+          // Changing collection membership can change category membership.
+          this.entryCategoriesService.updateEntryCategories(entryId);
         },
         (error: HttpErrorResponse) => {
           this.alertService.detailedError(error);

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -20,7 +20,7 @@ import { FormControl, Validators } from '@angular/forms';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, NavigationEnd, Params, Router, RouterEvent } from '@angular/router/';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Dockstore } from '../shared/dockstore.model';
 import { Tag } from '../shared/swagger/model/tag';
@@ -38,6 +38,8 @@ import { SessionService } from './session/session.service';
 import { SourceFile } from './swagger';
 import { UrlResolverService } from './url-resolver.service';
 import { validationDescriptorPatterns, validationMessages } from './validationMessages.model';
+import { Category } from '../shared/openapi';
+import { EntryCategoriesService } from '../categories/state/entry-categories.service';
 
 @Directive()
 @Injectable()
@@ -71,6 +73,7 @@ export abstract class Entry implements OnDestroy {
   protected selected = new FormControl(0);
   labelFormControl = new FormControl('', [Validators.pattern('^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$')]);
   public verifiedLink: string;
+  public categories$: Observable<Array<Category>>;
   constructor(
     private trackLoginService: TrackLoginService,
     public providerService: ProviderService,
@@ -84,7 +87,8 @@ export abstract class Entry implements OnDestroy {
     protected sessionQuery: SessionQuery,
     protected gA4GHFilesService: GA4GHFilesService,
     protected alertService: AlertService,
-    protected entryService: EntriesService
+    protected entryService: EntriesService,
+    protected entryCategoriesService: EntryCategoriesService
   ) {
     this.location = locationService;
     this.gA4GHFilesService.clearFiles();
@@ -304,6 +308,11 @@ export abstract class Entry implements OnDestroy {
         this.versionsWithVerifiedPlatforms = [];
       }
     );
+  }
+
+  updateCategories(entryId: number): void {
+    this.entryCategoriesService.updateEntryCategories(entryId);
+    this.categories$ = this.entryCategoriesService.categories$;
   }
 
   /**

--- a/src/app/shared/modules/container.module.ts
+++ b/src/app/shared/modules/container.module.ts
@@ -58,6 +58,7 @@ import { ListContainersModule } from './list-containers.module';
 import { MarkdownWrapperModule } from './markdown-wrapper.module';
 import { SelectModule } from './select.module';
 import { SnackbarModule } from './snackbar.module';
+import { CategoryButtonModule } from './../../categories/button/category-button.module';
 
 @NgModule({
   declarations: [
@@ -95,6 +96,7 @@ import { SnackbarModule } from './snackbar.module';
     MarkdownWrapperModule,
     PipeModule,
     SnackbarModule,
+    CategoryButtonModule,
   ],
   providers: [
     EmailService,

--- a/src/app/shared/modules/workflow.module.ts
+++ b/src/app/shared/modules/workflow.module.ts
@@ -57,6 +57,7 @@ import { CustomMaterialModule } from './../modules/material.module';
 import { RefreshService } from './../refresh.service';
 import { MarkdownWrapperModule } from './markdown-wrapper.module';
 import { SnackbarModule } from './snackbar.module';
+import { CategoryButtonModule } from './../../categories/button/category-button.module';
 
 @NgModule({
   declarations: [
@@ -95,6 +96,7 @@ import { SnackbarModule } from './snackbar.module';
     RefreshAlertModule,
     MarkdownWrapperModule,
     SnackbarModule,
+    CategoryButtonModule,
   ],
   providers: [
     DateService,

--- a/src/app/workflow/workflow.component.css
+++ b/src/app/workflow/workflow.component.css
@@ -22,3 +22,13 @@ pre {
   white-space: pre-wrap;
   word-break: normal;
 }
+
+/* Force the label mat-chips to be the same height as the adjacent category buttons. */
+.labels * {
+  min-height: 28px;
+}
+
+/* Set a consistent spacing between each label mat-chip and category button that matches the mockup. */
+.labels mat-chip, app-category-button {
+  margin-right: 0.6rem !important;
+}

--- a/src/app/workflow/workflow.component.css
+++ b/src/app/workflow/workflow.component.css
@@ -30,5 +30,5 @@ pre {
 
 /* Set a consistent spacing between each label mat-chip and category button that matches the mockup. */
 .labels mat-chip, app-category-button {
-  margin-right: 0.6rem !important;
+  margin: 0 0.7rem 0 0 !important;
 }

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -101,13 +101,14 @@
     </div>
   </div>
   <div class="row m-1" *ngIf="!showRedirect">
-    <div *ngIf="workflow" class="col-sm-12" style="margin-bottom: 5px">
-      <span *ngIf="(categories$ | async).length > 0">
-        Categories
-        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow"></app-category-button>
+    <div *ngIf="workflow" class="size-12">
+      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-4 mt-1 mb-1">
+        <span class="mr-2">Categories</span>
+        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow" class="weight-500"></app-category-button>
       </span>
-      <span *ngIf="!labelsEditMode && !starGazersClicked">
-        <mat-chip-list>
+      <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
+        <mat-chip-list class="labels">
+          <span *ngIf="workflowEditData?.labels.length > 0" class="mr-2">Labels</span>
           <mat-chip class="workflow-label-tag" *ngFor="let label of workflowEditData?.labels" (click)="goToSearch(label)">{{
             label
           }}</mat-chip>
@@ -117,7 +118,7 @@
         </mat-chip-list>
       </span>
       <span *ngIf="labelsEditMode && !isWorkflowPublic">
-        <mat-form-field style="width: 100%">
+        <mat-form-field class="mt-3" style="width: 100%">
           <mat-chip-list #chipList>
             <mat-chip *ngFor="let label of workflowEditData?.labels" [removable]="true" (removed)="removeLabel(label)">
               {{ label }}

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -103,11 +103,11 @@
   <div class="row m-1" *ngIf="!showRedirect">
     <div *ngIf="workflow">
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
-        <span class="size-12 mr-2">Categories</span>
+        <span class="size-small mr-2">Categories</span>
         <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow" class="weight-500"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
-        <span *ngIf="workflowEditData?.labels.length > 0" class="size-12 mr-2">Labels</span>
+        <span *ngIf="workflowEditData?.labels.length > 0" class="size-small mr-2">Labels</span>
         <mat-chip-list class="labels">
           <mat-chip class="workflow-label-tag" *ngFor="let label of workflowEditData?.labels" (click)="goToSearch(label)">{{
             label

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -101,14 +101,14 @@
     </div>
   </div>
   <div class="row m-1" *ngIf="!showRedirect">
-    <div *ngIf="workflow" class="size-12">
-      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-4 mt-1 mb-1">
-        <span class="mr-2">Categories</span>
+    <div *ngIf="workflow">
+      <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
+        <span class="size-12 mr-2">Categories</span>
         <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow" class="weight-500"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
+        <span *ngIf="workflowEditData?.labels.length > 0" class="size-12 mr-2">Labels</span>
         <mat-chip-list class="labels">
-          <span *ngIf="workflowEditData?.labels.length > 0" class="mr-2">Labels</span>
           <mat-chip class="workflow-label-tag" *ngFor="let label of workflowEditData?.labels" (click)="goToSearch(label)">{{
             label
           }}</mat-chip>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -104,7 +104,7 @@
     <div *ngIf="workflow">
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
         <span class="size-small mr-2">Categories</span>
-        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow" class="weight-500"></app-category-button>
+        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
         <span *ngIf="workflowEditData?.labels.length > 0" class="size-small mr-2">Labels</span>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -104,6 +104,7 @@
     <div *ngIf="workflow" class="col-sm-12" style="margin-bottom: 5px">
       <span *ngIf="(categories$ | async).length > 0">
         Categories
+        <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow"></app-category-button>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked">
         <mat-chip-list>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -102,6 +102,9 @@
   </div>
   <div class="row m-1" *ngIf="!showRedirect">
     <div *ngIf="workflow" class="col-sm-12" style="margin-bottom: 5px">
+      <span *ngIf="(categories$ | async).length > 0">
+        Categories
+      </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked">
         <mat-chip-list>
           <mat-chip class="workflow-label-tag" *ngFor="let label of workflowEditData?.labels" (click)="goToSearch(label)">{{

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -58,6 +58,7 @@ import { UrlResolverService } from '../shared/url-resolver.service';
 import RoleEnum = Permission.RoleEnum;
 import { EntriesService } from '../shared/openapi';
 import { Title } from '@angular/platform-browser';
+import { EntryCategoriesService } from '../categories/state/entry-categories.service';
 
 @Component({
   selector: 'app-workflow',
@@ -118,7 +119,8 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
     public dialog: MatDialog,
     alertService: AlertService,
     entryService: EntriesService,
-    private titleService: Title
+    private titleService: Title,
+    protected entryCategoriesService: EntryCategoriesService,
   ) {
     super(
       trackLoginService,
@@ -133,7 +135,8 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
       sessionQuery,
       gA4GHFilesService,
       alertService,
-      entryService
+      entryService,
+      entryCategoriesService
     );
     this._toolType = 'workflows';
     this.location = location;
@@ -264,6 +267,7 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
           });
       }
       this.updateVerifiedPlatforms(this.workflow.id);
+      this.updateCategories(this.workflow.id);
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -856,7 +856,9 @@ body {
   font-weight: 500;
 }
 
-.size-12 {
+// In our UI mockups, non-header text is rendered in two sizes: a default size and a smaller size.
+// This style sets the font size to the smaller size.
+.size-small {
   font-size: 12px;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -863,6 +863,20 @@ body {
   vertical-align: middle;
 }
 
+// Set various font attributes
+.weight-500 {
+  font-weight: 500;
+}
+
+.size-12 {
+  font-size: 12px;
+}
+
+// Set display to inline-block
+.inline-block {
+  display: inline-block;
+}
+
 // Reduces the width of the sidebar tab by half (160px default). Can't seem to move this to the sidebar scss for some reason
 app-sidebar-accordion
   .mat-accordion

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -851,13 +851,8 @@ body {
   vertical-align: middle;
 }
 
-// Set various font attributes
-.weight-500 {
-  font-weight: 500;
-}
-
 // In our UI mockups, non-header text is rendered in two sizes: a default size and a smaller size.
-// This style sets the font size to the smaller size.
+// Use this style to set the font size to the smaller size.
 .size-small {
   font-size: 12px;
 }


### PR DESCRIPTION
**Description**
Third and final Categories PR of the initial UI implementation, which adds category buttons to the workflow and tool pages.  

The appearance is pretty close to the mockups, except that the indentation of the button row is similar to the existing "Last Modified" text directly above, so it matches.   It looked funny otherwise.

**Update: the below has been edited to reflect a new approach @ 2021/Nov/19 3:35pm PST**

To avoid a race condition bug, `EntryCategoriesService.updateEntryCategories()` is implemented slightly differently than other similar existing methods.  Before the HTTP request, the current update subscription (if it exists) is unsubscribed, and then set to the subscription for the new HTTP request.  This avoids the case where the updates for entry A and B overlap, the responses get reordered, and the categories of A are stored last and displayed on B's page.  Depending on the protocols and software involved, this could happen due to network problems and/or thread scheduling vagaries.  Imagine the user quickly navigating to one entry page and then another, and a server thread receiving the first categories request, and then blocking or not being scheduled again until another thread completes the second categories request.  Or, suppose the user is connected via HTTP/3-QUIC and packet loss delays the first request/response.  Similarly, HTTP/1.1 with multiple connections.  This kind of thing doesn't happen much, but it does happen.

This type of bug probably affects most of the existing Service methods that retrieve and store collections of objects.  

**Issue**
dockstore/dockstore#4476
https://ucsc-cgl.atlassian.net/browse/DOCK-1765

**Screenshots**
<img width="681" alt="Screen Shot 2021-11-18 at 5 35 01 PM" src="https://user-images.githubusercontent.com/88108675/142541907-7b69c40f-b7b8-4660-9e4f-1e637602f004.png">

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
