### PR TITLE
Fix CircleCI artifacts URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-17-jdk -yq
+            sudo apt install openjdk-17-jre-headless -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-11-jre -yq
+            sudo apt install openjdk-17-jre -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-17-jre-headless -yq
+            sudo apt install openjdk-17-jdk -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-11-jdk -yq
+            sudo apt install openjdk-17-jdk -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-11-jre -yq
+            sudo apt install openjdk-11-jdk -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-17-jre -yq
+            sudo apt install openjdk-11-jre -yq
       - run:
           name: Install npm
           command: |

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -59,7 +59,7 @@ export function resetDB() {
     cy.exec('java -jar dockstore-webservice.jar db drop-all --confirm-delete-everything test/web.yml');
     cy.exec(psqlInvocation + ' -h localhost webservice_test -U dockstore < test/db_dump.sql');
     cy.exec(
-      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0 test/web.yml'
+      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0 test/web.yml'
     );
   });
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.13.0-alpha.6",
-    "use_circle": false,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7486/workflows/4a0c1825-b2ca-4fe7-9030-643ea1fc8303/jobs/18504/artifacts",
-    "circle_build_id": "18569",
+    "use_circle": true,
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7557/workflows/432342bd-9a3e-4648-88a3-5b77de6b8879/jobs/18860/artifacts",
+    "circle_build_id": "18860",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.13.0-alpha.6",
-    "use_circle": true,
+    "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7557/workflows/432342bd-9a3e-4648-88a3-5b77de6b8879/jobs/18860/artifacts",
     "circle_build_id": "18860",
     "base_branch": "develop"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.13.0-alpha.6",
-    "use_circle": false,
+    "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7557/workflows/432342bd-9a3e-4648-88a3-5b77de6b8879/jobs/18860/artifacts",
     "circle_build_id": "18860",
     "base_branch": "develop"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -6,8 +6,6 @@ set -o xtrace
 
 GENERATOR_VERSION="4.3.0"
 BASE_PATH="https://raw.githubusercontent.com/dockstore/dockstore/$npm_package_config_webservice_version"
-CIRCLE_CI_PATH="https://""$npm_package_config_circle_build_id""-33383826-gh.circle-artifacts.com/0/tmp/artifacts"
-
 # DOCKSTORE-2428 - demo how to add new workflow language, generate from local copy of swagger
 # Uncomment this to use your local copy of swagger instead
 # BASE_PATH="../dockstore"
@@ -19,8 +17,8 @@ rm -Rf src/app/shared/openapi
 
 if [ "$npm_package_config_use_circle" = true ]
 then
-        SWAGGER_PATH="${CIRCLE_CI_PATH}""/swagger.yaml"
-        OPENAPI_PATH="${CIRCLE_CI_PATH}""/openapi.yaml"
+        SWAGGER_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id swagger.yaml)
+        OPENAPI_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id openapi.yaml)
 else
         SWAGGER_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/swagger.yaml"
         OPENAPI_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/openapi3/openapi.yaml"

--- a/scripts/generate-openapi-script.sh
+++ b/scripts/generate-openapi-script.sh
@@ -17,8 +17,8 @@ rm -Rf src/app/shared/openapi
 
 if [ "$npm_package_config_use_circle" = true ]
 then
-        SWAGGER_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id swagger.yaml)
-        OPENAPI_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id openapi.yaml)
+        SWAGGER_PATH=$(./scripts/get-circleci-artifact-url.sh "$npm_package_config_circle_build_id" swagger.yaml)
+        OPENAPI_PATH=$(./scripts/get-circleci-artifact-url.sh "$npm_package_config_circle_build_id" openapi.yaml)
 else
         SWAGGER_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/swagger.yaml"
         OPENAPI_PATH="${BASE_PATH}""/dockstore-webservice/src/main/resources/openapi3/openapi.yaml"

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_PATH "${ARTIFACT_NAME}" '.items[] | select( .path | contains($ARTIFACT_PATH) ) | .url ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url ')
 
 echo "${ARTIFACT_URL}"

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+if [[ -z ${1} || -z ${2} ]]; then
+    echo "Usage: $0 <circleci-build-id> <circleci-artifact-name>"
+    exit 1
+fi
+
+# This script gets the URL for a CircleCI artifact. 
+# It looks at all of the artifacts for a CircleCI build with <circleci-build-id> and returns the URL of the artifact with a path that contains <circleci-artifact-name>.
+
+CIRCLECI_BUILD_ID=${1}
+ARTIFACT_NAME=${2}
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_PATH "${ARTIFACT_NAME}" '.items[] | select( .path | contains($ARTIFACT_PATH) ) | .url ')
+
+echo "${ARTIFACT_URL}"

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o xtrace
 if [ "$npm_package_config_use_circle" = true ]
 then
