### PR TITLE
Update the links in the dashboard

### DIFF
--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -64,9 +64,9 @@
         <div class="w-100">
           <h3>Links</h3>
           <ul>
-            <li><a routerLink="quick-start">Quickstart</a></li>
-            <li><a routerLink="accounts">My Account</a></li>
-            <li><a routerLink="starred">My Starred</a></li>
+            <li><a [routerLink]="['../quick-start']">Quickstart</a></li>
+            <li><a [routerLink]="['../accounts']">My Account</a></li>
+            <li><a [routerLink]="['../starred']">My Starred</a></li>
             <li>
               <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer">Forum <mat-icon>open_in_new</mat-icon></a>
             </li>

--- a/src/app/home-page/home-logged-in/home-logged-in.component.html
+++ b/src/app/home-page/home-logged-in/home-logged-in.component.html
@@ -64,9 +64,9 @@
         <div class="w-100">
           <h3>Links</h3>
           <ul>
-            <li><a [routerLink]="['../quick-start']">Quickstart</a></li>
-            <li><a [routerLink]="['../accounts']">My Account</a></li>
-            <li><a [routerLink]="['../starred']">My Starred</a></li>
+            <li><a [routerLink]="['/quick-start']">Quickstart</a></li>
+            <li><a [routerLink]="['/accounts']">My Account</a></li>
+            <li><a [routerLink]="['/starred']">My Starred</a></li>
             <li>
               <a href="https://discuss.dockstore.org/" target="_blank" rel="noopener noreferrer">Forum <mat-icon>open_in_new</mat-icon></a>
             </li>


### PR DESCRIPTION
**Description**
After the dashboard URL was changed to '/dashboard', the 'Quick start', 'Accounts', and 'Starred' links brought you to the wrong links ('dashboard/...'). This PR updates the links to the working addresses.

**Issue**
[SEAB-4594](https://ucsc-cgl.atlassian.net/browse/SEAB-4594)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
