### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+The Dockstore system routinely receives security updates to the most recently
+released tagged minor version. All previous versions are unsupported.
+
+## Reporting a Vulnerability
+
+Users are able to open helpdesk tickets on [Discourse](https://discuss.dockstore.org/). Users can create helpdesk tickets in case of privacy complaints, security vulnerabilities, or any other urgent matter related to Dockstore. Helpdesk tickets will be addressed by Dockstore administrators.
+
+The following steps can be taken to create a helpdesk ticket (also shown [here](https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506)).
+
+1. Navigate to [Discourse](https://discuss.dockstore.org/) and login.
+2. Select your profile icon, located in the top right corner of the screen.
+3. Select the `mail` icon, located in the dropdown.
+4. Send a message to the `dockstore_admins` group.
+
+Note
+
+> If you are unable to see a New Message button on the mail page, you may be considered a new user and have insufficient privileges. Entering 5 topics and viewing 30 posts over a minimum of 10 minutes will raise your privileges. You will be notified of any privilege changes to your account via the mailbox.


### PR DESCRIPTION
**Description**

Adds the security policy as added in https://github.com/dockstore/dockstore/pull/4869

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ n/a] Check that your code compiles by running `npm run build`
- [n/a ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [n/a ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ n/a] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [n/a ] Do not use cookies, although this may change in the future
- [n/a ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [n/a ] Do due diligence on new 3rd party libraries, checking for CVEs
- [n/a ] Don't allow user-uploaded images to be served from the Dockstore domain
