### PR TITLE
Feature/seab 4040/fix starred page for apptools

### DIFF
--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -66,8 +66,8 @@
         <mat-card fxFlex *ngFor="let tool of starredTools; let last = last" class="m-1 mat-elevation-z4 pb-3">
           <ng-container
             *ngTemplateOutlet="
-              tool.mode == 'DOCKSTORE_YML' ? workflowSummary : toolSummary;
-              context: tool.mode == 'DOCKSTORE_YML' ? { workflow: tool, isAppTool: true } : { tool: tool }
+              tool.mode === 'DOCKSTORE_YML' ? workflowSummary : toolSummary;
+              context: tool.mode === 'DOCKSTORE_YML' ? { workflow: tool, isAppTool: true } : { tool: tool }
             "
           ></ng-container>
         </mat-card>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -44,7 +44,7 @@
     </mat-card>
     <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
       <mat-card fxFlex *ngFor="let workflow of starredWorkflows; let last = last" class="mat-elevation-z4 pb-3">
-        <ng-container *ngTemplateOutlet="workflowSummary; context: { workflow: workflow }"></ng-container>
+        <ng-container *ngTemplateOutlet="workflowSummary; context: { workflow: workflow, isAppTool: false }"></ng-container>
       </mat-card>
     </div>
   </mat-tab>
@@ -64,18 +64,26 @@
       </mat-card>
       <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
         <mat-card fxFlex *ngFor="let tool of starredTools; let last = last" class="m-1 mat-elevation-z4 pb-3">
-          <ng-container *ngTemplateOutlet="toolSummary; context: { tool: tool }"></ng-container>
+          <ng-container
+            *ngTemplateOutlet="
+              tool.mode == 'DOCKSTORE_YML' ? workflowSummary : toolSummary;
+              context: tool.mode == 'DOCKSTORE_YML' ? { workflow: tool, isAppTool: true } : { tool: tool }
+            "
+          ></ng-container>
         </mat-card>
       </div>
     </div>
   </mat-tab>
 
-  <ng-template #workflowSummary let-workflow="workflow">
+  <ng-template #workflowSummary let-workflow="workflow" let-isAppTool="isAppTool">
     <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
-      <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
+      <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
         <mat-card-header>
           <mat-card-title fxLayoutAlign="space-between" fxLayoutGap="1rem">
