### PR TITLE
improve success message on publish/unpublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.13.0-alpha.0",
-    "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7370/workflows/1c81d9be-84ec-4c0a-b1f3-262d9246110a/jobs/17903/artifacts",
-    "circle_build_id": "17903",
+    "webservice_version": "1.13.0-alpha.6",
+    "use_circle": false,
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7486/workflows/4a0c1825-b2ca-4fe7-9030-643ea1fc8303/jobs/18504/artifacts",
+    "circle_build_id": "18569",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -292,11 +292,9 @@ export abstract class Entry implements OnDestroy {
   }
 
   updateVersionsFileTypes(entryId: number, versionid: number): void {
-    this.alertService.start(`Getting version's unique file types`);
     this.entryService.getVersionsFileTypes(entryId, versionid).subscribe(
       (fileTypes: Array<SourceFile.TypeEnum>) => {
         this.versionsFileTypes = fileTypes;
-        this.alertService.simpleSuccess();
       },
       (error: HttpErrorResponse) => {
         this.alertService.detailedError(error);
@@ -309,7 +307,6 @@ export abstract class Entry implements OnDestroy {
     this.entryService.getVerifiedPlatforms(entryId).subscribe(
       (verifiedVersions: Array<VersionVerifiedPlatform>) => {
         this.versionsWithVerifiedPlatforms = verifiedVersions.map((value) => Object.assign({}, value));
-        this.alertService.simpleSuccess();
       },
       (error) => {
         this.alertService.detailedError(error);


### PR DESCRIPTION
**Description**
This PR improves the success message displayed when an entry is successfully published/unpublished.

A utility method that updates the version's file types was setting an obscure alertService snackbar message, which was being displayed upon success, overriding the "published successful" message.  This PR removes the intermediate message, and also removes the `simpleSuccess` call from the method (and another neighboring method), in the spirit of the "how to use the alert service" documentation: https://github.com/dockstore/dockstore-ui2/blob/ba49d9365ee90d45eb4a8b13a424227e7c63d9bc/src/app/shared/alert/state/alert.service.ts#L23

Here's the post-PR message for a successful publish:
<img width="403" alt="Screen Shot 2022-04-19 at 9 48 29 AM" src="https://user-images.githubusercontent.com/88108675/164054823-fc0eb27a-77d3-4e6b-83c9-e2a79c8d9088.png">

This PR contains the cherrypick that allows it to build on CircleCI.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2026

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
