### PR TITLE
git secrets fix

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -4,8 +4,8 @@
 
 # test/dbdump.sql
 test/db_dump.sql:.*
-test/github_app_tool_db_dump.sql:.*
-test/smoke_test_db.sql:.*
+test/github_app_tool_db_dump.sql:.*public.workflowversion
+test/smoke_test_db.sql:.*public.databasechangelog
 
 # src/app/organizations/events/events.component.html
 src/app/organizations/events/events.component.html:.*EventType.REMOVEFROMCOLLECTION

--- a/.gitallowed
+++ b/.gitallowed
@@ -4,6 +4,8 @@
 
 # test/dbdump.sql
 test/db_dump.sql:.*
+test/github_app_tool_db_dump.sql:.*
+test/smoke_test_db.sql:.*
 
 # src/app/organizations/events/events.component.html
 src/app/organizations/events/events.component.html:.*EventType.REMOVEFROMCOLLECTION


### PR DESCRIPTION
**Description**
Git secrets was failing locally to catch failed patterns within our test databases. Interestingly, I had setup and installed git-secrets manually using `brew`. This failed to capture the sql database secret warnings, but would catch fake keys, such as `AKIAIOSFODNN7EXAMPLES`, which led me to believe that it was working as expected.

Uninstalling locally with `brew uninstall git-secrets` and then reinstalling using the UI script `npm run install-git-secrets` seemed to fix the local issue, and caused `git secrets --scan` to start picking up the expected results.

If you aren't sure if git secrets is working locally, I'd suggest scanning one of the database files, such as `test/smoke_test_db.sql` while the line  `test/smoke_test_db.sql:.*public.databasechangelog` isn't in `.gitallowed`. If your scan passes, git secrets may be broken.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
