### PR TITLE
Fix relative links in README descriptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_nightly_tests
       - install_cypress_dependencies
       - run:
@@ -77,7 +78,8 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_nightly_tests
       - install_cypress_dependencies
       - run:
@@ -100,7 +102,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - run:
           name: Checkout merge commit (PRs only)
@@ -139,7 +142,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - run:
           name: Checkout merge commit (PRs only)
@@ -200,7 +204,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -215,7 +220,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -230,7 +236,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -450,7 +457,8 @@ commands:
         type: string
         default: "db_dump.sql"
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - get_workspace
       - install_container_dependencies
       - run:
@@ -482,7 +490,8 @@ commands:
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - install_container_dependencies
       - restore_cache:

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -350,7 +350,10 @@
         <div *ngIf="selectedVersion?.description || !isPublic">
           <label matTooltip="Description of tool obtained from tool descriptor"> Description </label>:
           <div *ngIf="selectedVersion?.description" class="well well-sm">
-            <app-markdown-wrapper [data]="selectedVersion?.description"></app-markdown-wrapper>
+            <app-markdown-wrapper
+              [data]="selectedVersion?.description"
+              [baseUrl]="tool?.providerUrl | baseUrl: selectedVersion?.reference"
+            ></app-markdown-wrapper>
           </div>
           <div *ngIf="!selectedVersion?.description && !isPublic" class="well well-sm">
             <mat-icon>warning</mat-icon>

--- a/src/app/shared/entry/base-url.pipe.spec.ts
+++ b/src/app/shared/entry/base-url.pipe.spec.ts
@@ -1,0 +1,11 @@
+import { BaseUrlPipe } from './base-url.pipe';
+
+describe('Pipe: BaseUrl', () => {
+  it('create an instance and return base url', () => {
+    const pipe = new BaseUrlPipe();
+    expect(pipe).toBeTruthy();
+    expect(pipe.transform('https://github.com/foobar/hello_world', 'master')).toBe('https://github.com/dockstore/foobar/blob/master/');
+    expect(pipe.transform('https://gitlab.com/foobar/hello_world', 'develop')).toBe('https://gitlab.com/foobar/hello_world/blob/develop/');
+    expect(pipe.transform('https://bitbucket.org/foobar/hello_world', '1.0')).toBe('https://bitbucket.org/dockstore/foobar/src/1.0/');
+  });
+});

--- a/src/app/shared/entry/base-url.pipe.spec.ts
+++ b/src/app/shared/entry/base-url.pipe.spec.ts
@@ -4,8 +4,8 @@ describe('Pipe: BaseUrl', () => {
   it('create an instance and return base url', () => {
     const pipe = new BaseUrlPipe();
     expect(pipe).toBeTruthy();
-    expect(pipe.transform('https://github.com/foobar/hello_world', 'master')).toBe('https://github.com/dockstore/foobar/blob/master/');
+    expect(pipe.transform('https://github.com/foobar/hello_world', 'master')).toBe('https://github.com/foobar/hello_world/blob/master/');
     expect(pipe.transform('https://gitlab.com/foobar/hello_world', 'develop')).toBe('https://gitlab.com/foobar/hello_world/blob/develop/');
-    expect(pipe.transform('https://bitbucket.org/foobar/hello_world', '1.0')).toBe('https://bitbucket.org/dockstore/foobar/src/1.0/');
+    expect(pipe.transform('https://bitbucket.org/foobar/hello_world', '1.0')).toBe('https://bitbucket.org/foobar/hello_world/src/1.0/');
   });
 });

--- a/src/app/shared/entry/base-url.pipe.ts
+++ b/src/app/shared/entry/base-url.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'baseUrl',
+})
+export class BaseUrlPipe implements PipeTransform {
+  /**
+   * Constructs a base url for relative links in markdown README files.
+   * @param providerUrl
+   * @param versionName
+   * @returns {string} base url to be used by ngx-markdown
+   */
+  transform(providerUrl: string, versionName: string): string {
+    if (!providerUrl || !versionName) {
+      console.error('providerUrl or versionName is not truthy');
+      return null;
+    }
+    if (providerUrl.startsWith('https://github.com/') || providerUrl.startsWith('https://gitlab.com/')) {
+      return providerUrl + '/blob/' + versionName + '/'; // the last slash is needed by ngx-markdown
+    } else if (providerUrl.startsWith('https://bitbucket.org/')) {
+      return providerUrl + '/src/' + versionName + '/'; // the last slash is needed by ngx-markdown
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -32,6 +32,7 @@ import { EntryActionsService } from '../entry-actions/entry-actions.service';
 import { PublicFileDownloadPipe } from '../entry/public-file-download.pipe';
 import { CustomMaterialModule } from '../modules/material.module';
 import { SnackbarModule } from '../modules/snackbar.module';
+import { BaseUrlPipe } from './base-url.pipe';
 import { CommitUrlPipe } from './commit-url.pipe';
 import { InfoTabCheckerWorkflowPathComponent } from './info-tab-checker-workflow-path/info-tab-checker-workflow-path.component';
 import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch-checker-workflow.component';
@@ -70,6 +71,7 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     PublicFileDownloadPipe,
     PrivateFilePathPipe,
     UrlDeconstructPipe,
+    BaseUrlPipe,
   ],
   exports: [
     InfoTabCheckerWorkflowPathComponent,
@@ -91,6 +93,7 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     UrlDeconstructPipe,
     RouterModule,
     ReactiveFormsModule,
+    BaseUrlPipe,
   ],
   providers: [BioschemaService, EntryActionsService],
 })

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.component.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.component.spec.ts
@@ -1,6 +1,7 @@
 import { SecurityContext } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MarkdownModule, MarkdownService, SECURITY_CONTEXT } from 'ngx-markdown';
