### PR TITLE
nicely format starred app tool and workflow descriptions

### DIFF
--- a/cypress/integration/group2/githubAppTools.ts
+++ b/cypress/integration/group2/githubAppTools.ts
@@ -145,18 +145,24 @@ describe('GitHub App Tools', () => {
     });
 
     it('Public view', () => {
+      cy.wait(1000);
       selectGitHubAppTool('test-github-app-tools/md5sum');
+      cy.wait(1000);
       cy.get('[data-cy=viewPublicWorkflowButton]').click();
       cy.get('[data-cy=tool-icon]').should('exist');
       cy.contains('Tool Information');
       cy.contains('Tool Version Information');
       cy.get('[data-cy=workflowTitle]').contains('github.com/C/test-github-app-tools/md5sum:invalidTool');
+      cy.wait(1000);
       goToTab('Versions');
+      cy.wait(1000);
       cy.contains('main').click();
       cy.get('[data-cy=workflowTitle]').contains('github.com/C/test-github-app-tools/md5sum:main');
       cy.get('#starringButton').click();
       cy.get('#starCountButton').should('contain', '1');
+      cy.wait(1000);
       goToTab('Info');
+      cy.wait(1000);
       cy.get('[data-cy=trs-link]').contains('TRS: github.com/C/test-github-app-tools/md5sum');
     });
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -102,6 +102,7 @@ import { UrlResolverService } from './shared/url-resolver.service';
 import { VerifiedByService } from './shared/verified-by.service';
 import { SitemapComponent } from './sitemap/sitemap.component';
 import { StargazersModule } from './stargazers/stargazers.module';
+import { MarkdownWrapperModule } from './shared/modules/markdown-wrapper.module';
 import { StarredEntriesComponent } from './starredentries/starredentries.component';
 import { StarringModule } from './starring/starring.module';
 import { TosBannerService } from './tosBanner/state/tos-banner.service';
@@ -183,6 +184,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     routing,
     StargazersModule,
     MarkdownModule.forRoot(),
+    MarkdownWrapperModule,
     ReactiveFormsModule,
     ApiModule.forRoot(getApiConfig),
     ApiModule2.forRoot(getApiConfig),

--- a/src/app/shared/entry/entry.module.ts
+++ b/src/app/shared/entry/entry.module.ts
@@ -32,7 +32,6 @@ import { EntryActionsService } from '../entry-actions/entry-actions.service';
 import { PublicFileDownloadPipe } from '../entry/public-file-download.pipe';
 import { CustomMaterialModule } from '../modules/material.module';
 import { SnackbarModule } from '../modules/snackbar.module';
-import { BaseUrlPipe } from './base-url.pipe';
 import { CommitUrlPipe } from './commit-url.pipe';
 import { InfoTabCheckerWorkflowPathComponent } from './info-tab-checker-workflow-path/info-tab-checker-workflow-path.component';
 import { LaunchCheckerWorkflowComponent } from './launch-checker-workflow/launch-checker-workflow.component';
@@ -71,7 +70,6 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     PublicFileDownloadPipe,
     PrivateFilePathPipe,
     UrlDeconstructPipe,
-    BaseUrlPipe,
   ],
   exports: [
     InfoTabCheckerWorkflowPathComponent,
@@ -93,7 +91,6 @@ import { VersionProviderUrlPipe } from './versionProviderUrl.pipe';
     UrlDeconstructPipe,
     RouterModule,
     ReactiveFormsModule,
-    BaseUrlPipe,
   ],
   providers: [BioschemaService, EntryActionsService],
 })

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -9,6 +9,7 @@ import { GetFacetSearchResultsPipe } from '../../search/facet-search/facet-searc
 import { GetHistogramStylePipe } from '../../search/get-histogram-style.pipe';
 import { MapFriendlyValuesPipe } from '../../search/map-friendly-values.pipe';
 import { SelectTabPipe } from '../entry/select-tab.pipe';
