### PR TITLE
My Tools temporarily show "No tools registered" when loading is not complete

### DIFF
--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -58,7 +58,13 @@
                   Register a Tool
                 </button>
               </div>
-              <p *ngIf="(hasGroupEntriesObject$ | async) === false && (hasGroupGitHubAppToolEntriesObjects$ | async) === false">
+              <p
+                *ngIf="
+                  (hasGroupEntriesObject$ | async) === false &&
+                  (hasGroupGitHubAppToolEntriesObjects$ | async) === false &&
+                  (loading$ | async) === false
+                "
+              >
                 You have not registered any tools
               </p>
               <app-workflow-sidebar-accordion


### PR DESCRIPTION
**Description**
If a user has tools, when the user tries to load their tools, in the process of loading them, they may see a message that says "You have not registered any tools" before they are fetched. This may be misleading for them. This fix adds a check to see if the page is still loading before presenting that message. Note that this bug was recreated only on 'coverbeck''s account.

**Issue**
GitHub Issue: [#4777](https://github.com/dockstore/dockstore/issues/4777)
JIRA ticket: [DOCK-2096](https://ucsc-cgl.atlassian.net/browse/DOCK-2096)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
