### PR TITLE
disable launch buttons correctly

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -115,7 +115,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   /**
    * Indicates whether the selected version has any content
    */
-  hasContent$ = this.descriptorsQuery.hasContent$.pipe(shareReplay());
+  hasContent$ = this.descriptorsQuery.hasContent$.pipe(shareReplay({refCount: true}));
 
   /**
    * Indicates whether the selected version's workflow has any file-based imports.

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -4,7 +4,7 @@ import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { combineLatest, Observable } from 'rxjs';
-import { map, share, takeUntil } from 'rxjs/operators';
+import { map, shareReplay, takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
 import { DescriptorTypeCompatService } from '../../shared/descriptor-type-compat.service';
 import { Dockstore } from '../../shared/dockstore.model';
@@ -115,7 +115,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   /**
    * Indicates whether the selected version has any content
    */
-  hasContent$ = this.descriptorsQuery.hasContent$.pipe(share());
+  hasContent$ = this.descriptorsQuery.hasContent$.pipe(shareReplay());
 
   /**
    * Indicates whether the selected version's workflow has any file-based imports.


### PR DESCRIPTION
**Description**
Fixes the enabling/disabling of the "launch" buttons on the right side of the workflow page, by replacing the `share` with a `shareReplay` call, which makes the multiple observables that depend on the `hasContent$` observable work correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1891
dockstore/dockstore#4423

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
