### PR TITLE
Add blog link below Username on User-pages

### DIFF
--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -13,6 +13,9 @@
       <img mat-card-image [src]="user?.avatarUrl" class="mt-0 mx-auto mb-3" alt="Dockstore avatar" />
       <mat-card-content fxLayout="column" fxLayoutAlign="center center">
         <h4 matLine class="accent-1-dark mt-2 mb-0">{{ user?.username }}</h4>
+        <a href="{{ gitHubProfile?.link }}" target="_blank" class="accent-1-dark">
+          <span>{{ gitHubProfile?.link }}</span>
+        </a>
       </mat-card-content>
     </mat-card>
 


### PR DESCRIPTION
**Description**
Add blog link (from github user page) below the username in user-pages. 

**Issue**
[DOCK-2165](https://ucsc-cgl.atlassian.net/browse/DOCK-2165)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
