### PR TITLE
Feature/3886/flakey auth tests round two

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,12 +351,6 @@ workflows:
             - lint_license_unit_test_coverage
           context:
             - dockerhub
-      - uptime_monitor_auth:
-          stack: "dev"
-          requires:
-            - lint_license_unit_test_coverage
-          context:
-            - dockerhub
       - local_smoke_tests:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,12 @@ workflows:
             - lint_license_unit_test_coverage
           context:
             - dockerhub
+      - uptime_monitor_auth:
+          stack: "dev"
+          requires:
+            - lint_license_unit_test_coverage
+          context:
+            - dockerhub
       - local_smoke_tests:
           filters:
             tags:

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -19,6 +19,8 @@ const workflowTuple = ['github.com', username, 'hello-dockstore-workflow'];
 // tuple of organization name, collection name
 const collectionTuple = ['test', 'testcollection'];
 
+const HARDCODED_WAIT_TIME = 10000;
+
 // get the dockstore token from env variable and put it in local storage
 function storeToken() {
   window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('TOKEN'));
@@ -38,7 +40,7 @@ function deleteTool() {
     storeToken();
     cy.server();
     cy.route('delete', '**/containers/**').as('containers');
-    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.contains('#deregisterButton', 'Delete').should('be.enabled');
     cy.contains('#deregisterButton', 'Delete').click();
     // cy.get('#deregisterButton').click();
@@ -66,7 +68,7 @@ function registerQuayTool(repo: string, name: string) {
     cy.visit('/my-tools');
     cy.wait('@tokens');
     // click thru the steps of registering a tool
-    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#register_tool_button').click();
     cy.wait('@orgs');
     // cy.wait(1000);
@@ -84,6 +86,9 @@ function registerQuayTool(repo: string, name: string) {
     });
     cy.wait('@containers');
     cy.contains('button', 'Finish').click();
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
+    cy.contains('button', 'Refresh').click();
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#publishToolButton').click();
     cy.wait('@publish');
   });
@@ -99,7 +104,7 @@ function registerRemoteSitesTool(repo: string, name: string) {
 
     cy.visit('/my-tools');
     cy.wait('@tokens');
-    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#register_tool_button').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on remote sites').click();
@@ -138,12 +143,12 @@ function registerToolOnDockstore(repo: string, name: string) {
     cy.wait('@metadata');
     cy.wait('@docker');
     cy.wait('@sourceControl');
-    cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
+    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#register_tool_button').should('be.visible').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on Dockstore.org').click();
       cy.contains('button', 'Next').click();
-      cy.wait(1000);
+      cy.wait(HARDCODED_WAIT_TIME);
       cy.get('#hostedImagePath').type(`${repo}/${name}`);
       cy.contains('button', 'Add Tool').click();
     });
@@ -281,7 +286,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.route('**/tokens').as('tokens');
       cy.visit('/my-tools');
       cy.wait('@tokens');
-      cy.wait(2000); // hardcoded 2s wait is least flaky option right now, revisit in future
+      cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     });
     unpublishTool();
     deleteTool();

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -96,7 +96,7 @@ function registerRemoteSitesTool(repo: string, name: string) {
 
     cy.visit('/my-tools');
     cy.wait('@tokens');
-    cy.get('#register_tool_button').should('be.visible').should('be.visible').click();
+    cy.get('#register_tool_button').should('be.visible').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on remote sites').click();
       cy.contains('button', 'Next').click();

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -19,8 +19,6 @@ const workflowTuple = ['github.com', username, 'hello-dockstore-workflow'];
 // tuple of organization name, collection name
 const collectionTuple = ['test', 'testcollection'];
 
-const HARDCODED_WAIT_TIME = 10000;
-
 // get the dockstore token from env variable and put it in local storage
 function storeToken() {
   window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('TOKEN'));
@@ -40,10 +38,7 @@ function deleteTool() {
     storeToken();
     cy.server();
     cy.route('delete', '**/containers/**').as('containers');
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
-    cy.contains('#deregisterButton', 'Delete').should('be.enabled');
-    cy.contains('#deregisterButton', 'Delete').click();
-    // cy.get('#deregisterButton').click();
+    cy.contains('#deregisterButton', 'Delete').should('be.visible').click();
     cy.contains('div', 'Are you sure you wish to delete this tool?').within(() => {
       cy.contains('button', 'Delete').click();
     });
@@ -68,8 +63,7 @@ function registerQuayTool(repo: string, name: string) {
     cy.visit('/my-tools');
     cy.wait('@tokens');
     // click thru the steps of registering a tool
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
-    cy.get('#register_tool_button').click();
+    cy.get('#register_tool_button').should('be.visible').click();
     cy.wait('@orgs');
     // cy.wait(1000);
     cy.get('mat-dialog-content').within(() => {
@@ -85,11 +79,9 @@ function registerQuayTool(repo: string, name: string) {
       });
     });
     cy.wait('@containers');
-    cy.contains('button', 'Finish').click();
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
-    cy.contains('button', 'Refresh').click();
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
-    cy.get('#publishToolButton').click();
+    cy.contains('button', 'Finish').should('be.visible').click();
+    cy.contains('button', 'Refresh').should('be.visible').click();
+    cy.get('#publishToolButton').should('be.visible').click();
     cy.wait('@publish');
   });
 }
