### PR TITLE
Feature/dock 1810/galaxy launch button test part 1

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -226,6 +226,7 @@
             [className]="'galaxy-launch'"
             [disabled]="(hasContent$ | async) === false"
             [matTooltip]="(hasContent$ | async) ? '' : 'The Galaxy workflow has no content.'"
+            data-cy="galaxyLaunchWith"
           ></app-multi-cloud-launch>
         </div>
         <div *ngIf="workflow?.descriptorType === WorkflowModel.DescriptorTypeEnum.NFL">

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.html
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.html
@@ -11,7 +11,7 @@
     <mat-icon>{{ expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
   </button>
 </div>
-<mat-menu #menu="matMenu" xPosition="before" yPosition="below">
+<mat-menu #menu="matMenu" xPosition="before" yPosition="below" data-cy="matMenu">
   <div class="px-4" fxLayout="column" fxLayoutAlign="center start">
     <p>Please choose a well-known server to launch on, or specify your own.</p>
     <mat-radio-group
@@ -26,6 +26,7 @@
         name="launchWithUrl"
         value="{{ instance.url }}"
         [checked]="this.defaultLaunchWith === instance.url"
+        data-cy="multiCloudLaunchOption"
       >
         {{ instance.displayName }}
       </mat-radio-button>
@@ -40,7 +41,7 @@
       <!--      >-->
       <!--        {{ usersInstance.displayName }} (Custom)-->
       <!--      </mat-radio-button>-->
-      <mat-radio-button value="other">
+      <mat-radio-button value="other" data-cy="multiCloudLaunchText">
         <mat-form-field class="small-text" color="accent" appearance="outline">
           <mat-label>Specify a url...</mat-label>
           <input matInput [(ngModel)]="customLaunchWith" (ngModelChange)="presetLaunchWith = 'other'" name="something" />
@@ -62,6 +63,7 @@
       color="accent"
       [disabled]="(!this.defaultLaunchWith && !this.launchWith.url) || (this.presetLaunchWithOption === 'other' && !customLaunchWithOption)"
       (click)="selectDefault()"
+      data-cy="multiCloudLaunchButton"
     >
       Launch
     </a>


### PR DESCRIPTION
**Description**
This PR adds some `data-cy` attributes required for a second PR I'll make for this ticket. This PR is required as my tests will not run on `localhost:4200` in circleCI due to this line,
https://github.com/dockstore/dockstore-ui2/blob/e88cc80d0fc2dc2b15a126e265202e4eae16348d/cypress/integration/smokeTests/sharedTests/basic-enduser.ts#L173

So, what I will do is merge this PR into develop, then use the circleCI nightly test setup (slightly modified) to run my proposed test for this ticket to verify it is working as intended and then make another PR.

**Issue**
[DOCK-1810](https://ucsc-cgl.atlassian.net/browse/DOCK-1810)
https://github.com/dockstore/dockstore/issues/4278

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
