### PR TITLE
re-enabled test in auth-tests.ts

### DIFF
--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -180,31 +180,27 @@ function testTool(registry: string, repo: string, name: string) {
 
   // disable test until hiding versions for Tools are working on dev
 
-  // describe('Hide and un-hide a tool version', () => {
-  //   registerQuayTool(repo, name);
-  //   it('hide a version', () => {
-  //     goToTab('Versions');
-  //     cy.contains('button', 'Actions').should('be.visible');
-  //     cy.contains('td', 'Actions')
-  //       .first()
-  //       .click();
-  //     cy.contains('button', 'Edit').click();
-  //     cy.contains('div', 'Hidden:').within(() => {
-  //       cy.get('[name=checkbox]').click();
-  //     });
-  //     cy.contains('button', 'Save Changes').click();
-  //     cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
-  //   });
-  //   it('refresh namespace', () => {
-  //     cy.contains('button', 'Refresh Namespace')
-  //       .first()
-  //       .click();
-  //     // check that the 'refresh succeeded' message appears
-  //     cy.contains('succeeded');
-  //   });
-  //   unpublishTool();
-  //   deleteTool();
-  // });
+  describe('Hide and un-hide a tool version', () => {
+    registerQuayTool(repo, name);
+    it('hide a version', () => {
+      goToTab('Versions');
+      cy.contains('button', 'Actions').should('be.visible');
+      cy.contains('td', 'Actions').first().click();
+      cy.contains('button', 'Edit').click();
+      cy.contains('div', 'Hidden:').within(() => {
+        cy.get('[name=checkbox]').click();
+      });
+      cy.contains('button', 'Save Changes').click();
+      cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
+    });
+    it('refresh namespace', () => {
+      cy.contains('button', 'Refresh Namespace').first().click();
+      // check that the 'refresh succeeded' message appears
+      cy.contains('succeeded');
+    });
+    unpublishTool();
+    deleteTool();
+  });
 }
 
 function testWorkflow(registry: string, repo: string, name: string) {


### PR DESCRIPTION
**Description**
A smoke test to check hiding versions was disabled in this [pull request](https://github.com/dockstore/dockstore-ui2/pull/1050), however the issue that caused this test to fail has been fixed on the backend.

This PR re-enables the test.

**Issue**
[DOCK-1585](https://ucsc-cgl.atlassian.net/browse/DOCK-1585)

https://github.com/dockstore/dockstore/issues/3816

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
