### PR TITLE
Feature/seab 3656/topic sentence

### DIFF
--- a/cypress/integration/group2/mytools.ts
+++ b/cypress/integration/group2/mytools.ts
@@ -80,6 +80,15 @@ describe('Dockstore my tools', () => {
       cy.contains('button', ' Save ').click();
       cy.visit('/my-tools/quay.io/A2/b1');
       cy.contains('/Dockerfile');
+
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.get('[data-cy=topicInput]').clear().type('badTopic');
+      cy.get('[data-cy=topicCancelButton]').click();
+      cy.contains('badTopic').should('not.exist');
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.get('[data-cy=topicInput]').clear().type('goodTopic');
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.contains('goodTopic').should('exist');
     });
     it('should be able to add labels', () => {
       cy.contains('quay.io/A2/a:latest');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -132,7 +132,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('badTopic').should('not.exist');
       cy.get('[data-cy=topicEditButton]').click();
       cy.get('[data-cy=topicInput]').clear().type('goodTopic');
-      cy.get('[data-cy=topicEditButton]').click();
+      cy.get('[data-cy=topicSaveButton]').click();
       cy.contains('goodTopic').should('exist');
     });
     it('should have mode tooltip', () => {

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -124,6 +124,14 @@ describe('Dockstore my workflows', () => {
       cy.contains('button', ' Save ').click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore.cwl');
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.get('[data-cy=topicInput]').clear().type('badTopic');
+      cy.get('[data-cy=topicCancelButton]').click();
+      cy.contains('badTopic').should('not.exist');
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.get('[data-cy=topicInput]').clear().type('goodTopic');
+      cy.get('[data-cy=topicEditButton]').click();
+      cy.contains('goodTopic').should('not.exist');
     });
     it('should have mode tooltip', () => {
       // .trigger('mouseover') doesn't work for some reason

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -124,6 +124,8 @@ describe('Dockstore my workflows', () => {
       cy.contains('button', ' Save ').click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore.cwl');
+
+      // Topic Editing
       cy.get('[data-cy=topicEditButton]').click();
       cy.get('[data-cy=topicInput]').clear().type('badTopic');
       cy.get('[data-cy=topicCancelButton]').click();
@@ -131,7 +133,7 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=topicEditButton]').click();
       cy.get('[data-cy=topicInput]').clear().type('goodTopic');
       cy.get('[data-cy=topicEditButton]').click();
-      cy.contains('goodTopic').should('not.exist');
+      cy.contains('goodTopic').should('exist');
     });
     it('should have mode tooltip', () => {
       // .trigger('mouseover') doesn't work for some reason

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.9",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6861/workflows/d3fe74f1-3b20-4276-890f-db35f3fca10f/jobs/15163/artifacts",
-    "circle_build_id": "15163"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6895/workflows/5121ffab-7610-4db2-afdd-dca94ff672b0/jobs/15356/artifacts",
+    "circle_build_id": "15356"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -251,7 +251,6 @@
               <span fxFlex>
                 <input
                   *ngIf="topicEditing"
-                  minlength="3"
                   maxlength="256"
                   type="text"
                   name="topic"

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -258,7 +258,7 @@
                   class="w-100"
                   data-cy="topicInput"
                   [(ngModel)]="tool.topic"
-                  placeholder="Short description of the workflow"
+                  placeholder="Short description of the tool"
                 />
               </span>
               <button

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -246,7 +246,7 @@
           <!-- This looks different than the others ones because it's new and doesn't use bootstrap 3 classes -->
           <li>
             <form fxLayout="row" fxLayoutAlign="start center" class="w-100">
-              <span><strong matTooltip="Short descripton of the tool">Topic</strong>:</span>
+              <span><strong matTooltip="Short descripton of the tool">Topic</strong>:&nbsp;</span>
               <span *ngIf="!topicEditing">{{ tool?.topic || 'n/a' }}</span>
               <span fxFlex>
                 <input

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -243,6 +243,49 @@
               </button>
             </form>
           </li>
+          <!-- This looks different than the others ones because it's new and doesn't use bootstrap 3 classes -->
+          <li>
+            <form fxLayout="row" fxLayoutAlign="start center" class="w-100">
+              <span><strong matTooltip="Short descripton of the tool">Topic</strong>:</span>
+              <span *ngIf="!topicEditing">{{ tool?.topic || 'n/a' }}</span>
+              <span fxFlex>
+                <input
+                  *ngIf="topicEditing"
+                  minlength="3"
+                  maxlength="256"
+                  type="text"
+                  name="topic"
+                  class="w-100"
+                  data-cy="topicInput"
+                  [(ngModel)]="tool.topic"
+                  placeholder="Short description of the workflow"
+                />
+              </span>
+              <button
+                data-cy="topicCancelButton"
+                *ngIf="!isPublic && topicEditing"
+                type="button"
+                mat-button
+                class="accent-1-dark"
+                (click)="cancelEditing()"
+              >
+                <mat-icon>cancel</mat-icon> Cancel
+              </button>
+              <button
+                *ngIf="!isPublic"
+                type="button"
+                [disabled]="!(!somethingIsBeingEdited() || topicEditing)"
+                mat-button
+                class="accent-1-dark"
+                data-cy="topicEditButton"
+                (click)="toggleEditTopic()"
+              >
+                <mat-icon *ngIf="topicEditing">save</mat-icon>
+                <mat-icon *ngIf="!topicEditing">edit</mat-icon>
+                {{ topicEditing ? 'Save' : 'Edit' }}
+              </button>
+            </form>
+          </li>
           <app-info-tab-checker-workflow-path
             *ngIf="tool?.mode !== DockstoreToolType.ModeEnum.HOSTED"
             [canRead]="true"

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -251,7 +251,7 @@
               <span fxFlex>
                 <input
                   *ngIf="topicEditing"
-                  maxlength="256"
+                  maxlength="150"
                   type="text"
                   name="topic"
                   class="w-100"

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -15,6 +15,8 @@
  */
 import { HttpResponse } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Base } from 'app/shared/base';
+import { takeUntil } from 'rxjs/operators';
 import { ga4ghPath } from '../../shared/constants';
 import { Dockstore } from '../../shared/dockstore.model';
 import { ExtendedToolsService } from '../../shared/extended-tools.service';
@@ -33,7 +35,7 @@ import DescriptorTypeEnum = ToolVersion.DescriptorTypeEnum;
   templateUrl: './info-tab.component.html',
   styleUrls: ['./info-tab.component.css'],
 })
-export class InfoTabComponent implements OnInit, OnChanges {
+export class InfoTabComponent extends Base implements OnInit, OnChanges {
   currentVersion: Tag;
   @Input() validVersions: Array<WorkflowVersion | Tag>;
   @Input() selectedVersion: Tag;
@@ -43,6 +45,7 @@ export class InfoTabComponent implements OnInit, OnChanges {
   public exampleDescriptorPatterns = exampleDescriptorPatterns;
   public DockstoreToolType = DockstoreTool;
   public tool: DockstoreTool;
+  public topicEditing: boolean;
   dockerFileEditing: boolean;
   cwlPathEditing: boolean;
   wdlPathEditing: boolean;
@@ -54,11 +57,9 @@ export class InfoTabComponent implements OnInit, OnChanges {
   downloadZipLink: string;
   isValidVersion = false;
   Dockstore = Dockstore;
-  constructor(
-    private infoTabService: InfoTabService,
-    private sessionQuery: SessionQuery,
-    private containersService: ExtendedToolsService
-  ) {}
+  constructor(private infoTabService: InfoTabService, private sessionQuery: SessionQuery, private containersService: ExtendedToolsService) {
+    super();
+  }
 
   ngOnChanges() {
     this.tool = JSON.parse(JSON.stringify(this.extendedDockstoreTool));
@@ -90,12 +91,13 @@ export class InfoTabComponent implements OnInit, OnChanges {
   }
 
   ngOnInit() {
-    this.infoTabService.dockerFileEditing$.subscribe((editing) => (this.dockerFileEditing = editing));
-    this.infoTabService.cwlPathEditing$.subscribe((editing) => (this.cwlPathEditing = editing));
-    this.infoTabService.wdlPathEditing$.subscribe((editing) => (this.wdlPathEditing = editing));
-    this.infoTabService.cwlTestPathEditing$.subscribe((editing) => (this.cwlTestPathEditing = editing));
-    this.infoTabService.wdlTestPathEditing$.subscribe((editing) => (this.wdlTestPathEditing = editing));
-    this.sessionQuery.isPublic$.subscribe((publicPage) => (this.isPublic = publicPage));
+    this.infoTabService.dockerFileEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.dockerFileEditing = editing));
+    this.infoTabService.cwlPathEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.cwlPathEditing = editing));
+    this.infoTabService.wdlPathEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.wdlPathEditing = editing));
+    this.infoTabService.cwlTestPathEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.cwlTestPathEditing = editing));
+    this.infoTabService.wdlTestPathEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.wdlTestPathEditing = editing));
+    this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
+    this.sessionQuery.isPublic$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((publicPage) => (this.isPublic = publicPage));
   }
 
   downloadZip() {
@@ -104,6 +106,17 @@ export class InfoTabComponent implements OnInit, OnChanges {
       const url = window.URL.createObjectURL(blob);
       window.open(url);
     });
