### PR TITLE
disable topic selected for hosted

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -319,7 +319,12 @@
               <div fxLayout="row" fxLayoutAlign="start center">
                 <span><strong matTooltip="Select which topic to display to the public">Topic Selection</strong>:&nbsp;</span>
                 <span>
-                  <mat-radio-group [(ngModel)]="tool.topicSelection" aria-label="Select an option" (change)="topicSelectionChange($event)">
+                  <mat-radio-group
+                    [(ngModel)]="tool.topicSelection"
+                    aria-label="Select an option"
+                    (change)="topicSelectionChange($event)"
+                    [disabled]="tool?.mode === DockstoreToolType.ModeEnum.HOSTED"
+                  >
                     <mat-radio-button [value]="TopicSelectionEnum.AUTOMATIC">Automatic</mat-radio-button>
                     <mat-radio-button class="ml-3" [value]="TopicSelectionEnum.MANUAL">Manual</mat-radio-button>
                   </mat-radio-group>

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -324,6 +324,11 @@
                     aria-label="Select an option"
                     (change)="topicSelectionChange($event)"
                     [disabled]="tool?.mode === DockstoreToolType.ModeEnum.HOSTED"
+                    [matTooltip]="
+                      tool?.mode === DockstoreToolType.ModeEnum.HOSTED
+                        ? 'Hosted tool topics are always manually entered'
+                        : 'Select whether the automatically harvested topic from source control is used or a manually input one'
+                    "
                   >
                     <mat-radio-button [value]="TopicSelectionEnum.AUTOMATIC">Automatic</mat-radio-button>
                     <mat-radio-button class="ml-3" [value]="TopicSelectionEnum.MANUAL">Manual</mat-radio-button>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -245,7 +245,12 @@
               <div fxLayout="row" fxLayoutAlign="start center">
                 <span><strong matTooltip="Select which topic to display to the public">Topic Selection</strong>:&nbsp;</span>
                 <span>
-                  <mat-radio-group [(ngModel)]="workflow.topicSelection" aria-label="Select an option" (change)="radioChange($event)">
+                  <mat-radio-group
+                    [(ngModel)]="workflow.topicSelection"
+                    aria-label="Select an option"
+                    (change)="radioChange($event)"
+                    [disabled]="workflow?.mode === WorkflowType.ModeEnum.HOSTED"
+                  >
                     <mat-radio-button [value]="TopicSelectionEnum.AUTOMATIC">Automatic</mat-radio-button>
                     <mat-radio-button class="ml-3" [value]="TopicSelectionEnum.MANUAL">Manual</mat-radio-button>
                   </mat-radio-group>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -250,6 +250,11 @@
                     aria-label="Select an option"
                     (change)="radioChange($event)"
                     [disabled]="workflow?.mode === WorkflowType.ModeEnum.HOSTED"
+                    [matTooltip]="
+                      workflow?.mode === WorkflowType.ModeEnum.HOSTED
+                        ? 'Hosted workflow topics are always manually entered'
+                        : 'Select whether the automatically harvested topic from source control is used or a manually input one'
+                    "
                   >
                     <mat-radio-button [value]="TopicSelectionEnum.AUTOMATIC">Automatic</mat-radio-button>
                     <mat-radio-button class="ml-3" [value]="TopicSelectionEnum.MANUAL">Manual</mat-radio-button>


### PR DESCRIPTION
**Description**
ui portion of following issue, disallows topic selected for hosted workflows since hosted workflows have no source control to pull topics from

**Issue**
https://github.com/dockstore/dockstore/issues/4591

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
