### PR TITLE
Feature/seab 4344/fix flaky apptool test

### DIFF
--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -29,7 +29,7 @@ describe('GitHub App Tools', () => {
 
   function selectGitHubAppTool(tool: string) {
     cy.get('#workflow-path').should('be.visible');
-    cy.contains('div .no-wrap', tool).click();
+    cy.contains('.org-accordion-list .no-wrap', tool).should('be.visible').click();
     cy.get('#workflow-path').contains(tool);
   }
 

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -29,7 +29,7 @@ describe('GitHub App Tools', () => {
 
   function selectGitHubAppTool(tool: string) {
     cy.get('#workflow-path').should('be.visible');
-    cy.contains('.org-accordion-list .no-wrap', tool).should('be.visible').click();
+    cy.contains('div .no-wrap', tool).should('be.visible').click();
     cy.get('#workflow-path').contains(tool);
   }
 

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -28,11 +28,9 @@ describe('GitHub App Tools', () => {
   }
 
   function selectGitHubAppTool(tool: string) {
-    cy.wait(1000);
     cy.get('#workflow-path').should('be.visible');
-    cy.contains('div .no-wrap', tool).should('be.visible').click();
+    cy.contains('div .no-wrap', tool).click();
     cy.get('#workflow-path').contains(tool);
-    cy.wait(1000);
   }
 
   describe('My Tools', () => {

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -145,6 +145,7 @@ describe('GitHub App Tools', () => {
     });
 
     it('Public view', () => {
+      cy.wait(1000);
       selectGitHubAppTool('test-github-app-tools/md5sum');
       cy.get('[data-cy=viewPublicWorkflowButton]').click();
       cy.get('[data-cy=tool-icon]').should('exist');

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -28,9 +28,11 @@ describe('GitHub App Tools', () => {
   }
 
   function selectGitHubAppTool(tool: string) {
+    cy.wait(1000);
     cy.get('#workflow-path').should('be.visible');
     cy.contains('div .no-wrap', tool).should('be.visible').click();
     cy.get('#workflow-path').contains(tool);
+    cy.wait(1000);
   }
 
   describe('My Tools', () => {
@@ -145,7 +147,6 @@ describe('GitHub App Tools', () => {
     });
 
     it('Public view', () => {
-      cy.wait(1000);
       selectGitHubAppTool('test-github-app-tools/md5sum');
       cy.get('[data-cy=viewPublicWorkflowButton]').click();
       cy.get('[data-cy=tool-icon]').should('exist');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -19,7 +19,9 @@
 const psqlInvocation: string = 'PASSWORD=dockstore psql';
 
 export function goToTab(tabName: string): void {
+  cy.wait(500);
   cy.contains('.mat-tab-label', tabName).should('be.visible').click();
+  cy.wait(500);
 }
 
 export function assertVisibleTab(tabName: string): void {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -19,6 +19,8 @@
 const psqlInvocation: string = 'PASSWORD=dockstore psql';
 
 export function goToTab(tabName: string): void {
+  // cypress tests run asynchronously, so if the DOM changes and an element-of-interest becomes detached while we're manipulating it, the test will fail.
+  // our current (admittedly primitive) go-to solution is to wait (sleep) for long enough that the DOM "settles", thus avoiding the "detached element" bug.
   cy.wait(500);
   cy.contains('.mat-tab-label', tabName).should('be.visible').click();
   cy.wait(500);


### PR DESCRIPTION
**Description**
Added some `cy.wait()`s to fix that flaky ui2 test, which was due to the DOM changing during the test, detaching the element we were about to `click()` on.   Before this change, the test was failing about 50% of the time.  I ran this fix four times in a row on CircleCI with no failures, so it's probably done.

This took me a bit longer to solve than it would have if I'd first examined the Cypress "Recorded Run" page, available at the end of the logs in the "Test" step of the CircleCI run:
https://dashboard.cypress.io/projects/1ya4vj/runs/23089
All of the relevant information is available in one place, letting you get to the root of the problem quickly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4344

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
