### PR TITLE
Feature/4500/rebase launch wes tab instructions

### DIFF
--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o xtrace
 if [ "$npm_package_config_use_circle" = true ]
 then
-	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-beta.1-SNAPSHOT.jar"
+	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.13.0-alpha.0-SNAPSHOT.jar"
 else
 	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 fi

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o xtrace
 if [ "$npm_package_config_use_circle" = true ]
 then
-	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.13.0-alpha.0-SNAPSHOT.jar"
+	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-beta.1-SNAPSHOT.jar"
 else
 	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 fi

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -27,6 +27,7 @@ export abstract class LaunchService {
   public readonly cwlrunnerTooltip = 'Commands for launching tools/workflows through cwl-runner. ' + this.nonStrict;
   public readonly cwltoolTooltip =
     'Commands for launching tools/workflows through CWLtool: the CWL reference implementation. ' + this.nonStrict;
+  public readonly wesTooltip = 'Commands for provisioning files and launching a workflow against AWS AGC infrastructure.';
   constructor(protected descriptorTypeCompatService: DescriptorTypeCompatService) {}
   abstract getParamsString(path: string, versionName: string, currentDescriptor: string): string;
   abstract getCliString(path: string, versionName: string, currentDescriptor: string): string;

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -90,8 +90,9 @@
           <!--TODO: replace with actual documentation link after https://github.com/dockstore/dockstore-documentation/pull/173-->
           <p>
             Learn how to configure the Dockstore CLI to communicate with AWS AGC infrastructure by reading the
-            <a href="https://docs.dockstore.org/en/stable/dockstore-introduction.html">Dockstore documentation</a>. For an introduction to
-            AWS AGC, see their official <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>.
+            <a [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/wes/cli-wes-tutorial.html'">Dockstore documentation</a>. For an
+            introduction to AWS AGC, see their official
+            <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>.
           </p>
 
           <div>

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -85,25 +85,24 @@
 
       <mat-card *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && (published$ | async)">
         <div [matTooltip]="wesTooltip">
-          <p>Launch this workflow using Amazon Web Services' (AWS) Amazon Genomics CLI (AGC) cloud infrastructure.</p>
+          <p>Launch this workflow on Amazon Web Services' (AWS) Amazon Genomics CLI (AGC) cloud infrastructure.</p>
 
           <!--TODO: replace with actual documentation link after https://github.com/dockstore/dockstore-documentation/pull/173-->
           <p>
-            For an introduction to AWS AGC, see their official
-            <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>. To learn how to configure the
-            Dockstore CLI to communicate with AWS AGC infrastructure, see the
-            <a href="https://docs.dockstore.org/en/stable/dockstore-introduction.html">Dockstore documentation</a>.
+            Learn how to configure the Dockstore CLI to communicate with AWS AGC infrastructure by reading the
+            <a href="https://docs.dockstore.org/en/stable/dockstore-introduction.html">Dockstore documentation</a>. For an introduction to
+            AWS AGC, see their official <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>.
           </p>
 
           <div>
             Make a runtime JSON template and fill in desired inputs, outputs, and other parameters
             <pre>{{ params }}</pre>
 
-            Create a wrapper JSON used by AWS AGC.
+            Create a wrapper JSON file, which is used by AWS AGC.
             <pre>{{ wesWrapperJson }}</pre>
 
             Launch the workflow. (Note: Any input files required to run this workflow must be specified using the `--attach` or `-a` command
-            line switch)
+            line switch.)
             <pre>{{ wesLaunchCommand }}</pre>
           </div>
         </div>

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -82,6 +82,32 @@
         </mat-card>
         <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
       </div>
+
+      <mat-card *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && (published$ | async)">
+        <div [matTooltip]="wesTooltip">
+          <p>Launch this workflow using Amazon Web Services' (AWS) Amazon Genomics CLI (AGC) cloud infrastructure.</p>
+
+          <!--TODO: replace with actual documentation link after https://github.com/dockstore/dockstore-documentation/pull/173-->
+          <p>
+            For an introduction to AWS AGC, see their official
+            <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>. To learn how to configure the
+            Dockstore CLI to communicate with AWS AGC infrastructure, see the
+            <a href="https://docs.dockstore.org/en/stable/dockstore-introduction.html">Dockstore documentation</a>.
+          </p>
+
+          <div>
+            Make a runtime JSON template and fill in desired inputs, outputs, and other parameters
+            <pre>{{ params }}</pre>
+
+            Create a wrapper JSON used by AWS AGC.
+            <pre>{{ wesWrapperJson }}</pre>
+
+            Launch the workflow. (Note: Any input files required to run this workflow must be specified using the `--attach` or `-a` command
+            line switch)
+            <pre>{{ wesLaunchCommand }}</pre>
+          </div>
+        </div>
+      </mat-card>
     </div>
   </div>
 </div>

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -68,6 +68,9 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   EntryType = EntryType;
   protected published$: Observable<boolean>;
   protected ngUnsubscribe: Subject<{}> = new Subject();
+  wesWrapperJson: string;
+  wesLaunchCommand: string;
+  wesTooltip = this.launchService.wesTooltip;
 
   constructor(
     private launchService: WorkflowLaunchService,
@@ -111,6 +114,8 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     this.nextflowLocalLaunchDescription = this.launchService.getNextflowLocalLaunchString();
     this.nextflowDownloadFileDescription = this.launchService.getNextflowDownload(basePath, versionName);
     this.updateWgetTestJsonString(workflowPath, versionName, descriptorType);
+    this.wesLaunchCommand = this.launchService.getWesLaunch(workflowPath, versionName);
+    this.wesWrapperJson = this.launchService.getAgcFileWrapper();
   }
 
   /**

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -24,6 +24,7 @@ import { GA4GHFilesService } from '../../shared/ga4gh-files/ga4gh-files.service'
 import { WorkflowQuery } from '../../shared/state/workflow.query';
 import { ToolDescriptor, ToolFile } from '../../shared/swagger';
 import { DockstoreTool } from '../../shared/swagger/model/dockstoreTool';
+import { Dockstore } from '../../shared/dockstore.model';
 import { Workflow } from '../../shared/swagger/model/workflow';
 import { WorkflowVersion } from '../../shared/swagger/model/workflowVersion';
 import { WorkflowLaunchService } from '../launch/workflow-launch.service';
@@ -44,6 +45,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   @Input() selectedVersion: WorkflowVersion;
   @Input() entryType: EntryType;
 
+  Dockstore = Dockstore;
   DockstoreToolType = DockstoreTool;
   WorkflowType = Workflow;
   params: string;

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -24,6 +24,9 @@ import { EntryType } from '../../shared/enum/entry-type';
 @Injectable()
 export class WorkflowLaunchService extends LaunchService {
   private type = 'workflow';
+  private wesInputFile = 'Dockstore.json';
+  private agcWrapperFile = 'agcWrapper.json';
+
   constructor(protected descriptorTypeCompatService: DescriptorTypeCompatService) {
     super(descriptorTypeCompatService);
   }
@@ -63,5 +66,13 @@ export class WorkflowLaunchService extends LaunchService {
 
   getCheckWorkflowString(path: string, versionName: string): string {
     return this.getCheckEntry(path, versionName);
+  }
+
+  getWesLaunch(workflowPath: string, versionName: string) {
+    return `dockstore workflow wes launch --entry ${workflowPath}:${versionName} --json ${this.agcWrapperFile} -a ${this.wesInputFile}`;
+  }
+
+  getAgcFileWrapper() {
+    return `echo '{\"workflowInputs\": \"${this.wesInputFile}\"}' > ${this.agcWrapperFile}`;
   }
 }


### PR DESCRIPTION
**Description**
Targeting release branch to go along with the CLI WES changes.

This PR adds launch tab instructions to WDL workflows, which looks like:
<img width="962" alt="Screen Shot 2022-03-08 at 4 14 08 PM" src="https://user-images.githubusercontent.com/36607471/157326026-267077b1-845c-496f-8501-550feac8422f.png">

The tab also links out to the AGC quick start guide and Dockstore documentation. 

TODO somewhere down the line:
1. Once the AGC documentation has been released, the link should be updated to the exact docs page.
2. Once AGC changes the need for `agcWrapper.json`, that section should be removed.

I also created a followup ticket that would cover an advanced launch tab for AGC WES, if we decide to go down that route: https://github.com/dockstore/dockstore/issues/4776

**Issue**
[A link to a github issue or SEAB- ticket (using that as a prefix)](https://ucsc-cgl.atlassian.net/browse/DOCK-1936)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that your code compiles by running `npm run build`
- [X] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [X] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [X] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [X] Do not use cookies, although this may change in the future
- [X] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [X] Do due diligence on new 3rd party libraries, checking for CVEs
- [X] Don't allow user-uploaded images to be served from the Dockstore domain
