### PR TITLE
Remove invalid source code link for hosted tools

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -22,7 +22,7 @@
       </mat-card-header>
       <mat-card-content class="p-3">
         <ul class="list-unstyled container-info">
-          <li *ngIf="tool?.providerUrl">
+          <li *ngIf="tool?.providerUrl && tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
             <strong matTooltip="Source code repository for the associated tool descriptors and Dockerfile">Source Code</strong>:
             <a
               *ngIf="tool?.providerUrl"


### PR DESCRIPTION
**Description**
Tools hosted on Dockstore should not have a link as it is invalid once the user clicks on it, this PR adds a condition to the source code, matching the behaviour shown in workflows.

**Issue**
GitHub Issue: [#4954](https://github.com/dockstore/dockstore/issues/4954)
JIRA ticket: [DOCK-2184](https://ucsc-cgl.atlassian.net/browse/DOCK-2184)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
