### PR TITLE
Feature/4163/non auth tests

### DIFF
--- a/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
@@ -4,8 +4,8 @@ import { ToolDescriptor } from '../../../../src/app/shared/swagger/model/toolDes
 
 // Test an entry, these should be ambiguous between tools and workflows.
 describe('run stochastic smoke test', () => {
-  testEntry('Tools');
-  testEntry('Workflows');
+  // testEntry('Tools');
+  // testEntry('Workflows');
 });
 function testEntry(tab: string) {
   beforeEach('get random entry on first page', () => {
@@ -180,6 +180,8 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     cy.visit('/workflows/' + url + ':' + version1);
     goToTab('Launch');
     cy.url().should('contain', '?tab=launch');
+    goToTab('Info');
+    cy.url().should('contain', '?tab=info');
     cy.contains('mat-card-header', 'Workflow Information');
   });
 
@@ -198,17 +200,10 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     cy.contains('Descriptor Files');
     cy.get('.ace_editor').should('be.visible');
     goToTab('Test Parameter Files');
-    if (Cypress.config('baseUrl') === 'https://dev.dockstore.net' || Cypress.config('baseUrl') === 'http://localhost:4200') {
-      if (type === ToolDescriptor.TypeEnum.NFL) {
-        cy.contains('This version has no files of this type.');
-        cy.get('.ace_editor').should('not.be.visible');
-      }
-    } else {
-      if (type === ToolDescriptor.TypeEnum.NFL) {
-        cy.contains('Nextflow does not have the concept of a test parameter file.');
-      } else {
-        cy.get('[data-cy=testParamFiles]');
-      }
+    cy.wait(3000);
+    if (type === ToolDescriptor.TypeEnum.NFL) {
+      cy.contains('This version has no files of this type.');
+      cy.get('.ace_editor').should('not.be.visible');
     }
   });
 

--- a/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
@@ -104,6 +104,7 @@ describe('Test search page functionality', () => {
     cy.contains('mat-checkbox', 'Nextflow').click();
     cy.get('[data-cy=workflowColumn] a');
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
+    cy.wait(3000);
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
       cy.wrap($el).contains('NFL');
     });
@@ -202,7 +203,6 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     goToTab('Test Parameter Files');
     if (type === ToolDescriptor.TypeEnum.NFL) {
       cy.contains('This version has no files of this type.');
-      cy.get('.ace_editor').should('not.be.visible');
     }
   });
 

--- a/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/integration/smokeTests/sharedTests/basic-enduser.ts
@@ -4,8 +4,8 @@ import { ToolDescriptor } from '../../../../src/app/shared/swagger/model/toolDes
 
 // Test an entry, these should be ambiguous between tools and workflows.
 describe('run stochastic smoke test', () => {
-  // testEntry('Tools');
-  // testEntry('Workflows');
+  testEntry('Tools');
+  testEntry('Workflows');
 });
 function testEntry(tab: string) {
   beforeEach('get random entry on first page', () => {
@@ -200,7 +200,6 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     cy.contains('Descriptor Files');
     cy.get('.ace_editor').should('be.visible');
     goToTab('Test Parameter Files');
-    cy.wait(3000);
     if (type === ToolDescriptor.TypeEnum.NFL) {
       cy.contains('This version has no files of this type.');
       cy.get('.ace_editor').should('not.be.visible');


### PR DESCRIPTION
**Description**
After the dev release to staging for 1.12, some old dev-only tests were broken. Some notes:
1. Added a wait to the loading of search page descriptor types as this was flakey when running locally.
2. The `.ace-editor` for test parameter files on NFL workflows still appears (at least temporarily), so modified the test to check for the appropriate notification text only.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4163

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
