### PR TITLE
Feature/seab 4301/reporting nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
-        environment:
+        environment:bin/bash: -c: bin/bash: -c: 
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
       - image: cimg/postgres:13.3
         command: postgres -c max_connections=200 -c jit=off
@@ -382,44 +382,6 @@ workflows:
             - lint_license_unit_test_coverage
           context:
             - dockerhub
-#DELETE BELOW
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_dev"
-          stack: "dev"
-          context:
-            - dockerhub
-            - oicr-slack
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_staging"
-          stack: "staging"
-          context:
-            - dockerhub
-            - oicr-slack
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_prod"
-          stack: "prod"
-          context:
-            - dockerhub
-            - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_dev"
-          stack: "dev"
-          context:
-            - dockerhub
-            - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_staging"
-          stack: "staging"
-          context:
-            - dockerhub
-            - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_prod"
-          stack: "prod"
-          context:
-            - dockerhub
-            - oicr-slack
- #DELETE ABOVE 
       # Upload builds for tags and branches to s3.
       - upload_to_s3:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
-        environment:bin/bash: -c: bin/bash: -c: 
+        environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
       - image: cimg/postgres:13.3
         command: postgres -c max_connections=200 -c jit=off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.4.4
   browser-tools: circleci/browser-tools@1.2.4
 executors:
   integration_test_exec: # declares a reusable executor
@@ -60,11 +60,14 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
+      - slack/notify:
           channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-          webhook: $SLACK_WEBHOOK
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: $<< parameters.stack >>_id
+          event: pass
+          template: basic_success_1
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
@@ -89,11 +92,14 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
+      - slack/notify:
           channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> auth tests failed!
-          webhook: $SLACK_WEBHOOK
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: $<< parameters.stack >>_id
+          event: pass
+          template: basic_success_1
 
   audit:
     working_directory: ~/repo
