### PR TITLE
fix/dock-1924/fix-cli-install-link

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -132,12 +132,14 @@
               </li>
               <li>
                 Download and install the
-                <a target="_blank" rel="noopener noreferrer" [href]="Dockstore.DOCUMENTATION_URL + '/launch-with/launch.html#dockstore-cli'"
+                <a [routerLink]="['/quick-start']"
                   >Dockstore CLI</a
                 >
-                and set up the <a [routerLink]="['/quick-start']">configuration file</a>.
+                and set up the configuration file.
               </li>
-              <li>Run the following launch commands.</li>
+              <li>
+                Run the following launch commands.
+              </li>
             </ul>
           </div>
           <div fxFlex>


### PR DESCRIPTION
**Description**
This PR is a duplicate of a previous [unmerged and now closed] PR, but correctly targeted to the hotfix branch (I hope).

This PR changes the Dockstore CLI link mentioned in the issue to point to the /quick-start instructions. The phrasing of the sentence itself seemed fine, so I left it as-is. Also, this PR adjusts the indentation of the list item bodies in the enclosing list to be consistent, both with other items in the list, and with the indentation elsewhere on the page.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1924
dockstore/dockstore#4485