### PR TITLE
remove trailing hyperlink underlines

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -99,7 +99,12 @@
     </div>
     <div *ngIf="!publicPage" class="col-md-5">
       <h3>
-        <app-tool-actions [tool]="tool" [selectedVersion]="selectedVersion" [entryType]="EntryType.Tool" (showVersions)="selectVersionsTab()"></app-tool-actions>
+        <app-tool-actions
+          [tool]="tool"
+          [selectedVersion]="selectedVersion"
+          [entryType]="EntryType.Tool"
+          (showVersions)="selectVersionsTab()"
+        ></app-tool-actions>
       </h3>
     </div>
   </div>
@@ -108,15 +113,18 @@
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
         <span class="size-small mr-2">Categories</span>
         <mat-chip-list class="bubble-list">
-          <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="tool"></app-category-button>
+          <app-category-button *ngFor="let category of categories$ | async" [category]="category" entryType="tool"></app-category-button>
         </mat-chip-list>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
         <span *ngIf="containerEditData?.labels.length > 0" class="size-small mr-2">Labels</span>
         <mat-chip-list class="bubble-list">
-          <mat-chip class="bubble container-background pointer" *ngFor="let label of containerEditData?.labels" (click)="goToSearch(label)">{{
-            label
-          }}</mat-chip>
+          <mat-chip
+            class="bubble container-background pointer"
+            *ngFor="let label of containerEditData?.labels"
+            (click)="goToSearch(label)"
+            >{{ label }}</mat-chip
+          >
           <button type="button" *ngIf="!labelsEditMode && !isToolPublic" class="btn btn-link" (click)="toggleLabelsEditMode()">
             Manage labels
           </button>
@@ -288,8 +296,8 @@
                   [ngStyle]="{ 'font-weight': selectedVersion?.name === sortedVersion?.name ? 'bold' : 'normal' }"
                   (click)="onSelectedVersionChange(sortedVersion)"
                   class="panel-body-anchor"
-                  >{{ sortedVersion.name }}
-                </a>
+                  >{{ sortedVersion.name }}</a
+                >&nbsp;
                 <small>{{ sortedVersion.last_built | date }}</small>
               </p>
               <hr class="m-0" />

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -49,18 +49,14 @@
           <span *ngIf="isPublic && isValidVersion">
             <li *ngIf="trsLinkCWL">
               <strong matTooltip="TRS link to the main CWL descriptor for the selected tool version">TRS CWL</strong>:
-              <a [href]="trsLinkCWL">
-                {{ tool?.tool_path }}
-              </a>
+              <a [href]="trsLinkCWL">{{ tool?.tool_path }}</a>
               <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID" appSnackbar>
                 <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
               </button>
             </li>
             <li *ngIf="trsLinkWDL">
               <strong matTooltip="TRS link to the main WDL descriptor for the selected tool version">TRS WDL</strong>:
-              <a [href]="trsLinkWDL">
-                {{ tool?.tool_path }}
-              </a>
+              <a [href]="trsLinkWDL">{{ tool?.tool_path }}</a>
               <button mat-icon-button color="secondary" [cdkCopyToClipboard]="tool?.tool_path" matTooltip="Copy TRS ID" appSnackbar>
                 <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
               </button>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -57,7 +57,7 @@
         </li>
         <li *ngIf="isPublic && isValidVersion">
           <strong matTooltip="TRS link to the main descriptor for the selected workflow version">TRS</strong>:
-          <a [href]="trsLink"> #{{ entryType$ | async }}/{{ workflow?.full_workflow_path }} </a>
+          <a [href]="trsLink"> #{{ entryType$ | async }}/{{ workflow?.full_workflow_path }}</a>
           <button mat-icon-button color="secondary" matTooltip="Copy TRS ID" [cdkCopyToClipboard]="displayTextForButton" appSnackbar>
             <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
           </button>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -106,7 +106,11 @@
       <span *ngIf="(categories$ | async).length > 0" class="inline-block mr-5 mt-1 mb-1">
         <span class="size-small mr-2">Categories</span>
         <mat-chip-list class="bubble-list">
-          <app-category-button *ngFor="let category of (categories$ | async)" [category]="category" entryType="workflow"></app-category-button>
+          <app-category-button
+            *ngFor="let category of categories$ | async"
+            [category]="category"
+            entryType="workflow"
+          ></app-category-button>
         </mat-chip-list>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
@@ -369,8 +373,8 @@
                   [ngStyle]="{ 'font-weight': selectedVersion?.name === sortedVersion?.name ? 'bold' : 'normal' }"
                   (click)="onSelectedVersionChange(sortedVersion)"
                   class="panel-body-anchor"
-                  >{{ sortedVersion.name }}
-                </a>
+                  >{{ sortedVersion.name }}</a
+                >&nbsp;
                 <small>{{ sortedVersion.last_modified | date }}</small>
               </p>
               <hr class="m-0" />


### PR DESCRIPTION
**Description**
Replacing hyperlinked trailing spaces with non-hyperlinked non-breaking spaces

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2007

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
