### PR TITLE
Display gxformat2 as Galaxy on collections page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7331/workflows/56ee2021-675a-460f-ae3e-663f456fc27c/jobs/17708/artifacts",
     "circle_build_id": "17708",
-    "base_branch": "release/2.9"
+    "base_branch": "hotfix/2.9.1"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -159,7 +159,9 @@
                             <span>Verified</span>
                           </span>
                         </mat-chip>
-                        <span class="bubble" *ngFor="let descriptorType of entry.descriptorTypes">{{ descriptorType }}</span>
+                        <span class="bubble" *ngFor="let descriptorType of entry.descriptorTypes">{{
+                          'descriptor_type' | mapFriendlyValue: descriptorType
+                        }}</span>
                       </mat-chip-list>
                     </div>
                     <button mat-raised-button class="small-mat-btn-skin small-btn-structure" color="accent">View</button>


### PR DESCRIPTION
**Description**
This PR uses the `mapFriendlyValue` pipe to display `gxformat2` as `Galaxy` for Galaxy workflows on a collection page. 

This PR also changes the `base_branch` in `package.json` to the hotfix branch so the CircleCI audit tests run against the hotfix branch instead of develop.

Before:
![image](https://user-images.githubusercontent.com/25287123/169593901-28c9c0cd-f9a3-4dc1-a5a8-fee040addb10.png)


After:
![image](https://user-images.githubusercontent.com/25287123/169593828-948f7db5-f614-40a1-bb23-6074d7cc9ff2.png)


**Issue**
dockstore/dockstore#4427

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
