### PR TITLE
prevent edit collection click event from propagating to parent

### DIFF
--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -37,7 +37,7 @@
             </div>
             <div *ngIf="canEdit$ | async">
               <mat-card-content fxLayout="row" fxLayoutGap="10px" class="m-0">
-                <button mat-icon-button (click)="editCollection(collection)" id="editCollection" matTooltip="Edit the collection">
+                <button mat-icon-button (click)="editCollection(collection); $event.stopPropagation(); $event.preventDefault()" id="editCollection" matTooltip="Edit the collection">
                   <mat-icon>edit</mat-icon>
                 </button>
               </mat-card-content>

--- a/src/app/organizations/collections/create-collection/create-collection.component.html
+++ b/src/app/organizations/collections/create-collection/create-collection.component.html
@@ -14,49 +14,49 @@
    limitations under the License.
 -->
 <ng-container *ngIf="title$ | async as title">
-<ng-container *ngIf="saveLabel$ | async as saveLabel">
-<div>
-  <h1 mat-dialog-title>{{ title }}</h1>
-  <div mat-dialog-content>
-    <app-alert></app-alert>
-    <form [formGroup]="createCollectionForm" fxLayout="column">
-      <mat-form-field>
-        <input type="text" matInput formControlName="name" placeholder="Name" required />
-        <mat-error *ngIf="name.hasError('required')">Name is required</mat-error>
-        <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
-        <mat-error *ngIf="name.hasError('maxlength')">Name should be at most 39 characters long</mat-error>
-        <mat-error *ngIf="name.hasError('pattern')">Name can only contain alphanumeric characters. It must begin with a letter.</mat-error>
-        <mat-hint>The name of the collection</mat-hint>
-      </mat-form-field>
-      <mat-form-field>
-        <input type="text" matInput formControlName="displayName" placeholder="Display Name" required />
-        <mat-error *ngIf="displayName.hasError('required')">Display Name is required</mat-error>
-        <mat-error *ngIf="displayName.hasError('minlength')">Display Name should be at least 3 characters long</mat-error>
-        <mat-error *ngIf="displayName.hasError('maxlength')">Display Name should be at most 50 characters long</mat-error>
-        <mat-error *ngIf="displayName.hasError('pattern')"
-          >Display Name can contain alphanumeric characters, spaces, and some punctuation.</mat-error
+  <ng-container *ngIf="saveLabel$ | async as saveLabel">
+    <div>
+      <h1 mat-dialog-title>{{ title }}</h1>
+      <div mat-dialog-content>
+        <app-alert></app-alert>
+        <form [formGroup]="createCollectionForm" fxLayout="column">
+          <mat-form-field>
+            <input type="text" matInput formControlName="name" placeholder="Name" required />
+            <mat-error *ngIf="name.hasError('required')">Name is required</mat-error>
+            <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
+            <mat-error *ngIf="name.hasError('maxlength')">Name should be at most 39 characters long</mat-error>
+            <mat-error *ngIf="name.hasError('pattern')">Name can only contain alphanumeric characters. It must begin with a letter.</mat-error>
+            <mat-hint>The name of the collection</mat-hint>
+          </mat-form-field>
+          <mat-form-field>
+            <input type="text" matInput formControlName="displayName" placeholder="Display Name" required />
+            <mat-error *ngIf="displayName.hasError('required')">Display Name is required</mat-error>
+            <mat-error *ngIf="displayName.hasError('minlength')">Display Name should be at least 3 characters long</mat-error>
+            <mat-error *ngIf="displayName.hasError('maxlength')">Display Name should be at most 50 characters long</mat-error>
+            <mat-error *ngIf="displayName.hasError('pattern')"
+              >Display Name can contain alphanumeric characters, spaces, and some punctuation.</mat-error
+            >
+            <mat-hint>The display name of the collection</mat-hint>
+          </mat-form-field>
+          <mat-form-field>
+            <input type="text" matInput formControlName="topic" placeholder="Topic" required />
+          </mat-form-field>
+        </form>
+      </div>
+      <div mat-dialog-actions class="pull-right">
+        <button matTooltip="Cancel" mat-button mat-dialog-close>Cancel</button>
+        <button
+          id="createOrUpdateCollectionButton"
+          [matTooltip]="title"
+          mat-flat-button
+          color="primary"
+          [disabled]="!createCollectionForm.valid"
+          (click)="createCollection()"
+          cdkFocusInitial
         >
