### PR TITLE
Feature/seab 4047/published app tools

### DIFF
--- a/cypress/integration/group2/githubAppTools.ts
+++ b/cypress/integration/group2/githubAppTools.ts
@@ -164,7 +164,7 @@ describe('GitHub App Tools', () => {
       cy.visit('/apptools');
       cy.url().should('contain', 'apptools');
       cy.contains('Search app tools');
-      cy.get('[data-cy=entry-link]').should('contain', 'A/l');
+      cy.get('[data-cy=entry-link]').should('contain', 'test-github-app-tools');
     });
   });
 });

--- a/cypress/integration/group2/githubAppTools.ts
+++ b/cypress/integration/group2/githubAppTools.ts
@@ -1,5 +1,5 @@
-import { goToTab, insertAppTools, isActiveTab, resetDB, setTokenUserViewPort, typeInInput } from '../../support/commands';
 import { LambdaEvent } from '../../../src/app/shared/swagger';
+import { goToTab, insertAppTools, isActiveTab, resetDB, setTokenUserViewPort } from '../../support/commands';
 
 describe('GitHub App Tools', () => {
   resetDB();
@@ -158,6 +158,13 @@ describe('GitHub App Tools', () => {
       cy.get('#starCountButton').should('contain', '1');
       goToTab('Info');
       cy.get('[data-cy=trs-link]').contains('TRS: github.com/C/test-github-app-tools/md5sum');
+    });
+
+    it('Table view', () => {
+      cy.visit('/apptools');
+      cy.url().should('contain', 'apptools');
+      cy.contains('Search app tools');
+      cy.get('[data-cy=entry-link]').should('contain', 'A/l');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.12.0-beta.1",
-    "use_circle": true,
+    "webservice_version": "feature/seab-4047/publishedAppTools",
+    "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7331/workflows/56ee2021-675a-460f-ae3e-663f456fc27c/jobs/17708/artifacts",
     "circle_build_id": "17708",
     "base_branch": "release/2.9"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "feature/seab-4047/publishedAppTools",
+    "webservice_version": "1.12.0-beta.2",
     "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7331/workflows/56ee2021-675a-460f-ae3e-663f456fc27c/jobs/17708/artifacts",
     "circle_build_id": "17708",

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -67,6 +67,11 @@ const APP_ROUTES: Routes = [
     data: { title: 'Dockstore | Services' },
   },
   {
+    path: 'apptools',
+    loadChildren: () => import('app/workflows/apptools/apptools.module').then((m) => m.AppToolsModule),
+    data: { title: 'Dockstore | App Tools' },
+  },
+  {
     path: 'search-workflows',
     loadChildren: () => import('app/workflows/workflows.module').then((m) => m.WorkflowsModule),
     data: { title: 'Dockstore | Workflows' },

--- a/src/app/entry/router-link.pipe.spec.ts
+++ b/src/app/entry/router-link.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { EntryType } from '../shared/enum/entry-type';
+import { sampleWorkflow1 } from '../test/openapi-mocked-objects';
+import { RouterLinkPipe } from './router-link.pipe';
+
+describe('RouterLinkPipe', () => {
+  it('create an instance', () => {
+    const pipe = new RouterLinkPipe();
+    expect(pipe).toBeTruthy();
+  });
+  it('generates the right router links', () => {
+    const pipe = new RouterLinkPipe();
+    expect(pipe.transform(null, null)).toBeNull();
+    expect(pipe.transform(EntryType.Service, null)).toBeNull();
+    expect(pipe.transform(null, sampleWorkflow1)).toBeNull();
+
+    expect(pipe.transform(EntryType.AppTool, sampleWorkflow1)).toEqual('/containers/github.com/updatedOrganization/updatedWorkflowPath');
+    expect(pipe.transform(EntryType.Service, sampleWorkflow1)).toEqual('/services/github.com/updatedOrganization/updatedWorkflowPath');
+    expect(pipe.transform(EntryType.BioWorkflow, sampleWorkflow1)).toEqual('/workflows/github.com/updatedOrganization/updatedWorkflowPath');
+  });
+});

--- a/src/app/entry/router-link.pipe.ts
+++ b/src/app/entry/router-link.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { EntryType } from '../shared/enum/entry-type';
+import { Workflow } from '../shared/openapi';
+
+@Pipe({
+  name: 'routerLink',
+})
+export class RouterLinkPipe implements PipeTransform {
+  transform(entryType: EntryType, workflow: Workflow): String | null {
+    if (!workflow || !entryType) {
+      return null;
+    }
+    switch (entryType) {
+      case EntryType.BioWorkflow:
+        return '/workflows/' + workflow.full_workflow_path;
+      case EntryType.Service:
+        return '/services/' + workflow.full_workflow_path;
+      case EntryType.AppTool:
+        return '/containers/' + workflow.full_workflow_path;
+    }
+    return null;
+  }
+}

--- a/src/app/shared/modules/list-workflows.module.ts
+++ b/src/app/shared/modules/list-workflows.module.ts
@@ -19,12 +19,13 @@ import { RouterModule } from '@angular/router';
 import { ListWorkflowsComponent } from '../../workflows/list/list.component';
 import { PublishedWorkflowsDataSource } from '../../workflows/list/published-workflows.datasource';
 import { EntryModule } from '../entry/entry.module';
+import { PipeModule } from '../pipe/pipe.module';
 import { HeaderModule } from './header.module';
 import { CustomMaterialModule } from './material.module';
 
 @NgModule({
   declarations: [ListWorkflowsComponent],
-  imports: [CommonModule, RouterModule, HeaderModule, CustomMaterialModule, EntryModule],
+  imports: [CommonModule, RouterModule, HeaderModule, CustomMaterialModule, EntryModule, PipeModule],
   providers: [PublishedWorkflowsDataSource],
   exports: [ListWorkflowsComponent],
 })

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FilePathPipe } from '../../entry/file-path.pipe';
+import { RouterLinkPipe } from '../../entry/router-link.pipe';
 import { GravatarPipe } from '../../gravatar/gravatar.pipe';
 import { TimeAgoMsgPipe } from '../../organizations/organization/time-ago-msg.pipe';
 import { GetFacetSearchUpdatePipe } from '../../search/facet-search/facet-search-update.pipe';
@@ -18,6 +19,7 @@ const DECLARATIONS: any[] = [
   GetFacetSearchResultsPipe,
   GetFacetSearchUpdatePipe,
   GravatarPipe,
+  RouterLinkPipe,
 ];
 @NgModule({
   imports: [CommonModule],

--- a/src/app/shared/session/session.query.ts
+++ b/src/app/shared/session/session.query.ts
@@ -28,7 +28,15 @@ import { SessionState, SessionStore } from './session.store';
 export class SessionQuery extends Query<SessionState> {
   isPublic$: Observable<boolean> = this.select((session) => session.isPublic);
   entryType$: Observable<EntryType> = this.select((session) => session.entryType);
-  entryPageTitle$: Observable<string> = this.entryType$.pipe(map((entryType: EntryType) => entryType + 's'));
+  entryTypeDisplayName$: Observable<string> = this.entryType$.pipe(
+    map((entryType: EntryType) => {
+      if (entryType === EntryType.AppTool) {
+        return 'app tool';
+      }
+      return entryType + ''; // convert to string
+    })
+  );
+  entryPageTitle$: Observable<string> = this.entryTypeDisplayName$.pipe(map((displayName: string) => displayName + 's'));
   myEntryPageTitle$: Observable<string> = this.entryType$.pipe(map((entryType: EntryType) => 'my ' + entryType + 's'));
   isService$: Observable<boolean> = this.entryType$.pipe(map((entryType) => entryType === EntryType.Service));
   gitHubAppInstallationLink$: Observable<string> = this.entryType$.pipe(

--- a/src/app/sitemap/sitemap.component.html
+++ b/src/app/sitemap/sitemap.component.html
@@ -22,6 +22,9 @@
         <div class="beta-label">preview</div>
       </li>
       <li>
+        <a [routerLink]="['/apptools']">App Tools</a>
+      </li>
+      <li>
         <a [routerLink]="['/search']"> Search </a>
       </li>
       <li>

--- a/src/app/test/openapi-mocked-objects.ts
+++ b/src/app/test/openapi-mocked-objects.ts
@@ -1,0 +1,16 @@
+import { Workflow } from '../shared/openapi';
+
+export const sampleWorkflow1: Workflow = {
+  type: 'whatever',
+  id: 1,
+  gitUrl: 'updatedGitUrl',
+  mode: Workflow.ModeEnum.FULL,
+  organization: 'updatedOrganization',
+  repository: 'updatedRepository',
+  workflow_path: 'updatedWorkflowPath',
+  workflowVersions: [],
+  defaultTestParameterFilePath: 'updatedTestParameterPath',
+  sourceControl: 'github.com',
+  source_control_provider: 'GITHUB',
+  full_workflow_path: 'github.com/updatedOrganization/updatedWorkflowPath',
+};

--- a/src/app/workflows/apptools/apptools.module.ts
+++ b/src/app/workflows/apptools/apptools.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { WorkflowsPageModule } from '../../shared/modules/workflowsPage.module';
+import { AppToolsRoutes } from './apptools.routing';
+
+@NgModule({
+  declarations: [],
+  imports: [WorkflowsPageModule, AppToolsRoutes],
+})
+export class AppToolsModule {}

--- a/src/app/workflows/apptools/apptools.routing.ts
+++ b/src/app/workflows/apptools/apptools.routing.ts
@@ -1,0 +1,19 @@
+import { RouterModule, Routes } from '@angular/router';
+import { EntryType } from 'app/shared/enum/entry-type';
+import { WorkflowComponent } from 'app/workflow/workflow.component';
+import { SearchWorkflowsComponent } from '../search/search.component';
+import { WorkflowsComponent } from '../workflows.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: WorkflowsComponent,
+    data: { title: 'Dockstore | App Tool', entryType: EntryType.AppTool },
+    children: [
+      { path: '', component: SearchWorkflowsComponent, data: { title: 'Dockstore | App Tools' } },
+      { path: '**', component: WorkflowComponent, data: { title: 'Dockstore | App Tools' } },
+    ],
+  },
+];
+
+export const AppToolsRoutes = RouterModule.forChild(routes);

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -29,7 +29,7 @@
     <ng-container matColumnDef="repository">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
       <mat-cell *matCellDef="let workflow">
-        <a [routerLink]="'/' + (entryType$ | async) + 's/' + workflow?.full_workflow_path">{{
+        <a [routerLink]="entryType$ | async | routerLink: workflow">{{
           workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
         }}</a>
       </mat-cell>

--- a/src/app/workflows/list/list.component.html
+++ b/src/app/workflows/list/list.component.html
@@ -22,14 +22,14 @@
   </ng-template>
   <div [hidden]="previewMode">
     <mat-form-field>
-      <input matInput placeholder="Search {{ entryType$ | async }}s" #input />
+      <input matInput placeholder="Search {{ entryTypeDisplayName$ | async }}s" #input />
     </mat-form-field>
   </div>
   <mat-table [dataSource]="dataSource" matSort matSortActive="stars" matSortDirection="desc" matSortDisableClear>
     <ng-container matColumnDef="repository">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
       <mat-cell *matCellDef="let workflow">
-        <a [routerLink]="entryType$ | async | routerLink: workflow">{{
+        <a [routerLink]="entryType$ | async | routerLink: workflow" data-cy="entry-link">{{
           workflow?.organization + '/' + workflow?.repository + (workflow?.workflowName ? '/' + workflow?.workflowName : '')
         }}</a>
       </mat-cell>

--- a/src/app/workflows/list/list.component.ts
+++ b/src/app/workflows/list/list.component.ts
@@ -37,6 +37,7 @@ export class ListWorkflowsComponent extends ToolLister implements OnInit {
 
   public displayedColumns = ['repository', 'verified', 'author', 'descriptorType', 'projectLinks', 'stars'];
   public entryType$: Observable<EntryType>;
+  public entryTypeDisplayName$: Observable<string>;
   type: 'tool' | 'workflow' = 'workflow';
   constructor(
     private dockstoreService: DockstoreService,
@@ -53,6 +54,7 @@ export class ListWorkflowsComponent extends ToolLister implements OnInit {
 
   ngOnInit() {
     this.entryType$ = this.sessionQuery.entryType$;
+    this.entryTypeDisplayName$ = this.sessionQuery.entryTypeDisplayName$;
     this.pageSize$ = this.paginatorQuery.workflowPageSize$;
     this.pageIndex$ = this.paginatorQuery.workflowPageIndex$;
     this.dataSource = new PublishedWorkflowsDataSource(this.workflowsService, this.providerService);


### PR DESCRIPTION
**Description**
Add browse view of app tools.

This makes the term "App tool" sort of public, but this is a fallback UI if ES is not working, and it page is not linked to directly on the main Dockstore pages (there is a link to it on the sitemap).

![Screen Shot 2022-03-14 at 3 04 05 PM](https://user-images.githubusercontent.com/1049340/158269088-4620ced2-391f-4234-829e-c45e75b02059.png)

**Issue**
[SEAB-4047](https://ucsc-cgl.atlassian.net/browse/SEAB-4047)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