+import { BaseUrlPipe } from '../entry/base-url.pipe';
 import { MarkdownWrapperComponent } from './markdown-wrapper.component';
 
 describe('MarkdownWrapperComponent', () => {
@@ -90,6 +91,20 @@ describe('MarkdownWrapperComponent', () => {
       expect(fixture.nativeElement.innerHTML).toContain('class="mat-focus-indicator mat-flat-button mat-button-base mat-primary');
       expect(fixture.nativeElement.innerHTML).toContain('href="javascript:window.alert(\'mashing\')"');
       expect(fixture.nativeElement.innerHTML).toContain('Safe!');
+    })
+  );
+
+  it(
+    'Link generated for relative link in markdown should be correct',
+    waitForAsync(() => {
+      const pipe = new BaseUrlPipe();
+      wrapperComponent.data = '[relative link here](docs/hello_world.md)';
+      wrapperComponent.baseUrl = pipe.transform('https://github.com/kathy-t/hello_world', 'master');
+      wrapperComponent.ngOnChanges(); // has to be called manually in unit tests (TestBed doesn't by default)
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toContain(
+        '<a href="https://github.com/kathy-t/hello_world/blob/master/docs/hello_world.md">relative link here</a>'
+      );
     })
   );
 });

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.component.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.component.ts
@@ -12,9 +12,12 @@ import { MarkdownService } from 'ngx-markdown';
  Wrapper for ngx-markdown. Allows custom sanitization of user-input markdown through DOMPurify, which is not accessible
  through the built-in sanitizer, DOMSanitize.
  DOMSanitize's safe-lists can be seen https://github.com/angular/angular/blob/master/packages/core/src/sanitization/html_sanitizer.ts
+
+ Also specifies the base url used for relative links.
  */
 export class MarkdownWrapperComponent implements OnInit, OnChanges {
   @Input() data: string;
+  @Input() baseUrl?: string;
   cleanedData: string;
 
   // tags and attributes that will be sanitized by DOMPurify.
@@ -26,7 +29,7 @@ export class MarkdownWrapperComponent implements OnInit, OnChanges {
   constructor(private markdownService: MarkdownService) {}
 
   ngOnChanges(): void {
-    this.cleanedData = this.customSanitize(this.data);
+    this.cleanedData = this.customSanitize(this.customCompile(this.data, this.baseUrl));
   }
 
   ngOnInit(): void {
@@ -37,8 +40,20 @@ export class MarkdownWrapperComponent implements OnInit, OnChanges {
     });
   }
 
+  /**
+   * Compiles markdown into HTML with custom options.
+   * @param data
+   * @param baseUrl A base url used as a prefix for relative links
+   * @returns
+   */
+  customCompile(data, baseUrl): string {
+    return this.markdownService.compile(data, undefined, undefined, {
+      baseUrl: baseUrl,
+    });
+  }
+
   customSanitize(data): string {
     // compile markdown into html then pass it to DOMPurify to be sanitized.
-    return DOMPurify.sanitize(this.markdownService.compile(data));
+    return DOMPurify.sanitize(data);
   }
 }

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.component.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.component.ts
@@ -44,7 +44,7 @@ export class MarkdownWrapperComponent implements OnInit, OnChanges {
    * Compiles markdown into HTML with custom options.
    * @param data
    * @param baseUrl A base url used as a prefix for relative links
-   * @returns
+   * @returns {string} HTML string
    */
   customCompile(data, baseUrl): string {
     return this.markdownService.compile(data, undefined, undefined, {
@@ -52,8 +52,8 @@ export class MarkdownWrapperComponent implements OnInit, OnChanges {
     });
   }
 
-  customSanitize(data): string {
-    // compile markdown into html then pass it to DOMPurify to be sanitized.
-    return DOMPurify.sanitize(data);
+  customSanitize(html): string {
+    // Passes HTML to DOMPurify to be sanitized.
+    return DOMPurify.sanitize(html);
   }
 }

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -417,7 +417,10 @@
         <div *ngIf="selectedVersion?.description || !isPublic">
           <label matTooltip="Description of workflow obtained from workflow descriptor"> Description </label>:
           <div *ngIf="selectedVersion?.description" class="well well-sm">
-            <app-markdown-wrapper [data]="selectedVersion?.description"></app-markdown-wrapper>
+            <app-markdown-wrapper
+              [data]="selectedVersion?.description"
+              [baseUrl]="workflow?.providerUrl | baseUrl: selectedVersion?.name"
+            ></app-markdown-wrapper>
           </div>
           <div *ngIf="!selectedVersion?.description && !isPublic" class="well well-sm">
             <mat-icon>warning</mat-icon>


### PR DESCRIPTION
**Description**
This PR fixes the relative links displayed in an entry's README description by specifying a base URL for relative links. 

ngx-markdown allows options like `baseUrl` (prefix url for relative links) to be specified as [MarkedOptions](https://github.com/jfcere/ngx-markdown#markedoptions). However, MarkedOptions is meant to be defined globally, which isn't ideal for us because relative links only really show up in README descriptions and not in other places where we use markdown. Setting it globally also prevents us from changing the base URL dynamically based on entry repo.

Found a work-around by passing in MarkedOptions in the MarkDownService's `compile` method, which we already use. My PR only specifies base URLs for tool and workflow descriptions.

I found that GitLab and BitBucket also support relative links in their READMEs, so this PR handles those services as well.

**Issue**
[#4453](https://github.com/dockstore/dockstore/issues/4453)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
