### PR TITLE
Show all GitHub orgs you have access to, even if there are no entries

### DIFF
--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -29,20 +29,21 @@ import { RegisterToolComponent } from '../../container/register-tool/register-to
 import { RegisterToolService } from '../../container/register-tool/register-tool.service';
 import { Tool } from '../../container/register-tool/tool';
 import { AccountsService } from '../../loginComponents/accounts/external/accounts.service';
+import { OrgWorkflowObject } from '../../myworkflows/my-workflow/my-workflow.component';
+import { MyWorkflowsService } from '../../myworkflows/myworkflows.service';
 import { AlertQuery } from '../../shared/alert/state/alert.query';
 import { ContainerService } from '../../shared/container.service';
 import { MyEntry, OrgEntryObject } from '../../shared/my-entry';
 import { TokenQuery } from '../../shared/state/token.query';
+import { TokenService } from '../../shared/state/token.service';
+import { WorkflowQuery } from '../../shared/state/workflow.query';
+import { WorkflowService } from '../../shared/state/workflow.service';
 import { AppTool, DockstoreTool, Workflow } from '../../shared/swagger';
 import { Configuration } from '../../shared/swagger/configuration';
 import { ToolQuery } from '../../shared/tool/tool.query';
 import { UrlResolverService } from '../../shared/url-resolver.service';
 import { UserQuery } from '../../shared/user/user.query';
 import { MytoolsService } from '../mytools.service';
-import { OrgWorkflowObject } from '../../myworkflows/my-workflow/my-workflow.component';
-import { MyWorkflowsService } from '../../myworkflows/myworkflows.service';
-import { WorkflowService } from '../../shared/state/workflow.service';
-import { WorkflowQuery } from '../../shared/state/workflow.query';
 
 @Component({
   selector: 'app-my-tool',
@@ -81,6 +82,7 @@ export class MyToolComponent extends MyEntry implements OnInit {
     private toolQuery: ToolQuery,
     private alertQuery: AlertQuery,
     private alertService: AlertService,
+    private tokenService: TokenService,
     protected sessionQuery: SessionQuery,
     protected myEntriesQuery: MyEntriesQuery,
     protected myEntriesStateService: MyEntriesStateService,
@@ -127,6 +129,7 @@ export class MyToolComponent extends MyEntry implements OnInit {
         this.dialog.closeAll();
       }
     });
+    this.tokenService.getGitHubOrganizations();
     this.commonMyEntriesOnInit();
     this.containerService.setTool(null);
     this.containerService.setTools(null);
@@ -157,9 +160,13 @@ export class MyToolComponent extends MyEntry implements OnInit {
       })
     );
 
