### PR TITLE
Feature/dock 2090/support dashes in collection names

### DIFF
--- a/src/app/organizations/collections/create-collection/create-collection.component.html
+++ b/src/app/organizations/collections/create-collection/create-collection.component.html
@@ -26,7 +26,7 @@
             <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
             <mat-error *ngIf="name.hasError('maxlength')">Name should be at most 39 characters long</mat-error>
             <mat-error *ngIf="name.hasError('pattern')"
-              >Name can only contain alphanumeric characters. It must begin with a letter.</mat-error
+              >Name can only contain alphanumeric characters and internal nonconsecutive dashes. It must begin with a letter.</mat-error
             >
             <mat-hint>The name of the collection</mat-hint>
           </mat-form-field>

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -110,7 +110,10 @@ export class CreateCollectionService {
     }
 
     const createOrUpdateCollectionForm = this.builder.group({
-      name: [name, [Validators.required, Validators.maxLength(39), Validators.minLength(3), Validators.pattern(/^[a-zA-Z][a-zA-Z\d]*$/)]],
+      name: [
+        name,
+        [Validators.required, Validators.maxLength(39), Validators.minLength(3), Validators.pattern(/^[a-zA-Z](-?[a-zA-Z\d])*$/)],
+      ],
       displayName: [
         displayName,
         [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(/^[a-zA-Z\d ,_\-&()']*$/)],


### PR DESCRIPTION
**Description**
This PR adds UI support for internal nonconsecutive dashes in collection/category names.  Basically, it's a regexp change and a tweak to the message which describes what's allowed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2090

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
