### PR TITLE
Edit username functionality for sidebar & global warning/alert style update

### DIFF
--- a/cypress/integration/group2/usernameChangeRequired.ts
+++ b/cypress/integration/group2/usernameChangeRequired.ts
@@ -52,7 +52,7 @@ describe('Testing user with invalid username', () => {
       cy.get('.alert-warning').contains('Your username contains one or more banned words.');
 
       cy.visit('/accounts');
-      cy.contains('Dockstore Account & Preferences').click();
+      cy.contains('Edit Dockstore Username').click();
       cy.get('.alert-warning').contains('Your username contains one or more banned words.');
     });
   });

--- a/cypress/integration/immutableDatabaseTests/disabledAccountControls.ts
+++ b/cypress/integration/immutableDatabaseTests/disabledAccountControls.ts
@@ -30,6 +30,7 @@ describe('Go to disabled Dockstore Account & Preferences', () => {
     cy.contains('Delete Dockstore Account').should('be.disabled');
   });
   it('Should have the change username button disabled', () => {
-    cy.contains('Update Username').should('be.disabled');
+    cy.contains('Edit Dockstore Username').click();
+    cy.contains('Save').should('be.disabled');
   });
 });

--- a/cypress/integration/immutableDatabaseTests/dropdown.ts
+++ b/cypress/integration/immutableDatabaseTests/dropdown.ts
@@ -343,8 +343,9 @@ describe('Dropdown test', () => {
       cy.contains('Yes, delete my account').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/logout');
     });
