### PR TITLE
move category search facet to top of sidebar

### DIFF
--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -546,13 +546,13 @@ export class SearchService {
 
   initializeEntryOrder() {
     return new Map([
+      ['categories.name.keyword', new SubBucket()],
       ['descriptorType', new SubBucket()],
       ['author', new SubBucket()],
       ['registry', new SubBucket()],
       ['source_control_provider.keyword', new SubBucket()],
       ['namespace', new SubBucket()],
       ['organization', new SubBucket()],
-      ['categories.name.keyword', new SubBucket()],
       ['labels.value.keyword', new SubBucket()],
       ['private_access', new SubBucket()],
       ['verified', new SubBucket()],


### PR DESCRIPTION
**Description**
This PR moves the category search facet from the middle to the top of the search sidebar, per our mockups.

**NOTE TO TESTER: make sure you have created a category with at least one entry in it, or the category search facet will not appear.**

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3799

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
