### PR TITLE
Feature/4539/version tag

### DIFF
--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -33,7 +33,7 @@
       <mat-error *ngIf="formErrors.versionTag">{{ formErrors.versionTag }}</mat-error>
     </mat-form-field>
     <mat-form-field class="w-100">
-      <mat-label>Git Reference</mat-label>
+      <mat-label>Git Branch or Tag Name</mat-label>
       <input
         matInput
         id="gitReferenceInput"
@@ -41,10 +41,10 @@
         [(ngModel)]="unsavedVersion.reference"
         maxlength="128"
         [pattern]="validationPatterns.reference"
-        title="Git branch or tag name."
-        placeholder="e.g. develop"
+        placeholder="develop"
         required
       />
+      <mat-hint>e.g. "develop" is the branch name of "https://github.com/dockstore/dockstore/tree/develop"</mat-hint>
       <mat-error *ngIf="formErrors.reference">{{ formErrors.reference }}</mat-error>
     </mat-form-field>
     <mat-form-field class="w-100">

--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -32,7 +32,7 @@
       <mat-hint>e.g. "20.04" is the tag name of "docker pull ubuntu:20.04" </mat-hint>
       <mat-error *ngIf="formErrors.versionTag">{{ formErrors.versionTag }}</mat-error>
     </mat-form-field>
-    <mat-form-field class="w-100">
+    <mat-form-field class="w-100 my-3">
       <mat-label>Git Branch or Tag Name</mat-label>
       <input
         matInput

--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -18,7 +18,7 @@
   <app-alert></app-alert>
   <form #addTagForm="ngForm" name="addTagForm">
     <mat-form-field class="w-100">
-      <mat-label>Version Tag</mat-label>
+      <mat-label>Docker Image Tag Name</mat-label>
       <input
         matInput
         id="versionTagInput"
@@ -27,9 +27,9 @@
         maxlength="128"
         [pattern]="validationPatterns.versionTag"
         required
-        title="Docker Image tag name."
-        placeholder="e.g. develop"
+        placeholder="20.04"
       />
+      <mat-hint>e.g. "20.04" is the tag name of "docker pull ubuntu:20.04" </mat-hint>
       <mat-error *ngIf="formErrors.versionTag">{{ formErrors.versionTag }}</mat-error>
     </mat-form-field>
     <mat-form-field class="w-100">


### PR DESCRIPTION
**Description**
Attempt to elaborate on Version Tag and Git Reference. Looks like people don't notice the tooltip. Removed the existing tooltip and used it as the form field label instead. Added a hint which explains where the e.g. values came from.

**Issue**
For dockstore/dockstore#4539 

![image](https://user-images.githubusercontent.com/24548904/143502999-11061074-ef3d-4bdc-850f-26710f9ae3fb.png)
