### PR TITLE
rename smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
 jobs:
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  uptime_monitor_no_auth:
+  no_auth_smoke_tests:
     parameters:
       stack:
         type: string
@@ -71,7 +71,7 @@ jobs:
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  uptime_monitor_auth:
+  auth_smoke_tests:
     parameters:
       stack:
         type: string
@@ -413,38 +413,38 @@ workflows:
               only:
                 - develop
     jobs:
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_dev"
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_dev"
           stack: "dev"
           context:
             - dockerhub
             - oicr-slack
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_staging"
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_staging"
           stack: "staging"
           context:
             - dockerhub
             - oicr-slack
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_prod"
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_prod"
           stack: "prod"
           context:
             - dockerhub
             - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_dev"
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_dev"
           stack: "dev"
           context:
             - dockerhub
             - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_staging"
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_staging"
           stack: "staging"
           context:
             - dockerhub
             - oicr-slack
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_prod"
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_prod"
           stack: "prod"
           context:
             - dockerhub


### PR DESCRIPTION
**Description**
This PR changes the name of the CI smoke tests such that they are a bit more intuitive.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
