### PR TITLE
fix display issue with exact phrase search

### DIFF
--- a/src/app/search/advancedsearch/state/advanced-search.query.ts
+++ b/src/app/search/advancedsearch/state/advanced-search.query.ts
@@ -23,7 +23,7 @@ export class AdvancedSearchQuery extends Query<SearchState> {
     })
   );
   aNDSplitFilterText$ = this.advancedSearch$.pipe(map((advancedSearchObject) => this.joinComma(advancedSearchObject.ANDSplitFilter)));
-  aNDNoSplitFilterText$ = this.advancedSearch$.pipe(map((advancedSearchObject) => this.joinComma(advancedSearchObject.ANDNoSplitFilter)));
+  aNDNoSplitFilterText$ = this.advancedSearch$.pipe(map((advancedSearchObject) => advancedSearchObject.ANDNoSplitFilter));
   oRFilterText$ = this.advancedSearch$.pipe(map((advancedSearchObject) => this.joinComma(advancedSearchObject.ORFilter)));
   nOTFilterText$ = this.advancedSearch$.pipe(map((advancedSearchObject) => this.joinComma(advancedSearchObject.NOTFilter)));
   constructor(protected store: SearchStore) {


### PR DESCRIPTION
**Description**
Part of https://github.com/dockstore/dockstore/pull/5042 is a display issue
An exact phrase search should not be broken up when displayed in the UI

**Issue**
https://github.com/dockstore/dockstore/issues/4059

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
