### PR TITLE
Upping this timeout as well for Cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,7 @@
   "viewportHeight": 900,
   "viewportWidth": 1440,
   "defaultCommandTimeout": 45000,
-  "requestTimeout": 30000,
+  "requestTimeout": 45000,
   "retries": {
     "runMode": 3,
     "openMode": 0


### PR DESCRIPTION
**Description**
There appear to be smoke test timeouts failing after a 30 second wait. Upping the request timeout to 45 seconds (in a previous PR, the command timeout was increased to 45 seconds).

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