-            <img src="../../../assets/svg/sub-nav/workflow.svg" alt="workflow logo" />
+            <img
+              src="../../../assets/svg/sub-nav/{{ isAppTool ? 'tool' : 'workflow' }}.svg"
+              alt="{{ isAppTool ? 'tool' : 'workflow' }} logo"
+            />
             <h4>
               {{ workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}
             </h4>
@@ -162,6 +170,7 @@
       </div>
     </div>
   </ng-template>
+
   <!-- Services not done -->
   <mat-tab *ngIf="starredServices">
     <ng-template mat-tab-label>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -126,7 +126,7 @@
             </span>
           </div>
         </div>
-        <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
+        <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
           <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
         </a>
       </div>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -44,58 +44,7 @@
     </mat-card>
     <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
       <mat-card fxFlex *ngFor="let workflow of starredWorkflows; let last = last" class="mat-elevation-z4 pb-3">
-        <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
-          <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
-            <mat-card-header>
-              <mat-card-title fxLayoutAlign="space-between" fxLayoutGap="1rem">
-                <img src="../../../assets/svg/sub-nav/workflow.svg" alt="workflow logo" />
-                <h4>
-                  {{ workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}
-                </h4>
-              </mat-card-title>
-            </mat-card-header>
-          </a>
-          <app-starring class="pull-right" [workflow]="workflow" (starGazersChange)="starGazersChange()"></app-starring>
-        </div>
-        <mat-card-header>
-          <div *ngIf="workflow?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center"></div>
-          <mat-card-subtitle class="truncate-text-1">{{ workflow?.description }}</mat-card-subtitle>
-        </mat-card-header>
-        <div>
-          <hr />
-          <div fxLayout="row" fxLayoutAlign="space-between stretch">
-            <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-              <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
-              <div fxLayout="row wrap" fxLayoutGap="1rem">
-                <span>
-                  <mat-chip-list>
-                    <mat-chip class="bubble workflow-background" *ngFor="let label of workflow?.labels | slice: 0:3">{{
-                      label.value
-                    }}</mat-chip>
-                    <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
-                      <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
-                        <mat-icon class="verified-icon">done</mat-icon>
-                        <span>Verified</span>
-                      </span>
-                    </mat-chip>
-                    <mat-chip class="bubble">
-                      {{ workflow?.descriptorType | uppercase }}
-                    </mat-chip>
-                    <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
-                      <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
-                        <mat-icon class="verified-icon">done</mat-icon>
-                        <span>Verified</span>
-                      </span>
-                    </mat-chip>
-                  </mat-chip-list>
-                </span>
-              </div>
-            </div>
-            <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
-              <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
-            </a>
-          </div>
-        </div>
+        <ng-container *ngTemplateOutlet="workflowSummary; context: { workflow: workflow }"></ng-container>
       </mat-card>
     </div>
   </mat-tab>
@@ -115,46 +64,104 @@
       </mat-card>
       <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
         <mat-card fxFlex *ngFor="let tool of starredTools; let last = last" class="m-1 mat-elevation-z4 pb-3">
-          <div fxLayout="row" fxLayoutAlign="space-between">
-            <a routerLink="/containers/{{ tool.tool_path }}" class="no-underline">
-              <mat-card-header>
-                <mat-card-title fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-                  <img src="../../../assets/svg/sub-nav/tool.svg" alt="tool logo" />
-                  <h4>{{ tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '') }}</h4>
-                </mat-card-title>
-                <div *ngIf="tool?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center"></div>
-              </mat-card-header>
-            </a>
-            <app-starring class="pull-right" [tool]="tool" (starGazersChange)="starGazersChange()"></app-starring>
-          </div>
-          <div>
-            <hr />
-            <div fxLayout="row" fxLayoutAlign="space-between stretch">
-              <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-                <small class="spacing">Last updated {{ tool?.lastUpdated | date }}</small>
-                <mat-chip-list>
-                  <mat-chip class="bubble container-background" *ngFor="let label of tool?.labels | slice: 0:3">{{ label.value }}</mat-chip>
-                  <mat-chip *ngIf="tool?.versionVerified" matTooltip="Verified" class="bubble">
-                    <a class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
-                      <mat-icon class="verified-icon">done</mat-icon>
-                      <span>Verified</span>
-                    </a>
-                  </mat-chip>
-                  <mat-chip class="bubble" *ngFor="let descriptortype of tool?.descriptorType">
-                    {{ descriptortype }}
-                  </mat-chip>
-                </mat-chip-list>
-              </div>
-              <a routerLink="/containers/{{ tool.tool_path }}" class="no-underline">
-                <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
-              </a>
-            </div>
-          </div>
+          <ng-container *ngTemplateOutlet="toolSummary; context: { tool: tool }"></ng-container>
         </mat-card>
       </div>
     </div>
   </mat-tab>
 
+  <ng-template #workflowSummary let-workflow="workflow">
+    <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
+      <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
+        <mat-card-header>
+          <mat-card-title fxLayoutAlign="space-between" fxLayoutGap="1rem">
+            <img src="../../../assets/svg/sub-nav/workflow.svg" alt="workflow logo" />
+            <h4>
+              {{ workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '') }}
+            </h4>
+          </mat-card-title>
+        </mat-card-header>
+      </a>
+      <app-starring class="pull-right" [workflow]="workflow" (starGazersChange)="starGazersChange()"></app-starring>
+    </div>
+    <mat-card-header>
+      <div *ngIf="workflow?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center"></div>
+      <mat-card-subtitle class="truncate-text-1">{{ workflow?.description }}</mat-card-subtitle>
+    </mat-card-header>
+    <div>
+      <hr />
+      <div fxLayout="row" fxLayoutAlign="space-between stretch">
+        <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
+          <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
+          <div fxLayout="row wrap" fxLayoutGap="1rem">
+            <span>
+              <mat-chip-list>
+                <mat-chip class="bubble workflow-background" *ngFor="let label of workflow?.labels | slice: 0:3">{{
+                  label.value
+                }}</mat-chip>
+                <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
+                  <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
+                    <mat-icon class="verified-icon">done</mat-icon>
+                    <span>Verified</span>
+                  </span>
+                </mat-chip>
+                <mat-chip class="bubble">
+                  {{ workflow?.descriptorType | uppercase }}
+                </mat-chip>
+                <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
+                  <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
+                    <mat-icon class="verified-icon">done</mat-icon>
+                    <span>Verified</span>
+                  </span>
+                </mat-chip>
+              </mat-chip-list>
+            </span>
+          </div>
+        </div>
+        <a routerLink="/workflows/{{ workflow.full_workflow_path }}" class="no-underline">
+          <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
+        </a>
+      </div>
+    </div>
+  </ng-template>
+
+  <ng-template #toolSummary let-tool="tool">
+    <div fxLayout="row" fxLayoutAlign="space-between">
+      <a routerLink="/containers/{{ tool.tool_path }}" class="no-underline">
+        <mat-card-header>
+          <mat-card-title fxLayoutAlign="flex-start" fxLayoutGap="1rem">
+            <img src="../../../assets/svg/sub-nav/tool.svg" alt="tool logo" />
+            <h4>{{ tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '') }}</h4>
+          </mat-card-title>
+          <div *ngIf="tool?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center"></div>
+        </mat-card-header>
+      </a>
+      <app-starring class="pull-right" [tool]="tool" (starGazersChange)="starGazersChange()"></app-starring>
+    </div>
+    <div>
+      <hr />
+      <div fxLayout="row" fxLayoutAlign="space-between stretch">
+        <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
+          <small class="spacing">Last updated {{ tool?.lastUpdated | date }}</small>
+          <mat-chip-list>
+            <mat-chip class="bubble container-background" *ngFor="let label of tool?.labels | slice: 0:3">{{ label.value }}</mat-chip>
+            <mat-chip *ngIf="tool?.versionVerified" matTooltip="Verified" class="bubble">
+              <a class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
+                <mat-icon class="verified-icon">done</mat-icon>
+                <span>Verified</span>
+              </a>
+            </mat-chip>
+            <mat-chip class="bubble" *ngFor="let descriptortype of tool?.descriptorType">
+              {{ descriptortype }}
+            </mat-chip>
+          </mat-chip-list>
+        </div>
+        <a routerLink="/containers/{{ tool.tool_path }}" class="no-underline">
+          <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
+        </a>
+      </div>
+    </div>
+  </ng-template>
   <!-- Services not done -->
   <mat-tab *ngIf="starredServices">
     <ng-template mat-tab-label>


