### PR TITLE
Hiding a version should show on table without refreshing page

### DIFF
--- a/cypress/integration/group2/githubAppTools.ts
+++ b/cypress/integration/group2/githubAppTools.ts
@@ -108,10 +108,15 @@ describe('GitHub App Tools', () => {
       cy.contains('Edit').click();
       cy.contains('Edit Tool');
       cy.contains('Tool Path');
-      cy.get('[data-cy=hiddenLabel]').click();
+      cy.get('[type="checkbox"]').check();
       cy.get('[data-cy=save-version]').click();
       cy.get('[data-cy=valid').should('exist');
       cy.get('[data-cy=hidden').should('exist');
+      cy.contains('button', 'Actions').should('be.visible').click();
+      cy.contains('Edit').click();
+      cy.get('[type="checkbox"]').uncheck();
+      cy.get('[data-cy=save-version]').click();
+      cy.get('[data-cy=hidden').should('not.exist');
 
       goToTab('Files');
       isActiveTab('Files');

--- a/cypress/integration/group2/githubAppTools.ts
+++ b/cypress/integration/group2/githubAppTools.ts
@@ -111,7 +111,7 @@ describe('GitHub App Tools', () => {
       cy.get('[data-cy=hiddenLabel]').click();
       cy.get('[data-cy=save-version]').click();
       cy.get('[data-cy=valid').should('exist');
-      // cy.get('[data-cy=hidden').should('exist');
+      cy.get('[data-cy=hidden').should('exist');
 
       goToTab('Files');
       isActiveTab('Files');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -117,9 +117,9 @@ describe('Dockstore my workflows', () => {
       // Change the file path
       cy.contains('button', ' Edit ').click();
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore2.cwl');
+      cy.contains('button', ' Save ').click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore2.cwl');
-      cy.contains('button', ' Save ').click();
       // Change the file path back
       cy.contains('button', ' Edit ').click();
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore.cwl');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -117,14 +117,6 @@ describe('Dockstore my workflows', () => {
       // Change the file path
       cy.contains('button', ' Edit ').click();
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore2.cwl');
-      // Hide version
-      cy.get('[data-cy=hiddenLabel]').click();
-      cy.contains('button', ' Save ').click();
-      // Check for hidden version and unhide
-      cy.get('[data-cy=hidden').should('exist');
-      cy.contains('Edit').click();
-      cy.get('[data-cy=hiddenLabel]').click();
-
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore2.cwl');
       // Change the file path back
@@ -186,6 +178,22 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=remove-test-parameter-file-button]').click();
       cy.get('[data-cy=save-version').click();
       cy.get('[data-cy=save-version').should('not.exist');
+    });
+    it('Should be able to hide/unhide', () => {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.contains('Versions').click();
+      cy.get('td').contains('Actions').should('exist').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      cy.get('[type="checkbox"]').check();
+      cy.contains('button', ' Save ').click();
+      // Check for hidden version and unhide
+      cy.get('[data-cy=hidden').should('exist');
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.contains('Versions').click();
+      cy.get('td').contains('Actions').should('exist').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      cy.get('[type="checkbox"]').uncheck();
+      cy.contains('button', ' Save ').click();
     });
   });
 

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -119,6 +119,7 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore2.cwl');
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore2.cwl');
+      cy.contains('button', ' Save ').click();
       // Change the file path back
       cy.contains('button', ' Edit ').click();
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore.cwl');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -117,7 +117,14 @@ describe('Dockstore my workflows', () => {
       // Change the file path
       cy.contains('button', ' Edit ').click();
       cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore2.cwl');
+      // Hide version
+      cy.get('[data-cy=hiddenLabel]').click();
       cy.contains('button', ' Save ').click();
+      // Check for hidden version and unhide
+      cy.get('[data-cy=hidden').should('exist');
+      cy.contains('Edit').click();
+      cy.get('[data-cy=hiddenLabel]').click();
+
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore2.cwl');
       // Change the file path back

--- a/src/app/workflow/version-modal/version-modal.component.ts
+++ b/src/app/workflow/version-modal/version-modal.component.ts
@@ -16,7 +16,6 @@
 import { AfterViewChecked, Component, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { BioWorkflow } from 'app/shared/swagger/model/bioWorkflow';
 import { Service } from 'app/shared/swagger/model/service';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, shareReplay, takeUntil } from 'rxjs/operators';
@@ -25,14 +24,13 @@ import { formInputDebounceTime } from '../../shared/constants';
 import { DateService } from '../../shared/date.service';
 import { SessionQuery } from '../../shared/session/session.query';
 import { WorkflowQuery } from '../../shared/state/workflow.query';
-import { ToolDescriptor } from '../../shared/swagger';
+import { AppTool, BioWorkflow, ToolDescriptor } from '../../shared/swagger';
 import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { Tooltip } from '../../shared/tooltip';
 import { formErrors, validationDescriptorPatterns, validationMessages } from '../../shared/validationMessages.model';
 import { VersionModalService } from './version-modal.service';
-import { AppTool } from '../../shared/openapi';
 import { EntryType } from '../../shared/enum/entry-type';
 
 export interface Dialogdata {
@@ -50,8 +48,8 @@ export class VersionModalComponent implements OnInit, AfterViewChecked, OnDestro
   isPublic: boolean;
   isModalShown: boolean;
   version: WorkflowVersion;
-  originalVersion: WorkflowVersion;
   workflow: BioWorkflow | Service | AppTool;
+  originalVersion: WorkflowVersion;
   testParameterFiles: SourceFile[];
   versionEditorForm: NgForm;
   public tooltip = Tooltip;
@@ -143,6 +141,7 @@ export class VersionModalComponent implements OnInit, AfterViewChecked, OnDestro
     }
 
     this.versionModalService.saveVersion(
+      this.workflow,
       this.originalVersion,
       this.version,
       this.originalTestParameterFilePaths,

--- a/src/app/workflow/version-modal/version-modal.service.spec.ts
+++ b/src/app/workflow/version-modal/version-modal.service.spec.ts
@@ -25,9 +25,22 @@ import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { RefreshStubService, WorkflowsStubService, WorkflowStubService } from '../../test/service-stubs';
 import { VersionModalService } from './version-modal.service';
+import { BioWorkflow, Workflow } from '../../shared/swagger';
+import DescriptorTypeSubclassEnum = Workflow.DescriptorTypeSubclassEnum;
 
 describe('Service: version-modal.service.ts', () => {
   let workflowQuery: jasmine.SpyObj<WorkflowQuery>;
+  const workflow: BioWorkflow = {
+    mode: 'FULL',
+    gitUrl: 'git@github.com:test/potato.git',
+    organization: 'test',
+    repository: 'potato',
+    sourceControl: 'github.com',
+    descriptorType: 'CWL',
+    workflow_path: 'github.com/test/potato',
+    defaultTestParameterFilePath: null,
+    descriptorTypeSubclass: DescriptorTypeSubclassEnum.NOTAPPLICABLE,
+  };
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, MatSnackBarModule, MatDialogModule],
@@ -60,7 +73,7 @@ describe('Service: version-modal.service.ts', () => {
     [VersionModalService, AlertQuery],
     (service: VersionModalService, alertQuery: AlertQuery) => {
       workflowQuery.getActive.and.returnValue(<any>{ id: 1 });
-      service.saveVersion(expectedVersion, expectedVersion, ['a', 'b'], ['b', 'c'], 'FULL');
+      service.saveVersion(workflow, expectedVersion, expectedVersion, ['a', 'b'], ['b', 'c'], 'FULL');
       // Refresh service takes modifying the refreshMessage from the third message;
       alertQuery.message$.subscribe((refreshMessage) => expect(refreshMessage).toEqual(''));
     }

--- a/src/app/workflow/version-modal/version-modal.service.ts
+++ b/src/app/workflow/version-modal/version-modal.service.ts
@@ -23,6 +23,8 @@ import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { WorkflowsService } from '../../shared/swagger/api/workflows.service';
 import { SourceFile } from '../../shared/swagger/model/sourceFile';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
+import { WorkflowService } from '../../shared/state/workflow.service';
+import { AppTool, BioWorkflow, Service } from '../../shared/swagger';
 
 @Injectable()
 export class VersionModalService {
@@ -32,6 +34,7 @@ export class VersionModalService {
     private alertService: AlertService,
     private workflowQuery: WorkflowQuery,
     private workflowsService: WorkflowsService,
+    private workflowService: WorkflowService,
     private refreshService: RefreshService,
     private matDialog: MatDialog
   ) {}
@@ -56,6 +59,7 @@ export class VersionModalService {
    * @memberof VersionModalService
    */
   saveVersion(
+    workflow: BioWorkflow | Service | AppTool,
     originalVersion: WorkflowVersion,
     workflowVersion: WorkflowVersion,
     originalTestParameterFilePaths,
@@ -74,6 +78,8 @@ export class VersionModalService {
     if (workflowMode !== 'HOSTED') {
       this.workflowsService.updateWorkflowVersion(workflowId, [workflowVersion]).subscribe(
         (response) => {
+          workflow = { ...workflow, workflowVersions: response };
+          this.workflowService.setWorkflow(workflow);
           this.alertService.start(message2);
           this.modifyTestParameterFiles(workflowVersion, originalTestParameterFilePaths, newTestParameterFiles).subscribe(
             (success) => {
@@ -103,6 +109,8 @@ export class VersionModalService {
     } else {
       this.workflowsService.updateWorkflowVersion(workflowId, [workflowVersion]).subscribe(
         (response) => {
+          workflow = { ...workflow, workflowVersions: response };
+          this.workflowService.setWorkflow(workflow);
           this.alertService.detailedSuccess();
           this.matDialog.closeAll();
         },

--- a/src/app/workflow/version-modal/version-modal.service.ts
+++ b/src/app/workflow/version-modal/version-modal.service.ts
@@ -78,8 +78,8 @@ export class VersionModalService {
     if (workflowMode !== 'HOSTED') {
       this.workflowsService.updateWorkflowVersion(workflowId, [workflowVersion]).subscribe(
         (response) => {
-          workflow = { ...workflow, workflowVersions: response };
-          this.workflowService.setWorkflow(workflow);
+          const updatedWorkflow: BioWorkflow | Service | AppTool = { ...workflow, workflowVersions: response };
+          this.workflowService.setWorkflow(updatedWorkflow);
           this.alertService.start(message2);
           this.modifyTestParameterFiles(workflowVersion, originalTestParameterFilePaths, newTestParameterFiles).subscribe(
             (success) => {
@@ -109,8 +109,8 @@ export class VersionModalService {
     } else {
       this.workflowsService.updateWorkflowVersion(workflowId, [workflowVersion]).subscribe(
         (response) => {
-          workflow = { ...workflow, workflowVersions: response };
-          this.workflowService.setWorkflow(workflow);
+          const updatedWorkflow: BioWorkflow | Service | AppTool = { ...workflow, workflowVersions: response };
+          this.workflowService.setWorkflow(updatedWorkflow);
           this.alertService.detailedSuccess();
           this.matDialog.closeAll();
         },


### PR DESCRIPTION
**Description**
The version table wasn't updating before after hiding/unhiding a version for workflows in general. This fixes that.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3847

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
