### PR TITLE
My Sidebar for Homepage - Fixed Small Window Layout

### DIFF
--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -14,63 +14,72 @@
   ~    limitations under the License.
   -->
 
-<div id="column-holder" fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="start start" fxLayoutGap="10px">
+<div fxLayout>
   <app-my-sidebar fxFlexAlign="stretch"></app-my-sidebar>
 
-  <div
-    fxLayout="column"
-    fxLayoutAlign="start start"
-    fxLayoutGap="20px"
-    fxFlex="1 2 100%"
-    class="px-4 side-column left-side-column"
-    fxFlexAlign="stretch"
-  >
-    <app-entries *ngIf="user$ | async" class="w-100"></app-entries>
-    <app-organizations *ngIf="user$ | async" class="w-100"></app-organizations>
-  </div>
-
-  <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutAlign="start start" fxLayoutGap="10px" class="w-100" fxFlex="1 1 100%">
-    <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="20px" class="px-4 w-100" fxFlex="1 1 100%" fxFlexAlign="stretch">
-      <div class="widget-section">
-        <h3>News and Updates</h3>
-        <div class="news-container">
-          <app-news-updates data-cy="news-updates-container"></app-news-updates>
-        </div>
-        <app-alert></app-alert>
-        <app-featured-news></app-featured-news>
-      </div>
-      <div class="widget-section">
-        <h3>Explore Featured Content</h3>
-        <app-alert></app-alert>
-        <app-featured-content></app-featured-content>
-      </div>
-      <div class="widget-section">
-        <h3>Recent Activity</h3>
-        <div class="m-auto mw-macbook-13">
-          <app-recent-events></app-recent-events>
-        </div>
-      </div>
+  <div id="column-holder" fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="start start" fxLayoutGap="10px">
+    <div
+      fxLayout="column"
+      fxLayoutAlign="start start"
+      fxLayoutGap="20px"
+      fxFlex="1 2 100%"
+      class="px-4 side-column left-side-column"
+      fxFlexAlign="stretch"
+    >
+      <app-entries *ngIf="user$ | async" class="w-100"></app-entries>
+      <app-organizations *ngIf="user$ | async" class="w-100"></app-organizations>
     </div>
-    <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="20px" fxFlex="1 2 100%" class="px-4 side-column" fxFlexAlign="stretch">
-      <app-requests *ngIf="user$ | async" class="w-100"></app-requests>
-      <div class="w-100">
-        <h3>Links</h3>
-        <ul>
-          <li><a routerLink="quick-start">Quickstart</a></li>
-          <li><a routerLink="accounts">My Account</a></li>
-          <li><a routerLink="starred">My Starred</a></li>
-          <li>
-            <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer">Forum <mat-icon>open_in_new</mat-icon></a>
-          </li>
-          <li>
-            <a href="https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506" target="_blank" rel="noopener noreferrer"
-              >Help Desk <mat-icon>open_in_new</mat-icon></a
-            >
-          </li>
-        </ul>
+
+    <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutAlign="start start" fxLayoutGap="10px" class="w-100" fxFlex="1 1 100%">
+      <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="20px" class="px-4 w-100" fxFlex="1 1 100%" fxFlexAlign="stretch">
+        <div class="widget-section">
+          <h3>News and Updates</h3>
+          <div class="news-container">
+            <app-news-updates data-cy="news-updates-container"></app-news-updates>
+          </div>
+          <app-alert></app-alert>
+          <app-featured-news></app-featured-news>
+        </div>
+        <div class="widget-section">
+          <h3>Explore Featured Content</h3>
+          <app-alert></app-alert>
+          <app-featured-content></app-featured-content>
+        </div>
+        <div class="widget-section">
+          <h3>Recent Activity</h3>
+          <div class="m-auto mw-macbook-13">
+            <app-recent-events></app-recent-events>
+          </div>
+        </div>
       </div>
-      <div class="w-100">
-        <div class="my-3 twitter" #twitter></div>
+      <div
+        fxLayout="column"
+        fxLayoutAlign="start start"
+        fxLayoutGap="20px"
+        fxFlex="1 2 100%"
+        class="px-4 side-column"
+        fxFlexAlign="stretch"
+      >
+        <app-requests *ngIf="user$ | async" class="w-100"></app-requests>
+        <div class="w-100">
+          <h3>Links</h3>
+          <ul>
+            <li><a routerLink="quick-start">Quickstart</a></li>
+            <li><a routerLink="accounts">My Account</a></li>
+            <li><a routerLink="starred">My Starred</a></li>
+            <li>
+              <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer">Forum <mat-icon>open_in_new</mat-icon></a>
+            </li>
+            <li>
+              <a href="https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506" target="_blank" rel="noopener noreferrer"
+                >Help Desk <mat-icon>open_in_new</mat-icon></a
+              >
+            </li>
+          </ul>
+        </div>
+        <div class="w-100">
+          <div class="my-3 twitter" #twitter></div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/home-page/home-logged-in/home-logged-in.component.scss
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.scss
@@ -14,6 +14,7 @@ mat-sidenav-container {
 
 .left-side-column {
   background-color: #f6f8fa;
+  z-index: 1;
 }
 
 @media screen and (min-width: 992px) {
@@ -40,11 +41,7 @@ ul {
   border-top: 0.1rem solid #e0e1e2;
 }
 
-// Let sidebar shadow fall on top of side-column
+// Let sidebar shadow fall on top of left-side-column
 app-my-sidebar {
   z-index: 2;
-}
-
-.left-side-column {
-  z-index: 1;
 }

--- a/src/app/home-page/home-logged-in/home-logged-in.component.scss
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.scss
@@ -40,7 +40,11 @@ ul {
   border-top: 0.1rem solid #e0e1e2;
 }
 
-// Remove 10px layout gap between sidenav and side column
-.side-column {
-  margin-left: -10px;
+// Let sidebar shadow fall on top of side-column
+app-my-sidebar {
+  z-index: 2;
+}
+
+.left-side-column {
+  z-index: 1;
 }


### PR DESCRIPTION
**Description**
So I added the my sidebar to the home/dashboard page as a final change on Friday and didn't to check for resizing… forgot to enclose all of the components into a new “row” `fxLayout` div. Went and updated that. Also added z-indexes so that the sidebar shadow can fall on top of the component next to it.

![image](https://user-images.githubusercontent.com/97123241/158180477-fc0044b7-d881-4215-9c24-859b284392eb.png)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
