### PR TITLE
Fix authors table columns

### DIFF
--- a/src/app/containers/list/list.component.html
+++ b/src/app/containers/list/list.component.html
@@ -61,7 +61,7 @@
       <mat-cell *matCellDef="let tool">{{ tool?.descriptorType ? (tool?.descriptorType.toString() | uppercase) : '' }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef>Links</mat-header-cell>
       <mat-cell *matCellDef="let tool">
         <a [href]="tool?.providerUrl" *ngIf="tool?.providerUrl">
           <fa-icon class="fa-lg" [icon]="tool.providerIcon" [matTooltip]="tool?.provider"> </fa-icon>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -75,7 +75,7 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Links</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
         <a [href]="tool?.providerUrl" *ngIf="tool?.providerUrl">
           <fa-icon class="fa-lg" [icon]="tool.providerIcon" [matTooltip]="tool?.provider"></fa-icon>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -43,7 +43,7 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Links</mat-header-cell>
       <mat-cell fxShow fxHide.lt-md *matCellDef="let entry">
         <a [href]="entry?.providerUrl" *ngIf="entry?.providerUrl">
           <fa-icon class="fa-lg" [icon]="entry.providerIcon" [matTooltip]="entry?.provider"></fa-icon>

--- a/src/app/shared/styles/entry-table.scss
+++ b/src/app/shared/styles/entry-table.scss
@@ -13,16 +13,6 @@
   max-width: 115px;
 }
 
-.mat-cell:not(:first-of-type),
-.mat-header-cell:not(:first-of-type) {
-  padding-left: 16px;
-}
-
-.mat-cell:not(:last-of-type),
-.mat-header-cell:not(:last-of-type) {
-  padding-right: 16px;
-}
-
 .mat-column-starredUsers,
 .mat-column-stars {
   justify-content: flex-end;

--- a/src/app/workflow/info-tab/info-tab.component.css
+++ b/src/app/workflow/info-tab/info-tab.component.css
@@ -18,6 +18,12 @@
   text-decoration: underline;
 }
 
