### PR TITLE
link tool labels to tool search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.13.0-alpha.0",
-    "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7370/workflows/1c81d9be-84ec-4c0a-b1f3-262d9246110a/jobs/17903/artifacts",
-    "circle_build_id": "17903",
+    "webservice_version": "1.13.0-alpha.6",
+    "use_circle": false,
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7486/workflows/4a0c1825-b2ca-4fe7-9030-643ea1fc8303/jobs/18504/artifacts",
+    "circle_build_id": "18569",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -122,7 +122,7 @@
           <mat-chip
             class="bubble container-background pointer"
             *ngFor="let label of containerEditData?.labels"
-            (click)="goToSearch(label)"
+            (click)="goToSearch(label, Entry.Type.Tool)"
             >{{ label }}</mat-chip
           >
           <button

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -122,7 +122,7 @@
           <mat-chip
             class="bubble container-background pointer"
             *ngFor="let label of containerEditData?.labels"
-            (click)="goToSearch(label, Entry.Type.Tool)"
+            (click)="goToSearch(label, EntryType.Tool)"
             >{{ label }}</mat-chip
           >
           <button

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -31,6 +31,7 @@ import { ContainerService } from '../shared/container.service';
 import { DateService } from '../shared/date.service';
 import { DockstoreService } from '../shared/dockstore.service';
 import { Entry } from '../shared/entry';
+import { EntryType } from '../shared/enum/entry-type';
 import { ExtendedDockstoreToolQuery } from '../shared/extended-dockstoreTool/extended-dockstoreTool.query';
 import { GA4GHFilesService } from '../shared/ga4gh-files/ga4gh-files.service';
 import { ImageProviderService } from '../shared/image-provider.service';

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -496,9 +496,9 @@ export abstract class Entry implements OnDestroy {
     // If the entry type is a tool or workflow, search for that particular type of entry
     // Otherwise, perform the default type of search
     let searchType: string = undefined;
-    if (entryType === EntryType.Tool || entryType == EntryType.AppTool) {
+    if (entryType === EntryType.Tool || entryType === EntryType.AppTool) {
       searchType = 'tools';
-    } else if (entryType == EntryType.BioWorkflow) {
+    } else if (entryType === EntryType.BioWorkflow) {
       searchType = 'workflows';
     }
     // construct the url, adding parameters in an order that will remain the same when the search page later rewrites it

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -501,6 +501,7 @@ export abstract class Entry implements OnDestroy {
     } else if (entryType == EntryType.BioWorkflow) {
       searchType = 'workflows';
     }
+    // construct the url, adding parameters in an order that will remain the same when the search page later rewrites it
     let url = '/search?labels.value.keyword=' + searchValue;
     if (searchType !== undefined) {
       url += '&entryType=' + searchType;

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -490,9 +490,21 @@ export abstract class Entry implements OnDestroy {
   /**
    * Go to the search page with a query preloaded
    * @param {string} searchValue Value to search for
+   * @param {EntryType} entryType Type of entry to search for
    */
-  goToSearch(searchValue: string): void {
-    window.location.href = '/search?labels.value.keyword=' + searchValue + '&searchMode=files';
+  goToSearch(searchValue: string, entryType: EntryType): void {
+    let searchType: string = undefined;
+    if (entryType === EntryType.Tool || entryType == EntryType.AppTool) {
+      searchType = 'tools';
+    } else if (entryType == EntryType.BioWorkflow) {
+      searchType = 'workflows';
+    }
+    let url = '/search?labels.value.keyword=' + searchValue;
+    if (searchType !== undefined) {
+      url += '&entryType=' + searchType;
+    }
+    url += '&searchMode=files';
+    window.location.href = url;
   }
 
   /**

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -493,6 +493,8 @@ export abstract class Entry implements OnDestroy {
    * @param {EntryType} entryType Type of entry to search for
    */
   goToSearch(searchValue: string, entryType: EntryType): void {
+    // If the entry type is a tool or workflow, search for that particular type of entry
+    // Otherwise, perform the default type of search
     let searchType: string = undefined;
     if (entryType === EntryType.Tool || entryType == EntryType.AppTool) {
       searchType = 'tools';

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -122,9 +122,12 @@
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="inline-block mt-1 mb-1">
         <span *ngIf="workflowEditData?.labels.length > 0" class="size-small mr-2">Labels</span>
         <mat-chip-list class="bubble-list">
-          <mat-chip class="bubble workflow-background pointer" *ngFor="let label of workflowEditData?.labels" (click)="goToSearch(label)">{{
-            label
-          }}</mat-chip>
+          <mat-chip
+            class="bubble workflow-background pointer"
+            *ngFor="let label of workflowEditData?.labels"
+            (click)="goToSearch(label, entryType)"
+            >{{ label }}</mat-chip
+          >
           <button
             type="button"
             *ngIf="!labelsEditMode && !isWorkflowPublic"


### PR DESCRIPTION
**Description**
This PR changes the labels on tools to link to the search results for tools.  Not much else to add, it does what it says.

This PR contains the cherrypick that allows it to build on CircleCI.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2024

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
