### PR TITLE
Fix disabled member edit/delete buttons do not look disabled

### DIFF
--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -49,7 +49,13 @@
             </div>
           </div>
           <div fxLayoutAlign="center" *ngIf="canEditMembership$ | async">
-            <mat-card-content fxLayout="row" fxLayoutGap="35px" class="m-0" fxLayoutAlign="space-evenly">
+            <mat-card-content
+              *ngIf="organizationUser.user.id !== (userId$ | async)"
+              fxLayout="row"
+              fxLayoutGap="35px"
+              class="m-0"
+              fxLayoutAlign="space-evenly"
+            >
               <button
                 mat-button
                 class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"


### PR DESCRIPTION
**Description**
As an admin of an organization, when looking at the members page, their own member card's edit and delete buttons are disabled however they do not appear as disabled. Since the icons are fixed in colour, I think it makes sense to not show the buttons at all in this case.

**Issue**
GitHub Issue [4963](https://github.com/dockstore/dockstore/issues/4963)
JIRA ticket: [DOCK-2188](https://ucsc-cgl.atlassian.net/browse/DOCK-2188)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
