### PR TITLE
Feature/4554/use git ref

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -28,9 +28,9 @@
               *ngIf="tool?.providerUrl"
               id="sourceRepository"
               data-cy="sourceRepository"
-              [href]="tool?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')"
+              [href]="tool?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.reference : '')"
             >
-              {{ tool?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.name : '') }}
+              {{ tool?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.reference : '') }}
             </a>
           </li>
           <li *ngIf="tool?.mode === DockstoreToolType.ModeEnum.HOSTED">


### PR DESCRIPTION
**Description**
Use the name of the github reference, not the docker image tag name. They aren't always the same. This will actually update the links on a number of tools which may or may not have been broken links before. There were some tags that don't have the same reference and name, but the link to github was not broken because they happened to have a tag named the same anyway.

**Issue**
dockstore/dockstore#4554

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain