### PR TITLE
[DOCK-2053] Change "Cancel" to "OK" in workflow version modal

### DIFF
--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -206,7 +206,7 @@
     </fieldset>
   </div>
   <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
-    <button type="button" mat-flat-button class="secondary-1" mat-dialog-close>Cancel</button>
+    <button type="button" mat-flat-button class="secondary-1" mat-dialog-close>OK</button>
     <button
       data-cy="save-version"
       type="button"


### PR DESCRIPTION
**Description**
When viewing the version of a workflow, closing the modal should say "OK" instead of "Cancel".

**Issue**
[https://ucsc-cgl.atlassian.net/browse/DOCK-2053]

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
