### PR TITLE
Update circleci artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "config": {
     "webservice_version": "1.11.10",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6978/workflows/9916bece-6273-4890-b365-a0ce3d3d52a6/jobs/15792/artifacts",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6978/workflows/f7281873-ea62-48b4-a646-505a9c7f3be8/jobs/15792/artifacts",
     "circle_build_id": "15792"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.10",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6861/workflows/d3fe74f1-3b20-4276-890f-db35f3fca10f/jobs/15163/artifacts",
-    "circle_build_id": "15163"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/6978/workflows/9916bece-6273-4890-b365-a0ce3d3d52a6/jobs/15792/artifacts",
+    "circle_build_id": "15792"
   },
   "scripts": {
     "ng": "npx ng",


### PR DESCRIPTION
**Description**
Nightly tests failed because the CircleCI artifacts expired and don't exist anymore. Updating the CircleCI artifacts to the most recent develop build

**Issue**
n/a

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
