### PR TITLE
Feature/flynn/seab 4406/spread out timings of tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ workflows:
   nightly_auth:
     triggers:
       - schedule:
-          cron: "0 11 * * *" # This is 4am PDT / 3am PST
+          cron: "0 12 * * *" # This is 5am PDT / 4am PST TODO change to 11, just wanted to ensure it worked
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
-  slack: circleci/slack@4.4.4
+  slack: circleci/slack@3.4.2
   browser-tools: circleci/browser-tools@1.2.4
 executors:
   integration_test_exec: # declares a reusable executor
@@ -34,7 +34,7 @@ executors:
 jobs:
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  no_auth_smoke_tests:
+  uptime_monitor_no_auth:
     parameters:
       stack:
         type: string
@@ -60,18 +60,15 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/notify:
+      - slack/status:
+          fail_only: true
           channel: $<< parameters.stack >>_id
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          channel: $<< parameters.stack >>_id
-          event: pass
-          template: basic_success_1
+          failure_message: Nightly << parameters.stack >> non-auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  auth_smoke_tests:
+  uptime_monitor_auth:
     parameters:
       stack:
         type: string
@@ -92,14 +89,11 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
-      - slack/notify:
+      - slack/status:
+          fail_only: true
           channel: $<< parameters.stack >>_id
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          channel: $<< parameters.stack >>_id
-          event: pass
-          template: basic_success_1
+          failure_message: Nightly << parameters.stack >> auth tests failed!
+          webhook: $SLACK_WEBHOOK
 
   audit:
     working_directory: ~/repo
@@ -404,7 +398,33 @@ workflows:
           context:
             - dockerhub
 
-  nightly:
+  nightly_no_auth:
+    triggers:
+      - schedule:
+          cron: "0 10 * * *" # This is 3am PDT / 2am PST
+          filters:
+            branches:
+              only:
+                - develop
+                - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
+    jobs:
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_dev"
+          stack: "dev"
+          context:
+            - dockerhub
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_staging"
+          stack: "staging"
+          context:
+            - dockerhub
+      - uptime_monitor_no_auth:
+          name: "uptime_monitor_no_auth_prod"
+          stack: "prod"
+          context:
+            - dockerhub
+
+  nightly_auth:
     triggers:
       - schedule:
           cron: "0 11 * * *" # This is 4am PDT / 3am PST
@@ -412,43 +432,23 @@ workflows:
             branches:
               only:
                 - develop
+                - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
     jobs:
-      - no_auth_smoke_tests:
-          name: "no_auth_smoke_tests_dev"
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_dev"
           stack: "dev"
           context:
             - dockerhub
-            - oicr-slack
-      - no_auth_smoke_tests:
-          name: "no_auth_smoke_tests_staging"
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_staging"
           stack: "staging"
           context:
             - dockerhub
-            - oicr-slack
-      - no_auth_smoke_tests:
-          name: "no_auth_smoke_tests_prod"
+      - uptime_monitor_auth:
+          name: "uptime_monitor_auth_prod"
           stack: "prod"
           context:
             - dockerhub
-            - oicr-slack
-      - auth_smoke_tests:
-          name: "auth_smoke_tests_dev"
-          stack: "dev"
-          context:
-            - dockerhub
-            - oicr-slack
-      - auth_smoke_tests:
-          name: "auth_smoke_tests_staging"
-          stack: "staging"
-          context:
-            - dockerhub
-            - oicr-slack
-      - auth_smoke_tests:
-          name: "auth_smoke_tests_prod"
-          stack: "prod"
-          context:
-            - dockerhub
-            - oicr-slack
 
 commands:
   install_container_dependencies:
@@ -457,7 +457,9 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-17-jdk -yq
+            sudo apt install openjdk-17-jdk -yq    All Pipelines
+
+All Pipelines
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.4.4
   browser-tools: circleci/browser-tools@1.2.4
 executors:
   integration_test_exec: # declares a reusable executor
@@ -34,7 +34,7 @@ executors:
 jobs:
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  uptime_monitor_no_auth:
+  no_auth_smoke_tests:
     parameters:
       stack:
         type: string
@@ -60,15 +60,18 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-waf-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
+      - slack/notify:
           channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> non-auth tests failed!
-          webhook: $SLACK_WEBHOOK
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: $<< parameters.stack >>_id
+          event: pass
+          template: basic_success_1
 
   # Specify the webpage url (https://dev.dockstore.net or https://staging.dockstore.org or https://dockstore.org)
   # and stack (dev or staging or prod) and the no auth smoke tests will be run against the corresponding webpage.
-  uptime_monitor_auth:
+  auth_smoke_tests:
     parameters:
       stack:
         type: string
@@ -89,11 +92,14 @@ jobs:
           environment:
             MOCHA_FILE: nightly-test-results/junit/test-<< parameters.stack >>-auth-[hash].xml
       - upload_nightly_artifacts
-      - slack/status:
-          fail_only: true
+      - slack/notify:
           channel: $<< parameters.stack >>_id
-          failure_message: Nightly << parameters.stack >> auth tests failed!
-          webhook: $SLACK_WEBHOOK
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: $<< parameters.stack >>_id
+          event: pass
+          template: basic_success_1
 
   audit:
     working_directory: ~/repo
