### PR TITLE
DOCK-2012: Fix the search "quick click" bug (and some other problems)

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -141,7 +141,7 @@
                         <mat-checkbox
                           class="search-facet-checkboxes"
                           type="checkbox"
-                          [checked]="checkboxMap.get(key).get(subBucket)"
+                          [checked]="checkboxMap?.get(key)?.get(subBucket)"
                           (change)="onClick(key, subBucket)"
                         >
                           {{ key | mapFriendlyValue: subBucket }}
@@ -169,7 +169,7 @@
                       <mat-checkbox
                         class="search-facet-checkboxes"
                         type="checkbox"
-                        [checked]="checkboxMap.get(key).get(subBucket)"
+                        [checked]="checkboxMap?.get(key)?.get(subBucket)"
                         (change)="onClick(key, subBucket)"
                       >
                         {{ key | mapFriendlyValue: subBucket }}
@@ -186,7 +186,7 @@
                         matTooltip="{{ subBucket }}"
                         [matTooltipPosition]="'after'"
                         type="checkbox"
-                        [checked]="checkboxMap.get(key).get(subBucket)"
+                        [checked]="checkboxMap?.get(key)?.get(subBucket)"
                         (change)="onClick(key, subBucket)"
                       >
                         {{ key | mapFriendlyValue: subBucket }}

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -418,7 +418,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       entryType: SearchService.convertTabIndexToEntryType(this.searchQuery.getValue().currentTabIndex),
     };
     const linkArray = this.searchService.createPermalinks(searchInfo);
-    this.searchService.handleLink(linkArray);
+    this.searchService.handleLink(linkArray, this.location.path());
   }
 
   /**===============================================

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -359,8 +359,8 @@ export class SearchService {
     return [url, httpParams.toString()];
   }
 
-  handleLink(linkArray: Array<string>) {
-    this.router.navigateByUrl('search?' + linkArray[1]);
+  handleLink(linkArray: Array<string>, currentLocation: string) {
+    this.router.navigateByUrl('search?' + linkArray[1], currentLocation == '/search' ? { replaceUrl: true } : {});
     this.setShortUrl(linkArray[0] + '?' + linkArray[1]);
   }
 
@@ -644,9 +644,9 @@ export class SearchService {
    */
   saveCurrentTabAndClear(index: number) {
     if (index === SearchService.WORKFLOWS_TAB_INDEX) {
-      this.router.navigateByUrl('search?entryType=workflows&searchMode=Files');
+      this.router.navigateByUrl('search?entryType=workflows&searchMode=files');
     } else {
-      this.router.navigateByUrl('search?entryType=tools&searchMode=Files');
+      this.router.navigateByUrl('search?entryType=tools&searchMode=files');
     }
   }
 


### PR DESCRIPTION
**Description**
This PR addresses three bugs in the UI2 search interface:
1. The "quick click" bug, which occurred when toggling rapidly between the workflows and tools results.  The search code was updating the `checkboxMap` object, and the template was accessing it while it was not fully-formed.
2. A bug with the back button, which would not allow the user to move from more than one level down in the search to back past the root search page. 
3. An inconsistent setting of `searchMode`.  It should be `file`, rather than `File` (I think).

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2012
#4619

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
