### PR TITLE
Fix 'info' icon not appearing under Activity of user page

### DIFF
--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -1,6 +1,6 @@
 <app-loading [loading]="loading$ | async">
   <div *ngIf="noEvents$ | async">
-    <mat-card class="alert alert-info" role="alert">
+    <mat-card class="alert alert-info mx-1" role="alert">
       <mat-icon class="mat-icon material-icons">info</mat-icon> No events found. Star entries or organizations to see events for them. Read
       <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">Starring Tools and Workflows</a>
       to learn how to star entries.

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -1,10 +1,10 @@
 <app-loading [loading]="loading$ | async">
   <div *ngIf="noEvents$ | async">
-    <mat-card class="alert alert-info mx-1" role="alert">
-      <mat-icon>info</mat-icon> No events found. Star entries or organizations to see events for them. Read
+    <mat-card class="alert alert-info" role="alert">
+      <mat-icon class="mat-icon material-icons">info</mat-icon> No events found. Star entries or organizations to see events for them. Read
       <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">Starring Tools and Workflows</a>
-      to learn how to star entries.</mat-card
-    >
+      to learn how to star entries.
+    </mat-card>
   </div>
   <!-- Possible changes: Toggle highlighting of verbs and nouns. Toggle dates into a separate column to the left -->
   <mat-card *ngIf="(events$ | async)?.length > 0">

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -1,7 +1,7 @@
 <app-loading [loading]="loading$ | async">
   <div *ngIf="noEvents$ | async">
     <mat-card class="alert alert-info mx-1" role="alert">
-      <mat-icon class="mat-icon material-icons">info</mat-icon> No events found. Star entries or organizations to see events for them. Read
+      <mat-icon>info</mat-icon> No events found. Star entries or organizations to see events for them. Read
       <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">Starring Tools and Workflows</a>
       to learn how to star entries.
     </mat-card>

--- a/src/app/home-page/recent-events/recent-events.module.ts
+++ b/src/app/home-page/recent-events/recent-events.module.ts
@@ -7,11 +7,12 @@ import { MatCardModule } from '@angular/material/card';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatDividerModule } from '@angular/material/divider';
 import { RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [RecentEventsComponent, EntryToDisplayNamePipe],
   providers: [],
-  imports: [RefreshAlertModule, CommonModule, MatCardModule, FlexLayoutModule, MatDividerModule, RouterModule],
+  imports: [RefreshAlertModule, MatIconModule, CommonModule, MatCardModule, FlexLayoutModule, MatDividerModule, RouterModule],
   exports: [RecentEventsComponent],
 })
 export class RecentEventsModule {}


### PR DESCRIPTION
**Description**
On the new user page, the 'info' icon was not appearing correctly and was appearing as text instead under the activity bar. This was fixed by manually adding material-icon and mat-icon classes to the mat-icon element that should appear for it automatically but does not in this case. Unsure as to why it does not work here and would love to hear ideas/alternative solutions from other devs.

**Issue**
GitHub issue: [#4902](https://github.com/dockstore/dockstore/issues/4902)
Jira: [DOCK-2168](https://ucsc-cgl.atlassian.net/browse/DOCK-2168)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
