### PR TITLE
Reduce changeDescriptor calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.2.4
 executors:
   integration_test_exec: # declares a reusable executor
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_nightly_tests
       - install_cypress_dependencies
       - run:
@@ -77,7 +78,8 @@ jobs:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_nightly_tests
       - install_cypress_dependencies
       - run:
@@ -100,7 +102,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - run:
           name: Checkout merge commit (PRs only)
@@ -139,7 +142,8 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - run:
           name: Checkout merge commit (PRs only)
@@ -200,7 +204,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -215,7 +220,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -230,7 +236,8 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -450,7 +457,8 @@ commands:
         type: string
         default: "db_dump.sql"
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - get_workspace
       - install_container_dependencies
       - run:
@@ -482,7 +490,8 @@ commands:
           command: bash scripts/wait-for.sh
   setup_nightly_tests:
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - install_container_dependencies
       - restore_cache:

--- a/.gitallowed
+++ b/.gitallowed
@@ -34,3 +34,5 @@ src/app/workflow/dag/cwl-viewer/cwl-viewer.service.spec.ts:.*9283b35ae651477f5e7
 
 # src/app/workflow/launch-third-party/launch-third-party.component.ts
 src/app/workflow/launch-third-party/launch-third-party.component.ts:.*https://github.com/dockstore/dockstore/blob/0a734abe9dbe34eed12404d4697ebc43b71da8d8*
+
+.circleci/config.yml:.*https://raw.githubusercontent.com/dockstore/dockstore-ui2/.*

--- a/src/app/container/launch/launch.component.ts
+++ b/src/app/container/launch/launch.component.ts
@@ -16,7 +16,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Base } from 'app/shared/base';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 import { SourceFile, ToolDescriptor } from '../../shared/swagger';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
 import { Workflow } from '../../shared/swagger/model/workflow';


### PR DESCRIPTION
**Description**
Reduce the number of changeDescriptor calls from 3 or 4 to 1 or 2 using behavior subjects and combineLatest with an odd trick (debounceTime(0)). Downside of this PR is that it introduces 3 new behavior subjects which is kind of duplicating values

Not entirely sure if it's even worth doing.

**Issue**
dockstore/dockstore#4194

