### PR TITLE
Update entry-actions.service.ts

### DIFF
--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -111,7 +111,7 @@ export class EntryActionsService {
   openNoDefaultDialog(entry: Entry, entryType: string, showVersions: EventEmitter<void> | null): void {
     const informationDialogData: InformationDialogData = {
       title: 'Default Version Required',
-      message: `Your ${entryType} must have a default version to be published.  Please use the the Actions menu in the Versions tab to select a default version.`,
+      message: `Your ${entryType} must have a default version to be published.  Please use the Actions menu in the Versions tab to select a default version.`,
       closeButtonText: 'OK',
     };
     const observable = this.informationDialogService.openDialog(informationDialogData, bootstrap4mediumModalSize);


### PR DESCRIPTION
**Description**
Fix typo in dialog box informing the user that published entries need a default version. There are two more instances of "the the" in this repo not in this PR.

**Issue**
https://github.com/dockstore/dockstore/issues/4853

Feel free to reject this PR if it's more trouble than it's worth r/e testing -- I was not able to get our CI working correctly on my machine. It's claiming there is a syntax error in the generated file node_modules/@angular/compiler-cli/bundles/ngcc/main-ngcc.js, which I want to flag here in case this is actually a bug... I get the feeling that could just as likely be a consequence of me fumbling the installation of three(?!) different versions of node, so I haven't made a ticket.