-a {
-  word-break: break-word;
+/* Max width set for author name so a really long name doesn't squish the other columns */
+.mat-column-name {
+  max-width: 25rem;
+}
+
+/* ORCID ID length is fixed */
+.mat-column-orcid_id {
+  width: 20rem;
 }

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -330,29 +330,31 @@
           <td mat-cell *matCellDef="let author">{{ author.name }}</td>
         </ng-container>
         <ng-container matColumnDef="role">
-          <th scope="col" mat-header-cell *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">Role</th>
-          <td mat-cell *matCellDef="let author">{{ author.role }}</td>
+          <th scope="col" mat-header-cell fxHide.lt-md *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">
+            Role
+          </th>
+          <td mat-cell fxHide.lt-md *matCellDef="let author">{{ author.role }}</td>
         </ng-container>
         <ng-container matColumnDef="affiliation">
-          <th scope="col" mat-header-cell *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">
+          <th scope="col" mat-header-cell fxHide.lt-md *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">
             Affiliation
           </th>
-          <td mat-cell *matCellDef="let author">{{ author.affiliation }}</td>
+          <td mat-cell fxHide.lt-md *matCellDef="let author">{{ author.affiliation }}</td>
         </ng-container>
         <ng-container matColumnDef="email">
           <th scope="col" mat-header-cell *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">Email</th>
           <td mat-cell *matCellDef="let author">
             <span *ngIf="author.email">
               <mat-icon class="info-icon" color="accent">email</mat-icon>
-              <span>
-                <a [href]="'mailto:' + author.email" target="_top">{{ author.email }}</a>
-              </span>
+              <a [href]="'mailto:' + author.email" target="_top">{{ author.email }}</a>
             </span>
           </td>
         </ng-container>
         <ng-container matColumnDef="orcid_id">
-          <th scope="col" mat-header-cell *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">ORCID ID</th>
-          <td mat-cell *matCellDef="let author">
+          <th scope="col" mat-header-cell fxHide.lt-sm *matHeaderCellDef [ngClass]="{ 'inactive-table-header': this.authors.length === 0 }">
+            ORCID ID
+          </th>
+          <td mat-cell fxHide.lt-sm *matCellDef="let author">
             <span *ngIf="author.orcid">
               <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
               <a href="https://orcid.org/{{ author.orcid }}">{{ author.orcid }}</a>

--- a/src/app/workflow/versions/versions.component.css
+++ b/src/app/workflow/versions/versions.component.css
@@ -21,23 +21,6 @@
 - Move some of these classes to scss so that it's easier to apply to all future tables and maintain consistent styling
   */
 
-/* Don't have multi-line headers */
-.mat-header-row {
-  white-space: nowrap;
-}
-
-/* Material says it should have 16dp to the left and right, sadly Angular Material does not */
-.mat-cell:not(:first-of-type),
-.mat-header-cell:not(:first-of-type) {
-  padding-left: 1.6rem;
-}
-
-/* Material says it should have 16dp to the left and right, sadly Angular Material does not */
-.mat-cell:not(:last-of-type),
-.mat-header-cell:not(:last-of-type) {
-  padding-right: 1.6rem;
-}
-
 /* Center columns with only icons and cannot be sorted (because the sorting icon takes up space so it doesn't look center anymore) */
 .mat-column-snapshot {
   text-align: center;

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -58,7 +58,7 @@
       <mat-cell *matCellDef="let workflow">{{ workflow?.descriptorType | uppercase }}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="projectLinks">
-      <mat-header-cell *matHeaderCellDef>Project Links</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef>Links</mat-header-cell>
       <mat-cell *matCellDef="let entry">
         <a [href]="entry?.providerUrl" *ngIf="entry.providerUrl">
           <fa-icon class="fa-lg" [icon]="entry.providerIcon" [matTooltip]="entry?.provider"> </fa-icon>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -929,7 +929,12 @@ app-sidebar-accordion
 }
 
 // Remove any default link styling from a bubble, and ensure the font-weight is correct.
-a.bubble, a.bubble:hover, a.bubble:focus, a.bubble:active, a.bubble:link, a.bubble:visited {
+a.bubble,
+a.bubble:hover,
+a.bubble:focus,
+a.bubble:active,
+a.bubble:link,
+a.bubble:visited {
   font-weight: 500;
   border: none;
   outline: none;
@@ -952,7 +957,6 @@ app-category-button {
 .pointer {
   cursor: pointer !important;
 }
-
 
 // Make the dropdown at least the size of the default material dropdown.
 // Making the general width to grow to 50% of the parent width so that there's more room to display long file names
@@ -1208,4 +1212,21 @@ $truncate-text-values: 1, 2, 3;
 // This style is used by table headers when there is no data to display
 .inactive-table-header {
   color: #d8d8d8 !important;
+}
+
+/* Don't have multi-line headers */
+.mat-header-row {
+  white-space: nowrap;
+}
+
+/* Material says it should have 16dp to the left and right, sadly Angular Material does not */
+.mat-cell:not(:first-of-type),
+.mat-header-cell:not(:first-of-type) {
+  padding-left: 1.6rem;
+}
+
+/* Material says it should have 16dp to the left and right, sadly Angular Material does not */
+.mat-cell:not(:last-of-type),
+.mat-header-cell:not(:last-of-type) {
+  padding-right: 1.6rem;
 }


### PR DESCRIPTION
**Description**
Added padding to the columns and set a max-width for the name column and a fixed width for the ORCID id column. Also hid some of the columns if the screen size was small.

Screenshots of the Authors table for public workflows:
![Screenshot 2022-01-18 at 08-59-48 Dockstore Workflow github com DataBiosphere topmed-workflows UM_variant_caller_wdl github](https://user-images.githubusercontent.com/25287123/149963803-37bb468b-93c0-48ef-ae7d-2f9618e6fa2c.png)
![Screenshot 2022-01-18 at 09-03-38 Dockstore Workflow github com kathy-t test-authors foobar github com kathy-t test-authors](https://user-images.githubusercontent.com/25287123/149963908-cb9deb12-7f4f-4ae6-a6fc-c6c394496e79.png)
![Screenshot 2022-01-18 at 09-04-04 Dockstore Workflow github com kathy-t test-authors foobar github com ICGC-TCGA-PanCancer ](https://user-images.githubusercontent.com/25287123/149963983-ef28e446-baf5-4374-8028-2229840c99a0.png)

Screenshots of hidden columns:
![Screenshot 2022-01-18 at 09-48-15 Dockstore Workflow github com kathy-t test-authors foobar](https://user-images.githubusercontent.com/25287123/149964105-ecca4b70-7eb9-4d67-8f39-60094706df43.png)
![Screenshot 2022-01-18 at 09-48-28 Dockstore Workflow github com kathy-t test-authors foobar](https://user-images.githubusercontent.com/25287123/149964112-3c59d6b7-8b8b-4a5b-8802-d77105d2cdc4.png)
![Screenshot 2022-01-18 at 09-48-52 Dockstore Workflow github com kathy-t test-authors foobar github com NCI-GDC gdc-dnaseq-c](https://user-images.githubusercontent.com/25287123/149964123-1d887516-8fa9-45ae-8f8c-a5b8a0c1c482.png)

Notes:
- The padding was being set in specific component styling sheets, so I moved it to the global sheet to reduce duplication. 
- I also made the no multi-line headers style global and while I was checking all the tables on the site, I noticed this style made the Project Links column in search table weird so I changed the column name to Links (which is used by the [new design](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc7ceb4fd8d340926d62d6d))
  - Old: ![Screenshot 2022-01-18 at 10-07-10 Dockstore Search](https://user-images.githubusercontent.com/25287123/149963465-1ee4a96a-8fcf-4ef2-b09c-b4df848e9f05.png)
  - New: ![Screenshot 2022-01-18 at 10-07-25 Dockstore Search](https://user-images.githubusercontent.com/25287123/149963480-2567b34c-106c-4e1c-92bf-b52915d0e453.png)


**Issue**
[#4462](https://github.com/dockstore/dockstore/issues/4462)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