-	JAR_PATH="https://""${npm_package_config_circle_build_id}""-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.13.0-alpha.0-SNAPSHOT.jar"
+	JAR_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id dockstore-webservice)
 else
 	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 fi

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o xtrace
 if [ "$npm_package_config_use_circle" = true ]
 then
-	JAR_PATH=$(./scripts/get-circleci-artifact-url.sh $npm_package_config_circle_build_id dockstore-webservice)
+	JAR_PATH=$(./scripts/get-circleci-artifact-url.sh "$npm_package_config_circle_build_id" dockstore-webservice)
 else
 	JAR_PATH="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-webservice/${npm_package_config_webservice_version}/dockstore-webservice-${npm_package_config_webservice_version}.jar"
 fi

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -16,4 +16,4 @@ psql -h localhost -c "create user dockstore with password 'dockstore' createdb;"
 psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
 psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
 psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
-java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0 test/web.yml
+java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0 test/web.yml


### PR DESCRIPTION
**Description**
This PR fixes the failure to retrieve CircleCI artifacts. They're not missing from CircleCI (can see them in the Artifacts URL of a CircleCI build). The problem is that the artifact download URL changed after this [build](https://app.circleci.com/pipelines/github/dockstore/dockstore/7435/workflows/b025395e-4a6e-4c55-a449-62226dc54729/jobs/18239).

- Old URL: `https://18239-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.13.0-SNAPSHOT.jar`
- New URL: `https://output.circle-artifacts.com/output/job/94cd379a-e46a-4a0a-b24e-0a644c192a5d/artifacts/0/tmp/artifacts/dockstore-webservice-1.13.0-SNAPSHOT.jar`

This [discuss topic](https://discuss.circleci.com/t/artifact-urls-now-private/43282) has people who ran into this change as well and a [CircleCI employee said that they made some changes internally](https://discuss.circleci.com/t/artifact-urls-now-private/43282/8). It seems like the URL we were using is part of the [v1 API](https://circleci.com/docs/api/#download-an-artifact-file), which is deprecated, so it's probably best to move away from it anyway.

This PR creates a script that gets the artifact URL by calling the [CircleCI endpoint that retrieves all artifacts for a build](https://circleci.com/docs/api/v2/#operation/getJobArtifacts), finding the correct artifact based on its path, and returning its URL. This method should guarantee that any future changes to the artifact URL doesn't affect us. 

Note that the script finds the correct artifact by looking for an artifact with a path that contains the `<artifact-name>` that is provided. The artifacts that we're interested in have paths with the format `tmp/artifacts/<artifact-name>`. An advantage of using a "contains" filter to find the artifact is that we won't need to specify the specific Dockstore webservice jar version in `scripts/run-webservice-script.sh`. It'll look for an artifact that contains `dockstore-webservice` in the CircleCI build.

Somewhat unrelated changes:
- Added 1.13.0 migrations (forgot to do this for the front-end)
- I updated the Java version from 11 to 17 because the latest develop CircleCI webservice JAR failed to start on CircleCI due to this error: `java.lang.UnsupportedClassVersionError: io/dockstore/common/EntryType has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0`.
  - Had to use `openjdk-17-jdk` instead of `openjdk-17-jre` because the jre version failed to install on CircleCI.
  - Tested Java 17 with the current artifactory `1.13.0-alpha.6` JAR and most of the tests passed. The failed tests are due to unrelated flakiness. Can view the CircleCI job [here](https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/7600/workflows/54c20b38-3dc0-44d4-883e-30bfffd476de) if curious.

**Issue**
[SEAB-4239](https://ucsc-cgl.atlassian.net/browse/SEAB-4239)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