+import { BaseUrlPipe } from '../entry/base-url.pipe';
 
 const DECLARATIONS: any[] = [
   FilePathPipe,
@@ -20,6 +21,7 @@ const DECLARATIONS: any[] = [
   GetFacetSearchUpdatePipe,
   GravatarPipe,
   RouterLinkPipe,
+  BaseUrlPipe,
 ];
 @NgModule({
   imports: [CommonModule],

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -86,7 +86,7 @@
 
         <ng-template #workflowSummary let-workflow="workflow" let-isAppTool="isAppTool">
           <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
-            <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
+            <a [routerLink]="(isAppTool ? entryType.AppTool : entryType.BioWorkflow) | routerLink: workflow" class="no-underline">
               <mat-card-header>
                 <mat-card-title fxLayoutAlign="space-between" fxLayoutGap="1rem">
                   <img
@@ -138,7 +138,7 @@
                 </span>
               </div>
             </div>
-            <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
+            <a [routerLink]="(isAppTool ? entryType.AppTool : entryType.BioWorkflow) | routerLink: workflow" class="no-underline">
               <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
             </a>
           </div>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -101,44 +101,46 @@
             </a>
             <app-starring class="pull-right" [workflow]="workflow" (starGazersChange)="starGazersChange()"></app-starring>
           </div>
-          <mat-card-header>
-            <div *ngIf="workflow?.starredUsers.length !== 0" fxLayout="row" fxLayoutAlign="end center"></div>
-            <mat-card-subtitle class="truncate-text-1">{{ workflow?.description }}</mat-card-subtitle>
-          </mat-card-header>
-          <div>
-            <hr />
-            <div fxLayout="row" fxLayoutAlign="space-between stretch">
-              <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-                <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
-                <div fxLayout="row wrap" fxLayoutGap="1rem">
-                  <span>
-                    <mat-chip-list>
-                      <mat-chip class="bubble workflow-background" *ngFor="let label of workflow?.labels | slice: 0:3">{{
-                        label.value
-                      }}</mat-chip>
-                      <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
-                        <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
-                          <mat-icon class="verified-icon">done</mat-icon>
-                          <span>Verified</span>
-                        </span>
-                      </mat-chip>
-                      <mat-chip class="bubble">
-                        {{ workflow?.descriptorType | uppercase }}
-                      </mat-chip>
-                      <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
-                        <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
-                          <mat-icon class="verified-icon">done</mat-icon>
-                          <span>Verified</span>
-                        </span>
-                      </mat-chip>
-                    </mat-chip-list>
-                  </span>
-                </div>
-              </div>
-              <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
-                <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
-              </a>
+          <div class="ml-4 mr-2">
+            <div class="truncate-text-3 mb-3">
+              <app-markdown-wrapper
+                [data]="workflow?.description"
+                [baseUrl]="workflow?.providerUrl | baseUrl: workflow?.defaultVersion"
+              ></app-markdown-wrapper>
             </div>
+            <hr />
+          </div>
+          <div fxLayout="row" fxLayoutAlign="space-between stretch">
+            <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
+              <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
+              <div fxLayout="row wrap" fxLayoutGap="1rem">
+                <span>
+                  <mat-chip-list>
+                    <mat-chip class="bubble workflow-background" *ngFor="let label of workflow?.labels | slice: 0:3">{{
+                      label.value
+                    }}</mat-chip>
+                    <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
+                      <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
+                        <mat-icon class="verified-icon">done</mat-icon>
+                        <span>Verified</span>
+                      </span>
+                    </mat-chip>
+                    <mat-chip class="bubble">
+                      {{ workflow?.descriptorType | uppercase }}
+                    </mat-chip>
+                    <mat-chip class="bubble" *ngIf="workflow.versionVerified === true">
+                      <span class="verified-check" fxLayoutGap="0.5rem" fxLayoutAlign=" center">
+                        <mat-icon class="verified-icon">done</mat-icon>
+                        <span>Verified</span>
+                      </span>
+                    </mat-chip>
+                  </mat-chip-list>
+                </span>
+              </div>
+            </div>
+            <a routerLink="{{ isAppTool ? '/containers/' : '/workflows/' }}{{ workflow.full_workflow_path }}" class="no-underline">
+              <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>
+            </a>
           </div>
         </ng-template>
 

--- a/src/app/starredentries/starredentries.component.ts
+++ b/src/app/starredentries/starredentries.component.ts
@@ -11,6 +11,7 @@ import { ExtendedDockstoreTool } from 'app/shared/models/ExtendedDockstoreTool';
 import { ExtendedWorkflow } from 'app/shared/models/ExtendedWorkflow';
 // import { DockstoreService } from 'app/shared/dockstore.service';
 import { OrgLogoService } from '../shared/org-logo.service';
+import { EntryType } from '../shared/enum/entry-type';
 
 @Component({
   selector: 'app-starredentries',
@@ -26,6 +27,7 @@ export class StarredEntriesComponent extends Base implements OnInit {
   user: any;
   starGazersClicked = false;
   organizationStarGazersClicked = false;
+  readonly entryType = EntryType;
 
   constructor(
     private userQuery: UserQuery,


### PR DESCRIPTION
**Description**
This PR changes the "starred" entry pages so that (up to) the first three lines of the formatted description is displayed with each workflow or app tool, rather than the full block of raw Markdown.

See https://ucsc-cgl.atlassian.net/browse/SEAB-4106 for the "before", and the screenshot below for the "after".

Note that the description that's displayed on the "starred" entry pages is the value of the "description" field of the entry object returned by the starred endpoint, which I believe corresponds to the value of the "description" column in the entry's table.  This is not necessarily the same as the description that is displayed in the info tab, which corresponds to the currently-selected version.  Many workflows have versions with descriptions, but no description is stored in the workflow table itself.

I removed this line, because it didn't seem to have any functional effect:
https://github.com/dockstore/dockstore-ui2/blob/cd9414fade28e209cd3bdfcb0868d89b2b9af574/src/app/starredentries/starredentries.component.html#L105
If you understand its purpose, please chime in.

There was an existing css class to limit the number of lines displayed, but it was set on the `mat-card-subtitle` element, which caused it to not work.  Embedding the "limited"-and-formatted description in a `div` within the `mat-card-subtitle` caused some weird overflow and horizontal scrollbar behavior.  So, the `mat-card-subtitle` went away.

Most of the diff is indentation changes.

One IT flaked three successive times, so I added `cy.wait`s to make it pass.  Some of them are probably not necessary.   It looks like this test has failed in 10 out of the 25 most recent CircleCI runs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4106

**Screenshot**
<img width="1002" alt="Screen Shot 2022-03-31 at 5 48 05 PM" src="https://user-images.githubusercontent.com/88108675/161173302-c94d9512-8b62-435c-8649-69b557270d78.png">


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
