### PR TITLE
A feature flag approach

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,12 +46,14 @@ import { CustomHeaderInterceptor } from './interceptors/custom-header.intercepto
 import { WorkflowVersionsInterceptor } from './interceptors/workflow-versions.interceptor';
 import { LoginComponent } from './login/login.component';
 import { LoginService } from './login/login.service';
+import { AccountSidebarModule } from './loginComponents/accounts/account-sidebar/account-sidebar.module';
 import { AccountsComponent } from './loginComponents/accounts/accounts.component';
 import { ControlsComponent } from './loginComponents/accounts/controls/controls.component';
 import { DeleteAccountDialogComponent } from './loginComponents/accounts/controls/delete-account-dialog/delete-account-dialog.component';
 import { AccountsExternalComponent } from './loginComponents/accounts/external/accounts.component';
 import { AccountsService } from './loginComponents/accounts/external/accounts.service';
 import { GetTokenUsernamePipe } from './loginComponents/accounts/external/getTokenUsername.pipe';
+import { ChangeUsernameModule } from './loginComponents/accounts/internal/change-username/change-username.module';
 import { AuthComponent } from './loginComponents/auth/auth.component';
 import { DownloadCLIClientComponent } from './loginComponents/onboarding/downloadcliclient/downloadcliclient.component';
 import { OnboardingComponent } from './loginComponents/onboarding/onboarding.component';
@@ -81,7 +83,9 @@ import { HeaderModule } from './shared/modules/header.module';
 import { ImgFallbackModule } from './shared/modules/img-fallback.module';
 import { ListContainersModule } from './shared/modules/list-containers.module';
 import { ListWorkflowsModule } from './shared/modules/list-workflows.module';
+import { MarkdownWrapperModule } from './shared/modules/markdown-wrapper.module';
 import { CustomMaterialModule } from './shared/modules/material.module';
+import { MySidebarModule } from './shared/modules/my-sidebar.module';
 import { OrderByModule } from './shared/modules/orderby.module';
 import { SnackbarModule } from './shared/modules/snackbar.module';
 import { ApiModule as ApiModule2 } from './shared/openapi/api.module';
@@ -100,7 +104,6 @@ import { UrlResolverService } from './shared/url-resolver.service';
 import { VerifiedByService } from './shared/verified-by.service';
 import { SitemapComponent } from './sitemap/sitemap.component';
 import { StargazersModule } from './stargazers/stargazers.module';
-import { MarkdownWrapperModule } from './shared/modules/markdown-wrapper.module';
 import { StarredEntriesComponent } from './starredentries/starredentries.component';
 import { StarringModule } from './starring/starring.module';
 import { TosBannerService } from './tosBanner/state/tos-banner.service';
@@ -108,9 +111,6 @@ import { TosBannerComponent } from './tosBanner/tos-banner.component';
 import { ExporterStepComponent } from './workflow/snapshot-exporter-modal/exporter-step/exporter-step.component';
 import { SnaphotExporterModalComponent } from './workflow/snapshot-exporter-modal/snaphot-exporter-modal.component';
 import { ViewService } from './workflow/view/view.service';
-import { MySidebarModule } from './shared/modules/my-sidebar.module';
-import { AccountSidebarModule } from './loginComponents/accounts/account-sidebar/account-sidebar.module';
-import { ChangeUsernameModule } from './loginComponents/accounts/internal/change-username/change-username.module';
 
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   showDelay: 500,
@@ -239,6 +239,7 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: myCustomSnackbarDefaults },
     { provide: HTTP_INTERCEPTORS, useClass: WorkflowVersionsInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: CustomHeaderInterceptor, multi: true },
+    { provide: Window, useValue: window },
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/configuration.service.spec.ts
+++ b/src/app/configuration.service.spec.ts
@@ -1,6 +1,5 @@
-import { inject, TestBed } from '@angular/core/testing';
-
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { ConfigService } from 'ng2-ui-auth';
 import { ConfigurationService } from './configuration.service';
 
