### PR TITLE
Fix Navigation bar items overlap

### DIFF
--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 <mat-toolbar color="primary">
-  <mat-toolbar-row class="toolbar-holder hidden-xs">
+  <mat-toolbar-row class="toolbar-holder hidden-sm hidden-xs">
     <div [ngClass]="'container navbar-fluid'">
       <span class="flex-toolbar">
         <a id="home-nav-button" (click)="resetPageNumber()" routerLink="" data-cy="home-nav-button">
@@ -116,7 +116,7 @@
       </span>
     </div>
   </mat-toolbar-row>
-  <mat-toolbar-row class="visible-xs toolbar-holder toolbar-holder-sm clearfix">
+  <mat-toolbar-row class="visible-sm visible-xs toolbar-holder toolbar-holder-sm clearfix">
     <div class="container-fluid navbar-holder">
       <div fxLayout="row" fxLayoutAlign="space-between center">
         <a fxFlex id="home-nav-button-mobile" (click)="resetPageNumber()" routerLink="">
@@ -127,7 +127,7 @@
       </div>
     </div>
   </mat-toolbar-row>
-  <mat-toolbar-row class="visible-xs toolbar-holder text-center toolbar-holder-sm">
+  <mat-toolbar-row class="visible-sm visible-xs toolbar-holder text-center toolbar-holder-sm">
     <div class="container-fluid navbar-holder">
       <a mat-button class="icon" routerLink="/search">Search</a>
       <a mat-button class="icon" routerLink="/organizations">Organizations</a>


### PR DESCRIPTION
**Description**
Items in the navigation bar overlap when the window is sized down, narrowing it further sets it to a new row. Chrome does not have the overlapping issue, the solution is tested on both browser types and works as expected.

**Issue**
GitHub Issue [#4872](https://github.com/dockstore/dockstore/issues/4872)
JIRA: [DOCK-2149](https://github.com/dockstore/dockstore/issues/4872)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
