### PR TITLE
Get logged in user during canActivate to check authentication

### DIFF
--- a/cypress/integration/immutableDatabaseTests/titleTag.ts
+++ b/cypress/integration/immutableDatabaseTests/titleTag.ts
@@ -20,7 +20,7 @@ describe('Verify Title Tags', () => {
   describe('Dropdown links', () => {
     it('/starred', () => {
       cy.visit('/starred');
-      cy.title().should('eq', 'Dockstore | Starred Tools & Workflows');
+      cy.title().should('eq', 'Dockstore | Starred Tools, Workflows & Organizations');
     });
 
     it('/accounts', () => {

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -129,7 +129,7 @@ const APP_ROUTES: Routes = [
     path: 'starred',
     component: StarredEntriesComponent,
     canActivate: [AuthGuard],
-    data: { title: 'Dockstore | Starred Tools & Workflows' },
+    data: { title: 'Dockstore | Starred Tools, Workflows & Organizations' },
   },
   { path: 'maintenance', component: MaintenanceComponent, data: { title: 'Dockstore | Maintenance' } },
   { path: 'funding', component: FundingComponent, data: { title: 'Dockstore | Funding' } },

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -40,6 +40,7 @@ const APP_ROUTES: Routes = [
     component: HomeLoggedInComponent,
     pathMatch: 'full',
     data: { title: 'Dockstore | Dashboard' },
+    canActivate: [AuthGuard],
   },
   {
     path: 'docs',
@@ -124,7 +125,12 @@ const APP_ROUTES: Routes = [
   { path: 'onboarding', component: OnboardingComponent, canActivate: [AuthGuard], data: { title: 'Dockstore | Onboarding' } },
   { path: 'accounts', component: AccountsComponent, canActivate: [AuthGuard], data: { title: 'Dockstore | Accounts' } },
   { path: 'auth/:provider', component: AuthComponent },
-  { path: 'starred', component: StarredEntriesComponent, data: { title: 'Dockstore | Starred Tools & Workflows' } },
+  {
+    path: 'starred',
+    component: StarredEntriesComponent,
+    canActivate: [AuthGuard],
+    data: { title: 'Dockstore | Starred Tools & Workflows' },
+  },
   { path: 'maintenance', component: MaintenanceComponent, data: { title: 'Dockstore | Maintenance' } },
   { path: 'funding', component: FundingComponent, data: { title: 'Dockstore | Funding' } },
   { path: 'sitemap', component: SitemapComponent, data: { title: 'Dockstore | Sitemap' } },

--- a/src/app/shared/auth.guard.ts
+++ b/src/app/shared/auth.guard.ts
@@ -32,7 +32,7 @@ export class AuthGuard implements CanActivate {
   ) {}
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     return this.usersService.getUser().pipe(
-      catchError((error) => {
+      catchError(() => {
         return of(null);
       }),
       map((user) => {

--- a/src/app/shared/auth.guard.ts
+++ b/src/app/shared/auth.guard.ts
@@ -17,15 +17,35 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 import { AuthService } from 'ng2-ui-auth';
+import { of } from 'rxjs/internal/observable/of';
+import { catchError, map } from 'rxjs/operators';
+import { LogoutService } from './logout.service';
+import { UsersService } from './openapi';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(
+    private auth: AuthService,
+    private router: Router,
+    private logoutService: LogoutService,
+    private usersService: UsersService
+  ) {}
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    if (this.auth.isAuthenticated()) {
-      return true;
-    }
-    this.router.navigate(['/login']);
-    return false;
+    return this.usersService.getUser().pipe(
+      catchError((error) => {
+        return of(null);
+      }),
+      map((user) => {
+        if (user) {
+          return true;
+        }
+        if (this.auth.isAuthenticated()) {
+          this.logoutService.logout();
+        } else {
+          this.router.navigate(['/login']);
+        }
+        return false;
+      })
+    );
   }
 }

--- a/test/web.yml
+++ b/test/web.yml
@@ -40,7 +40,7 @@ esconfiguration:
   port: 9200
   hostname: localhost
 
-authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
+authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10s
 
 database:
   # the name of your JDBC driver


### PR DESCRIPTION
**Description**
Companion PRs:
- compose_setup: https://github.com/dockstore/compose_setup/pull/230
- webservice: https://github.com/dockstore/dockstore/pull/5031

I recommend reviewing the compose_setup PR first, then this PR, then the webservice PR for things to make the most sense.

This PR checks if the user is authenticated by calling the get logged in user endpoint before navigating to authenticated pages. In a multiple webservice scenario where a user might have two browsers open, if they delete their account in browser 1, then browser 2 will still think they're authenticated until the page is refreshed because the token store isn't cleared in browser 2. I believe this is what happened during my experiment in the ticket description. Adding this check to the AuthGuard ensures that a deleted user gets logged out when they try to navigate to different authenticated pages in browser 2.

Also added auth guards to some pages that should have it.

How I tested this locally:
- To imitate the scenario where the user still has access on a second instance:
  - In the webservice, don't invalidate the user tokens when the user is deleted
  - In the UI, don't automatically log a user out when they delete their account so the user can still navigate pages
- Logged in as myself, delete my account.
- Navigate to My Workflows.
- Get redirected to the logged out page.
- In the console, see that the get logged in endpoint returned a 401 unauthorized or a 404 user not found. You'll get a 401 if you wait 10 seconds (the time it takes for the cache to expire) or you'll get a 404 if you navigate to an authorized page before 10 seconds.

**Issue**
[SEAB-3895](https://ucsc-cgl.atlassian.net/browse/SEAB-3895)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