-    this.groupAppToolEntryObjects$ = combineLatest([this.workflowService.workflows$, this.workflowQuery.workflow$]).pipe(
-      map(([workflows, workflow]) => {
-        return this.myWorkflowsService.convertEntriesToOrgEntryObject(workflows, workflow);
+    this.groupAppToolEntryObjects$ = combineLatest([
+      this.workflowService.workflows$,
+      this.workflowQuery.workflow$,
+      this.tokenQuery.gitHubOrganizations$,
+    ]).pipe(
+      map(([workflows, workflow, gitHubOrganizations]) => {
+        return this.myWorkflowsService.convertEntriesToOrgEntryObject(workflows, workflow, gitHubOrganizations);
       })
     );
 

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -166,9 +166,13 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
           console.error('Something has gone horribly wrong with sharedWorkflows$ and/or workflows$');
         }
       );
-    this.groupEntriesObject$ = combineLatest([this.workflowService.workflows$, this.workflowQuery.selectActive()]).pipe(
-      map(([workflows, workflow]) => {
-        return this.myWorkflowsService.convertEntriesToOrgEntryObject(workflows, workflow);
+    this.groupEntriesObject$ = combineLatest([
+      this.workflowService.workflows$,
+      this.workflowQuery.selectActive(),
+      this.tokenQuery.gitHubOrganizations$,
+    ]).pipe(
+      map(([workflows, workflow, gitHubOrganizations]) => {
+        return this.myWorkflowsService.convertEntriesToOrgEntryObject(workflows, workflow, gitHubOrganizations);
       })
     );
 

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -23,7 +23,6 @@ import { SessionQuery } from 'app/shared/session/session.query';
 import { SessionService } from 'app/shared/session/session.service';
 import { MyEntriesQuery } from 'app/shared/state/my-entries.query';
 import { MyEntriesStateService } from 'app/shared/state/my-entries.service';
-import { TokenService } from 'app/shared/state/token.service';
 import { BioWorkflow } from 'app/shared/swagger/model/bioWorkflow';
 import { Service } from 'app/shared/swagger/model/service';
 import { UserService } from 'app/shared/user/user.service';
@@ -100,7 +99,6 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
     protected tokenQuery: TokenQuery,
     protected workflowQuery: WorkflowQuery,
     private alertQuery: AlertQuery,
-    private tokenService: TokenService,
     protected sessionService: SessionService,
     protected sessionQuery: SessionQuery,
     private myWorkflowsService: MyWorkflowsService,
@@ -130,7 +128,6 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
   ngOnInit() {
     this.myWorkflowsService.clearPartialState();
     this.gitHubAppInstallationLink$ = this.sessionQuery.gitHubAppInstallationLink$;
-    this.tokenService.getGitHubOrganizations();
     this.isRefreshing$ = this.alertQuery.showInfo$;
     /**
      * This handles selecting of a workflow based on changing URL. It also handles when the router changes url

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -23,6 +23,7 @@ import { SessionQuery } from 'app/shared/session/session.query';
 import { SessionService } from 'app/shared/session/session.service';
 import { MyEntriesQuery } from 'app/shared/state/my-entries.query';
 import { MyEntriesStateService } from 'app/shared/state/my-entries.service';
+import { TokenService } from 'app/shared/state/token.service';
 import { BioWorkflow } from 'app/shared/swagger/model/bioWorkflow';
 import { Service } from 'app/shared/swagger/model/service';
 import { UserService } from 'app/shared/user/user.service';
@@ -99,6 +100,7 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
     protected tokenQuery: TokenQuery,
     protected workflowQuery: WorkflowQuery,
     private alertQuery: AlertQuery,
+    private tokenService: TokenService,
     protected sessionService: SessionService,
     protected sessionQuery: SessionQuery,
     private myWorkflowsService: MyWorkflowsService,
@@ -128,6 +130,7 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
   ngOnInit() {
     this.myWorkflowsService.clearPartialState();
     this.gitHubAppInstallationLink$ = this.sessionQuery.gitHubAppInstallationLink$;
+    this.tokenService.getGitHubOrganizations();
     this.isRefreshing$ = this.alertQuery.showInfo$;
     /**
      * This handles selecting of a workflow based on changing URL. It also handles when the router changes url

--- a/src/app/myworkflows/myworkflows.service.spec.ts
+++ b/src/app/myworkflows/myworkflows.service.spec.ts
@@ -157,5 +157,13 @@ describe('MyWorkflowsService', () => {
     expect(service.convertEntriesToOrgEntryObject(tools, tool1).length).toBe(3);
     expect(service.convertEntriesToOrgEntryObject(tools, tool1)).toEqual(expectedResult);
     expect(service.convertEntriesToOrgEntryObject([], tool1)).toEqual([]);
+
+    const orgNotInExistingTools = 'foobar';
+    const convertedEntries = service.convertEntriesToOrgEntryObject(tools, tool1, [orgNotInExistingTools]);
+    expect(convertedEntries.length).toBe(4);
+    const emptyOrgObject = convertedEntries.find((e) => e.organization === orgNotInExistingTools);
+    expect(emptyOrgObject.published.length).toBe(0);
+    expect(emptyOrgObject.unpublished.length).toBe(0);
+    expect(service.convertEntriesToOrgEntryObject(tools, tool1, [orgNotInExistingTools, tool1.organization]).length).toBe(4);
   }));
 });

--- a/src/app/shared/myentries.service.ts
+++ b/src/app/shared/myentries.service.ts
@@ -20,7 +20,7 @@ import { DockstoreTool, Workflow } from './swagger';
 import { UrlResolverService } from './url-resolver.service';
 
 export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O extends OrgToolObject<E> | OrgWorkflowObject<E>> {
-  constructor(protected urlResolverService: UrlResolverService) {}
+  protected constructor(protected urlResolverService: UrlResolverService) {}
 
   recomputeWhatEntryToSelect(entries: E[]): E | null {
     const foundEntry = this.findEntryFromPath(this.urlResolverService.getEntryPathFromUrl(), entries);

--- a/src/app/shared/state/token.query.ts
+++ b/src/app/shared/state/token.query.ts
@@ -14,15 +14,11 @@ export class TokenQuery extends QueryEntity<TokenState, TokenUser> {
   hasGitHubToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GITHUB)));
   hasGoogleToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GOOGLE)));
   hasZenodoToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ZENODO)));
-  gitHubOrganizations$: Observable<any> = this.select((state) => state.gitHubOrganizations);
   hasOrcidToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ORCID)));
   hasSourceControlToken$: Observable<boolean> = this.tokens$.pipe(
     map((tokens) => this.hasEntity(TokenSource.GITHUB) || this.hasEntity(TokenSource.BITBUCKET) || this.hasEntity(TokenSource.GITLAB))
   );
   userTokenStatusSet$: Observable<any> = this.tokens$.pipe(map((tokens) => (tokens ? this.getUserTokenStatusSet(tokens) : null)));
-  tokenSetComplete$: Observable<boolean> = this.userTokenStatusSet$.pipe(
-    map((tokenStatusSet) => (tokenStatusSet ? tokenStatusSet.github : false))
-  );
 
   constructor(protected store: TokenStore) {
     super(store);

--- a/src/app/shared/state/token.query.ts
+++ b/src/app/shared/state/token.query.ts
@@ -14,11 +14,15 @@ export class TokenQuery extends QueryEntity<TokenState, TokenUser> {
   hasGitHubToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GITHUB)));
   hasGoogleToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GOOGLE)));
   hasZenodoToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ZENODO)));
+  gitHubOrganizations$: Observable<any> = this.select((state) => state.gitHubOrganizations);
   hasOrcidToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ORCID)));
   hasSourceControlToken$: Observable<boolean> = this.tokens$.pipe(
     map((tokens) => this.hasEntity(TokenSource.GITHUB) || this.hasEntity(TokenSource.BITBUCKET) || this.hasEntity(TokenSource.GITLAB))
   );
   userTokenStatusSet$: Observable<any> = this.tokens$.pipe(map((tokens) => (tokens ? this.getUserTokenStatusSet(tokens) : null)));
+  tokenSetComplete$: Observable<boolean> = this.userTokenStatusSet$.pipe(
+    map((tokenStatusSet) => (tokenStatusSet ? tokenStatusSet.github : false))
+  );
 
   constructor(protected store: TokenStore) {
     super(store);

--- a/src/app/shared/state/token.query.ts
+++ b/src/app/shared/state/token.query.ts
@@ -14,15 +14,12 @@ export class TokenQuery extends QueryEntity<TokenState, TokenUser> {
   hasGitHubToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GITHUB)));
   hasGoogleToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.GOOGLE)));
   hasZenodoToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ZENODO)));
-  gitHubOrganizations$: Observable<any> = this.select((state) => state.gitHubOrganizations);
+  gitHubOrganizations$: Observable<string[]> = this.select((state) => state.gitHubOrganizations);
   hasOrcidToken$: Observable<boolean> = this.tokens$.pipe(map((tokens) => this.hasEntity(TokenSource.ORCID)));
   hasSourceControlToken$: Observable<boolean> = this.tokens$.pipe(
     map((tokens) => this.hasEntity(TokenSource.GITHUB) || this.hasEntity(TokenSource.BITBUCKET) || this.hasEntity(TokenSource.GITLAB))
   );
   userTokenStatusSet$: Observable<any> = this.tokens$.pipe(map((tokens) => (tokens ? this.getUserTokenStatusSet(tokens) : null)));
-  tokenSetComplete$: Observable<boolean> = this.userTokenStatusSet$.pipe(
-    map((tokenStatusSet) => (tokenStatusSet ? tokenStatusSet.github : false))
-  );
 
   constructor(protected store: TokenStore) {
     super(store);

--- a/src/app/shared/state/token.service.ts
+++ b/src/app/shared/state/token.service.ts
@@ -60,13 +60,13 @@ export class TokenService {
     return this.tokensService.deleteToken(tokenId);
   }
 
-  setGitHubOrganizations(gitHubOrganizations: any) {
-    this.tokenStore.update({ gitHubOrganizations: gitHubOrganizations });
-  }
-
   getGitHubOrganizations() {
-    this.usersService.getMyGitHubOrgs().subscribe((gitHubOrganizations) => {
+    this.usersService.getUserOrganizations('github.com').subscribe((gitHubOrganizations) => {
       this.setGitHubOrganizations(gitHubOrganizations);
     });
+  }
+
+  private setGitHubOrganizations(gitHubOrganizations: string[]) {
+    this.tokenStore.update({ gitHubOrganizations: gitHubOrganizations });
   }
 }

--- a/src/app/shared/state/token.service.ts
+++ b/src/app/shared/state/token.service.ts
@@ -59,14 +59,4 @@ export class TokenService {
   deleteToken(tokenId: number) {
     return this.tokensService.deleteToken(tokenId);
   }
-
-  setGitHubOrganizations(gitHubOrganizations: any) {
-    this.tokenStore.update({ gitHubOrganizations: gitHubOrganizations });
-  }
-
-  getGitHubOrganizations() {
-    this.usersService.getMyGitHubOrgs().subscribe((gitHubOrganizations) => {
-      this.setGitHubOrganizations(gitHubOrganizations);
-    });
-  }
 }

--- a/src/app/shared/state/token.service.ts
+++ b/src/app/shared/state/token.service.ts
@@ -59,4 +59,14 @@ export class TokenService {
   deleteToken(tokenId: number) {
     return this.tokensService.deleteToken(tokenId);
   }
+
+  setGitHubOrganizations(gitHubOrganizations: any) {
+    this.tokenStore.update({ gitHubOrganizations: gitHubOrganizations });
+  }
+
+  getGitHubOrganizations() {
+    this.usersService.getMyGitHubOrgs().subscribe((gitHubOrganizations) => {
+      this.setGitHubOrganizations(gitHubOrganizations);
+    });
+  }
 }

--- a/src/app/shared/state/token.store.ts
+++ b/src/app/shared/state/token.store.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@angular/core';
 import { EntityState, EntityStore, StoreConfig } from '@datorama/akita';
 import { TokenUser } from '../swagger';
 
-export interface TokenState extends EntityState<TokenUser> {
-  gitHubOrganizations: Array<any>;
-}
+export interface TokenState extends EntityState<TokenUser> {}
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'token', idKey: 'tokenSource' })

--- a/src/app/shared/state/token.store.ts
+++ b/src/app/shared/state/token.store.ts
@@ -3,7 +3,7 @@ import { EntityState, EntityStore, StoreConfig } from '@datorama/akita';
 import { TokenUser } from '../swagger';
 
 export interface TokenState extends EntityState<TokenUser> {
-  gitHubOrganizations: Array<any>;
+  gitHubOrganizations: Array<string>;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/shared/state/token.store.ts
+++ b/src/app/shared/state/token.store.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { EntityState, EntityStore, StoreConfig } from '@datorama/akita';
 import { TokenUser } from '../swagger';
 
-export interface TokenState extends EntityState<TokenUser> {}
+export interface TokenState extends EntityState<TokenUser> {
+  gitHubOrganizations: Array<any>;
+}
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'token', idKey: 'tokenSource' })

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -322,6 +322,9 @@ export class UsersStubService {
   getUserTokens(userId: number, extraHttpRequestParams?: any): Observable<Array<TokenUser>> {
     return observableOf([]);
   }
+  getUserOrganizations(gitRegistry: string) {
+    return observableOf([]);
+  }
   getExtendedUserData() {
     return observableOf(null);
   }

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -17,8 +17,6 @@ import { EntryType } from 'app/shared/enum/entry-type';
 import { BehaviorSubject, EMPTY, Observable, of as observableOf } from 'rxjs';
 import { SearchFields } from '../search/state/search.service';
 import { TagEditorMode } from '../shared/enum/tagEditorMode.enum';
-import RoleEnum = Permission.RoleEnum;
-import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
 import { CloudInstance } from '../shared/openapi';
 import { Dockstore } from './../shared/dockstore.model';
 import { AdvancedSearchObject } from './../shared/models/AdvancedSearchObject';
@@ -33,6 +31,8 @@ import { User } from './../shared/swagger/model/user';
 import { Workflow } from './../shared/swagger/model/workflow';
 import { WorkflowVersion } from './../shared/swagger/model/workflowVersion';
 import { bitbucketToken, gitHubToken, gitLabToken, quayToken, sampleTag, sampleWorkflow1, updatedWorkflow } from './mocked-objects';
+import RoleEnum = Permission.RoleEnum;
+import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
 
 export class ContainerStubService {
   private copyBtnSource = new BehaviorSubject<any>(null); // This is the currently selected copy button.
@@ -326,9 +326,6 @@ export class UsersStubService {
     return observableOf(null);
   }
   getUserMemberships() {
-    return observableOf([]);
-  }
-  getMyGitHubOrgs() {
     return observableOf([]);
   }
   checkUserExists(username) {


### PR DESCRIPTION
**Description**
Call `/users/registries/github.com/organizations` endpoint instead of `/users/github/organizations` and use it. Create empty `OrgWorkflowObject`s for orgs without repos.

The new endpoint is currently slow, but it's the right thing to do if we want to show the logs for all GitHub orgs.

I will also create a web service PR that:

1. Optimizes the endpoint -- I think I see a way
2. Only returns logs for repos that you have permissions to
3. Deletes the now unused endpoint.

Apologies for the first review I requested; I was initially going to break this into 2 PRs, but then realized it was easier to to repurpose the code making the call to the unused endpoint.

***Small Other Changes***
* Changed a constructor to protected in abstract class because WebStorm gave  a warning
* Did a `forkJoin` because the way we were doing the success message wasn't quite right.

**Issue**
dockstore/dockstore#4845

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