-    it('Should have the change username button enabled', () => {
-      cy.contains('Update Username').should('not.be.disabled');
+    it('Should have the change username button disabled for current username', () => {
+      cy.contains('Edit Dockstore Username').click();
+      cy.contains('Save').should('be.disabled');
     });
   });
   const everythingOk = () => {

--- a/src/app/aliases/aliases.component.html
+++ b/src/app/aliases/aliases.component.html
@@ -1,7 +1,7 @@
 <app-header> Redirecting </app-header>
 <div class="container">
-  <mat-card class="alert alert-warning" role="alert" *ngIf="!validType">
-    <mat-icon>warning</mat-icon>
+  <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!validType">
+    <mat-icon class="alert-warning-icon">warning</mat-icon>
     &nbsp;<strong>{{ type }}</strong> is not a valid type
   </mat-card>
   <div *ngIf="loading$ | async; else doneLoading">
@@ -24,8 +24,8 @@
       <mat-progress-bar mode="indeterminate"></mat-progress-bar>
       Redirecting to the tool <strong>{{ tool.tool_path }}</strong>
     </div>
-    <mat-card class="alert alert-warning" role="alert" *ngIf="types.includes(type) && (aliasNotFound$ | async)">
-      <mat-icon>warning</mat-icon>
+    <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="types.includes(type) && (aliasNotFound$ | async)">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       &nbsp;No <strong>{{ type }}</strong> with the alias <strong>{{ alias }}</strong> found
     </mat-card>
   </ng-template>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,7 +52,6 @@ import { DeleteAccountDialogComponent } from './loginComponents/accounts/control
 import { AccountsExternalComponent } from './loginComponents/accounts/external/accounts.component';
 import { AccountsService } from './loginComponents/accounts/external/accounts.service';
 import { GetTokenUsernamePipe } from './loginComponents/accounts/external/getTokenUsername.pipe';
-import { ChangeUsernameComponent } from './loginComponents/accounts/internal/change-username/change-username.component';
 import { AuthComponent } from './loginComponents/auth/auth.component';
 import { DownloadCLIClientComponent } from './loginComponents/onboarding/downloadcliclient/downloadcliclient.component';
 import { OnboardingComponent } from './loginComponents/onboarding/onboarding.component';
@@ -111,6 +110,7 @@ import { SnaphotExporterModalComponent } from './workflow/snapshot-exporter-moda
 import { ViewService } from './workflow/view/view.service';
 import { MySidebarModule } from './shared/modules/my-sidebar.module';
 import { AccountSidebarModule } from './loginComponents/accounts/account-sidebar/account-sidebar.module';
+import { ChangeUsernameModule } from './loginComponents/accounts/internal/change-username/change-username.module';
 
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   showDelay: 500,
@@ -148,7 +148,6 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     MaintenanceComponent,
     FundingComponent,
     BannerComponent,
-    ChangeUsernameComponent,
     YoutubeComponent,
     SitemapComponent,
     GithubCallbackComponent,
@@ -197,6 +196,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     PipeModule,
     MySidebarModule,
     AccountSidebarModule,
+    ChangeUsernameModule,
   ],
   providers: [
     AccountsService,

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -16,9 +16,9 @@
 <div *ngIf="tool; else workflow">
   <div class="row m-1" *ngIf="error || missingWarning">
     <div class="col-md-12" *ngIf="!isToolPublic">
-      <mat-card class="alert alert-warning" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
+      <mat-card class="alert alert-warning mat-elevation-z" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
         <button type="button" class="close" data-dismiss="alert" ng-click="missingWarning = false">&times;</button>
-        <mat-icon>warning</mat-icon>
+        <mat-icon class="alert-warning-icon">warning</mat-icon>
         {{ missingContent.length === 1 ? 'Field that is missing from file: ' : 'Fields that are missing from file: ' }} {{ missingContent }}
       </mat-card>
     </div>
@@ -223,7 +223,9 @@
             ></app-launch>
             <ng-template #noTags>
               <div class="p-3">
-                <mat-card class="alert alert-warning" role="alert"> <mat-icon>warning</mat-icon> No tags exist for this </mat-card>
+                <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                  <mat-icon class="alert-warning-icon">warning</mat-icon> No tags exist for this
+                </mat-card>
               </div>
             </ng-template>
           </mat-tab>
@@ -289,7 +291,9 @@
       <div *ngIf="publicPage" class="mt-2 mr-3">
         <div *ngIf="tool?.topicId !== null; else noTopicId" id="discourse-comments"></div>
         <ng-template #noTopicId>
-          <mat-card class="alert alert-warning" role="alert"> <mat-icon>info</mat-icon> No Discourse topic exists for this tool. </mat-card>
+          <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+            <mat-icon class="alert-warning-icon">info</mat-icon> No Discourse topic exists for this tool.
+          </mat-card>
         </ng-template>
       </div>
     </div>

--- a/src/app/container/descriptors/descriptors.component.html
+++ b/src/app/container/descriptors/descriptors.component.html
@@ -14,12 +14,14 @@
   ~    limitations under the License.
   -->
 <div *ngIf="!_selectedVersion" class="p-3">
-  <mat-card class="alert alert-warning" role="alert"> <mat-icon>warning</mat-icon> No versions exist for this tool. </mat-card>
+  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+    <mat-icon class="alert-warning-icon">warning</mat-icon> No versions exist for this tool.
+  </mat-card>
 </div>
 <div *ngIf="_selectedVersion" class="p-3">
   <span *ngIf="!publicPage">
-    <mat-card *ngIf="validationMessage" class="alert alert-warning">
-      <mat-icon>warning</mat-icon>
+    <mat-card *ngIf="validationMessage" class="alert alert-warning mat-elevation-z">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       &nbsp;
       <span *ngFor="let item of validationMessage | keyvalue">
         <strong>{{ item.key }}</strong
@@ -43,8 +45,8 @@
       </span>
     </div>
 
-    <mat-card class="alert alert-warning" role="alert" *ngIf="!content">
-      <mat-icon>warning</mat-icon>
+    <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!content">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       &nbsp;A Descriptor File associated with this Docker container could not be found.
     </mat-card>
 

--- a/src/app/container/dockerfile/dockerfile.component.html
+++ b/src/app/container/dockerfile/dockerfile.component.html
@@ -14,14 +14,14 @@
   ~    limitations under the License.
   -->
 <div *ngIf="!_selectedVersion" class="p-3">
-  <mat-card class="alert alert-warning" role="alert">
-    <mat-icon>warning</mat-icon>
+  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+    <mat-icon class="alert-warning-icon">warning</mat-icon>
     &nbsp;No versions exist for this tool.
   </mat-card>
 </div>
 <div *ngIf="_selectedVersion" class="p-3">
-  <mat-card class="alert alert-warning" role="alert" *ngIf="!content">
-    <mat-icon>warning</mat-icon>
+  <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!content">
+    <mat-icon class="alert-warning-icon">warning</mat-icon>
     &nbsp;A Dockerfile associated with this Docker container could not be found.
   </mat-card>
 

--- a/src/app/container/launch/launch.component.html
+++ b/src/app/container/launch/launch.component.html
@@ -16,14 +16,14 @@
 
 <div class="p-3">
   <div *ngIf="!_selectedVersion">
-    <mat-card class="alert alert-warning" role="alert">
-      <mat-icon>warning</mat-icon> To see launch with, please select a version.
+    <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+      <mat-icon class="alert-warning-icon">warning</mat-icon> To see launch with, please select a version.
     </mat-card>
   </div>
   <div *ngIf="_selectedVersion">
     <div *ngIf="!_selectedVersion.valid">
-      <mat-card class="alert alert-warning" role="alert">
-        <mat-icon>warning</mat-icon> This section is only available for valid versions.
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+        <mat-icon class="alert-warning-icon">warning</mat-icon> This section is only available for valid versions.
       </mat-card>
     </div>
     <div *ngIf="_selectedVersion.valid">

--- a/src/app/container/paramfiles/paramfiles.component.html
+++ b/src/app/container/paramfiles/paramfiles.component.html
@@ -14,15 +14,15 @@
   ~    limitations under the License.
   -->
 <div *ngIf="!_selectedVersion" class="p-3">
-  <mat-card class="alert alert-warning" role="alert">
-    <mat-icon>warning</mat-icon>
+  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+    <mat-icon class="alert-warning-icon">warning</mat-icon>
     &nbsp;No versions exist for this tool.
   </mat-card>
 </div>
 <div *ngIf="_selectedVersion" class="p-3">
   <span *ngIf="!publicPage">
-    <mat-card class="alert alert-danger" role="alert" *ngIf="validationMessage">
-      <mat-icon>warning</mat-icon>
+    <mat-card class="alert alert-danger mat-elevation-z" role="alert" *ngIf="validationMessage">
+      <mat-icon class="alert-danger-icon">warning</mat-icon>
       &nbsp;
       <span *ngFor="let item of validationMessage | keyvalue">
         <strong>{{ item?.key }}</strong
@@ -46,8 +46,8 @@
         </span>
       </span>
     </div>
-    <mat-card class="alert alert-warning" role="alert" *ngIf="!content">
-      <mat-icon>warning</mat-icon>
+    <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!content">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       &nbsp;A Test Parameter File associated with this Docker container, descriptor type and version could not be found.
     </mat-card>
     <div [hidden]="!content">

--- a/src/app/container/refresh-wizard/refresh-wizard.component.html
+++ b/src/app/container/refresh-wizard/refresh-wizard.component.html
@@ -4,10 +4,10 @@
     Requires a Quay.io account linked on Dockstore and also Git build triggers to be present on the repository.
   </p>
   <app-loading [loading]="loading$ | async">
-    <mat-card class="alert alert-danger" role="alert" *ngIf="error$ | async as error">
+    <mat-card class="alert alert-danger mat-elevation-z" role="alert" *ngIf="error$ | async as error">
       <button type="button" class="close" data-dismiss="alert" (click)="clearError()">&times;</button>
       <p>
-        <mat-icon>warning</mat-icon>
+        <mat-icon class="alert-danger-icon">warning</mat-icon>
         The webservice encountered an error.
       </p>
       <p class="error-output">

--- a/src/app/container/version-modal/version-modal.component.html
+++ b/src/app/container/version-modal/version-modal.component.html
@@ -220,13 +220,13 @@
                 </span>
               </div>
               <div *ngIf="formErrors.cwlTestParameterFilePath" class="form-error-messages">
-                <mat-card class="alert alert-danger" role="alert">
-                  <mat-icon>error</mat-icon> {{ formErrors.cwlTestParameterFilePath }}
+                <mat-card class="alert alert-danger mat-elevation-z" role="alert">
+                  <mat-icon class="alert-danger-icon">error</mat-icon> {{ formErrors.cwlTestParameterFilePath }}
                 </mat-card>
               </div>
               <div *ngIf="hasDuplicateTestJson(DescriptorType.CWL)">
-                <mat-card class="alert alert-danger" role="alert">
-                  <mat-icon>error</mat-icon> Duplicate test json files are not allowed.
+                <mat-card class="alert alert-danger mat-elevation-z" role="alert">
+                  <mat-icon class="alert-danger-icon">error</mat-icon> Duplicate test json files are not allowed.
                 </mat-card>
               </div>
             </div>
@@ -316,13 +316,13 @@
                 </span>
               </div>
               <div *ngIf="formErrors.wdlTestParameterFilePath" class="form-error-messages">
-                <mat-card class="alert alert-danger" role="alert">
-                  <mat-icon>error</mat-icon> {{ formErrors.wdlTestParameterFilePath }}
+                <mat-card class="alert alert-danger mat-elevation-z" role="alert">
+                  <mat-icon class="alert-danger-icon">error</mat-icon> {{ formErrors.wdlTestParameterFilePath }}
                 </mat-card>
               </div>
               <div *ngIf="hasDuplicateTestJson(DescriptorType.WDL)">
-                <mat-card class="alert alert-danger" role="alert">
-                  <mat-icon>error</mat-icon> Duplicate test json files are not allowed.
+                <mat-card class="alert alert-danger mat-elevation-z" role="alert">
+                  <mat-icon class="alert-danger-icon">error</mat-icon> Duplicate test json files are not allowed.
                 </mat-card>
               </div>
             </div>

--- a/src/app/home-page/home-logged-out/home.component.scss
+++ b/src/app/home-page/home-logged-out/home.component.scss
@@ -125,7 +125,7 @@ h3 {
 }
 
 .warn-1 {
-  color: mat.get-color-from-palette($dockstore-app-warn, darker);
+  color: mat.get-color-from-palette($dockstore-app-error, darker);
 }
 
 // Style home search mat-form-field which is vastly different from all other form fields on the site due to the accented border on a non-white background

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.html
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.html
@@ -7,7 +7,12 @@
     <img src="{{ user?.avatarUrl }}" alt="Dockstore avatar" />
     <h4>{{ user?.name }}</h4>
     <span fxLayoutGap="1rem">
-      <mat-icon *ngIf="showEmailWarning" class="alert-danger-icon">warning</mat-icon>
+      <mat-icon
+        class="alert-danger-icon"
+        *ngIf="showEmailWarning"
+        matTooltip="We strongly suggest you change your username to something other than an email address."
+        >warning</mat-icon
+      >
       <button mat-button class="private-btn small-btn-structure" (click)="editUsernameModal()">
         <img src="../../../../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit Dockstore Username" />
         Edit Dockstore Username

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.html
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.html
@@ -6,10 +6,13 @@
     </div>
     <img src="{{ user?.avatarUrl }}" alt="Dockstore avatar" />
     <h4>{{ user?.name }}</h4>
-    <button mat-button class="private-btn small-btn-structure">
-      <img src="../../../../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit Dockstore Username" />
-      Edit Dockstore Username
-    </button>
+    <span fxLayoutGap="1rem">
+      <mat-icon *ngIf="showEmailWarning" class="alert-danger-icon">warning</mat-icon>
+      <button mat-button class="private-btn small-btn-structure" (click)="editUsernameModal()">
+        <img src="../../../../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit Dockstore Username" />
+        Edit Dockstore Username
+      </button>
+    </span>
   </div>
   <hr />
 

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.scss
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.scss
@@ -22,7 +22,7 @@ div.p-3 {
   width: 18vw;
   min-width: 28rem;
   height: 100%;
-  min-height: 100rem;
+  min-height: 115rem;
   border-right: 0.1rem solid mat.get-color-from-palette($kim-gray, 4);
   box-shadow: 0.1rem 0.2rem 0.1rem rgba(0, 0, 0, 0.1);
 }

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { AlertQuery } from '../../../shared/alert/state/alert.query';
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { TokenSource } from '../../../shared/enum/token-source.enum';
@@ -8,6 +8,9 @@ import { Profile, User } from '../../../shared/swagger';
 import { UsersService } from '../../../shared/swagger/api/users.service';
 import { UserQuery } from '../../../shared/user/user.query';
 import { UserService } from '../../../shared/user/user.service';
+import { takeUntil } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
+import { ChangeUsernameComponent } from '../../../../app/loginComponents/accounts/internal/change-username/change-username.component';
 
 @Component({
   selector: 'app-account-sidebar',
@@ -24,13 +27,16 @@ export class AccountSidebarComponent implements OnInit {
   public isRefreshing$: Observable<boolean>;
   public syncBadgeGit: boolean = false;
   public syncBadgeGoogle: boolean = false;
+  public showEmailWarning = false;
+  protected ngUnsubscribe: Subject<{}> = new Subject();
   constructor(
     private userService: UserService,
     private usersService: UsersService,
     private tokenQuery: TokenQuery,
     private userQuery: UserQuery,
     private alertQuery: AlertQuery,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private dialog: MatDialog
   ) {
     this.hasGitHubToken$ = this.tokenQuery.hasGitHubToken$;
     this.hasGoogleToken$ = this.tokenQuery.hasGoogleToken$;
@@ -85,7 +91,14 @@ export class AccountSidebarComponent implements OnInit {
     });
   }
 
+  editUsernameModal() {
+    this.dialog.open(ChangeUsernameComponent, { width: '776px' });
+  }
+
   ngOnInit(): void {
     this.getUser();
+    this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((user) => {
+      this.showEmailWarning = this.user.username.includes('@');
+    });
   }
 }

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { AlertQuery } from '../../../shared/alert/state/alert.query';
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { TokenSource } from '../../../shared/enum/token-source.enum';

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
@@ -8,7 +8,6 @@ import { Profile, User } from '../../../shared/swagger';
 import { UsersService } from '../../../shared/swagger/api/users.service';
 import { UserQuery } from '../../../shared/user/user.query';
 import { UserService } from '../../../shared/user/user.service';
-import { takeUntil } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ChangeUsernameComponent } from '../../../../app/loginComponents/accounts/internal/change-username/change-username.component';
 
@@ -87,6 +86,8 @@ export class AccountSidebarComponent implements OnInit {
             this.gitHubProfile.avatarURL = this.userService.gravatarUrl(this.gitHubProfile.email, this.gitHubProfile.avatarURL);
           }
         }
