### PR TITLE
DOCK-1958: Disable delete menu option for default tag, inform on tag deletion error

### DIFF
--- a/src/app/container/view/view.component.html
+++ b/src/app/container/view/view.component.html
@@ -20,7 +20,7 @@
   <button type="button" mat-menu-item color="accent" *ngIf="isPublic$ | async" (click)="setMode(TagEditorMode.View); (false)">View</button>
   <ng-container *ngIf="(isPublic$ | async) === false">
     <button data-cy="editTagButton" type="button" mat-menu-item color="accent" (click)="setMode(TagEditorMode.Edit); (false)">Edit</button>
-    <button type="button" mat-menu-item color="warn" *ngIf="isManualTool" (click)="deleteTag(); (false)">Delete</button>
+    <button type="button" mat-menu-item color="warn" *ngIf="isManualTool" [disabled]="(isRefreshing$ | async) || version.name === tool.defaultVersion" (click)="deleteTag(); (false)">Delete</button>
     <button
       type="button"
       mat-menu-item

--- a/src/app/container/view/view.component.ts
+++ b/src/app/container/view/view.component.ts
@@ -71,12 +71,21 @@ export class ViewContainerComponent extends View implements OnInit {
     const deleteMessage = 'Are you sure you want to delete tag ' + this.version.name + ' for tool ' + this.tool.tool_path + '?';
     const confirmDelete = confirm(deleteMessage);
     if (confirmDelete) {
-      this.containertagsService.deleteTags(this.tool.id, this.version.id).subscribe(() => {
-        this.containertagsService.getTagsByPath(this.tool.id).subscribe((response) => {
-          this.tool.workflowVersions = response;
-          this.containerService.setTool(this.tool);
-        });
-      });
+      this.alertService.start('Deleting tag ' + this.version.name);
+      this.containertagsService.deleteTags(this.tool.id, this.version.id).subscribe(
+        () => {
+          this.alertService.simpleSuccess();
+          this.containertagsService.getTagsByPath(this.tool.id).subscribe(
+            (response) => {
+              this.tool.workflowVersions = response;
+              this.containerService.setTool(this.tool);
+            }
+          );
+        },
+        (error: HttpErrorResponse) => {
+          this.alertService.detailedError(error);
+        }
+      );
     }
   }
 


### PR DESCRIPTION
**Description**
Prevents the user from deleting a tool's default tag.

The referenced issue noted that the user received no feedback when an attempting to delete the default tag (which is not allowed) failed on the webservice.  This PR implements some UI feedback via the alert service.

However, that's a band-aid fix, because the UI should simply not give the user the option to delete the default tag.

To that end, this PR disables the "Delete" button if the tag is the default tag, using the same disable code as the "Set as Default Version" button directly below it.

I user tested both the "notice" change, and then the "disable delete" change.  The latter makes a code path through the former very rare.

I can write integration tests for either, but IMHO, my time is better invested elsewhere.  Your call.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1958
https://github.com/dockstore/dockstore/issues/4536

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
