### PR TITLE
LGTM fix - Use regex replaceAll until EC2021

### DIFF
--- a/src/app/loginComponents/accounts/accounts.component.ts
+++ b/src/app/loginComponents/accounts/accounts.component.ts
@@ -57,6 +57,6 @@ export class AccountsComponent extends Base implements OnInit {
   setAccountsTab(tabName: string) {
     // Adding the & symbol causes the URL to be parsed in an unexpected way.
     // TODO: Change replace to replaceAll once we use EC2021
-    this.location.replaceState('accounts?tab=' + tabName.replace('&', 'and'));
+    this.location.replaceState('accounts?tab=' + tabName.replace(/&/g, 'and'));
   }
 }


### PR DESCRIPTION
**Description**

A fix suggested by LGTM to avoid missing other `&` in the parameters.

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-3876

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
