### PR TITLE
DOCK-2105: Render newlines in GitHub app log messages

### DIFF
--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -39,9 +39,7 @@
               class="expanded-row-detail"
               [@detailExpand]="element === expandedElement ? 'expanded' : 'collapsed'"
             >
-              <div class="p-2">
-                {{ element.message }}
-              </div>
+              <div class="p-2 log-entry-message">{{ element.message }}</div>
             </div>
           </td>
         </ng-container>

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.scss
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.scss
@@ -25,3 +25,9 @@ tr.element-row:not(.expanded-row):active {
   overflow: hidden;
   display: flex;
 }
+
+.log-entry-message {
+  white-space: pre-wrap;
+  font-family: monospace;
+  line-height: 1.25;
+}

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.scss
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.scss
@@ -29,5 +29,6 @@ tr.element-row:not(.expanded-row):active {
 .log-entry-message {
   white-space: pre-wrap;
   font-family: monospace;
-  line-height: 1.25;
+  line-height: 1.4;
+  font-size: 12px;
 }


### PR DESCRIPTION
**Description**
This PR changes the UI so that newlines in the github apps log messages are formatted as newlines, rather than whitespace.  The log message style is changed so it preserves whitespace and is rendered in a small, monospace font, with a tighter-than-usual line height to fit more output in the available space.  The formatting is similar to how the message might look if it was within a `<pre>` tag.

<img width="770" alt="Screen Shot 2022-05-04 at 5 31 28 PM" src="https://user-images.githubusercontent.com/88108675/166848092-b0b4268a-38f5-4ed2-ab3f-d8fdbd367225.png">

These changes will improve the readability of multiline messages, and preserve the formatting of useful, preformatted messages, such as [some of] those that emerge via exceptions from deep in the YAML parser.

This PR was motivated by Kathy's review ticket feedback, combined with my earlier realization that it was The Right Thing to Do.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2105

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
