### PR TITLE
Fix notification bar styling

### DIFF
--- a/src/app/notifications/notifications.component.scss
+++ b/src/app/notifications/notifications.component.scss
@@ -1,6 +1,6 @@
 .notification-bar {
   background-color: #3b4045;
-  width: 100%;
+  max-width: 100%;
 }
 
 .low {


### PR DESCRIPTION
**Description**
A previous change caused the notification bar to not extend the full width, now this PR should change it back to fitting the entire width.

**Issue**
[DOCK-2115](https://ucsc-cgl.atlassian.net/browse/DOCK-2115)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
