### PR TITLE
Feature/3800/remove dna stack launch with hotfix

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -89,18 +89,19 @@
           </div>
           <ng-template #oldWdlLaunch>
             <div fxLayout="column" fxLayoutAlign="space-between center" fxLayoutGap="0.625rem">
-              <a
-                mat-raised-button
-                class="old-launch-with-button"
-                [matTooltip]="!(hasContent$ | async) ? 'The WDL workflow has no content.' : ''"
-                target="_blank"
-                rel="noopener"
-                [attr.href]="config.DNASTACK_IMPORT_URL + '?descriptorType=wdl&path=' + workflowPathAsQueryValue"
-                [disabled]="!(hasContent$ | async)"
-                color="primary"
-                data-cy="dnastackLaunchWith"
-                ><img class="partner-icon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" /> DNAstack &raquo;</a
-              >
+              <!--              Commenting out as part of https://ucsc-cgl.atlassian.net/browse/SEAB-3800. We can keep this around in case DNAStack spins up another instance.-->
+              <!--              <a-->
+              <!--                mat-raised-button-->
+              <!--                class="old-launch-with-button"-->
+              <!--                [matTooltip]="(hasContent$ | async) ? '' : 'The WDL workflow has no content.'"-->
+              <!--                target="_blank"-->
+              <!--                rel="noopener"-->
+              <!--                [attr.href]="config.DNASTACK_IMPORT_URL + '?descriptorType=wdl&path=' + workflowPathAsQueryValue"-->
+              <!--                [disabled]="(hasContent$ | async) === false"-->
+              <!--                color="primary"-->
+              <!--                data-cy="dnastackLaunchWith"-->
+              <!--                ><img class="partner-icon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" /> DNAstack &raquo;</a-->
+              <!--              >-->
               <a
                 mat-raised-button
                 class="old-launch-with-button"

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -93,14 +93,14 @@
               <!--              <a-->
               <!--                mat-raised-button-->
               <!--                class="old-launch-with-button"-->
-              <!--                [matTooltip]="(hasContent$ | async) ? '' : 'The WDL workflow has no content.'"-->
+              <!--                [matTooltip]="!(hasContent$ | async) ? 'The WDL workflow has no content.' : ''"-->
               <!--                target="_blank"-->
               <!--                rel="noopener"-->
               <!--                [attr.href]="config.DNASTACK_IMPORT_URL + '?descriptorType=wdl&path=' + workflowPathAsQueryValue"-->
-              <!--                [disabled]="(hasContent$ | async) === false"-->
+              <!--                [disabled]="!(hasContent$ | async)"-->
               <!--                color="primary"-->
               <!--                data-cy="dnastackLaunchWith"-->
-              <!--                ><img class="partner-icon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" /> DNAstack &raquo;</a-->
+              <!--              ><img class="partner-icon" src="../assets/images/thirdparty/dnastack.png" alt="DNAstack icon" /> DNAstack &raquo;</a-->
               <!--              >-->
               <a
                 mat-raised-button

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -57,7 +57,7 @@ describe('LaunchThirdPartyComponent', () => {
 
     // Verify urls are correct; got these from prod (except for Terra, which is new) to verify there is no breakage.
     // This test was removed as part of: https://ucsc-cgl.atlassian.net/browse/SEAB-3800
-    // /* eslint-disable max-len */
+    // tslint:disable:max-line-length
     // if (!Dockstore.FEATURES.enableMultiCloudLaunchWithDNAstack) {
     //   expect(
     //     nativeElement.querySelector(
@@ -66,6 +66,7 @@ describe('LaunchThirdPartyComponent', () => {
     //   ).toBeTruthy();
     // }
 
+    // tslint:disable:max-line-length
     // https://platform.dnanexus.com/panx/tools/import-workflow?source=https://dockstore.org:443/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/master
     expect(
       nativeElement.querySelector(

--- a/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.spec.ts
@@ -56,14 +56,16 @@ describe('LaunchThirdPartyComponent', () => {
     const nativeElement: HTMLElement = fixture.nativeElement;
 
     // Verify urls are correct; got these from prod (except for Terra, which is new) to verify there is no breakage.
-    // tslint:disable:max-line-length
-    if (!Dockstore.FEATURES.enableMultiCloudLaunchWithDNAstack) {
-      expect(
-        nativeElement.querySelector(
-          'a[href="https://app.dnastack.com/#/app/workflow/import/dockstore?descriptorType=wdl&path=github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl"]'
-        )
-      ).toBeTruthy();
-    }
+    // This test was removed as part of: https://ucsc-cgl.atlassian.net/browse/SEAB-3800
+    // /* eslint-disable max-len */
+    // if (!Dockstore.FEATURES.enableMultiCloudLaunchWithDNAstack) {
+    //   expect(
+    //     nativeElement.querySelector(
+    //       'a[href="https://app.dnastack.com/#/app/workflow/import/dockstore?descriptorType=wdl&path=github.com/DataBiosphere/topmed-workflows/UM_aligner_wdl"]'
+    //     )
+    //   ).toBeTruthy();
+    // }
+
     // https://platform.dnanexus.com/panx/tools/import-workflow?source=https://dockstore.org:443/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere%2Ftopmed-workflows%2FUM_aligner_wdl/versions/master
     expect(
       nativeElement.querySelector(


### PR DESCRIPTION
**Description**
This PR comments out the DNAStack launch-with button:
<img width="1333" alt="Screen Shot 2022-01-26 at 9 18 49 AM" src="https://user-images.githubusercontent.com/36607471/151181726-03b304b5-aac2-4753-9a4a-48f3757bc743.png">

But keeps the multi-cloud launch (For when that config option is set):
<img width="1327" alt="Screen Shot 2022-01-26 at 9 32 29 AM" src="https://user-images.githubusercontent.com/36607471/151182080-b15c2b2e-c858-44d0-9b90-74daad644e3d.png">

Related documentation ticket: https://github.com/dockstore/dockstore-documentation/pull/162

We're failing the lint check against the hotfix branch, but not develop. Looks like things were cleaned up here: https://github.com/dockstore/dockstore-ui2/pull/1260/files. We could cherry-pick that, or ignore for now?

**Issue**
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3800

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that your code compiles by running `npm run build`
- [X] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [X] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [X] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [X] Do not use cookies, although this may change in the future
- [X] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [X] Do due diligence on new 3rd party libraries, checking for CVEs
- [X] Don't allow user-uploaded images to be served from the Dockstore domain