### PR DESCRIPTION
**Description**
This PR adapts the starred tools tab to properly handle apptools.  Before this PR, any apptools returned by the `getStarredTools` endpoint were misformatted (see "Before PR" screenshot below).  The basic concept here is that the apptool summary boxes are rendered with an adapted version of the workflow summary box rendering code.  Please check the workflow template to make sure I found all of the stuff that needs to be rendered conditionally.

The entryType is not included with each tool returned by `getStarredTools`, so I use `mode == 'DOCKSTORE_YML'` to differentiate apptools from normal tools, which Denis advises is correct.

The diffs look big, but most of the action is moving the tool and workflow rendering code into templates.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4040

**Screenshots**
In these screenshots, a normal tool is at top, and an apptool is at bottom.  The width of the browser differs between the two screenshots, thus the change in font/element sizes.

Before PR:
<img width="775" alt="Screen Shot 2022-03-09 at 8 53 55 AM" src="https://user-images.githubusercontent.com/88108675/157509450-4fb876c6-b5b1-46f2-8cf4-635d6f54cde6.png">

After PR:
<img width="990" alt="Screen Shot 2022-03-09 at 10 41 11 AM" src="https://user-images.githubusercontent.com/88108675/157509466-c0c9af27-33df-462b-870c-2a252d6f980d.png">

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
