### PR TITLE
Don't request categories for unpublished entries (dockstore/dockstore#4821)

### DIFF
--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -26,7 +26,7 @@ export class EntryCategoriesService {
   constructor(
     private entryCategoriesStore: EntryCategoriesStore,
     private entryCategoriesQuery: EntryCategoriesQuery,
-    private entriesService: EntriesService,
+    private entriesService: EntriesService
   ) {
     /**
      * An observable list of the categories for a given entry.
@@ -42,14 +42,13 @@ export class EntryCategoriesService {
   /**
    * Updates the list of categories for the specified entry.
    */
-  updateEntryCategories(entryId: number) {
+  updateEntryCategories(entryId: number, published: boolean) {
     this.entryCategoriesStore.setLoading(true);
     this.entryCategoriesStore.setError(false);
     this.entryCategoriesStore.remove();
     this.currentSubscription?.unsubscribe();
-    this.currentSubscription = this.entriesService
-      .entryCategories(entryId)
-      .subscribe(
+    if (published) {
+      this.currentSubscription = this.entriesService.entryCategories(entryId).subscribe(
         (categories: Array<Category>) => {
           this.entryCategoriesStore.setLoading(false);
           this.entryCategoriesStore.setError(false);
@@ -60,5 +59,8 @@ export class EntryCategoriesService {
           this.entryCategoriesStore.setError(true);
         }
       );
+    } else {
+      this.entryCategoriesStore.set(null);
+    }
   }
 }

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -41,14 +41,17 @@ export class EntryCategoriesService {
 
   /**
    * Updates the list of categories for the specified entry.
+   * @param {number} entryId - The ID for the associated entry.
+   * @param {boolean} published - The published status for the entry, non-published entries cannot belong to a category.
    */
   updateEntryCategories(entryId: number, published: boolean) {
-    this.entryCategoriesStore.setLoading(true);
-    this.entryCategoriesStore.setError(false);
     this.entryCategoriesStore.remove();
     this.currentSubscription?.unsubscribe();
     this.currentSubscription = null;
+    this.entryCategoriesStore.setError(false);
+    this.entryCategoriesStore.setLoading(false);
     if (published) {
+      this.entryCategoriesStore.setLoading(true);
       this.currentSubscription = this.entriesService.entryCategories(entryId).subscribe(
         (categories: Array<Category>) => {
           this.entryCategoriesStore.setLoading(false);

--- a/src/app/categories/state/entry-categories.service.ts
+++ b/src/app/categories/state/entry-categories.service.ts
@@ -47,6 +47,7 @@ export class EntryCategoriesService {
     this.entryCategoriesStore.setError(false);
     this.entryCategoriesStore.remove();
     this.currentSubscription?.unsubscribe();
+    this.currentSubscription = null;
     if (published) {
       this.currentSubscription = this.entriesService.entryCategories(entryId).subscribe(
         (categories: Array<Category>) => {
@@ -59,8 +60,6 @@ export class EntryCategoriesService {
           this.entryCategoriesStore.setError(true);
         }
       );
-    } else {
-      this.entryCategoriesStore.set(null);
     }
   }
 }

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -225,7 +225,7 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
       this.contactAuthorHREF = this.emailService.composeContactAuthorEmail(this.tool);
       this.sortedVersions = this.getSortedTags(this.tool.workflowVersions, this.defaultVersion);
       this.updateVerifiedPlatforms(this.tool.id);
-      this.updateCategories(this.tool.id);
+      this.updateCategories(this.tool.id, this.tool.is_published);
     }
   }
 

--- a/src/app/organizations/collection/state/add-entry.service.ts
+++ b/src/app/organizations/collection/state/add-entry.service.ts
@@ -107,7 +107,7 @@ export class AddEntryService {
           this.alertService.detailedSuccess();
           this.currentCollectionsService.get(entryId);
           // Changing collection membership can change category membership.
-          this.entryCategoriesService.updateEntryCategories(entryId);
+          this.entryCategoriesService.updateEntryCategories(entryId, true);
         },
         (error: HttpErrorResponse) => {
           this.alertService.detailedError(error);

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -315,8 +315,8 @@ export abstract class Entry implements OnDestroy {
     );
   }
 
-  updateCategories(entryId: number): void {
-    this.entryCategoriesService.updateEntryCategories(entryId);
+  updateCategories(entryId: number, published: boolean): void {
+    this.entryCategoriesService.updateEntryCategories(entryId, published);
     this.categories$ = this.entryCategoriesService.categories$;
   }
 

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -275,7 +275,7 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
           });
       }
       this.updateVerifiedPlatforms(this.workflow.id);
-      this.updateCategories(this.workflow.id);
+      this.updateCategories(this.workflow.id, this.workflow.is_published);
     }
   }
 


### PR DESCRIPTION
**Description**
Removes fetching of categories for non-published entries. Attempting to request categories for a 
non-published workflow will currently result in a 400.

<img width="1264" alt="Screen Shot 2022-06-08 at 2 19 40 PM" src="https://user-images.githubusercontent.com/1947534/172719338-24d60a85-7b57-4427-b871-67f1b04304ed.png">


**Issue**
https://github.com/dockstore/dockstore/issues/4821

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
