### PR TITLE
correct category homepage icon image references

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -64,11 +64,11 @@
     <div class="container">
       <span>Browse popular categories</span>
       <div *ngIf="(workflowCategories$ | async).length > 0" class="labels">
-        <img src="assets/svg/sub-nav/workflow.svg" class="ml-4 mr-1" alt="workflow icon" />
+        <img src="../../../assets/svg/sub-nav/workflow.svg" class="ml-4 mr-1" alt="workflow icon" />
         <app-category-button *ngFor="let category of (workflowCategories$ | async | slice:0:4)" [category]="category" entryType="workflow"></app-category-button>
       </div>
       <div *ngIf="(toolCategories$ | async).length > 0" class="labels">
-        <img src="assets/svg/sub-nav/tool.svg" class="ml-3 mr-1" alt="tool icon" />
+        <img src="../../../assets/svg/sub-nav/tool.svg" class="ml-3 mr-1" alt="tool icon" />
         <app-category-button *ngFor="let category of (toolCategories$ | async | slice:0:4)" [category]="category" entryType="tool"></app-category-button>
       </div>
     </div>


### PR DESCRIPTION
**Description**
Corrects the references to the icon svgs in the "browse popular categories" portion of the logged-out home page.  It worked locally, but malfunctions on dev. 

**Issue**
broadly related to DOCK-1765

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
