### PR TITLE
Organization members page has crowded UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0-alpha.6",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7655/workflows/351dcd6c-eab7-4b55-b2d3-4fe2a22500ff/jobs/19376/artifacts",
-    "circle_build_id": "19376",
+    "circle_ci_source": "https://circleci.com/api/v2/project/gh/dockstore/dockstore/20475/artifacts",
+    "circle_build_id": "20475",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "config": {
     "webservice_version": "1.13.0-alpha.6",
     "use_circle": true,
-    "circle_ci_source": "https://circleci.com/api/v2/project/gh/dockstore/dockstore/20475/artifacts",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/7871/workflows/d603dc05-1719-4205-bac8-06f628aad895/jobs/20475/artifacts",
     "circle_build_id": "20475",
     "base_branch": "develop"
   },

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -17,37 +17,39 @@
   <div class="pt-2" fxLayout="row wrap">
     <div fxFlex="50" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
       <mat-card fxFlex class="m-2" *ngIf="organizationUser?.accepted">
-        <div fxLayout="row" fxLayoutAlign="space-between stretch">
-          <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
-            <img *ngIf="organizationUser.user?.avatarUrl" mat-card-avatar class="header-image" [src]="organizationUser.user?.avatarUrl" />
-            <img
-              *ngIf="!organizationUser.user?.avatarUrl"
-              mat-card-avatar
-              class="header-image"
-              src="https://via.placeholder.com/300x300?text=Avatar+Not+Found"
-            />
-            <div fxFlex="80" fxLayout="column" fxLayoutAlign="start stretch">
-              <div fxLayout="row" fxLayoutAlign="space-between center">
-                <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
-                  <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
-                </a>
-                <span class="bubble ml-3">{{ organizationUser.role | titlecase }}</span>
-              </div>
-              <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row wrap">
-                <div>
-                  ORCID
-                  <img
-                    src="../../../assets/images/account-logos/orcid.svg"
-                    alt="ORCID iD logo"
-                    class="orcid-id-logo site-icons-small mr-3"
-                  />
+        <div fxLayout="column">
+          <div fxLayout="row" fxLayoutAlign="space-between stretch">
+            <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
+              <img *ngIf="organizationUser.user?.avatarUrl" mat-card-avatar class="header-image" [src]="organizationUser.user?.avatarUrl" />
+              <img
+                *ngIf="!organizationUser.user?.avatarUrl"
+                mat-card-avatar
+                class="header-image"
+                src="https://via.placeholder.com/300x300?text=Avatar+Not+Found"
+              />
+              <div fxFlex="80" fxLayout="column" fxLayoutAlign="start stretch">
+                <div fxLayout="row" fxLayoutAlign="space-between center">
+                  <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
+                    <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
+                  </a>
+                  <span class="bubble">{{ organizationUser.role | titlecase }}</span>
                 </div>
-                <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
-              </span>
+                <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row wrap">
+                  <div>
+                    ORCID
+                    <img
+                      src="../../../assets/images/account-logos/orcid.svg"
+                      alt="ORCID iD logo"
+                      class="orcid-id-logo site-icons-small mr-3"
+                    />
+                  </div>
+                  <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
+                </span>
+              </div>
             </div>
           </div>
-          <div fxFlex fxGrow="1" fxLayoutAlign="end center" *ngIf="canEditMembership$ | async">
-            <mat-card-content fxLayout="row" fxLayoutGap="10px" class="m-0">
+          <div fxLayoutAlign="center" *ngIf="canEditMembership$ | async">
+            <mat-card-content fxLayout="row" fxLayoutGap="35px" class="m-0" fxLayoutAlign="space-evenly">
               <button
                 mat-button
                 class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -917,7 +917,6 @@ app-workflow-sidebar-accordion
   max-height: 26px !important;
   padding: 0 0.75rem !important;
   display: inline-block !important;
-  min-width: 32px !important;
   font-weight: 500 !important;
   background: mat.get-color-from-palette($dockstore-app-gray, lighter);
 }


### PR DESCRIPTION
**Description**
When viewing the organization's members page as an admin, there are too many buttons in one row, causing the UI to look very bunched and crowded. This PR proposes putting the edit/delete buttons that only appear for organization admins onto a separate row below, and removes the 'min-width' set for `bubble` type labels (admin/maintainer) which caused the maintainer label to overflow.

**Issue**
[SEAB-4362](https://ucsc-cgl.atlassian.net/browse/SEAB-4362)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
