### PR TITLE
Corrected config.yml so that it only installs Google Chrome and Chrome Driver once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,8 +193,6 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -209,8 +207,6 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -225,8 +221,6 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}
@@ -241,8 +235,6 @@ jobs:
     executor: integration_test_exec
     working_directory: ~/repo
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - setup_integration_test
       - restore_cache:
           key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "./package-lock.json" }}


### PR DESCRIPTION
**Description**
The Cypress dependencies Google Chrome and Chrome Driver were always being installed twice. This PR corrects that issue by installing the dependencies only once.

**Issue**
[DOCK-1996](https://ucsc-cgl.atlassian.net/browse/DOCK-1996) 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.cXom/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
