### PR TITLE
Fix "Restub" button overlapping with mode in Workflow Information

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -319,7 +319,7 @@
             <strong matTooltip="Currently disabled for Hosted Workflows and Nextflow Workflows">Checker Workflow</strong>: n/a
           </div>
           <li *ngIf="!isPublic">
-            <div fxFlex="noshrink" fxLayoutAlign="center">
+            <div fxFlex="noshrink" fxLayoutAlign="start center">
               <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ 'mode' | mapFriendlyValue: workflow?.mode }}
             </div>
             <button

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -319,10 +319,12 @@
             <strong matTooltip="Currently disabled for Hosted Workflows and Nextflow Workflows">Checker Workflow</strong>: n/a
           </div>
           <li *ngIf="!isPublic">
-            <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ 'mode' | mapFriendlyValue: workflow?.mode }}
+            <div fxFlex="noshrink" fxLayoutAlign="center">
+              <strong [matTooltip]="modeTooltipContent">Mode</strong>: {{ 'mode' | mapFriendlyValue: workflow?.mode }}
+            </div>
             <button
               mat-raised-button
-              class="push-right small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+              class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
               type="button"
               *ngIf="workflow?.mode === WorkflowType.ModeEnum.FULL && !workflow?.is_published && !workflow?.isChecker"
               (click)="restubWorkflow()"


### PR DESCRIPTION
**Description**
There was a bug that caused the "Restub" button to overlap with the Mode text when viewing workflow information of a full and unpublished workflow.

**Issue**
[GitHub issue](https://github.com/dockstore/dockstore/issues/4761)
[JIRA ticket](https://ucsc-cgl.atlassian.net/browse/DOCK-2086)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
