### PR TITLE
Smoke tests structure for staging and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,10 +410,13 @@ workflows:
           stack: "staging"
           context:
             - dockerhub
-      - uptime_monitor_auth:
-          stack: "prod"
-          context:
-            - dockerhub
+
+# TODO: wait until 1.12 release
+#      - uptime_monitor_auth:
+#          stack: "prod"
+#          context:
+#            - dockerhub
+
 commands:
   install_container_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,12 +401,19 @@ workflows:
 #          stack: "prod"
 #          context:
 #            - dockerhub
-      # TODO: Add auth tests for staging/prod once https://ucsc-cgl.atlassian.net/browse/SEAB-2071 is done.
+
       - uptime_monitor_auth:
           stack: "dev"
           context:
             - dockerhub
-
+      - uptime_monitor_auth:
+          stack: "staging"
+          context:
+            - dockerhub
+      - uptime_monitor_auth:
+          stack: "prod"
+          context:
+            - dockerhub
 commands:
   install_container_dependencies:
     steps:

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -6,7 +6,7 @@ import { goToTab } from '../../../support/commands';
  *    2. DockstoreTestUser4 registered on dev.dockstore.net with github and quay accounts linked (at minimum)
  *        -- must have the entries on their github and quay accounts (dockstore-tool-md5sum and hello-dockstore-workflow)
  *    3. Dockstore token for DockstoreTestUser4 must be passed to cypress using the TOKEN environment variable
- *    4. The 'testtest' dockstore organization must exist with 'testcollection' Collection and DockstoreTestUser4 as member
+ *    4. The 'DockstoreAuthTestOrg' dockstore organization must exist with 'SimpleCollection' Collection and DockstoreTestUser4 as member
  *    5. Tests will either fail or be flaky if artifacts are left behind from a failed run (ie tool not deleted or workflow unpublished)
  *        -- if tests keep failing double check that these were removed
  */
@@ -18,7 +18,7 @@ const toolName = 'dockstore-tool-md5sum';
 const toolTuple = ['github.com', username, toolName];
 const workflowTuple = ['github.com', username, 'hello-dockstore-workflow'];
 // tuple of organization name, collection name
-const collectionTuple = ['test', 'testcollection'];
+const collectionTuple = ['DockstoreAuthTestOrg', 'SimpleCollection'];
 const hardcodedWaitTime = 8000;
 
 // get the dockstore token from env variable and put it in local storage

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -5,7 +5,9 @@ import { goToTab } from '../../../support/commands';
  *    1. Base url for cypress must be set to dev.dockstore.net (or if local make sure user is in local database)
  *    2. DockstoreTestUser4 registered on dev.dockstore.net with github and quay accounts linked (at minimum)
  *        -- must have the entries on their github and quay accounts (dockstore-tool-md5sum and hello-dockstore-workflow)
- *    3. Dockstore token for DockstoreTestUser4 must be passed to cypress using the TOKEN environment variable
+ *    3. Dockstore token for DockstoreTestUser4 must be passed to cypress using the TOKEN environment variable. The token environment variable should
+ *    match the target Dockstore stage. DEV_TOKEN, STAGING_TOKEN, and PROD_TOKEN for the respective stages. Cypress env variables must be
+ *    prepended with 'CYPRESS_', so to set the token for dev, you would make an environment variable named CYPRESS_DEV_TOKEN.
  *    4. The 'DockstoreAuthTestOrg' dockstore organization must exist with 'SimpleCollection' Collection and DockstoreTestUser4 as member
  *    5. Tests will either fail or be flaky if artifacts are left behind from a failed run (ie tool not deleted or workflow unpublished)
  *        -- if tests keep failing double check that these were removed
@@ -23,7 +25,13 @@ const hardcodedWaitTime = 8000;
 
 // get the dockstore token from env variable and put it in local storage
 function storeToken() {
-  window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('TOKEN'));
+  if (Cypress.config('baseUrl') === 'https://dockstore.org') {
+    window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('PROD_TOKEN'));
+  } else if (Cypress.config('baseUrl') === 'https://staging.dockstore.org') {
+    window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('STAGING_TOKEN'));
+  } else {
+    window.localStorage.setItem('ng2-ui-auth_token', Cypress.env('DEV_TOKEN'));
+  }
 }
 
 function unpublishTool() {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.11.12",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7141/workflows/85f15db7-5bf9-4cb2-b8d8-983e42a1cd0e/jobs/16688/artifacts",
-    "circle_build_id": "16688",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7226/workflows/eff33fbe-2763-48d7-8399-abf528a655d4/jobs/17137/artifacts",
+    "circle_build_id": "17137",
     "base_branch": "develop"
   },
   "scripts": {

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o xtrace
 if [ "$npm_package_config_use_circle" = true ]
 then
-	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.12.0-beta.1-SNAPSHOT.jar"
+	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.13.0-alpha.0-SNAPSHOT.jar"
 else
 	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 fi


### PR DESCRIPTION
**Description**
This PR introduces staging tests to the nightly CI job. The current auth smoke tests do not function against prod, but do against dev and staging. After the release is complete, the smoke tests should work everywhere, and the prod tests can be turned on.

Working dev auth tests: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/7371/workflows/dd3967ca-4b86-40f0-9dff-d039f13ef6e6/jobs/25898
Working staging auth tests: https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/7371/workflows/dd3967ca-4b86-40f0-9dff-d039f13ef6e6/jobs/25897

Setup process (doesn't need to be repeated, just documenting):
1. The user `DockstoreTestUser4` was added to each stage manually.
2. Registered this workflow: https://github.com/DockstoreTestUser4/hello-dockstore-workflow
3. Linked quay accounts
4. Created an organization named `DockstoreAuthTestOrg` with empty collection `SimpleCollection`. This organization doesn't need to be approved, but still must be accessible by `DockstoreTestUser4`.

Created 3 CircleCI env variables to house the Dockstore tokens, these are accessed during the auth tests:
1. `CYPRESS_DEV_TOKEN`
2. `CYPRESS_STAGING_TOKEN`
3. `CYPRESS_PROD_TOKEN`

This PR also means that we can replace the dev database with a newer version from prod without breaking the auth tests (from a data standpoint, if the user tokens change then the tests will break).

Added a note a ticket for updating staging nightly with a censored copy of the prod DB to also account for tokens: https://github.com/dockstore/dockstore/issues/3982

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-1871

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that your code compiles by running `npm run build`
- [X] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [X] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [X] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [X] Do not use cookies, although this may change in the future
- [X] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [X] Do due diligence on new 3rd party libraries, checking for CVEs
- [X] Don't allow user-uploaded images to be served from the Dockstore domain
