### PR TITLE
Align Organization Members in Columns

### DIFF
--- a/src/app/organizations/events/events.component.scss
+++ b/src/app/organizations/events/events.component.scss
@@ -1,0 +1,3 @@
+mat-chip {
+  border-radius: 0.8rem;
+}

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -14,9 +14,9 @@
    limitations under the License.
 -->
 <app-loading [loading]="loading$ | async">
-  <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">
-    <div *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
-      <mat-card class="m-2 mat-elevation-z2" fxFlex *ngIf="organizationUser?.accepted">
+  <div class="pt-2" fxLayout="row wrap">
+    <div fxFlex="50" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
+      <mat-card fxFlex class="m-2 mat-elevation-z2" *ngIf="organizationUser?.accepted">
         <div fxLayout="row" fxLayoutAlign="space-between stretch">
           <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
             <img *ngIf="organizationUser.user?.avatarUrl" mat-card-avatar class="header-image" [src]="organizationUser.user?.avatarUrl" />
@@ -28,8 +28,8 @@
             />
             <div fxFlex="80" fxLayout="column" fxLayoutAlign="start stretch">
               <div fxLayout="row" fxLayoutAlign="space-between center">
-                <h5>{{ organizationUser.user?.username }}</h5>
-                <span class="role-display">{{ organizationUser.role | titlecase }}</span>
+                <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
+                <span class="bubble ml-3">{{ organizationUser.role | titlecase }}</span>
               </div>
               <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row wrap">
                 <div>

--- a/src/app/organizations/organization-members/organization-members.component.scss
+++ b/src/app/organizations/organization-members/organization-members.component.scss
@@ -1,12 +1,22 @@
+@use '@angular/material' as mat;
 @import '/src/materialColorScheme.scss';
 
 .header-image {
   background-size: cover;
 }
 
+mat-card {
+  padding: 0.7rem 0.9rem;
+}
+
 .mat-card-avatar {
   height: 50px !important;
   width: 50px !important;
+}
+
+// Allow word break/wrapping for long usernames (ex. emails)
+h5 {
+  word-break: break-all;
 }
 
 .orcid {
@@ -18,21 +28,8 @@
   border: 0;
 }
 
-.mat-standard-chip {
-  font-size: 1.1rem;
-  border-radius: 1rem;
-  padding: none;
-}
-
 a {
-  text-decoration: underline;
-}
-
-.role-display {
-  background: #e0e0e0;
-  border-radius: 1rem;
-  padding: 0.5rem 0.7rem;
-  font-size: 1.3rem;
+  color: mat.get-color-from-palette($kim-secondary, 2);
 }
 
 * {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -358,7 +358,7 @@ h4.title.caption {
 }
 
 a {
-  color: #3d7d86;
+  color: mat.get-color-from-palette($kim-secondary, 2);
   text-decoration: underline;
 }
 
@@ -900,7 +900,7 @@ app-sidebar-accordion
 .bubble {
   color: black !important;
   text-decoration: none !important;
-  border-radius: 1rem !important;
+  border-radius: 0.8rem !important;
   font-size: 12px !important;
   line-height: 26px !important;
   min-height: 26px !important;
@@ -908,6 +908,7 @@ app-sidebar-accordion
   padding: 0 0.75rem !important;
   display: inline-block !important;
   min-width: 32px !important;
+  font-weight: 500 !important;
   background: mat.get-color-from-palette($dockstore-app-gray, lighter);
 }
 


### PR DESCRIPTION
**Description**
JIRA: [SEAB-2248](https://ucsc-cgl.atlassian.net/browse/SEAB-2284?atlOrigin=eyJpIjoiYjc1YjNhZDVkMjFhNDQ4OGFjZTZkYTBlODVjYTczMmQiLCJwIjoiaiJ9)

The purpose of this ticket is to update the organization members tab to match the redesign on [Zeplin](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/60073fdcfd3287a25b5169a6), in particular, reformatting the cards into two columns.

**Without Changes:**
![image](https://user-images.githubusercontent.com/97123241/158876524-7331343c-75ed-4922-b006-31181ba91583.png)
**With Changes:**
![image](https://user-images.githubusercontent.com/97123241/158876631-7908c9db-346d-4dcd-b76f-b86849432445.png)
**And a single column when in mobile view:**
![image](https://user-images.githubusercontent.com/97123241/158877160-ca685c24-3bdb-4dcc-8043-4fb1a4f2963b.png)

### Additional changes:

**Wrapping for long usernames and keep bubble in card:**
![image](https://user-images.githubusercontent.com/97123241/158877377-4417bd50-e644-4e29-aed9-c66e8d9c4370.png)

**Small changes to global "bubble" style to match Zeplin:**
* Tighter border radius and font weight change

![image](https://user-images.githubusercontent.com/97123241/158877819-7424a337-594c-4b59-9ff1-3ac1a1fe23e1.png)

**Updated mat-chip on " Organization Updates" to match the bubble style**
* There's no Zeplin page for this tab but I think it makes sense to keep the "bubble" look consistent

![image](https://user-images.githubusercontent.com/97123241/158878178-e908a631-11e6-4125-b211-04e3108f4e9a.png)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