+  }
+
+  toggleEditTopic() {
+    if (this.topicEditing) {
+      this.infoTabService.saveTopic(this.tool, this.revertTopic);
+    }
+    this.infoTabService.setTopicEditing(!this.topicEditing);
+  }
+
+  revertTopic() {
+    this.tool.topic = this.extendedDockstoreTool.topic;
   }
 
   toggleEditDockerFile() {
@@ -141,7 +154,14 @@ export class InfoTabComponent implements OnInit, OnChanges {
   }
 
   somethingIsBeingEdited(): boolean {
-    return this.dockerFileEditing || this.cwlPathEditing || this.wdlPathEditing || this.cwlTestPathEditing || this.wdlTestPathEditing;
+    return (
+      this.dockerFileEditing ||
+      this.cwlPathEditing ||
+      this.wdlPathEditing ||
+      this.cwlTestPathEditing ||
+      this.wdlTestPathEditing ||
+      this.topicEditing
+    );
   }
 
   /**
@@ -151,6 +171,7 @@ export class InfoTabComponent implements OnInit, OnChanges {
    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
+    this.revertTopic();
   }
 
   /**

--- a/src/app/container/info-tab/info-tab.service.ts
+++ b/src/app/container/info-tab/info-tab.service.ts
@@ -90,21 +90,19 @@ export class InfoTabService extends Base {
     this.topicEditing$.next(editing);
   }
 
-  saveTopic(tool: DockstoreTool, callback: () => void) {
+  saveTopic(tool: DockstoreTool, errorCallback: () => void) {
     this.alertService.start('Updating topic');
     const partialTool = this.getPartialToolForUpdate(tool);
-    console.log(tool.topic);
     this.containersService.updateContainer(this.tool.id, partialTool).subscribe(
       (response) => {
         this.alertService.detailedSuccess();
 
         const newTopic = response.topic;
-        console.log(newTopic);
         this.containerService.updateActiveTopic(newTopic);
       },
       (error) => {
         this.alertService.detailedError(error);
-        callback();
+        errorCallback();
       }
     );
   }

--- a/src/app/container/info-tab/info-tab.service.ts
+++ b/src/app/container/info-tab/info-tab.service.ts
@@ -31,6 +31,7 @@ export class InfoTabService extends Base {
   public wdlPathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public cwlTestPathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public wdlTestPathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  public topicEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   /**
    * The original tool that should be in sync with the database
@@ -85,6 +86,29 @@ export class InfoTabService extends Base {
     this.wdlTestPathEditing$.next(editing);
   }
 
+  setTopicEditing(editing: boolean) {
+    this.topicEditing$.next(editing);
+  }
+
+  saveTopic(tool: DockstoreTool, callback: () => void) {
+    this.alertService.start('Updating topic');
+    const partialTool = this.getPartialToolForUpdate(tool);
+    console.log(tool.topic);
+    this.containersService.updateContainer(this.tool.id, partialTool).subscribe(
+      (response) => {
+        this.alertService.detailedSuccess();
+
+        const newTopic = response.topic;
+        console.log(newTopic);
+        this.containerService.updateActiveTopic(newTopic);
+      },
+      (error) => {
+        this.alertService.detailedError(error);
+        callback();
+      }
+    );
+  }
+
   updateAndRefresh(tool: ExtendedDockstoreTool) {
     const message = 'Tool Info';
     const partialTool = this.getPartialToolForUpdate(tool);
@@ -131,6 +155,7 @@ export class InfoTabService extends Base {
       defaultCWLTestParameterFile: tool.defaultCWLTestParameterFile,
       defaultWDLTestParameterFile: tool.defaultWDLTestParameterFile,
       default_dockerfile_path: tool.default_dockerfile_path,
+      topic: tool.topic,
     };
     return partialTool;
   }
@@ -155,6 +180,7 @@ export class InfoTabService extends Base {
     this.wdlPathEditing$.next(false);
     this.wdlTestPathEditing$.next(false);
     this.cwlTestPathEditing$.next(false);
+    this.topicEditing$.next(false);
     this.restoreTool();
   }
 

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -77,11 +77,13 @@ export class QueryBuilderService {
       'name',
       'namespace',
       'organization',
+      'private_access',
       'providerUrl',
       'repository',
       'starredUsers',
       'toolname',
       'tool_path',
+      'topic',
       'verified',
       'workflowName',
     ]);

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -42,7 +42,7 @@
             tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '')
           }}</a>
         </ng-template>
-        <small *ngIf="tool.topic">{{ tool.topic }}</small>
+        <small class="truncate-text-2" *ngIf="tool.topic">{{ tool.topic }}</small>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -42,7 +42,7 @@
             tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '')
           }}</a>
         </ng-template>
-        <small class="truncate-text-2" *ngIf="tool.topic">{{ tool.topic }}</small>
+        <span class="truncate-text-2 size-small" *ngIf="tool.topic">{{ tool.topic }}</span>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -27,7 +27,8 @@
   >
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
-      <mat-cell data-cy="toolNames" *matCellDef="let tool">
+      <!-- the wrap causes slightly odd behavior with the mat-icon but is needed for the topic -->
+      <mat-cell data-cy="toolNames" *matCellDef="let tool" fxLayout="row wrap">
         <span *ngIf="tool.private_access">
           <app-private-icon></app-private-icon>
         </span>
@@ -41,6 +42,7 @@
             tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '')
           }}</a>
         </ng-template>
+        <small *ngIf="tool.topic">{{ tool.topic }}</small>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -17,7 +17,7 @@
         <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="'/workflows/' + workflow?.full_workflow_path">{{
           workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
         }}</a>
-        <small *ngIf="workflow.topic">{{ workflow.topic }}</small>
+        <small class="truncate-text-2" *ngIf="workflow.topic">{{ workflow.topic }}</small>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">
@@ -33,10 +33,8 @@
       <mat-cell fxShow fxHide.lt-sm class="duration-cell" *matCellDef="let workflow">{{ workflow?.author || 'n/a' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
-      <mat-header-cell fxShow fxHide.lt-sm data-cy="descriptorTypeHeader" *matHeaderCellDef mat-sort-header fxFlex="20%"
-        >Format</mat-header-cell
-      >
-      <mat-cell fxShow fxHide.lt-sm data-cy="descriptorType" *matCellDef="let workflow" fxFlex="20%">
+      <mat-header-cell fxShow fxHide.lt-sm data-cy="descriptorTypeHeader" *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
+      <mat-cell fxShow fxHide.lt-sm data-cy="descriptorType" *matCellDef="let workflow">
         <div>
           <span class="nonclick-badge">{{
             workflow?.descriptorType === 'gxformat2' ? galaxyShortfriendlyName : (workflow?.descriptorType | uppercase)

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -13,10 +13,11 @@
   >
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
-      <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
+      <mat-cell data-cy="workflowColumn" *matCellDef="let workflow" fxLayout="row wrap">
         <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="'/workflows/' + workflow?.full_workflow_path">{{
           workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
         }}</a>
+        <small *ngIf="workflow.topic">{{ workflow.topic }}</small>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -17,7 +17,7 @@
         <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="'/workflows/' + workflow?.full_workflow_path">{{
           workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
         }}</a>
-        <small class="truncate-text-2" *ngIf="workflow.topic">{{ workflow.topic }}</small>
+        <span class="truncate-text-2 size-small" *ngIf="workflow.topic">{{ workflow.topic }}</span>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.scss
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.scss
@@ -1,14 +1,9 @@
-.mat-column-projectLinks {
-  flex: 0 0 140px;
-  padding-left: 30px;
-}
-
 .mat-column-descriptorType {
-  max-width: 80px;
+  max-width: 90px;
 }
 
 .mat-column-projectLinks {
-  max-width: 105px;
+  max-width: 80px;
 }
 
 td.mat-cell {

--- a/src/app/shared/container.service.ts
+++ b/src/app/shared/container.service.ts
@@ -15,8 +15,11 @@
  */
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { ExtendedDockstoreToolService } from './extended-dockstoreTool/extended-dockstoreTool.service';
 import { DockstoreTool } from './swagger/model/dockstoreTool';
+import { ToolQuery } from './tool/tool.query';
 import { ToolService } from './tool/tool.service';
+import { ToolStore } from './tool/tool.store';
 
 /**
  * This is mostly deprecated in favor of ToolService for the selected tool
@@ -30,7 +33,12 @@ export class ContainerService {
   tools$ = new BehaviorSubject<DockstoreTool[]>(null); // This contains the list of unsorted tools
   private copyBtnSource = new BehaviorSubject<any>(null); // This is the currently selected copy button.
   copyBtn$ = this.copyBtnSource.asObservable();
-  constructor(private toolService: ToolService) {}
+  constructor(
+    private toolService: ToolService,
+    private toolQuery: ToolQuery,
+    private toolStore: ToolStore,
+    private extendedDockstoreToolService: ExtendedDockstoreToolService
+  ) {}
   setTool(tool: any) {
     this.toolService.setTool(tool);
   }
@@ -87,5 +95,11 @@ export class ContainerService {
 
   setCopyBtn(copyBtn: any) {
     this.copyBtnSource.next(copyBtn);
+  }
+
+  updateActiveTopic(topic: string) {
+    const newTool = { ...this.toolQuery.getActive(), topic: topic };
+    this.toolStore.upsert(newTool.id, newTool);
+    this.extendedDockstoreToolService.update(newTool);
   }
 }

--- a/src/app/shared/state/workflow.service.ts
+++ b/src/app/shared/state/workflow.service.ts
@@ -5,6 +5,7 @@ import { Workflow, WorkflowVersion } from '../swagger';
 import { BioWorkflow } from '../swagger/model/bioWorkflow';
 import { Service } from '../swagger/model/service';
 import { ExtendedWorkflowService } from './extended-workflow.service';
+import { WorkflowQuery } from './workflow.query';
 import { WorkflowStore } from './workflow.store';
 
 @Injectable({ providedIn: 'root' })
@@ -19,7 +20,11 @@ export class WorkflowService {
   nsWorkflows$: BehaviorSubject<Array<Workflow>> = new BehaviorSubject<Array<Workflow>>(null);
   private copyBtnSource = new BehaviorSubject<any>(null); // This is the currently selected copy button.
   copyBtn$ = this.copyBtnSource.asObservable();
-  constructor(private workflowStore: WorkflowStore, private extendedWorkflowService: ExtendedWorkflowService) {}
+  constructor(
+    private workflowStore: WorkflowStore,
+    private extendedWorkflowService: ExtendedWorkflowService,
+    private workflowQuery: WorkflowQuery
+  ) {}
 
   /**
    * Converts the mapping of roles to workflows to a concatentation of all the workflows
@@ -45,6 +50,12 @@ export class WorkflowService {
       this.workflowStore.remove();
       this.extendedWorkflowService.remove();
     }
+  }
+
+  updateActiveTopic(topic: string) {
+    const newWorkflow = { ...this.workflowQuery.getActive(), topic: topic };
+    this.workflowStore.upsert(newWorkflow.id, newWorkflow);
+    this.extendedWorkflowService.update(newWorkflow);
   }
 
   get() {

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -192,7 +192,7 @@
                     class="btn btn-link"
                     (click)="toggleEditTopic()"
                   >
-                    <mat-icon>add</mat-icon> Add
+                    <mat-icon>edit</mat-icon> Edit
                   </button>
                   <button
                     *ngIf="!isPublic && (workflow?.topic || topicEditing)"

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -96,6 +96,7 @@
                     *ngIf="!isPublic"
                     type="button"
                     [disabled]="
+                      topicEditing ||
                       defaultTestFilePathEditing ||
                       forumUrlEditing ||
                       (workflowPathEditing && !editWorkflowPathForm.valid) ||
@@ -141,6 +142,7 @@
                     *ngIf="!isPublic"
                     type="button"
                     [disabled]="
+                      topicEditing ||
                       workflowPathEditing ||
                       forumUrlEditing ||
                       (defaultTestFilePathEditing && !editTestFilePathForm.valid) ||
@@ -152,6 +154,47 @@
                     <mat-icon *ngIf="defaultTestFilePathEditing">save</mat-icon>
                     <mat-icon *ngIf="!defaultTestFilePathEditing">edit</mat-icon>
                     {{ defaultTestFilePathEditing ? 'Save' : 'Edit' }}
+                  </button>
+                </span>
+              </form>
+              <form #editForumUrl="ngForm" class="form-inline" fxLayout>
+                <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
+                  <strong matTooltip="Short description of the workflow">Topic</strong>:
+                  <span *ngIf="!topicEditing" fxFlexOffset="4px"> {{ workflow?.topic }} </span>
+                  <input
+                    *ngIf="topicEditing"
+                    maxlength="256"
+                    type="text"
+                    class="input-default form-control"
+                    name="topicEditing"
+                    [(ngModel)]="workflow.topic"
+                    placeholder="Short description of the workflow"
+                    fxFlex="noshrink"
+                    fxFlexOffset="4px"
+                  />
+                </div>
+                <span>
+                  <button *ngIf="!isPublic && topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                    <mat-icon>cancel</mat-icon> Cancel
+                  </button>
+                  <button
+                    *ngIf="!isPublic && !workflow?.topic && !topicEditing"
+                    [disabled]="forumUrlEditing || workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async)"
+                    type="button"
+                    class="btn btn-link"
+                    (click)="toggleEditTopic()"
+                  >
+                    <mat-icon>add</mat-icon> Add
+                  </button>
+                  <button
+                    *ngIf="!isPublic && (workflow?.topic || topicEditing)"
+                    type="button"
+                    class="btn btn-link"
+                    (click)="toggleEditTopic()"
+                  >
+                    <mat-icon *ngIf="topicEditing">save</mat-icon>
+                    <mat-icon *ngIf="!topicEditing">edit</mat-icon>
+                    {{ topicEditing ? 'Save' : 'Edit' }}
                   </button>
                 </span>
               </form>
@@ -182,7 +225,7 @@
                   </button>
                   <button
                     *ngIf="!isPublic && !workflow?.forumUrl && !forumUrlEditing"
-                    [disabled]="workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async)"
+                    [disabled]="topicEditing || workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async)"
                     type="button"
                     class="btn btn-link"
                     (click)="toggleEditForumUrl()"

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -82,7 +82,6 @@
                     type="text"
                     class="input-default form-control"
                     name="workflowPath"
-                    data-cy="topicInput"
                     [(ngModel)]="workflow.workflow_path"
                     placeholder="e.g. /Dockstore.cwl"
                     fxFlex="noshrink"
@@ -91,7 +90,6 @@
                 </div>
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                   <button
-                    data-cy="topicCancelButton"
                     *ngIf="!isPublic && workflowPathEditing"
                     type="button"
                     class="btn btn-link"
@@ -102,7 +100,6 @@
                   <button
                     *ngIf="!isPublic"
                     type="button"
-                    data-cy="topicEditButton"
                     [disabled]="
                       topicEditing ||
                       defaultTestFilePathEditing ||
@@ -176,13 +173,14 @@
                     class="input-default form-control"
                     name="topicEditing"
                     [(ngModel)]="workflow.topic"
+                    data-cy="topicInput"                         
                     placeholder="Short description of the workflow"
                     fxFlex="noshrink"
                     fxFlexOffset="4px"
                   />
                 </div>
                 <span>
-                  <button *ngIf="!isPublic && topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                  <button data-cy="topicCancelButton" *ngIf="!isPublic && topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
@@ -191,6 +189,7 @@
                     type="button"
                     class="btn btn-link"
                     (click)="toggleEditTopic()"
+                    data-cy="topicEditButton"
                   >
                     <mat-icon>edit</mat-icon> Edit
                   </button>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -207,7 +207,6 @@
                 </span>
               </form>
               <form
-                #editForumUrl="ngForm"
                 class="form-inline"
                 fxLayout
                 *ngIf="(isNFL$ | async) === false && workflow?.mode !== WorkflowType.ModeEnum.DOCKSTOREYML"

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -82,6 +82,7 @@
                     type="text"
                     class="input-default form-control"
                     name="workflowPath"
+                    data-cy="topicInput"
                     [(ngModel)]="workflow.workflow_path"
                     placeholder="e.g. /Dockstore.cwl"
                     fxFlex="noshrink"
@@ -89,12 +90,19 @@
                   />
                 </div>
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
-                  <button *ngIf="!isPublic && workflowPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                  <button
+                    data-cy="topicCancelButton"
+                    *ngIf="!isPublic && workflowPathEditing"
+                    type="button"
+                    class="btn btn-link"
+                    (click)="cancelEditing()"
+                  >
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
                     *ngIf="!isPublic"
                     type="button"
+                    data-cy="topicEditButton"
                     [disabled]="
                       topicEditing ||
                       defaultTestFilePathEditing ||

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -157,23 +157,20 @@
                   </button>
                 </span>
               </form>
-              <form #editForumUrl="ngForm" class="form-inline" fxLayout>
-                <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
-                  <strong matTooltip="Short description of the workflow">Topic</strong>:
-                  <span *ngIf="!topicEditing" fxFlexOffset="4px"> {{ workflow?.topic }} </span>
+              <form #editForumUrl="ngForm" fxLayout="row" fxLayout="start center" class="w-100">
+                <span><strong matTooltip="Short description of the workflow">Topic</strong>:&nbsp;</span>
+                <span *ngIf="!topicEditing"> {{ workflow?.topic }} </span>
+                <span fxFlex>
                   <input
                     *ngIf="topicEditing"
                     maxlength="256"
                     type="text"
-                    class="input-default form-control"
+                    class="w-100"
                     name="topicEditing"
                     [(ngModel)]="workflow.topic"
                     data-cy="topicInput"
                     placeholder="Short description of the workflow"
-                    fxFlex="noshrink"
-                    fxFlexOffset="4px"
-                  />
-                </div>
+                /></span>
                 <ng-container *ngIf="!isPublic">
                   <button data-cy="topicCancelButton" *ngIf="topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -157,7 +157,7 @@
                   </button>
                 </span>
               </form>
-              <form #editForumUrl="ngForm" fxLayout="row" fxLayout="start center" class="w-100">
+              <form #editForumUrl="ngForm" fxLayout="row" fxLayoutAlign="start center" class="w-100">
                 <span><strong matTooltip="Short description of the workflow">Topic</strong>:&nbsp;</span>
                 <span *ngIf="!topicEditing"> {{ workflow?.topic }} </span>
                 <span fxFlex>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -89,12 +89,7 @@
                   />
                 </div>
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
-                  <button
-                    *ngIf="!isPublic && workflowPathEditing"
-                    type="button"
-                    class="btn btn-link"
-                    (click)="cancelEditing()"
-                  >
+                  <button *ngIf="!isPublic && workflowPathEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
@@ -173,18 +168,18 @@
                     class="input-default form-control"
                     name="topicEditing"
                     [(ngModel)]="workflow.topic"
-                    data-cy="topicInput"                         
+                    data-cy="topicInput"
                     placeholder="Short description of the workflow"
                     fxFlex="noshrink"
                     fxFlexOffset="4px"
                   />
                 </div>
-                <span>
-                  <button data-cy="topicCancelButton" *ngIf="!isPublic && topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
+                <ng-container *ngIf="!isPublic">
+                  <button data-cy="topicCancelButton" *ngIf="topicEditing" type="button" class="btn btn-link" (click)="cancelEditing()">
                     <mat-icon>cancel</mat-icon> Cancel
                   </button>
                   <button
-                    *ngIf="!isPublic && !workflow?.topic && !topicEditing"
+                    *ngIf="!workflow?.topic && !topicEditing"
                     [disabled]="forumUrlEditing || workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async)"
                     type="button"
                     class="btn btn-link"
@@ -194,16 +189,17 @@
                     <mat-icon>edit</mat-icon> Edit
                   </button>
                   <button
-                    *ngIf="!isPublic && (workflow?.topic || topicEditing)"
+                    *ngIf="workflow?.topic || topicEditing"
                     type="button"
                     class="btn btn-link"
                     (click)="toggleEditTopic()"
+                    data-cy="topicSaveButton"
                   >
                     <mat-icon *ngIf="topicEditing">save</mat-icon>
                     <mat-icon *ngIf="!topicEditing">edit</mat-icon>
                     {{ topicEditing ? 'Save' : 'Edit' }}
                   </button>
-                </span>
+                </ng-container>
               </form>
               <form
                 class="form-inline"

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -163,7 +163,7 @@
                 <span fxFlex>
                   <input
                     *ngIf="topicEditing"
-                    maxlength="256"
+                    maxlength="150"
                     type="text"
                     class="w-100"
                     name="topicEditing"

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -44,7 +44,9 @@ import { InfoTabService } from './info-tab.service';
 export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   @Input() validVersions;
   @Input() defaultVersion;
+  // This should represent what's in the database
   @Input() extendedWorkflow: ExtendedWorkflow;
+  // This is what the user is currently seeing/editing
   public workflow: Workflow;
   currentVersion: WorkflowVersion;
   downloadZipLink: string;
@@ -61,6 +63,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   descriptorLanguages$: Observable<Array<Workflow.DescriptorTypeEnum>>;
   defaultTestFilePathEditing: boolean;
   forumUrlEditing: boolean;
+  topicEditing: boolean;
   isPublic: boolean;
   trsLink: string;
   displayTextForButton: string;
@@ -140,6 +143,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((entryType) => (this.displayTextForButton = '#' + entryType + '/' + this.workflow?.full_workflow_path));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
+    this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
   }
   /**
    * Handle restubbing a workflow
@@ -171,6 +175,13 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
     this.infoTabService.setWorkflowPathEditing(!this.workflowPathEditing);
   }
 
+  toggleEditTopic() {
+    if (this.topicEditing) {
+      this.infoTabService.saveTopic(this.workflow, this.revertTopic);
+    }
+    this.infoTabService.setTopicEditing(!this.topicEditing);
+  }
+
   toggleEditDefaultTestFilePath() {
     if (this.defaultTestFilePathEditing) {
       this.save();
@@ -183,6 +194,10 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       this.save();
     }
     this.infoTabService.setForumUrlEditing(!this.forumUrlEditing);
+  }
+
+  revertTopic() {
+    this.workflow.topic = this.extendedWorkflow.topic;
   }
 
   save() {
@@ -204,5 +219,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
+    this.revertTopic();
   }
 }

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -89,7 +89,7 @@ export class InfoTabService {
    * Warning, this could potentially update a few other properties
    * @param workflow
    */
-  saveTopic(workflow: Workflow, callback: () => void) {
+  saveTopic(workflow: Workflow, errorCallback: () => void) {
     this.alertService.start('Updating topic');
     const partialEntryForUpdate = this.getPartialEntryForUpdate(workflow);
     this.workflowsService.updateWorkflow(this.originalWorkflow.id, partialEntryForUpdate).subscribe(
@@ -100,7 +100,7 @@ export class InfoTabService {
       },
       (error) => {
         this.alertService.detailedError(error);
-        callback();
+        errorCallback();
       }
     );
   }

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -34,6 +34,7 @@ export class InfoTabService {
   public workflowPathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public defaultTestFilePathEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public forumUrlEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  public topicEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public descriptorLanguageMap = [];
 
   /**
@@ -72,12 +73,36 @@ export class InfoTabService {
     this.workflowPathEditing$.next(editing);
   }
 
+  setTopicEditing(editing: boolean) {
+    this.topicEditing$.next(editing);
+  }
+
   setDefaultTestFilePathEditing(editing: boolean) {
     this.defaultTestFilePathEditing$.next(editing);
   }
 
   setForumUrlEditing(editing: boolean) {
     this.forumUrlEditing$.next(editing);
+  }
+
+  /**
+   * Warning, this could potentially update a few other properties
+   * @param workflow
+   */
+  saveTopic(workflow: Workflow, callback: () => void) {
+    this.alertService.start('Updating topic');
+    const partialEntryForUpdate = this.getPartialEntryForUpdate(workflow);
+    this.workflowsService.updateWorkflow(this.originalWorkflow.id, partialEntryForUpdate).subscribe(
+      (response) => {
+        this.alertService.detailedSuccess();
+        const newTopic = response.topic;
+        this.workflowService.updateActiveTopic(newTopic);
+      },
+      (error) => {
+        this.alertService.detailedError(error);
+        callback();
+      }
+    );
   }
 
   updateAndRefresh(workflow: Workflow) {
@@ -185,11 +210,13 @@ export class InfoTabService {
     this.workflowPathEditing$.next(false);
     this.defaultTestFilePathEditing$.next(false);
     this.forumUrlEditing$.next(false);
+    this.topicEditing$.next(false);
     this.restoreWorkflow();
   }
 
   /**
    * Reverts the workflow info back to the original
+   * This actually doesn't work anymore
    *
    * @memberof InfoTabService
    */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1141,7 +1141,7 @@ mat-icon.mat-icon-sm {
   white-space: normal;
 }
 
-$truncate-text-values: 1, 3;
+$truncate-text-values: 1, 2, 3;
 
 // Hide overflow, values denote the number of lines to keep
 // Similar no-wrap except those are more meant single "words", this is for sentences


### PR DESCRIPTION
**Description**
Add topic sentence display to workflow information card. Also add the ability to update it (like workflow path).

Forgot to mention...it's slightly different than existing info tab buttons and such because it's closer to mocks. Presumably the rest of the info tab is converted to the mock ups before the next release.

Soon to be replaced by phase 2

**Issue**
For SEAB-3656