@@ -408,21 +414,24 @@ workflows:
                 - develop
                 - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
     jobs:
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_dev"
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_dev"
           stack: "dev"
           context:
             - dockerhub
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_staging"
+            - oicr-slack
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_staging"
           stack: "staging"
           context:
             - dockerhub
-      - uptime_monitor_no_auth:
-          name: "uptime_monitor_no_auth_prod"
+            - oicr-slack
+      - no_auth_smoke_tests:
+          name: "no_auth_smoke_tests_prod"
           stack: "prod"
           context:
             - dockerhub
+            - oicr-slack
 
   nightly_auth:
     triggers:
@@ -434,21 +443,24 @@ workflows:
                 - develop
                 - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
     jobs:
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_dev"
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_dev"
           stack: "dev"
           context:
             - dockerhub
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_staging"
+            - oicr-slack
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_staging"
           stack: "staging"
           context:
             - dockerhub
-      - uptime_monitor_auth:
-          name: "uptime_monitor_auth_prod"
+            - oicr-slack
+      - auth_smoke_tests:
+          name: "auth_smoke_tests_prod"
           stack: "prod"
           context:
             - dockerhub
+            - oicr-slack
 
 commands:
   install_container_dependencies:
@@ -457,9 +469,7 @@ commands:
           name: Install java
           command: |
             sudo apt update -y
-            sudo apt install openjdk-17-jdk -yq    All Pipelines
-
-All Pipelines
+            sudo apt install openjdk-17-jdk -yq
       - run:
           name: Install npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
           executor: aws-cli/default
           steps:
             - aws-cli/setup:
-                profile-name: WEB IDENTITY PROFILE
+                profile-name: WEB IDENTITY PROFILEOICR VPN for Linux
                 role-arn: $AWS_ROLE_ARN
                 role-session-name: "CircleCI-${CIRCLE_WORKFLOW_ID}-${CIRCLE_JOB}"
             - get_workspace
@@ -412,7 +412,6 @@ workflows:
             branches:
               only:
                 - develop
-                - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
     jobs:
       - no_auth_smoke_tests:
           name: "no_auth_smoke_tests_dev"
@@ -436,12 +435,11 @@ workflows:
   nightly_auth:
     triggers:
       - schedule:
-          cron: "0 12 * * *" # This is 5am PDT / 4am PST TODO change to 11, just wanted to ensure it worked
+          cron: "0 11 * * *" # This is 4am PDT / 3am PST 
           filters:
             branches:
               only:
                 - develop
-                - feature/flynn/SEAB-4406/spread_out_timings_of_tests #TODO REMOVE
     jobs:
       - auth_smoke_tests:
           name: "auth_smoke_tests_dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
           executor: aws-cli/default
           steps:
             - aws-cli/setup:
-                profile-name: WEB IDENTITY PROFILEOICR VPN for Linux
+                profile-name: WEB IDENTITY PROFILE
                 role-arn: $AWS_ROLE_ARN
                 role-session-name: "CircleCI-${CIRCLE_WORKFLOW_ID}-${CIRCLE_JOB}"
             - get_workspace

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -180,31 +180,27 @@ function testTool(registry: string, repo: string, name: string) {
 
   // disable test until hiding versions for Tools are working on dev
 
-  // describe('Hide and un-hide a tool version', () => {
-  //   registerQuayTool(repo, name);
-  //   it('hide a version', () => {
-  //     goToTab('Versions');
-  //     cy.contains('button', 'Actions').should('be.visible');
-  //     cy.contains('td', 'Actions')
-  //       .first()
-  //       .click();
-  //     cy.contains('button', 'Edit').click();
-  //     cy.contains('div', 'Hidden:').within(() => {
-  //       cy.get('[name=checkbox]').click();
-  //     });
-  //     cy.contains('button', 'Save Changes').click();
-  //     cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
-  //   });
-  //   it('refresh namespace', () => {
-  //     cy.contains('button', 'Refresh Namespace')
-  //       .first()
-  //       .click();
-  //     // check that the 'refresh succeeded' message appears
-  //     cy.contains('succeeded');
-  //   });
-  //   unpublishTool();
-  //   deleteTool();
-  // });
+  describe('Hide and un-hide a tool version', () => {
+    registerQuayTool(repo, name);
+    it('hide a version', () => {
+      goToTab('Versions');
+      cy.contains('button', 'Actions').should('be.visible');
+      cy.contains('td', 'Actions').first().click();
+      cy.contains('button', 'Edit').click();
+      cy.contains('div', 'Hidden:').within(() => {
+        cy.get('[name=checkbox]').click();
+      });
+      cy.contains('button', 'Save Changes').click();
+      cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
+    });
+    it('refresh namespace', () => {
+      cy.contains('button', 'Refresh Namespace').first().click();
+      // check that the 'refresh succeeded' message appears
+      cy.contains('succeeded');
+    });
+    unpublishTool();
+    deleteTool();
+  });
 }
 
 function testWorkflow(registry: string, repo: string, name: string) {


### PR DESCRIPTION
**Description**
Makes it so that the night auth and nightly no_auth tests run at different times. This makes it so that it is easier to diagnose the problem when something goes wrong.

**Issue**
[SEAB-4406](https://ucsc-cgl.atlassian.net/browse/SEAB-4406)
Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
