### PR TITLE
Fix ORCID ID font size

### DIFF
--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -40,7 +40,7 @@
             </a>
             <h6 class="text-break" *ngIf="stargazer.orcid">
               ORCID <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
-              <a href="https://orcid.org/{{ stargazer.orcid }}" style="font-size: 0.9em">{{ stargazer.orcid }}</a>
+              <a href="https://orcid.org/{{ stargazer.orcid }}">{{ stargazer.orcid }}</a>
             </h6>
           </div>
         </mat-card>

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -40,7 +40,7 @@
             </a>
             <h6 class="text-break" *ngIf="stargazer.orcid">
               ORCID <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID iD logo" class="orcid-id-logo site-icons-small" />
-              <a href="https://orcid.org/{{ stargazer.orcid }}" style="font-size: 0.8em">{{ stargazer.orcid }}</a>
+              <a href="https://orcid.org/{{ stargazer.orcid }}" style="font-size: 0.9em">{{ stargazer.orcid }}</a>
             </h6>
           </div>
         </mat-card>


### PR DESCRIPTION
**Description**
The change of font caused the original defined font-size to be too small, increased font size by a bit (0.1em) to match prod.

**Issue**
[DOCK-2146](https://ucsc-cgl.atlassian.net/browse/DOCK-2146)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
