### PR TITLE
Up the timeout to 45 seconds

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
   "baseUrl": "http://localhost:4200",
   "viewportHeight": 900,
   "viewportWidth": 1440,
-  "defaultCommandTimeout": 30000,
+  "defaultCommandTimeout": 45000,
   "requestTimeout": 30000,
   "retries": {
     "runMode": 3,


### PR DESCRIPTION
**Description**
Staging auth tests are failing due to a command timeout. Running the tests against staging from my local environment, we can see all the tests are passing, but some our running a bit long:
<img width="705" alt="Screen Shot 2022-04-04 at 10 03 01 AM" src="https://user-images.githubusercontent.com/36607471/161561283-a18771cc-5027-4824-9288-c1fdb7458d90.png">

This PR just ups the timeout duration for Cypress tests.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