@@ -113,7 +119,7 @@ jobs:
             then
               git fetch origin +refs/pull/${CIRCLE_PULL_REQUEST##*/}/merge:
               git checkout -qf FETCH_HEAD
-            fi
+            figit get the latest from master
       - install_container_dependencies
       - run:
           name: Run npm audit
@@ -376,6 +382,44 @@ workflows:
             - lint_license_unit_test_coverage
           context:
             - dockerhub
+#DELETE BELOW
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_dev"
+          stack: "dev"
+          context:
+            - dockerhub
+            - oicr-slack
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_staging"
+          stack: "staging"
+          context:
+            - dockerhub
+            - oicr-slack
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_prod"
+          stack: "prod"
+          context:
+            - dockerhub
+            - oicr-slack
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_dev"
+          stack: "dev"
+          context:
+            - dockerhub
+            - oicr-slack
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_staging"
+          stack: "staging"
+          context:
+            - dockerhub
+            - oicr-slack
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_prod"
+          stack: "prod"
+          context:
+            - dockerhub
+            - oicr-slack
+ #DELETE ABOVE 
       # Upload builds for tags and branches to s3.
       - upload_to_s3:
           requires:
@@ -412,31 +456,37 @@ workflows:
           stack: "dev"
           context:
             - dockerhub
+            - oicr-slack
       - uptime_monitor_no_auth:
           name: "uptime_monitor_no_auth_staging"
           stack: "staging"
           context:
             - dockerhub
+            - oicr-slack
       - uptime_monitor_no_auth:
           name: "uptime_monitor_no_auth_prod"
           stack: "prod"
           context:
             - dockerhub
+            - oicr-slack
       - uptime_monitor_auth:
           name: "uptime_monitor_auth_dev"
           stack: "dev"
           context:
             - dockerhub
+            - oicr-slack
       - uptime_monitor_auth:
           name: "uptime_monitor_auth_staging"
           stack: "staging"
           context:
             - dockerhub
+            - oicr-slack
       - uptime_monitor_auth:
           name: "uptime_monitor_auth_prod"
           stack: "prod"
           context:
             - dockerhub
+            - oicr-slack
 
 commands:
   install_container_dependencies:

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -180,27 +180,31 @@ function testTool(registry: string, repo: string, name: string) {
 
   // disable test until hiding versions for Tools are working on dev
 
-  describe('Hide and un-hide a tool version', () => {
-    registerQuayTool(repo, name);
-    it('hide a version', () => {
-      goToTab('Versions');
-      cy.contains('button', 'Actions').should('be.visible');
-      cy.contains('td', 'Actions').first().click();
-      cy.contains('button', 'Edit').click();
-      cy.contains('div', 'Hidden:').within(() => {
-        cy.get('[name=checkbox]').click();
-      });
-      cy.contains('button', 'Save Changes').click();
-      cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
-    });
-    it('refresh namespace', () => {
-      cy.contains('button', 'Refresh Namespace').first().click();
-      // check that the 'refresh succeeded' message appears
-      cy.contains('succeeded');
-    });
-    unpublishTool();
-    deleteTool();
-  });
+  // describe('Hide and un-hide a tool version', () => {
+  //   registerQuayTool(repo, name);
+  //   it('hide a version', () => {
+  //     goToTab('Versions');
+  //     cy.contains('button', 'Actions').should('be.visible');
+  //     cy.contains('td', 'Actions')
+  //       .first()
+  //       .click();
+  //     cy.contains('button', 'Edit').click();
+  //     cy.contains('div', 'Hidden:').within(() => {
+  //       cy.get('[name=checkbox]').click();
+  //     });
+  //     cy.contains('button', 'Save Changes').click();
+  //     cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
+  //   });
+  //   it('refresh namespace', () => {
+  //     cy.contains('button', 'Refresh Namespace')
+  //       .first()
+  //       .click();
+  //     // check that the 'refresh succeeded' message appears
+  //     cy.contains('succeeded');
+  //   });
+  //   unpublishTool();
+  //   deleteTool();
+  // });
 }
 
 function testWorkflow(registry: string, repo: string, name: string) {

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -180,31 +180,27 @@ function testTool(registry: string, repo: string, name: string) {
 
   // disable test until hiding versions for Tools are working on dev
 
-  // describe('Hide and un-hide a tool version', () => {
-  //   registerQuayTool(repo, name);
-  //   it('hide a version', () => {
-  //     goToTab('Versions');
-  //     cy.contains('button', 'Actions').should('be.visible');
-  //     cy.contains('td', 'Actions')
-  //       .first()
-  //       .click();
-  //     cy.contains('button', 'Edit').click();
-  //     cy.contains('div', 'Hidden:').within(() => {
-  //       cy.get('[name=checkbox]').click();
-  //     });
-  //     cy.contains('button', 'Save Changes').click();
-  //     cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
-  //   });
-  //   it('refresh namespace', () => {
-  //     cy.contains('button', 'Refresh Namespace')
-  //       .first()
-  //       .click();
-  //     // check that the 'refresh succeeded' message appears
-  //     cy.contains('succeeded');
-  //   });
-  //   unpublishTool();
-  //   deleteTool();
-  // });
+  describe('Hide and un-hide a tool version', () => {
+    registerQuayTool(repo, name);
+    it('hide a version', () => {
+      goToTab('Versions');
+      cy.contains('button', 'Actions').should('be.visible');
+      cy.contains('td', 'Actions').first().click();
+      cy.contains('button', 'Edit').click();
+      cy.contains('div', 'Hidden:').within(() => {
+        cy.get('[name=checkbox]').click();
+      });
+      cy.contains('button', 'Save Changes').click();
+      cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
+    });
+    it('refresh namespace', () => {
+      cy.contains('button', 'Refresh Namespace').first().click();
+      // check that the 'refresh succeeded' message appears
+      cy.contains('succeeded');
+    });
+    unpublishTool();
+    deleteTool();
+  });
 }
 
 function testWorkflow(registry: string, repo: string, name: string) {


### PR DESCRIPTION
**Description**
This PR makes it so that the nightly tests always report their outcomes to slack (before they only reported when they failed).

This PR also updated config.yml so that it uses the slack orb `circleci/slack@4.4.4` instead of `circleci/slack@3.4.2`. 

**Issue**
[SEAB-4301](https://ucsc-cgl.atlassian.net/browse/SEAB-4301?atlOrigin=eyJpIjoiYmYwN2JlYmQ3ZWVjNDQyZGI0MmJkY2E2NTBkODU0NjUiLCJwIjoiaiJ9) 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
