### PR TITLE
Fix 'Default Version Required' dialog typo

### DIFF
--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -111,12 +111,14 @@ export class EntryActionsService {
   openNoDefaultDialog(entry: Entry, entryType: string, showVersions: EventEmitter<void> | null): void {
     const informationDialogData: InformationDialogData = {
       title: 'Default Version Required',
-      message: `Your ${entryType} must have a default version to be published.  Please use the the Actions menu in the Versions tab to select a default version.`,
+      message: `Your ${entryType} must have a default version to be published.  Please use the Actions menu in the Versions tab to select a default version.`,
       closeButtonText: 'OK',
     };
     const observable = this.informationDialogService.openDialog(informationDialogData, bootstrap4mediumModalSize);
     if (showVersions != null) {
-      observable.subscribe(() => { showVersions.emit(); });
+      observable.subscribe(() => {
+        showVersions.emit();
+      });
     }
   }
 


### PR DESCRIPTION
**Description**
The dialog had a typo where the message had 'the the' in it, this PR takes out the extra 'the'.

**Issue**
GitHub Issue: [4853](https://github.com/dockstore/dockstore/issues/4853)
JIRA ticket: [DOCK-2135](https://ucsc-cgl.atlassian.net/browse/DOCK-2135)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
