### PR TITLE
Fix Copy TRS ID

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -147,7 +147,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .subscribe((editing) => (this.defaultTestFilePathEditing = editing));
     this.entryType$
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe((entryType) => (this.displayTextForButton = '#' + entryType + '/' + this.workflow?.full_workflow_path));
+      .subscribe((entryType) => (this.displayTextForButton = this.infoTabService.getTRSId(this.workflow, entryType)));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
     this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
   }

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -10,6 +10,7 @@ import { ExtendedWorkflowQuery } from 'app/shared/state/extended-workflow.query'
 import { WorkflowService } from 'app/shared/state/workflow.service';
 import { WorkflowsService } from 'app/shared/swagger';
 import { WorkflowsStubService, WorkflowStubService } from 'app/test/service-stubs';
+import { sampleWorkflow3 } from '../../test/mocked-objects';
 import { InfoTabService } from './info-tab.service';
 
 describe('ValueService', () => {
@@ -48,5 +49,14 @@ describe('ValueService', () => {
         '/tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FMetaphlan-ISBCGC/versions/master/plain-CWL/descriptor//metaphlan_wfl.cwl'
     );
     // TODO: service test
+  });
+
+  it(`getTRSId should work for tools and workflows`, () => {
+    service = TestBed.inject(InfoTabService);
+    const fullWorkflowPath = sampleWorkflow3.full_workflow_path;
+    expect(service.getTRSId(sampleWorkflow3, EntryType.BioWorkflow)).toBe(`#workflow/${fullWorkflowPath}`);
+    expect(service.getTRSId(sampleWorkflow3, EntryType.AppTool)).toBe(fullWorkflowPath);
+    expect(service.getTRSId(sampleWorkflow3, EntryType.Service)).toBe(`#service/${fullWorkflowPath}`);
+    expect(service.getTRSId(null, EntryType.BioWorkflow)).toBe('');
   });
 });

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -265,13 +265,36 @@ export class InfoTabService {
    * @memberof InfoTabService
    */
   getTRSLink(path: string, versionName: string, descriptorType: string, descriptorPath: string, entryType: EntryType): string {
-    const prefix: string = entryType === EntryType.BioWorkflow ? ga4ghWorkflowIdPrefix : ga4ghServiceIdPrefix;
     return (
-      `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(prefix + path)}` +
+      `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(this.getTRSIDFromPath(path, entryType))}` +
       `/versions/${encodeURIComponent(versionName)}/plain-` +
       descriptorType.toUpperCase() +
       `/descriptor/` +
       descriptorPath
     );
+  }
+
+  getTRSId(workflow: Workflow | undefined, entryType: EntryType): string {
+    if (!workflow) {
+      return '';
+    }
+    return this.getTRSIDFromPath(workflow.full_workflow_path, entryType);
+  }
+
+  private getTRSIDFromPath(fullWorkflowPath: string, entryType: EntryType): string {
+    return this.getTRSPrefix(entryType) + fullWorkflowPath;
+  }
+
+  private getTRSPrefix(entryType: EntryType): string {
+    switch (entryType) {
+      case EntryType.BioWorkflow:
+        return ga4ghWorkflowIdPrefix;
+      case EntryType.Service:
+        return ga4ghServiceIdPrefix;
+      case EntryType.Tool: // This one shouldn't get invoked from this code
+      case EntryType.AppTool:
+      default:
+        return '';
+    }
   }
 }


### PR DESCRIPTION
**Description**
We were appending `tool` to the TRS ID, which we shouldn't.

I could have gone for a simpler fix, but tried to cut down on duplication.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3828

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
