### PR TITLE
Fix search term input size

### DIFF
--- a/src/app/search/basic-search/basic-search.component.html
+++ b/src/app/search/basic-search/basic-search.component.html
@@ -1,6 +1,6 @@
 <mat-expansion-panel expanded>
   <mat-expansion-panel-header> Search </mat-expansion-panel-header>
-  <mat-form-field appearance="outline" class="search-form-field">
+  <mat-form-field appearance="outline" class="search-form-field w-100">
     <mat-label>Enter search term</mat-label>
     <input
       matInput


### PR DESCRIPTION
**Description**
A previous PR increased width of the containers globally across the site which introduced an oddity in the search term input

![image](https://user-images.githubusercontent.com/24548904/144323280-29cb550e-8b74-4cd2-ab21-e6788faff072.png)

**Issue**
Adhoc issue

