### PR TITLE
Create a new 'My Dockstore' tab so logged-in users can see both dashboard and the logged-out homepage

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -18,7 +18,7 @@ import { AboutComponent } from './about/about.component';
 import { FundingComponent } from './funding/funding.component';
 import { GithubCallbackComponent } from './github-callback/github-callback.component';
 import { HomeLoggedInComponent } from './home-page/home-logged-in/home-logged-in.component';
-import { HomePageComponent } from './home-page/home-page.component';
+import { HomeComponent } from './home-page/home-logged-out/home.component';
 import { LoginComponent } from './login/login.component';
 import { AccountsComponent } from './loginComponents/accounts/accounts.component';
 import { AuthComponent } from './loginComponents/auth/auth.component';
@@ -34,8 +34,13 @@ import { StarredEntriesComponent } from './starredentries/starredentries.compone
 export const CLIENT_ROUTER_PROVIDERS = [AuthGuard];
 
 const APP_ROUTES: Routes = [
-  { path: '', component: HomePageComponent, pathMatch: 'full', data: { title: 'Dockstore' } },
-  { path: 'beta-homepage', component: HomeLoggedInComponent, pathMatch: 'full', data: { title: 'Dockstore' } },
+  { path: '', component: HomeComponent, pathMatch: 'full', data: { title: 'Dockstore' } },
+  {
+    path: 'dashboard',
+    component: HomeLoggedInComponent,
+    pathMatch: 'full',
+    data: { title: 'Dockstore' },
+  },
   {
     path: 'docs',
     loadChildren: () => import('app/docs/docs.module').then((m) => m.DocsModule),

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -222,7 +222,7 @@
               <a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/watch?v=shMr_Bd01Ko"
                 ><button mat-raised-button color="accent">Tutorial</button></a
               >
-              <button mat-raised-button color="accent" routerLink="/register" data-cy="register-button">
+              <button *ngIf="(user$ | async) === null" mat-raised-button color="accent" routerLink="/register" data-cy="register-button">
                 Register with <fa-icon [icon]="faGithub"></fa-icon> or <fa-icon [icon]="faGoogle"></fa-icon>
               </button>
             </div>

--- a/src/app/my-sidebar/my-sidebar.component.html
+++ b/src/app/my-sidebar/my-sidebar.component.html
@@ -17,7 +17,13 @@
 <div fxFlex="0 0 auto">
   <!-- Dashboard links to homepage since page doesn't exist yet -->
   <!-- TO DO: Update routerLink (button and hr) with Dashboard page when avalible -->
-  <button mat-flat-button class="purple" routerLink="" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+  <button
+    mat-flat-button
+    class="purple"
+    [routerLink]="['/dashboard']"
+    routerLinkActive="active"
+    [routerLinkActiveOptions]="{ exact: true }"
+  >
     <div><img src="../assets/svg/my-nav/dashboard.svg" alt="dashboard" /></div>
     Dashboard
   </button>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -41,6 +41,9 @@
           <img class="site-icons-small hidden-sm" src="../assets/svg/main-nav/icons-navigation-forum.svg" alt="stacked pages" /> Forum
         </a>
         <span class="spacer"></span>
+        <a mat-button class="icon" (click)="resetPageNumber()" [routerLink]="['/dashboard']" routerLinkActive="icon-active">
+          <img src="../assets/svg/my-nav/dashboard.svg" alt="dashboard" /> My Dockstore
+        </a>
         <div fxLayoutGap="1rem" *ngIf="!isLoggedIn">
           <a routerLink="/login">
             <button mat-raised-button color="accent">Login</button>


### PR DESCRIPTION
**Description**
Created a new tab called "My Dockstore" following this [design](https://projects.invisionapp.com/share/VNZ92Z0T2B3#/screens/438676232) under /dashboard. Now the dockstore logo brings users to the logged out homescreen without the "Register with github or google" button. 

**Issue**
Github issue: [4863](https://github.com/dockstore/dockstore/issues/4863)
JIRA ticket: [DOCK-2145](https://ucsc-cgl.atlassian.net/browse/DOCK-2145)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