-        <mat-hint>The display name of the collection</mat-hint>
-      </mat-form-field>
-      <mat-form-field>
-        <input type="text" matInput formControlName="topic" placeholder="Topic" required />
-      </mat-form-field>
-    </form>
-  </div>
-  <div mat-dialog-actions class="pull-right">
-    <button matTooltip="Cancel" mat-button mat-dialog-close>Cancel</button>
-    <button
-      id="createOrUpdateCollectionButton"
-      [matTooltip]="title"
-      mat-flat-button
-      color="primary"
-      [disabled]="!createCollectionForm.valid"
-      (click)="createCollection()"
-      cdkFocusInitial
-    >
-      {{ saveLabel }}
-    </button>
-  </div>
-</div>
-</ng-container>
+          {{ saveLabel }}
+        </button>
+      </div>
+    </div>
+  </ng-container>
 </ng-container>

--- a/src/app/organizations/collections/create-collection/create-collection.component.html
+++ b/src/app/organizations/collections/create-collection/create-collection.component.html
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<div *ngIf="title$ | async as title">
+<ng-container *ngIf="title$ | async as title">
+<ng-container *ngIf="saveLabel$ | async as saveLabel">
+<div>
   <h1 mat-dialog-title>{{ title }}</h1>
   <div mat-dialog-content>
     <app-alert></app-alert>
@@ -52,7 +54,9 @@
       (click)="createCollection()"
       cdkFocusInitial
     >
-      {{ title }}
+      {{ saveLabel }}
     </button>
   </div>
 </div>
+</ng-container>
+</ng-container>

--- a/src/app/organizations/collections/create-collection/create-collection.component.ts
+++ b/src/app/organizations/collections/create-collection/create-collection.component.ts
@@ -22,6 +22,7 @@ export class CreateCollectionComponent implements OnInit, OnDestroy {
   createCollectionForm: FormGroup;
   public loading$: Observable<boolean>;
   public title$: Observable<string>;
+  public saveLabel$: Observable<string>;
   constructor(
     private createCollectionQuery: CreateCollectionQuery,
     private createCollectionService: CreateCollectionService,
@@ -32,9 +33,10 @@ export class CreateCollectionComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.loading$ = this.createCollectionQuery.loading$;
     this.title$ = this.createCollectionQuery.title$;
+    this.saveLabel$ = this.createCollectionQuery.saveLabel$;
     this.createCollectionService.clearState();
     this.createCollectionForm = this.createCollectionService.createForm(this.formsManager, this.data);
-    this.createCollectionService.setTitle(this.data);
+    this.createCollectionService.setValues(this.data);
   }
 
   createCollection() {

--- a/src/app/organizations/collections/state/create-collection.query.ts
+++ b/src/app/organizations/collections/state/create-collection.query.ts
@@ -8,6 +8,7 @@ import { CreateCollectionState, CreateCollectionStore } from './create-collectio
 export class CreateCollectionQuery extends Query<CreateCollectionState> {
   loading$: Observable<boolean> = this.selectLoading();
   title$: Observable<string> = this.select((state) => state.title);
+  saveLabel$: Observable<string> = this.select((state) => state.saveLabel);
   constructor(protected store: CreateCollectionStore) {
     super(store);
   }

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -122,18 +122,20 @@ export class CreateCollectionService {
   }
 
   /**
-   * Sets the title based on the mode
+   * Sets the title and save button label based on the mode
    *
    * @param {*} data  Data object during dialog component creation
    * @memberof CreateCollectionService
    */
-  setTitle(data: any): void {
+  setValues(data: any): void {
     const mode: TagEditorMode = data.mode;
     const title = mode === TagEditorMode.Add ? 'Create Collection' : 'Edit Collection';
+    const saveLabel = mode === TagEditorMode.Add ? 'Create Collection' : 'Save';
     this.createCollectionStore.update((state) => {
       return {
         ...state,
         title: title,
+        saveLabel: saveLabel,
       };
     });
   }

--- a/src/app/organizations/collections/state/create-collection.store.ts
+++ b/src/app/organizations/collections/state/create-collection.store.ts
@@ -3,11 +3,13 @@ import { Store, StoreConfig } from '@datorama/akita';
 
 export interface CreateCollectionState {
   title: string;
+  saveLabel: string;
 }
 
 export function createInitialState(): CreateCollectionState {
   return {
     title: '',
+    saveLabel: '',
   };
 }
 


### PR DESCRIPTION
**Description**
This PR prevents a click on the "edit collection" button from propagating to the parent collection summary, which triggered the page to change to the collection page behind the "edit collection" dialog.  Fix is similar to that used to prevent the same type of problem on the "remove entry from collection" button.

Also, implemented the "nice to have" goal: in the "edit collection" dialog, changed the save button label from "Edit Collection" to "Save".

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1756
https://github.com/dockstore/dockstore/issues/4166


**Screenshot**
<img width="662" alt="Screen Shot 2022-01-14 at 9 22 14 PM" src="https://user-images.githubusercontent.com/88108675/149610152-5e28adef-4649-4728-bc30-7ea7e47f134e.png">

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
