### PR TITLE
add more search boxes

### DIFF
--- a/src/app/search/facet-search/facet-search.pipe.ts
+++ b/src/app/search/facet-search/facet-search.pipe.ts
@@ -14,7 +14,11 @@ import { Pipe, PipeTransform } from '@angular/core';
  */
 export class GetFacetSearchResultsPipe implements PipeTransform {
   transform(items: Array<any>, searchText: string, facet: string): Array<any> {
-    if (!items || !searchText || facet !== 'author') {
+    if (
+      !items ||
+      !searchText ||
+      (facet !== 'author' && facet !== 'organization' && facet !== 'labels.value.keyword' && facet !== 'namespace')
+    ) {
       return items;
     }
     const value = searchText.toLowerCase();

--- a/src/app/search/facet-search/facet-search.pipe.ts
+++ b/src/app/search/facet-search/facet-search.pipe.ts
@@ -17,7 +17,11 @@ export class GetFacetSearchResultsPipe implements PipeTransform {
     if (
       !items ||
       !searchText ||
-      (facet !== 'author' && facet !== 'organization' && facet !== 'labels.value.keyword' && facet !== 'namespace')
+      (facet !== 'author' &&
+        facet !== 'organization' &&
+        facet !== 'labels.value.keyword' &&
+        facet !== 'namespace' &&
+        facet !== 'categories.name.keyword')
     ) {
       return items;
     }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -83,13 +83,17 @@
               class="pl-2"
             />
           </mat-expansion-panel-header>
-          <div *ngIf="key === 'author'">
+          <!-- watch out for GetFacetSearchResultsPipe when adding facets with search -->
+          <div *ngIf="key === 'author' || key === 'labels.value.keyword' || key === 'namespace' || key === 'organization'">
             <mat-form-field appearance="outline">
-              <mat-label>Search for {{ key }}</mat-label>
+              <mat-label>Search for {{ key.substring(0, key.indexOf('.')) }}</mat-label>
               <input
                 matInput
-                placeholder="Search for {{ key }}"
-                [(ngModel)]="facetSearchText"
+                type="text"
+                placeholder="Search for {{ key.substring(0, key.indexOf('.')) }}"
+                [ngModel]="facetSearchTextMap.get(key)"
+                [ngModelOptions]="{ updateOn: 'change' }"
+                (ngModelChange)="facetSearchTextMap.set(key, $event)"
                 (keyup)="onFacetSearchKey(key)"
                 [matAutocomplete]="auto"
               />
@@ -144,7 +148,10 @@
           </div>
           <div
             class="my-1"
-            *ngFor="let subBucket of getKeys(orderedBuckets.get(key).Items) | getFacetSearchResults: facetSearchText:key; let i = index"
+            *ngFor="
+              let subBucket of getKeys(orderedBuckets.get(key).Items) | getFacetSearchResults: facetSearchTextMap.get(key):key;
+              let i = index
+            "
           >
             <div [ngStyle]="orderedBuckets.get(key) | getHistogramStyle: subBucket:(selectedIndex$ | async)">
               <div class="panel-container-label">
@@ -188,12 +195,20 @@
               <!-- The anchor is an easy way to change the color of the icon and "more" -->
               <a>
                 <fa-icon [icon]="fullyExpandMap.get(key) ? faAngleDoubleUp : faAngleDoubleDown" aria-hidden="true"></fa-icon>
-                <span *ngIf="key !== 'author'">{{
-                  fullyExpandMap.get(key) ? 'Hide' : orderedBuckets.get(key).Items.size - 5 + ' more'
-                }}</span>
-                <span *ngIf="key === 'author'">{{
-                  fullyExpandMap.get(key) ? 'Hide' : (getKeys(orderedBuckets.get(key).Items) | getFacetSearchUpdate: facetSearchText)
-                }}</span>
+                <span
+                  *ngIf="
+                    key !== 'author' && key !== 'labels.value.keyword' && key !== 'namespace' && key !== 'organization';
+                    else facetLoading
+                  "
+                  >{{ fullyExpandMap.get(key) ? 'Hide' : orderedBuckets.get(key).Items.size - 5 + ' more' }}</span
+                >
+                <ng-template #facetLoading>
+                  <span>{{
+                    fullyExpandMap.get(key)
+                      ? 'Hide'
+                      : (getKeys(orderedBuckets.get(key).Items) | getFacetSearchUpdate: facetSearchTextMap.get(key))
+                  }}</span>
+                </ng-template>
               </a>
             </span>
           </div>

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -84,7 +84,15 @@
             />
           </mat-expansion-panel-header>
           <!-- watch out for GetFacetSearchResultsPipe when adding facets with search -->
-          <div *ngIf="key === 'author' || key === 'labels.value.keyword' || key === 'namespace' || key === 'organization'">
+          <div
+            *ngIf="
+              key === 'author' ||
+              key === 'labels.value.keyword' ||
+              key === 'namespace' ||
+              key === 'organization' ||
+              key === 'categories.name.keyword'
+            "
+          >
             <mat-form-field appearance="outline">
               <mat-label>Search for {{ key.substring(0, key.indexOf('.')) }}</mat-label>
               <input
@@ -197,7 +205,11 @@
                 <fa-icon [icon]="fullyExpandMap.get(key) ? faAngleDoubleUp : faAngleDoubleDown" aria-hidden="true"></fa-icon>
                 <span
                   *ngIf="
-                    key !== 'author' && key !== 'labels.value.keyword' && key !== 'namespace' && key !== 'organization';
+                    key !== 'author' &&
+                      key !== 'labels.value.keyword' &&
+                      key !== 'namespace' &&
+                      key !== 'organization' &&
+                      key != 'categories.name.keyword';
                     else facetLoading
                   "
                   >{{ fullyExpandMap.get(key) ? 'Hide' : orderedBuckets.get(key).Items.size - 5 + ' more' }}</span

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -209,7 +209,7 @@
                       key !== 'labels.value.keyword' &&
                       key !== 'namespace' &&
                       key !== 'organization' &&
-                      key != 'categories.name.keyword';
+                      key !== 'categories.name.keyword';
                     else facetLoading
                   "
                   >{{ fullyExpandMap.get(key) ? 'Hide' : orderedBuckets.get(key).Items.size - 5 + ' more' }}</span

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -610,6 +610,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       ['labels.value.keyword', ''],
       ['namespace', ''],
       ['organization', ''],
+      ['categories.name.keyword', ''],
     ]);
   }
 

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnDestroy, OnInit, ViewChild, HostListener, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, HostListener } from '@angular/core';
 import { Location } from '@angular/common';
 import { MatAccordion } from '@angular/material/expansion';
 import { MatTabChangeEvent } from '@angular/material/tabs';

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnDestroy, OnInit, ViewChild, HostListener } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, HostListener, ChangeDetectionStrategy } from '@angular/core';
 import { Location } from '@angular/common';
 import { MatAccordion } from '@angular/material/expansion';
 import { MatTabChangeEvent } from '@angular/material/tabs';
