### PR TITLE
[DOCK-2072] Add blog link to footer of dockstore.org

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -143,6 +143,11 @@
                 <small>Sitemap</small>
               </a>
             </li>
+            <li class="m-0">
+              <a href="https://medium.com/dockstore" target="_blank" rel="noopener noreferrer" class="footer-link">
+                <small>Dockstore Blog</small>
+              </a>
+            </li>
           </ul>
         </div>
 

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -145,7 +145,7 @@
             </li>
             <li class="m-0">
               <a href="https://medium.com/dockstore" target="_blank" rel="noopener noreferrer" class="footer-link">
-                <small>Dockstore Blog</small>
+                <small>Blog</small>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
**Description**
Original JIRA ticket asked for adding the link to two places (docs.dockstore.org and dockstore.org) but the docs page already has it in the ToC sidebar. New link is only added to the dockstore.org footer under Help Resources.

**Issue**
[JIRA DOCK-2072](https://ucsc-cgl.atlassian.net/browse/DOCK-2072)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
