### PR TITLE
Add contents write permissions for update license GitHub Action

### DIFF
--- a/.github/workflows/update_license.yml
+++ b/.github/workflows/update_license.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'dependabot/**'
 
+permissions:
+  contents: write
+
 jobs:
   update_license_file:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update_license.yml
+++ b/.github/workflows/update_license.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'dependabot/**'
 
+# Workflows triggered by Dependabot have a read-only token by default. 
+# Need to grant write permissions so this workflow can commit changes to the license file.
 permissions:
   contents: write
 


### PR DESCRIPTION
**Description**
Tried running the update license GItHub action for a Dependabot branch and it [failed](https://github.com/dockstore/dockstore-ui2/runs/6278398811?check_suite_focus=true). Turns out workflows triggered by Dependabot use a [read-only `GITHUB_TOKEN` by default](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) so the workflow couldn't commit the change. If we manually re-run the failed Dependabot workflow, then it'll work because it'll use a [read-write token](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#manually-re-running-a-workflow). 

It's not really ideal to manually re-run it, so this PR increases the permissions of the `GITHUB_TOKEN` to have `contents: write` so the workflow initiated by Dependabot can commit changes to the license file.

**Issue**
Part 2 of [SEAB-4223](https://ucsc-cgl.atlassian.net/browse/SEAB-4223)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