+        // Check username to display warning on sidebar
+        this.showEmailWarning = this.user.username.includes('@');
       }
     });
   }
@@ -97,8 +98,5 @@ export class AccountSidebarComponent implements OnInit {
 
   ngOnInit(): void {
     this.getUser();
-    this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((user) => {
-      this.showEmailWarning = this.user.username.includes('@');
-    });
   }
 }

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.component.ts
@@ -10,6 +10,7 @@ import { UserQuery } from '../../../shared/user/user.query';
 import { UserService } from '../../../shared/user/user.service';
 import { MatDialog } from '@angular/material/dialog';
 import { ChangeUsernameComponent } from '../../../../app/loginComponents/accounts/internal/change-username/change-username.component';
+import { bootstrap4largeModalSize } from '../../../shared/constants';
 
 @Component({
   selector: 'app-account-sidebar',
@@ -27,7 +28,6 @@ export class AccountSidebarComponent implements OnInit {
   public syncBadgeGit: boolean = false;
   public syncBadgeGoogle: boolean = false;
   public showEmailWarning = false;
-  protected ngUnsubscribe: Subject<{}> = new Subject();
   constructor(
     private userService: UserService,
     private usersService: UsersService,
@@ -93,7 +93,7 @@ export class AccountSidebarComponent implements OnInit {
   }
 
   editUsernameModal() {
-    this.dialog.open(ChangeUsernameComponent, { width: '776px' });
+    this.dialog.open(ChangeUsernameComponent, { width: bootstrap4largeModalSize });
   }
 
   ngOnInit(): void {

--- a/src/app/loginComponents/accounts/account-sidebar/account-sidebar.module.ts
+++ b/src/app/loginComponents/accounts/account-sidebar/account-sidebar.module.ts
@@ -20,6 +20,7 @@ import { CustomMaterialModule } from 'app/shared/modules/material.module';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CommonModule } from '@angular/common';
 import { ChangeUsernameModule } from '../internal/change-username/change-username.module';
+
 @NgModule({
   declarations: [AccountSidebarComponent],
   imports: [CustomMaterialModule, FlexLayoutModule, CommonModule, ChangeUsernameModule],

--- a/src/app/loginComponents/accounts/controls/controls.component.html
+++ b/src/app/loginComponents/accounts/controls/controls.component.html
@@ -1,17 +1,13 @@
 <div class="p-3">
-  <mat-card *ngIf="canChangeUsername$ | async" class="alert alert-danger" role="alert">
-    <mat-icon>error</mat-icon> Dockstore account controls have a large impact and should be used with extreme caution.
-  </mat-card>
-
-  <mat-card class="mb-2">
-    <h3>Change your Username</h3>
-    <app-change-username showText="true"></app-change-username>
+  <mat-card *ngIf="canChangeUsername$ | async" class="alert alert-danger mat-elevation-z" role="alert">
+    <mat-icon class="alert-danger-icon">error</mat-icon> Dockstore account controls have a large impact and should be used with extreme
+    caution.
   </mat-card>
 
   <mat-card>
     <h3>Delete your Dockstore Account</h3>
     <p>This action is only available for accounts with no published tools/workflows and have not shared workflows via permissions.</p>
-    <button class="mr-1" mat-raised-button color="warn" (click)="deleteAccount()" [disabled]="(canChangeUsername$ | async) === false">
+    <button class="mr-1" mat-flat-button color="warn" (click)="deleteAccount()" [disabled]="(canChangeUsername$ | async) === false">
       Delete Dockstore Account
     </button>
   </mat-card>

--- a/src/app/loginComponents/accounts/controls/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/app/loginComponents/accounts/controls/delete-account-dialog/delete-account-dialog.component.html
@@ -29,8 +29,8 @@
       </mat-form-field>
     </div>
     <div class="btn-group">
-      <button mat-raised-button mat-dialog-close>No</button>
-      <button mat-raised-button (click)="deleteAccount()" [disabled]="usernameForm.invalid" color="warn">Yes, delete my account</button>
+      <button mat-flat-button mat-dialog-close class="secondary-1">No</button>
+      <button mat-flat-button (click)="deleteAccount()" [disabled]="usernameForm.invalid" color="warn">Yes, delete my account</button>
     </div>
   </div>
 </div>

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.html
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.html
@@ -1,26 +1,52 @@
-<p *ngIf="showText">
-  Your current username is <strong>{{ user?.username }}</strong
-  >. It may have been auto-generated when you initially created a Dockstore account. You can update your username only if you meet certain
-  conditions.
-</p>
+<h1 mat-dialog-title *ngIf="!noDialog">Edit Dockstore Username</h1>
 
 <p>
-  You <strong>can<span *ngIf="(canChangeUsername$ | async) === false">'t</span></strong> change your username.
+  Your current username is <strong>{{ user?.username }}</strong
+  >. It may have been auto-generated when you initially created a Dockstore account.
+  <span *ngIf="(canChangeUsername$ | async) === true; else cannotChange"
+    >You <strong>can</strong> update your username since you have no published workflows/tools and have shared no workflows via
+    permissions.</span
+  >
+  <ng-template #cannotChange
+    >You <strong>cannot</strong> update your username since you have published workflows/tools or have shared workflows via
+    permissions.</ng-template
+  >
 </p>
 
-<mat-card class="alert alert-warning" role="alert" *ngIf="showEmailWarning">
-  <mat-icon>warning</mat-icon> Your username seems to be an email. We recommend changing your username to something else so that your email
-  is not picked up by a spambot. The @ symbol is not allowed in a username, so note that once you change your username you cannot change it
-  back to your email.
+<!-- Alert -->
+<mat-card *ngIf="showEmailWarning" class="alert alert-danger mat-elevation-z p-2" role="alert" fxLayout fxLayoutGap="1rem">
+  <mat-icon class="alert-danger-icon">warning</mat-icon>
+  <div>
+    <strong>Caution:</strong> Your username seems to be an email address. We recommend changing your username to something else so that your
+    email is not picked up by a spambot. The @ symbol is not allowed in a username, so note that once you change your username you cannot
+    change it back to your email.
+  </div>
 </mat-card>
 
-<mat-card class="alert alert-warning" role="alert" *ngIf="usernameChangeRequired">
-  <mat-icon>warning</mat-icon>Your username contains one or more banned words. Some operations on Dockstore will be blocked until you change
-  your username.
+<!-- Warnings -->
+<mat-card
+  *ngIf="(canChangeUsername$ | async) === true && !noDialog"
+  class="alert alert-warning mat-elevation-z p-2"
+  role="alert"
+  fxLayout
+  fxLayoutGap="1rem"
+>
+  <mat-icon class="alert-warning-icon">warning</mat-icon>
+  <div>
+    <strong>Warning:</strong> You may have unpublished workflows or tools. Changing your username could impact any shared unpublished
+    workflows or tools.
+  </div>
+</mat-card>
+<mat-card *ngIf="usernameChangeRequired" class="alert alert-warning mat-elevation-z p-2" role="alert" fxLayout fxLayoutGap="1rem">
+  <mat-icon class="alert-warning-icon">warning</mat-icon>
+  <div>
+    <strong>Warning:</strong> Your username contains one or more banned words. Some operations on Dockstore will be blocked until you change
+    your username.
+  </div>
 </mat-card>
 
 <div class="change-username-form">
-  <mat-form-field>
+  <mat-form-field appearance="outline" class="mb-4">
     <mat-label>Username</mat-label>
     <input
       [errorStateMatcher]="matcher"
@@ -30,38 +56,39 @@
       name="username"
       [(ngModel)]="username"
     />
-    <mat-error *ngIf="usernameFormControl.hasError('pattern'); else checkRequired"
+    <mat-error *ngIf="usernameFormControl.hasError('pattern'); else checkRequired" class="mt-2"
       >Invalid Username Pattern (Only alphanumeric characters and internal underscores and dashes allowed)</mat-error
     >
     <ng-template #checkRequired>
-      <mat-error *ngIf="usernameFormControl.hasError('required'); else checkMaxLength">Username is required</mat-error>
+      <mat-error *ngIf="usernameFormControl.hasError('required'); else checkMaxLength" class="mt-2">Username is required</mat-error>
       <ng-template #checkMaxLength>
-        <mat-error *ngIf="usernameFormControl.hasError('maxlength')">Username is too long (Max 39 characters)</mat-error>
+        <mat-error *ngIf="usernameFormControl.hasError('maxlength')" class="mt-2">Username is too long (Max 39 characters)</mat-error>
       </ng-template>
     </ng-template>
   </mat-form-field>
-  <span class="change-username-form-buttons">
+  <span fxLayout="row wrap" *ngIf="noDialog">
     <button
       mat-raised-button
-      color="primary"
+      class="accent-1-dark-btn mat-elevation-z"
       id="updateUsername"
       [disabled]="usernameTaken || usernameFormControl.invalid || (canChangeUsername$ | async) === false"
       (click)="updateUsername()"
     >
       Update Username
     </button>
-    <span *ngIf="(canChangeUsername$ | async) && usernameFormControl.valid">
-      <span *ngIf="!checkingIfValid">
-        <span *ngIf="!usernameTaken" class="vertical-center">
-          <mat-icon style="color: green">check</mat-icon>&nbsp;Username available
-        </span>
-        <span *ngIf="usernameTaken" class="vertical-center">
-          <mat-icon style="color: red">clear</mat-icon>&nbsp;Username not available
-        </span>
-      </span>
-      <span *ngIf="checkingIfValid" class="vertical-center">
-        <mat-spinner diameter="24"></mat-spinner>
-      </span>
-    </span>
+  </span>
+  <!-- Dialog actions -->
+  <span fxLayout="row wrap" fxLayoutAlign="end center" mat-dialog-actions *ngIf="!noDialog">
+    <button mat-flat-button class="secondary-1 mb-3" mat-dialog-close>Close</button>
+    <button
+      class="accent-1-dark-btn mat-elevation-z mb-3"
+      mat-raised-button
+      id="updateUsername"
+      [disabled]="usernameTaken || usernameFormControl.invalid || (canChangeUsername$ | async) === false"
+      (click)="updateUsername()"
+      mat-dialog-close
+    >
+      Save
+    </button>
   </span>
 </div>

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.scss
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.scss
@@ -46,13 +46,6 @@ mat-error {
   top: 1.84375em;
 }
 
-// Purple outline and text
-:host ::ng-deep .mat-form-field-appearance-outline .mat-form-field-outline,
-:host ::ng-deep .mat-form-field:not(.mat-form-field-invalid) .mat-form-field-label,
-:host ::ng-deep .mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label {
-  color: mat.get-color-from-palette($dockstore-app-accent-1, darker);
-}
-
 // Disabled form field
 :host ::ng-deep .mat-form-field-appearance-outline.mat-form-field-disabled .mat-form-field-outline {
   color: mat.get-color-from-palette($dockstore-app-primary, 4);

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.scss
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.scss
@@ -1,20 +1,61 @@
+@use '@angular/material' as mat;
+
+@import '/src/materialColorScheme.scss';
+
 .change-username-form {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
 }
 
-.change-username-form-buttons {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+mat-form-field {
+  width: 60%;
 }
 
-#updateUsername {
-  width: 200px;
+mat-error {
+  line-height: 2rem;
 }
 
 .vertical-center {
   display: flex;
   align-items: center;
+}
+
+// Form field inner
+:host ::ng-deep .mat-form-field-wrapper .mat-form-field-infix {
+  border: 0rem;
+  padding: 0rem;
+}
+
+//Form field box
+:host ::ng-deep .mat-form-field-wrapper {
+  margin: 0rem;
+  padding-bottom: 0.8rem;
+  line-height: 4rem;
+}
+
+// Form field label
+:host ::ng-deep .mat-form-field-wrapper .mat-form-field-flex .mat-form-field-infix .mat-form-field-label-wrapper .mat-form-field-label {
+  top: 1.8rem;
+}
+
+// Form field text animation re-implementation
+:host ::ng-deep .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+  transform: translateY(-1.1em) scale(0.75);
+  width: 133.33333%;
+  top: 1.84375em;
+}
+
+// Purple outline and text
+:host ::ng-deep .mat-form-field-appearance-outline .mat-form-field-outline,
+:host ::ng-deep .mat-form-field:not(.mat-form-field-invalid) .mat-form-field-label,
+:host ::ng-deep .mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label {
+  color: mat.get-color-from-palette($dockstore-app-accent-1, darker);
+}
+
+// Disabled form field
+:host ::ng-deep .mat-form-field-appearance-outline.mat-form-field-disabled .mat-form-field-outline {
+  color: mat.get-color-from-palette($dockstore-app-primary, 4);
+  background-color: mat.get-color-from-palette($dockstore-app-gray, 5);
+  border-radius: 5px;
 }

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
@@ -30,7 +30,7 @@ import { UsersService } from './../../../../shared/swagger/api/users.service';
   styleUrls: ['./change-username.component.scss'],
 })
 export class ChangeUsernameComponent implements OnInit {
-  @Input() showText;
+  @Input() noDialog: boolean;
   username: string;
   user: User;
   usernameTaken = false;
@@ -80,9 +80,7 @@ export class ChangeUsernameComponent implements OnInit {
       )
       .subscribe(
         (userExists: boolean) => {
-          if (userExists && this.username === this.user.username) {
-            this.usernameTaken = false;
-          } else {
+          if (userExists) {
             this.usernameTaken = userExists;
           }
         },

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.component.ts
@@ -80,9 +80,7 @@ export class ChangeUsernameComponent implements OnInit {
       )
       .subscribe(
         (userExists: boolean) => {
-          if (userExists) {
-            this.usernameTaken = userExists;
-          }
+          this.usernameTaken = userExists;
         },
         (error) => {
           console.error(error);

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.module.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.module.ts
@@ -19,11 +19,11 @@ import { CustomMaterialModule } from 'app/shared/modules/material.module';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CommonModule } from '@angular/common';
 import { ChangeUsernameComponent } from './change-username.component';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [ChangeUsernameComponent],
-  imports: [CustomMaterialModule, FlexLayoutModule, CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CustomMaterialModule, FlexLayoutModule, CommonModule, ReactiveFormsModule],
   providers: [],
   exports: [ChangeUsernameComponent],
 })

--- a/src/app/loginComponents/accounts/internal/change-username/change-username.module.ts
+++ b/src/app/loginComponents/accounts/internal/change-username/change-username.module.ts
@@ -15,15 +15,16 @@
  */
 
 import { NgModule } from '@angular/core';
-import { AccountSidebarComponent } from './account-sidebar.component';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CommonModule } from '@angular/common';
-import { ChangeUsernameModule } from '../internal/change-username/change-username.module';
+import { ChangeUsernameComponent } from './change-username.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
 @NgModule({
-  declarations: [AccountSidebarComponent],
-  imports: [CustomMaterialModule, FlexLayoutModule, CommonModule, ChangeUsernameModule],
+  declarations: [ChangeUsernameComponent],
+  imports: [CustomMaterialModule, FlexLayoutModule, CommonModule, FormsModule, ReactiveFormsModule],
   providers: [],
-  exports: [AccountSidebarComponent],
+  exports: [ChangeUsernameComponent],
 })
-export class AccountSidebarModule {}
+export class ChangeUsernameModule {}

--- a/src/app/loginComponents/onboarding/onboarding.component.html
+++ b/src/app/loginComponents/onboarding/onboarding.component.html
@@ -13,7 +13,7 @@
     <h3>Choose Your Username</h3>
     <hr />
 
-    <app-change-username showText="true"></app-change-username>
+    <app-change-username noDialog="true"></app-change-username>
     <button
       mat-raised-button
       matStepperNext

--- a/src/app/maintenance/maintenance.component.html
+++ b/src/app/maintenance/maintenance.component.html
@@ -12,8 +12,8 @@
     <div class="col-md-8 col-md-offset-2">
       <h3>Maintenance Notice</h3>
       <hr />
-      <mat-card class="alert alert-danger" role="alert">
-        <mat-icon>error</mat-icon>
+      <mat-card class="alert alert-danger mat-elevation-z" role="alert">
+        <mat-icon class="alert-danger-icon">error</mat-icon>
         The Dockstore Web Service API is currently inaccessible from this computer. If the condition persists, please contact an
         administrator for assistance.
       </mat-card>

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>GitHub App Logs</h1>
 <div mat-dialog-content>
   <app-loading [loading]="loading">
-    <mat-card *ngIf="showContent === 'error'" class="alert alert-warning" role="alert">
-      <mat-icon>warning</mat-icon> There were problems retrieving GitHub App logs for this organization.
+    <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
+      <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving GitHub App logs for this organization.
     </mat-card>
     <mat-card *ngIf="showContent === 'empty'" class="alert alert-info" role="alert">
       <mat-icon>warning</mat-icon> There are no GitHub App logs for this organization.

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -203,7 +203,7 @@
 
     <div class="col-md-9 containers-rsb" *ngIf="advancedSearchObject$ | async as advancedSearchObject">
       <div class="hits">
-        <mat-card *ngIf="searchService.noResults(searchTerm, hits)" class="alert alert-warning text-break">
+        <mat-card *ngIf="searchService.noResults(searchTerm, hits)" class="alert alert-warning mat-elevation-z text-break">
           Sorry, no matches found for <strong>{{ basicSearchText$ | async }}</strong
           >.
           <span *ngIf="suggestTerm$ | async"

--- a/src/app/shared/alert/alert.component.html
+++ b/src/app/shared/alert/alert.component.html
@@ -1,7 +1,7 @@
-<mat-card class="alert alert-danger alert-dismissable" role="alert" *ngIf="showError$ | async">
+<mat-card class="alert alert-danger mat-elevation-z alert-dismissable" role="alert" *ngIf="showError$ | async">
   <button type="button" class="close" data-dismiss="alert" (click)="clear()">&times;</button>
   <p>
-    <mat-icon>warning</mat-icon>
+    <mat-icon class="alert-danger-icon">warning</mat-icon>
     {{ message$ | async }}
   </p>
   <p class="error-output">{{ details$ | async }}</p>

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -1,7 +1,7 @@
 <app-loading class="w-100" [loading]="loading">
   <div *ngIf="version" class="p-3">
-    <mat-card class="alert alert-warning" *ngIf="validationMessage">
-      <mat-icon>warning</mat-icon>
+    <mat-card class="alert alert-warning mat-elevation-z" *ngIf="validationMessage">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       &nbsp;
       <span *ngFor="let item of validationMessage | keyvalue">
         <strong>{{ item.key }}</strong
@@ -10,19 +10,24 @@
     </mat-card>
   </div>
   <div *ngIf="!loading && (!fileTabs || fileTabs.size === 0) && !displayError" class="p-3">
-    <mat-card class="alert alert-warning"> <mat-icon>warning</mat-icon>This version has no files.</mat-card>
+    <mat-card class="alert alert-warning mat-elevation-z">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>This version has no files.</mat-card
+    >
   </div>
 
   <div *ngIf="displayError" class="p-3">
-    <mat-card class="alert alert-warning">
-      <mat-icon>warning</mat-icon>There was an error retrieving the files for this version. Please reload the page.</mat-card
+    <mat-card class="alert alert-warning mat-elevation-z">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>There was an error retrieving the files for this version. Please reload the
+      page.</mat-card
     >
   </div>
   <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
     <mat-tab *ngFor="let fileTab of fileTabs | keyvalue: originalOrder" [label]="fileTab.key">
       <ng-template matTabContent>
         <div class="p-3" *ngIf="fileTab.value.length === 0">
-          <mat-card class="alert alert-warning"> <mat-icon>warning</mat-icon>This version has no files of this type.</mat-card>
+          <mat-card class="alert alert-warning mat-elevation-z">
+            <mat-icon class="alert-warning-icon">warning</mat-icon>This version has no files of this type.</mat-card
+          >
         </div>
         <div *ngIf="fileTab.value.length > 0">
           <mat-toolbar color="primary">

--- a/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
+++ b/src/app/workflow/dag/cwl-viewer/cwl-viewer.html
@@ -1,6 +1,6 @@
 <div class="cwl-viewer">
-  <mat-card *ngIf="cwlViewerError" class="alert alert-warning">
-    <mat-icon>warning</mat-icon>&nbsp;
+  <mat-card *ngIf="cwlViewerError" class="alert alert-warning mat-elevation-z">
+    <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;
     <div>
       The Common Workflow Language Viewer was unable to process the CWL. <span *ngIf="errorMessage">It returned the following error:</span>
     </div>

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -17,14 +17,14 @@
   <div class="p-3" fxLayout="column" fxLayoutGap="10px">
     <div fxFlex *ngIf="(isNFL$ | async) && dagType === 'classic'">
       <!-- alert class not present because it adds too much margin above a DAG that actually exists -->
-      <mat-card class="alert-warning" role="alert">
-        <mat-icon>warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
+      <mat-card class="alert-warning mat-elevation-z" role="alert">
+        <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
       </mat-card>
     </div>
     <div fxFlex *ngIf="dagType === 'classic' && (isNFL$ | async) === false && (dagResult$ | async) === false">
       <!-- This covers CWL, WDL, Service, and other plugin languages (everything except NFL) -->
-      <mat-card class="alert alert-warning" role="alert" *ngIf="(dagResult$ | async) === false && !selectedVersion?.valid">
-        <mat-icon>warning</mat-icon>&nbsp;
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="(dagResult$ | async) === false && !selectedVersion?.valid">
+        <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;
         <span *ngIf="(descriptorType$ | async) !== ToolDescriptor.TypeEnum.SERVICE">
           The DAG cannot be displayed because the descriptor is either missing or not valid.
           {{
@@ -34,8 +34,9 @@
           }}
         </span>
       </mat-card>
-      <mat-card class="alert alert-warning" role="alert" *ngIf="(missingTool$ | async) && selectedVersion?.valid">
-        <mat-icon>warning</mat-icon>&nbsp; DAG cannot be created because some required tools are missing from Github repo.
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="(missingTool$ | async) && selectedVersion?.valid">
+        <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp; DAG cannot be created because some required tools are missing from
+        Github repo.
       </mat-card>
     </div>
     <div fxFlex #dagHolder id="dag-holder">

--- a/src/app/workflow/dag/wdl-viewer/wdl-viewer.html
+++ b/src/app/workflow/dag/wdl-viewer/wdl-viewer.html
@@ -1,7 +1,7 @@
 <!--ALLOW WDL VIEWER AGAIN -->
 <!--<div class="wdl-viewer w-100 h-100">-->
-<!--  <mat-card *ngIf="wdlViewerError" class="alert alert-warning">-->
-<!--    <mat-icon>warning</mat-icon>&nbsp;-->
+<!--  <mat-card *ngIf="wdlViewerError" class="alert alert-warning mat-elevation-z">-->
+<!--    <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;-->
 <!--    <div>EPAM WDL Visualizer was unable to visualize this workflow. <span *ngIf="errorMessage">It returned the following error:</span></div>-->
 <!--    <div>{{errorMessage}}</div>-->
 <!--  </mat-card>-->

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -384,9 +384,9 @@
       </div>
       <mat-divider [inset]="true" class="mt-3"></mat-divider>
       <div *ngIf="selectedVersion?.frozen && hasHttpImports" class="pt-3">
-        <mat-card class="alert alert-warning" role="alert">
-          <mat-icon>warning</mat-icon> This version is snapshotted but contains HTTP imports. HTTP imports may change and execution results
-          may vary.
+        <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+          <mat-icon class="alert-warning-icon">warning</mat-icon> This version is snapshotted but contains HTTP imports. HTTP imports may
+          change and execution results may vary.
         </mat-card>
       </div>
       <table mat-table [dataSource]="this.authors" class="w-100 mb-5" aria-describedby="Authors">

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -15,13 +15,14 @@
   -->
 
 <div class="p-3">
-  <mat-card *ngIf="!_selectedVersion" class="alert alert-warning" role="alert">
-    <mat-icon>warning</mat-icon> To see launch with, please refresh the workflow.
+  <mat-card *ngIf="!_selectedVersion" class="alert alert-warning mat-elevation-z" role="alert">
+    <mat-icon class="alert-warning-icon">warning</mat-icon> To see launch with, please refresh the workflow.
   </mat-card>
   <div *ngIf="_selectedVersion">
     <div *ngIf="!_selectedVersion.valid">
-      <mat-card class="alert alert-warning" role="alert">
-        <mat-icon>warning</mat-icon> This section is only available for valid versions. A valid version requires a valid descriptor file.
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+        <mat-icon class="alert-warning-icon">warning</mat-icon> This section is only available for valid versions. A valid version requires
+        a valid descriptor file.
       </mat-card>
     </div>
     <div *ngIf="_selectedVersion.valid" fxLayout="column" fxLayoutGap="1rem">

--- a/src/app/workflow/snapshot-exporter-modal/snaphot-exporter-modal.component.html
+++ b/src/app/workflow/snapshot-exporter-modal/snaphot-exporter-modal.component.html
@@ -148,7 +148,7 @@
       fxLayoutAlign="end top"
     >
       <div>
-        <mat-icon class="warning-icon">warning</mat-icon>
+        <mat-icon class="alert-danger-icon">warning</mat-icon>
       </div>
       <div>
         <div data-cy="zenodo-not-linked">
@@ -168,7 +168,7 @@
   <ng-template #orcidCheck>
     <div *ngIf="(hasOrcidToken$ | async) === false" class="alert-danger p-2" fxLayout="row" fxLayoutGap="0.625rem;" fxLayoutAlign="end top">
       <div>
-        <mat-icon class="account-warning">warning</mat-icon>
+        <mat-icon class="account-warning alert-danger-icon">warning</mat-icon>
       </div>
       <div>
         <div data-cy="orcid-not-linked">

--- a/src/app/workflow/tool-tab/tool-tab.component.html
+++ b/src/app/workflow/tool-tab/tool-tab.component.html
@@ -15,12 +15,12 @@
   -->
 <div class="p-3">
   <app-loading [loading]="loading">
-    <mat-card *ngIf="nullContent" class="alert alert-warning" role="alert">
-      <mat-icon>warning</mat-icon>
+    <mat-card *ngIf="nullContent" class="alert alert-warning mat-elevation-z" role="alert">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       No Records Found
     </mat-card>
-    <mat-card *ngIf="noContent" class="alert alert-warning" role="alert">
-      <mat-icon>warning</mat-icon>
+    <mat-card *ngIf="noContent" class="alert alert-warning mat-elevation-z" role="alert">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>
       Some tools associated with this workflow are missing from Git repo.
     </mat-card>
     <table *ngIf="hasContent" mat-table [dataSource]="toolContent" class="w-100">

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -66,7 +66,7 @@
               <div *ngIf="isService$ | async" class="label-value">
                 {{ version.workflow_path }}
               </div>
-              <mat-card *ngIf="formErrors.workflow_path && (isService$ | async) === false" class="alert alert-danger">
+              <mat-card *ngIf="formErrors.workflow_path && (isService$ | async) === false" class="alert alert-danger mat-elevation-z">
                 {{ formErrors.workflow_path }}
               </mat-card>
             </div>
@@ -160,7 +160,9 @@
               <div *ngIf="formErrors.testParameterFilePath" class="form-error-messages alert alert-danger">
                 {{ formErrors.testParameterFilePath }}
               </div>
-              <mat-card *ngIf="hasDuplicateTestJson()" class="alert alert-danger"> Duplicate test json files are not allowed. </mat-card>
+              <mat-card *ngIf="hasDuplicateTestJson()" class="alert alert-danger mat-elevation-z">
+                Duplicate test json files are not allowed.
+              </mat-card>
             </div>
             <div class="col-sm-9 col-md-9 col-lg-9" *ngIf="testParameterFilePaths.length === 0 && isPublic">
               <input class="form-control" placeholder="None provided" disabled />

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -16,9 +16,9 @@
 <div *ngIf="workflow">
   <div class="row m-1" *ngIf="error || missingWarning">
     <div class="col-md-12" *ngIf="!isWorkflowPublic">
-      <mat-card class="alert alert-warning" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
+      <mat-card class="alert alert-warning mat-elevation-z" ng-class="!editMode ? 'push-top' : ''" role="alert" *ngIf="missingWarning">
         <button type="button" class="close" data-dismiss="alert" ng-click="missingWarning = false">&times;</button>
-        <mat-icon>warning</mat-icon>
+        <mat-icon class="alert-warning-icon">warning</mat-icon>
       </mat-card>
     </div>
   </div>
@@ -218,8 +218,9 @@
             <mat-tab id="launchTab" label="Launch">
               <div *ngIf="(launchSupport$ | async) === false; else launchSupported">
                 <div class="p-3">
-                  <mat-card class="alert alert-warning" role="alert">
-                    <mat-icon>warning</mat-icon> Dockstore does not yet have customized launch-with instructions for this language.
+                  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                    <mat-icon class="alert-warning-icon">warning</mat-icon> Dockstore does not yet have customized launch-with instructions
+                    for this language.
                   </mat-card>
                 </div>
               </div>
@@ -238,8 +239,8 @@
               </ng-template>
               <ng-template #noVersions>
                 <div class="p-3">
-                  <mat-card class="alert alert-warning" role="alert">
-                    <mat-icon>warning</mat-icon> No versions exist for this workflow.
+                  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                    <mat-icon class="alert-warning-icon">warning</mat-icon> No versions exist for this workflow.
                   </mat-card>
                 </div>
               </ng-template>
@@ -338,8 +339,8 @@
                 </app-tool-tab>
               </div>
               <div *ngIf="isStub()" class="p-3">
-                <mat-card class="alert alert-warning" role="alert">
-                  <mat-icon>warning</mat-icon> To see tools, please refresh the workflow.
+                <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                  <mat-icon class="alert-warning-icon">warning</mat-icon> To see tools, please refresh the workflow.
                 </mat-card>
               </div>
             </mat-tab>
@@ -355,11 +356,13 @@
                 >
                 </app-dag>
                 <div *ngIf="!selectedVersion">
-                  <mat-card class="alert alert-warning p-3" role="alert"> <mat-icon>warning</mat-icon> No version selected. </mat-card>
+                  <mat-card class="alert alert-warning mat-elevation-z p-3" role="alert">
+                    <mat-icon class="alert-warning-icon">warning</mat-icon> No version selected.
+                  </mat-card>
                 </div>
                 <div *ngIf="isStub()" class="p-3">
-                  <mat-card class="alert alert-warning" role="alert">
-                    <mat-icon>warning</mat-icon> To see the DAG, please refresh the workflow.
+                  <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                    <mat-icon class="alert-warning-icon">warning</mat-icon> To see the DAG, please refresh the workflow.
                   </mat-card>
                 </div>
               </ng-template>
@@ -373,8 +376,8 @@
       <div *ngIf="publicPage" class="mt-2 mr-3">
         <div *ngIf="workflow?.topicId !== null; else noTopicId" id="discourse-comments"></div>
         <ng-template #noTopicId>
-          <mat-card class="alert alert-warning" role="alert">
-            <mat-icon>info</mat-icon> No Discourse topic exists for this {{ entryType }}.
+          <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+            <mat-icon class="alert-warning-icon">info</mat-icon> No Discourse topic exists for this {{ entryType }}.
           </mat-card>
         </ng-template>
       </div>

--- a/src/ds-style-fix.scss
+++ b/src/ds-style-fix.scss
@@ -716,23 +716,3 @@ mat-list.org-accordion-list > mat-list-item {
 .mat-drawer-inner-container {
   overflow: visible !important;
 }
-
-.alert-warning {
-  color: #8a6d3b !important;
-  background-color: #fcf8e3 !important;
-  border-color: #faebcc !important;
-  border: 0px !important;
-}
-
-.alert-info {
-  background-color: #d9edf7 !important;
-  border-color: #bce8f1 !important;
-  border: 0px !important;
-}
-
-.alert-danger {
-  color: #a94442 !important;
-  background-color: #f2dede !important;
-  border-color: #ebccd1 !important;
-  border: 0px !important;
-}

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -53,7 +53,7 @@ $kim-secondary: (
 );
 
 // Using kim's error instead (material doesn't differentiate between error and warn, kim's error seems more suitable)
-$kim-warn: (
+$kim-error: (
   1: #c14747,
   2: #e64a46,
   3: #e96f6c,
@@ -65,6 +65,23 @@ $kim-warn: (
     3: black,
     4: black,
     5: black,
+  ),
+);
+
+$kim-warn: (
+  1: #ffb74d,
+  2: #fdd835,
+  3: #fff176,
+  4: #fff59d,
+  5: #fff7d3,
+  6: #fffde7,
+  contrast: (
+    1: white,
+    2: white,
+    3: black,
+    4: black,
+    5: black,
+    6: black,
   ),
 );
 
@@ -110,6 +127,7 @@ $kim-gray: (
 // 4 was arbitarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
 $dockstore-app-primary: mat.define-palette($kim-primary, 2, 4, 1);
 $dockstore-app-accent: mat.define-palette($kim-secondary, 2, 4, 1);
+$dockstore-app-error: mat.define-palette($kim-error, 2, 4, 1);
 $dockstore-app-warn: mat.define-palette($kim-warn, 2, 4, 1);
 $dockstore-app-accent-1: mat.define-palette($kim-accent1-success, 2, 4, 1);
 
@@ -118,7 +136,7 @@ $dockstore-app-accent-1: mat.define-palette($kim-accent1-success, 2, 4, 1);
 $dockstore-app-gray: mat.define-palette($kim-gray, 2, 4, 1);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$dockstore-app-theme: mat.define-light-theme($dockstore-app-primary, $dockstore-app-accent, $dockstore-app-warn);
+$dockstore-app-theme: mat.define-light-theme($dockstore-app-primary, $dockstore-app-accent, $dockstore-app-error);
 
 // Include the grayscale palette in the theme object
 // Example of getting the palette: map-get($dockstore-app-theme, grayscale)

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1287,3 +1287,29 @@ a.small-mat-btn-skin:not([class*='mat-elevation-z']) {
   border: solid 1px mat.get-color-from-palette($dockstore-app-gray, 7);
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 3px 0 rgba(0, 0, 0, 0.08) !important;
 }
+
+// Alert and Warning styles
+.alert-warning {
+  background-color: mat.get-color-from-palette($dockstore-app-warn, 6) !important;
+  border: solid 1px mat.get-color-from-palette($dockstore-app-warn, 3) !important;
+  box-shadow: none !important;
+}
+
+.alert-warning-icon {
+  color: mat.get-color-from-palette($dockstore-app-warn, 1) !important;
+}
+
+.alert-info {
+  background-color: #d9edf7 !important;
+  border-color: #bce8f1 !important;
+  border: 0px !important;
+}
+
+.alert-danger {
+  background-color: mat.get-color-from-palette($dockstore-app-error, 5) !important;
+  border: solid 1px mat.get-color-from-palette($dockstore-app-error, 4) !important;
+}
+
+.alert-danger-icon {
+  color: mat.get-color-from-palette($dockstore-app-error, 2) !important;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1114,8 +1114,6 @@ mat-icon.mat-icon-sm {
 // Purple outline and text for mat-form-field
 .mat-form-field-appearance-outline.mat-focused:not(.mat-form-field-invalid) .mat-form-field-outline,
 .mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label,
-.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label,
-.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label .mat-form-field-required-marker,
 .mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label .mat-form-field-required-marker,
 .mat-form-field-appearance-legacy.mat-form-field-can-float.mat-form-field-should-float
   .mat-form-field-label:not(.mat-empty):not(.mat-form-field-empty) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1111,10 +1111,15 @@ mat-icon.mat-icon-sm {
   }
 }
 
-// Style the float label of the mat-form-field
+// Purple outline and text for mat-form-field
+.mat-form-field-appearance-outline.mat-focused:not(.mat-form-field-invalid) .mat-form-field-outline,
+.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label,
+.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label,
+.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label .mat-form-field-required-marker,
+.mat-form-field.mat-focused:not(.mat-form-field-invalid) .mat-form-field-label .mat-form-field-required-marker,
 .mat-form-field-appearance-legacy.mat-form-field-can-float.mat-form-field-should-float
   .mat-form-field-label:not(.mat-empty):not(.mat-form-field-empty) {
-  color: mat.get-color-from-palette($dockstore-app-accent, 1);
+  color: mat.get-color-from-palette($dockstore-app-accent-1, darker) !important;
 }
 
 // Keep the outer circle in a radio button gray even when selected


### PR DESCRIPTION
**Description**
The main purpose of this ticket is to add the edit username functionality to the button on the account sidebar and match the redesign on [zeplin](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c35efb6c6c520f059dd0b).  Because I was updating the alert/warning style that was already there I decided to update it globally so that is also part of this PR

**Summary of Changes:**
- The `change-username.component` is used in 2 places: 1) the edit username modal on the accounts page 2) the onbording component for a new user
- Updated the `change-username.component` to be used as a modal and directly on page (for the onboarding component)
- Removed `change-username.component` from “Dockstore Account & Preferences” tab
-  Global update for warning/alert styles - addition of warning/alert colours in `materialColorScheme.scss`
- Addition of email warning on account sidebar
- Updated tests: usernameChangeRequired.ts, disabledAccountControls.ts , dropdown.ts 

### Before:
![image](https://user-images.githubusercontent.com/97123241/164775265-88fad6cc-ef4f-4612-b390-ae0edd0f0de9.png)
### After:
![image](https://user-images.githubusercontent.com/97123241/164775368-2975b918-770e-43ab-95af-575b53f8355b.png)
**change-username.component also appears on the onboarding page:**
![image](https://user-images.githubusercontent.com/97123241/164775928-e370b0e3-cd5f-45d9-ac22-984f1b1b33a8.png)
### Invalid username:
![image](https://user-images.githubusercontent.com/97123241/164775560-e13d3b27-93d0-40bf-9048-ef0395fe3ea9.png)
### Disabled State:
- This is what it looks like when you are not able to change your username ([zeplin](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c37b7592ed6254c70d0a2))

![image](https://user-images.githubusercontent.com/97123241/164775671-0521db71-80aa-4da3-840c-db8d9d20fa6c.png)
### Email Warnings:
- Zeplin [disabled bar](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c333a03de2928fea160d0) (there is one additional warning in yellow, see note bellow)
- Zeplin [enabled bar](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c33b71502a018469a3439)
- Zeplin [tooltip and icon on account sidebar](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c32c84ce01d25a100d34b)

![image](https://user-images.githubusercontent.com/97123241/164801855-a1b1184f-1adf-4208-8a00-16cb079a1253.png)
- I couldn't actually change my username to an email (so the bar is red because I am trying _to_ change it to an email) but this is what the error would look like

![image](https://user-images.githubusercontent.com/97123241/164775728-ceb8b095-33dc-442a-a641-63e244e1e145.png)
- To add the icon to the account sidebar I added the check in the change username component to the account sidebar component

![image](https://user-images.githubusercontent.com/97123241/164799240-22d78269-b48a-40dd-bd94-4a351feb03c1.png)

### Disable update username button for your own existing username:
- When you click `Update Username` for your current username you immediately get a warning that you cannot change your username because it is already in use - so it doesn’t make much sense to keep that action available

![image](https://user-images.githubusercontent.com/97123241/164775820-16e2d11a-fc02-4a55-a5f5-2dbd918eab2c.png)
- Now the `save` button is disabled for your current username and will become enabled once you change your username

![image](https://user-images.githubusercontent.com/97123241/164775859-d587a800-20dc-4180-884a-b8124e7ad902.png)
![image](https://user-images.githubusercontent.com/97123241/164799393-5dd719bd-8315-4a4b-a060-d589aca09d66.png)

### Unpublished Tools/Workflows Warning:
- [Zeplin](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c35efb6c6c520f059dd0b) has a warning for unpublished tools/workflows before you change your username
- We have an endpoint to get published tools/workflows but not unpublished, so the message is changed to "you may have" and will be displayed if they **are able** to change their username
- If we want to match this with zeplin in the future, we may want to create an endpoint to get check unpublished entries

![image](https://user-images.githubusercontent.com/97123241/164793302-7377295b-49e2-4d17-9cb2-d333b9c68d8a.png)

### Global warning/alert styles update:
- Moved styles from `ds-style-fix` to the `styles.scss` file so that we could use the mat colour palette
- Renamed the "red" alert theme from `$kim-warn` to `$kim-alert` to match zeplin (warn is designated for the yellow colour, also renamed in the 1 other spot it was mentioned)
- Added the "yellow" warning theme as `$kim-warn` to the colour scheme (also from zeplin)
- Updated the border and background colours, added a global theme for the `mat-icon` colours needed to match the warning/alert themes
- New messages also don't have shadows so `mat-elevation-z` was added to each mat-card (I should have gotten them all for the alert and warning messages)

**Previous style -> updated style:**
![image](https://user-images.githubusercontent.com/97123241/164791560-e1dd7cc0-be8d-4766-a8a5-d8ad2f1a2e8d.png)

Last small change - changed the min height for the account sidebar to match the my-sidebar
![image](https://user-images.githubusercontent.com/97123241/164799728-dc782269-5f89-4603-82cc-1ea165458102.png)


**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
