### PR TITLE
Remove case-sensitive sort for repositories

### DIFF
--- a/src/app/shared/entry-wizard/entry-wizard.component.ts
+++ b/src/app/shared/entry-wizard/entry-wizard.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Repository } from '../openapi/model/repository';
 import { EntryWizardQuery } from '../state/entry-wizard.query';
 import { EntryWizardService } from '../state/entry-wizard.service';
@@ -25,7 +26,12 @@ export class EntryWizardComponent implements OnInit {
     this.isLoading$ = this.entryWizardQuery.selectLoading();
     this.gitRegistries$ = this.entryWizardQuery.selectGitRegistries$;
     this.gitOrganizations$ = this.entryWizardQuery.selectGitOrganizations$;
-    this.gitRepositories$ = this.entryWizardQuery.selectGitRepositories$;
+    this.gitRepositories$ = this.entryWizardQuery.selectGitRepositories$.pipe(
+      map((repositories) => {
+        repositories.sort((a, b) => a.repositoryName.localeCompare(b.repositoryName));
+        return repositories;
+      })
+    );
   }
 
   /**

--- a/src/app/shared/entry-wizard/entry-wizard.component.ts
+++ b/src/app/shared/entry-wizard/entry-wizard.component.ts
@@ -32,7 +32,7 @@ export class EntryWizardComponent implements OnInit {
           repositories.sort((a, b) => a.repositoryName.localeCompare(b.repositoryName));
           return repositories;
         } else {
-          return [];
+          return null;
         }
       })
     );

--- a/src/app/shared/entry-wizard/entry-wizard.component.ts
+++ b/src/app/shared/entry-wizard/entry-wizard.component.ts
@@ -28,8 +28,12 @@ export class EntryWizardComponent implements OnInit {
     this.gitOrganizations$ = this.entryWizardQuery.selectGitOrganizations$;
     this.gitRepositories$ = this.entryWizardQuery.selectGitRepositories$.pipe(
       map((repositories) => {
-        repositories.sort((a, b) => a.repositoryName.localeCompare(b.repositoryName));
-        return repositories;
+        if (repositories !== undefined) {
+          repositories.sort((a, b) => a.repositoryName.localeCompare(b.repositoryName));
+          return repositories;
+        } else {
+          return [];
+        }
       })
     );
   }

--- a/src/app/shared/entry-wizard/entry-wizard.component.ts
+++ b/src/app/shared/entry-wizard/entry-wizard.component.ts
@@ -28,7 +28,7 @@ export class EntryWizardComponent implements OnInit {
     this.gitOrganizations$ = this.entryWizardQuery.selectGitOrganizations$;
     this.gitRepositories$ = this.entryWizardQuery.selectGitRepositories$.pipe(
       map((repositories) => {
-        if (repositories !== undefined) {
+        if (repositories) {
           repositories.sort((a, b) => a.repositoryName.localeCompare(b.repositoryName));
           return repositories;
         } else {


### PR DESCRIPTION
**Description**
When creating a workflow from the "Quickly register remote workflows" step, the list of repositories are ordered case sensitively (uppercase repositories are listed at the top). This PR should remove case-sensitivity in sorting. 

**Issue**
GitHub issue: [#4583](https://github.com/dockstore/dockstore/issues/4583)
JIRA ticket: [DOCK-1993](https://ucsc-cgl.atlassian.net/browse/DOCK-1993)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
