### PR TITLE
recent activity update for apptools and publishing/unpublishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "config": {
     "webservice_version": "1.12.0-beta.1",
     "use_circle": false,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7166/workflows/ac6076c8-4a3d-4e19-910a-ccba74a9cb00/jobs/16822/artifacts",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7319/workflows/5886a587-6120-40cf-81ed-43fdce821dc8/jobs/17639/artifacts",
     "circle_build_id": "16822",
     "base_branch": "release/2.9"
   },

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -13,10 +13,19 @@
         <div [ngSwitch]="event?.type">
           <div *ngSwitchCase="EventType.ADDVERSIONTOENTRY">
             <strong>{{ event.initiatorUser?.username }} </strong> created the {{ event.version?.referenceType | lowercase }}
-            <strong>{{ event.version?.name }}</strong> in {{ event?.tool ? 'tool' : 'workflow' }}
-            <a [routerLink]="event?.tool ? '/tools/' + event?.tool.tool_path : '/workflows/' + event?.workflow.full_workflow_path">{{
-              (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName)
-            }}</a>
+            <strong>{{ event.version?.name }}</strong> in {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+            <a
+              [routerLink]="
+                event?.apptool
+                  ? '/tools/' + event?.apptool.full_workflow_path
+                  : event?.tool
+                  ? '/tools/' + event?.tool.tool_path
+                  : '/workflows/' + event?.workflow.full_workflow_path
+              "
+              >{{
+                (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+              }}</a
+            >
             <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
             <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
           </div>
@@ -31,16 +40,59 @@
             <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
           </div>
           <div *ngSwitchCase="EventType.ADDTOCOLLECTION">
-            <strong>{{ event.initiatorUser.username }} </strong> added the {{ event?.tool ? 'tool' : 'workflow' }}
-            <a [routerLink]="event?.tool ? '/tools/' + event?.tool.tool_path : '/workflows/' + event?.workflow.full_workflow_path">{{
-              (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName)
-            }}</a>
+            <strong>{{ event.initiatorUser.username }} </strong> added the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+            <a
+              [routerLink]="
+                event?.apptool
+                  ? '/tools/' + event?.apptool.full_workflow_path
+                  : event?.tool
+                  ? '/tools/' + event?.tool.tool_path
+                  : '/workflows/' + event?.workflow.full_workflow_path
+              "
+              >{{
+                (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+              }}</a
+            >
             to the collection
             <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
               >{{ event.collection?.name }}
             </a>
             in organization
             <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
+            <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+            <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
+          </div>
+          <div *ngSwitchCase="EventType.PUBLISHENTRY">
+            <strong>{{ event.user.username }} </strong> published the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+            <a
+              [routerLink]="
+                event?.apptool
+                  ? '/tools/' + event?.apptool.full_workflow_path
+                  : event?.tool
+                  ? '/tools/' + event?.tool.tool_path
+                  : '/workflows/' + event?.workflow.full_workflow_path
+              "
+              >{{
+                (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+              }}</a
+            >
+            <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+            <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
+          </div>
+          <div *ngSwitchCase="EventType.UNPUBLISHENTRY">
+            <strong>{{ event.user.username }} </strong> unpublished the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+            <a
+              [routerLink]="
+                event?.apptool
+                  ? '/tools/' + event?.apptool.full_workflow_path
+                  : event?.tool
+                  ? '/tools/' + event?.tool.tool_path
+                  : '/workflows/' + event?.workflow.full_workflow_path
+              "
+              >{{
+                (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+              }}</a
+            >
             <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
             <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
           </div>

--- a/src/app/home-page/recent-events/recent-events.component.ts
+++ b/src/app/home-page/recent-events/recent-events.component.ts
@@ -24,7 +24,13 @@ export class RecentEventsComponent implements OnInit {
   noEvents$: Observable<boolean>;
   readonly starringDocUrl = `${Dockstore.DOCUMENTATION_URL}/end-user-topics/starring.html#starring-tools-and-workflows`;
   homepage = true;
-  readonly supportedEventTypes = [Event.TypeEnum.ADDVERSIONTOENTRY, Event.TypeEnum.CREATECOLLECTION, Event.TypeEnum.ADDTOCOLLECTION];
+  readonly supportedEventTypes = [
+    Event.TypeEnum.ADDVERSIONTOENTRY,
+    Event.TypeEnum.CREATECOLLECTION,
+    Event.TypeEnum.ADDTOCOLLECTION,
+    Event.TypeEnum.PUBLISHENTRY,
+    Event.TypeEnum.UNPUBLISHENTRY,
+  ];
   constructor(private recentEventsQuery: RecentEventsQuery, private recentEventsService: RecentEventsService) {}
 
   ngOnInit() {


### PR DESCRIPTION
**Description**
Adds UI support for github app tools (pretty ugly though) 
Also publishing and unpublishing events because I got confused as to why they weren't showing up

Blocks on https://github.com/dockstore/dockstore/pull/4778

![Screenshot from 2022-03-09 15-17-51](https://user-images.githubusercontent.com/1730679/157533696-6da3019a-5903-4007-bd46-b92dcb79b2b2.png)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4041
https://ucsc-cgl.atlassian.net/browse/SEAB-3787


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
