### PR TITLE
Global import of Roboto font family

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -23,6 +23,7 @@ $material-design-icons-font-directory-path: '~material-design-icons-iconfont/dis
 @import '~ngx-sharebuttons/themes/default/default-theme';
 @import 'featured-content.scss';
 @import '/src/materialColorScheme.scss';
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 /*@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,600);*/
 
 /* #487980 GREEN */
@@ -208,7 +209,7 @@ angular-tag-cloud > span.w1:hover {
 /* Main Styles */
 
 body {
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  font-family: 'Roboto', 'Helvetica Neue', sans-serif;
   font-weight: normal;
   color: #313131;
   font-size: 14px;


### PR DESCRIPTION
**Description**

When working on my search sidebar ticket I noticed something strange about the fonts used on Dockstore... according to styles.scss we're supposed to be using Roboto as our primary font, but after some investigation I realized that we're actually not.  There isn't an import for the Roboto font family specified anywhere in our repository, so Dockstore has been rendering with fallback fonts for probably this entire time.

![image](https://user-images.githubusercontent.com/97123241/155231528-862c18fb-0196-4e40-a6d1-f03c98fd6e3b.png)

Depending on your operating system, with use of inspect you can find that for these fonts have been used as fallbacks:
* **Ubuntu:** Liberation Sans (3rd fallback: default sans serif font)
* **Windows:** Arial (3rd fallback: default sans serif font)
* **Mac:** Helvetica Neue (2nd fallback)

Its pretty inconsistent and also doesn't match Zeplin which calls  for Roboto.  The font differences also causes a lot of formatting inconsistencies like the font weight, ex. where font-weight 400 & 500 render the same but with Roboto there is a distinct weight difference that Zeplin calls for.

![image](https://user-images.githubusercontent.com/97123241/155339461-690e69a4-e9ee-4460-9268-395b79b726a7.png)

### Solution
Simply import the Roboto font family into our global style sheet so users can render the primary font we've specified.

### Implementation
Quick discussion on implementation, my preferred method (and the most simple method) is just with an `@import` rule in styles.scss. Roboto is a google font so we'll call their API and import it into the style sheet. I've had some discussions about best practice and after some additional searches I'd say this is a pretty recommended method for font importing.

[Stackoverflow answer:](https://stackoverflow.com/questions/44878591/best-practice-style-for-importing-font-into-angular-4-cli-web-application)
![image](https://user-images.githubusercontent.com/97123241/155336872-19120f1c-9adf-46d3-97d1-578ac631aa93.png)

[Article specific to Angular: Method 2 – @import (Recommended)](https://www.softaox.info/best-way-to-use-google-fonts-in-your-angular-project/)
![image](https://user-images.githubusercontent.com/97123241/155337014-04ca525f-2438-4a00-b7d5-7214bd7e747f.png)

An alternative method would be to download all of the font files from google, create an additional global style sheet (or include it in the original but it would be a large chunk of code) then link each font file and specify individual weights with the `@font-face` rule. Further details [here](https://www.w3schools.com/cssref/css3_pr_font-face_rule.asp) and [here](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face).

Let me know what you think in the comments and if you have any alternative methods. In this PR I have included the `@import` rule as my preferred solution. It'll be merging into develop so that we can keep an eye on any formatting issues as this is a global change. Thanks!

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