@@ -8,7 +7,7 @@ describe('ConfigurationService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [ConfigurationService, { provide: ConfigService, useValue: {} }],
+      providers: [ConfigurationService, { provide: ConfigService, useValue: {} }, { provide: Window, useValue: window }],
     })
   );
 

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -3,13 +3,19 @@ import { ConfigService } from 'ng2-ui-auth';
 import { IOauth2Options } from 'ng2-ui-auth/lib/config-interfaces';
 import { AuthConfig } from './shared/auth.model';
 import { Dockstore } from './shared/dockstore.model';
+import { FeatureService } from './shared/feature.service';
 import { Config, MetadataService } from './shared/swagger';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ConfigurationService {
-  constructor(private metadataService: MetadataService, private configService: ConfigService) {}
+  constructor(
+    private metadataService: MetadataService,
+    private configService: ConfigService,
+    private window: Window,
+    private featureService: FeatureService
+  ) {}
 
   load(): Promise<void> {
     return this.metadataService
@@ -20,6 +26,7 @@ export class ConfigurationService {
           this.updateDockstoreModel(config);
 
           this.updateAuthProviders();
+          this.featureService.updateFeatureFlags(window.location.search);
         },
         (e) => {
           console.error('Error downloading config.json', e);

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -102,5 +102,6 @@ export class Dockstore {
     enableLaunchWithGalaxy: true,
     enableMultiCloudLaunchWithDNAstack: false,
     enableOrcidExport: true,
+    enableNewDashboard: false,
   };
 }

--- a/src/app/shared/feature.service.spec.ts
+++ b/src/app/shared/feature.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { Dockstore } from './dockstore.model';
+
+import { FeatureService } from './feature.service';
+
+describe('FeatureService', () => {
+  let service: FeatureService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FeatureService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+  it('should set feature flag correctly', () => {
+    service.updateFeatureFlags('?newDashboard');
+    expect(Dockstore.FEATURES.enableNewDashboard).toBeTrue();
+    // We're ignoring the value
+    service.updateFeatureFlags('?irrelevantKey&newDashboard');
+    expect(Dockstore.FEATURES.enableNewDashboard).toBeTrue();
+    service.updateFeatureFlags('?newDashboard=false');
+    expect(Dockstore.FEATURES.enableNewDashboard).toBeTrue();
+    service.updateFeatureFlags(null);
+    expect(Dockstore.FEATURES.enableNewDashboard).toBeFalse();
+    service.updateFeatureFlags('');
+    expect(Dockstore.FEATURES.enableNewDashboard).toBeFalse();
+  });
+});

--- a/src/app/shared/feature.service.ts
+++ b/src/app/shared/feature.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Dockstore } from './dockstore.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FeatureService {
+  constructor() {}
+
+  updateFeatureFlags(queryParams: string) {
+    const urlSearchParams = new URLSearchParams(queryParams);
+    const newDashboard = urlSearchParams.has('newDashboard');
+    Dockstore.FEATURES.enableNewDashboard = newDashboard;
+  }
+}


### PR DESCRIPTION
**Description**
One approach to the feature flag.

* User manually enters https://dev.dockstore.net?newDashboard when initially navigating to the site
* New dashboard would stay active until user reloads the page via the browser without that query param.
* Eileen changes src/app/home-page/home-logged-in/home-logged-in.component.html to have `*ngIf`, e.g.,
```
<div *ngIf="Dockstore.FEATURES.enableNewDashboard">
<!-- New Dashboard html or component -->
</div>
<div *ngIf="!Dockstore.FEATURES.enableNewDashboard">
<!-- Old dashboard html or component -->
</div>
```
Anybody who knows the query param would be able to access.

Other approaches are discussed in the [issue](https://ucsc-cgl.atlassian.net/browse/SEAB-4597), e.g., we could do something fancier with the routes so that if the flag is enabled, the route is for the new dashboard component, otherwise it's for the old dashboard component. Or we can add "guards" to only allow certain users to see the new dashboard, etc.

**Issue**
[SEAB-4597](https://ucsc-cgl.atlassian.net/browse/SEAB-4597)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
