### PR TITLE
Fix short search topic

### DIFF
--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -28,21 +28,23 @@
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
       <!-- the wrap causes slightly odd behavior with the mat-icon but is needed for the topic -->
-      <mat-cell data-cy="toolNames" *matCellDef="let tool" fxLayout="row wrap">
-        <span *ngIf="tool.private_access">
-          <app-private-icon></app-private-icon>
-        </span>
-        <div *ngIf="tool | isAppTool; else docktoreToolName">
-          <a [matTooltip]="tool?.full_workflow_path" [routerLink]="'/containers/' + tool.full_workflow_path">{{
-            tool?.organization + '/' + tool?.repository + (tool?.workflowName ? '/' + tool?.workflowName : '')
-          }}</a>
+      <mat-cell data-cy="toolNames" *matCellDef="let tool">
+        <div>
+          <span *ngIf="tool.private_access">
+            <app-private-icon></app-private-icon>
+          </span>
+          <div *ngIf="tool | isAppTool; else docktoreToolName">
+            <a [matTooltip]="tool?.full_workflow_path" [routerLink]="'/containers/' + tool.full_workflow_path">{{
+              tool?.organization + '/' + tool?.repository + (tool?.workflowName ? '/' + tool?.workflowName : '')
+            }}</a>
+          </div>
+          <ng-template #docktoreToolName>
+            <a [matTooltip]="tool?.tool_path" [routerLink]="'/containers/' + tool.tool_path">{{
+              tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '')
+            }}</a>
+          </ng-template>
+          <div class="truncate-text-2 size-small" *ngIf="tool.topicAutomatic">{{ tool.topicAutomatic }}</div>
         </div>
-        <ng-template #docktoreToolName>
-          <a [matTooltip]="tool?.tool_path" [routerLink]="'/containers/' + tool.tool_path">{{
-            tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '')
-          }}</a>
-        </ng-template>
-        <span class="truncate-text-2 size-small" *ngIf="tool.topicAutomatic">{{ tool.topicAutomatic }}</span>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -13,11 +13,13 @@
   >
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
-      <mat-cell data-cy="workflowColumn" *matCellDef="let workflow" fxLayout="row wrap">
-        <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="'/workflows/' + workflow?.full_workflow_path">{{
-          workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
-        }}</a>
-        <span class="truncate-text-2 size-small" *ngIf="workflow.topicAutomatic">{{ workflow.topicAutomatic }}</span>
+      <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
+        <div>
+          <a [matTooltip]="workflow?.full_workflow_path" [routerLink]="'/workflows/' + workflow?.full_workflow_path">{{
+            workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
+          }}</a>
+          <div class="truncate-text-2 size-small" *ngIf="workflow.topicAutomatic">{{ workflow.topicAutomatic }}</div>
+        </div>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="verified">


### PR DESCRIPTION
**Description**
The default mat-cell uses flexLayout="row". Previously it was overriden to "row wrap" which appear to work for all cases. Turns out, there was an issue with a very short topic + very short entry path. 

Circumventing the flexLayout by putting everything inside in a single div

**Issue**
Fix for issue discovered from previous SEAB-3698 PR
