### PR TITLE
Change Workflow 'Labels' to Angular routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.13.0-alpha.7",
-    "use_circle": false,
+    "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8054/workflows/a8b4f969-3415-4457-b198-826af9564417/jobs/21610/artifacts",
     "circle_build_id": "21610",
     "base_branch": "develop"

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -504,7 +504,7 @@ export abstract class Entry implements OnDestroy {
       url += '&entryType=' + searchType;
     }
     url += '&searchMode=files';
-    window.location.href = url;
+    this.router.navigateByUrl(url);
   }
 
   /**


### PR DESCRIPTION
**Description**
Currently labels displayed in the workflow use `href` instead of angular routing, causing the page to reload each time a label is clicked, this PR changes it to `router` instead. 

**Issue**
GitHub Issue [#4076](https://github.com/dockstore/dockstore/issues/4076)
JIRA ticket: [DOCK-1727](https://ucsc-cgl.atlassian.net/browse/DOCK-1727)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