@@ -138,7 +138,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   // For search within facets
   public facetAutocompleteTerms$: Observable<Array<string>>;
   public hasFacetAutoCompleteTerms$: Observable<boolean>;
-  public facetSearchText = '';
+  public facetSearchTextMap: Map<string, string>;
   /**
    * This should be parameterised from src/app/shared/dockstore.model.ts
    * @param providerService
@@ -163,6 +163,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.friendlyNames = this.searchService.initializeFriendlyNames();
     this.entryOrder = this.searchService.initializeEntryOrder();
     this.toolTips = this.searchService.initializeToolTips();
+    this.clearFacetSearches();
   }
 
   getKeys(bucketMap: Map<any, any>): Array<string> {
@@ -527,7 +528,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   resetFilters() {
     this.searchService.reset();
     this.searchTerm = false;
-    this.facetSearchText = '';
+    this.clearFacetSearches();
     this.unsubmittedSearchText = '';
   }
 
@@ -598,9 +599,18 @@ export class SearchComponent implements OnInit, OnDestroy {
       this.checkboxMap.get(category).set(categoryValue, !checked);
       this.filters = this.searchService.handleFilters(category, categoryValue, this.filters);
     }
-    this.facetSearchText = '';
+    this.clearFacetSearches();
     this.searchService.setSearchText(this.unsubmittedSearchText);
     this.updatePermalink();
+  }
+
+  private clearFacetSearches() {
+    this.facetSearchTextMap = new Map<string, string>([
+      ['author', ''],
+      ['labels.value.keyword', ''],
+      ['namespace', ''],
+      ['organization', ''],
+    ]);
   }
 
   clickExpand(key: string) {
@@ -642,7 +652,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 
   // Get autocomplete terms
   onFacetSearchKey(key) {
-    const values = this.facetSearchText.toLowerCase();
+    const values = this.facetSearchTextMap.get(key).toLowerCase();
     const unfilteredItems = Array.from(this.orderedBuckets.get(key).Items.entries());
     const filteredItems = unfilteredItems.filter((item) => item[0].toLowerCase().includes(values)).map((item) => item[0]);
     this.searchService.setFacetAutocompleteTerms(filteredItems);


### PR DESCRIPTION
**Description**
Adds mores search boxes. 

Efficiency issue, should be more familiar with change detection than I am, does it make sense that `GetFacetSearchUpdatePipe` is being called for all facets even if only one facet is being typed-in/changed?

**Issue**
https://github.com/dockstore/dockstore/issues/2062

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