@@ -104,8 +96,7 @@ function registerRemoteSitesTool(repo: string, name: string) {
 
     cy.visit('/my-tools');
     cy.wait('@tokens');
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
-    cy.get('#register_tool_button').click();
+    cy.get('#register_tool_button').should('be.visible').should('be.visible').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on remote sites').click();
       cy.contains('button', 'Next').click();
@@ -113,7 +104,7 @@ function registerRemoteSitesTool(repo: string, name: string) {
       cy.get('#imageRegistryInput').type(`${repo}/${name}`);
       cy.contains('button', 'Add Tool').click();
     });
-    cy.get('#publishToolButton').click();
+    cy.get('#publishToolButton').should('be.visible').click();
     cy.wait('@publish');
   });
 }
@@ -143,14 +134,12 @@ function registerToolOnDockstore(repo: string, name: string) {
     cy.wait('@metadata');
     cy.wait('@docker');
     cy.wait('@sourceControl');
-    cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     cy.get('#register_tool_button').should('be.visible').click();
     cy.get('mat-dialog-content').within(() => {
       cy.contains('mat-radio-button', 'Create tool with descriptor(s) on Dockstore.org').click();
-      cy.contains('button', 'Next').click();
-      cy.wait(HARDCODED_WAIT_TIME);
+      cy.contains('button', 'Next').should('be.visible').click();
       cy.get('#hostedImagePath').type(`${repo}/${name}`);
-      cy.contains('button', 'Add Tool').click();
+      cy.contains('button', 'Add Tool').should('be.visible').click();
     });
     // should not be able to publish because there should be no files or versions
     cy.contains('button', 'Publish').should('be.disabled');
@@ -278,7 +267,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.visit(`/organizations/${org}/collections/${collection}`);
       cy.contains(`quay.io/${repo}/${name}`);
       cy.get('#removeEntryButton').click();
-      cy.get('[data-cy=accept-remove-entry-from-org]').click();
+      cy.get('[data-cy=accept-remove-entry-from-org]').should('be.visible').click();
       cy.contains('This collection has no associated entries');
       cy.visit(`/organizations/${org}`);
       cy.contains('Members').should('be.visible');
@@ -286,7 +275,6 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.route('**/tokens').as('tokens');
       cy.visit('/my-tools');
       cy.wait('@tokens');
-      cy.wait(HARDCODED_WAIT_TIME); // hardcoded 2s wait is least flaky option right now, revisit in future
     });
     unpublishTool();
     deleteTool();


### PR DESCRIPTION
(The reason the test was failing was due to a leftover registered tool from a past run. Deleting this tool seemed to fix the issue, but this is the second time I've made a PR for these tests, so I took another stab at making them more reliable...)

**Description**
This PR fixes broken dev auth tests. To verify they were actually fixed, a CI job was run using the dev auth tests on this branch: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/7138/workflows/b583cade-3dbf-4c60-b30e-83254662e7d4/jobs/24606

It looks like the `cy.wait()`s we had hanging around weren't waiting long enough to be reliable, and some of the `click()` actions were grabbing the DOM too early, so the buttons never became actionable. Removing the waits, and explicitly waiting for buttons to be visible before attempting a click seemed to fix the flakiness issue.

That being said, these auth tests create active data on the dev account, so:
1. If they fail once, they will keep failing until fixed, as there will be leftover tools/workflows hanging around in the test account.
2. If the job is canceled before it's finished, there will most likely be leftover tools/workflows, so subsequent runs will fail.

---

The Cypress docs discourage conditional DOM testing, but perhaps a followup ticket to conditional cleanup resources from previous runs (i.e. `if a tool exists unpublish and delete, otherwise do nothing`) would prevent further flakiness.

---

**Issue**
https://github.com/dockstore/dockstore/issues/4589

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that your code compiles by running `npm run build`
- [X] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [X] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [X] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [X] Do not use cookies, although this may change in the future
- [X] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [X] Do due diligence on new 3rd party libraries, checking for CVEs
- [X] Don't allow user-uploaded images to be served from the Dockstore domain
