### PR TITLE
redirect correctly

### DIFF
--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -345,8 +345,9 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
           this.updateWorkflowUrl(this.workflow);
         },
         (error) => {
-          const regex = /\/((workflows)|(containers))\/(github.com)|(gitlab.com)|(bitbucket.org)\/.+/;
-          if (regex.test(this.resourcePath)) {
+          const workflowRegex = /\/workflows\/(github.com)|(gitlab.com)|(bitbucket.org)\/.+/;
+          const gitHubAppToolRegex = /\/containers\/(github.com)\/.+/;
+          if (workflowRegex.test(this.resourcePath) || gitHubAppToolRegex.test(this.resourcePath)) {
             this.router.navigate(['../']);
           } else {
             this.showRedirect = true;

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -345,7 +345,7 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
           this.updateWorkflowUrl(this.workflow);
         },
         (error) => {
-          const regex = /\/workflows\/(github.com)|(gitlab.com)|(bitbucket.org)\/.+/;
+          const regex = /\/((workflows)|(containers))\/(github.com)|(gitlab.com)|(bitbucket.org)\/.+/;
           if (regex.test(this.resourcePath)) {
             this.router.navigate(['../']);
           } else {


### PR DESCRIPTION
**Description**
Again, couldn't really reproduce the flakiness of what the original ticket described, but this is a related bug nonetheless. The public tool page wasn't redirecting correctly to the home page if the tool was unpublished.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2038

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
