### PR TITLE
Stop never-ending indeterminate progress bar

### DIFF
--- a/src/app/workflow/permissions/permissions.component.ts
+++ b/src/app/workflow/permissions/permissions.component.ts
@@ -10,8 +10,8 @@ import { Dockstore } from '../../shared/dockstore.model';
 import { TokenSource } from '../../shared/enum/token-source.enum';
 import { TokenQuery } from '../../shared/state/token.query';
 import { Permission, Workflow, WorkflowsService } from '../../shared/swagger';
-
 import RoleEnum = Permission.RoleEnum;
+
 @Component({
   selector: 'app-permissions',
   templateUrl: './permissions.component.html',
@@ -76,6 +76,7 @@ export class PermissionsComponent implements OnInit {
         .addWorkflowPermission(this.workflow.full_workflow_path, { email: value, role: permission }, this.entryType === EntryType.Service)
         .subscribe(
           (userPermissions: Permission[]) => {
+            this.alertService.detailedSuccess('Permissions updated');
             this.updating--;
             this.processResponse(userPermissions);
           },

--- a/src/app/workflow/permissions/permissions.component.ts
+++ b/src/app/workflow/permissions/permissions.component.ts
@@ -52,10 +52,12 @@ export class PermissionsComponent implements OnInit {
 
   remove(entity: string, permission: RoleEnum) {
     this.updating++;
+    this.alertService.start('Removing permissions');
     this.workflowsService
       .removeWorkflowRole(this.workflow.full_workflow_path, entity, permission, this.entryType === EntryType.Service)
       .subscribe(
         (userPermissions: Permission[]) => {
+          this.alertService.detailedSuccess('Removed permissions');
           this.updating--;
           this.processResponse(userPermissions);
         },

--- a/src/app/workflow/permissions/permissions.component.ts
+++ b/src/app/workflow/permissions/permissions.component.ts
@@ -50,14 +50,14 @@ export class PermissionsComponent implements OnInit {
     });
   }
 
-  remove(entity: string, permission: RoleEnum) {
+  remove(email: string, permission: RoleEnum) {
     this.updating++;
-    this.alertService.start('Removing permissions');
+    this.alertService.start(`Removing ${email}`);
     this.workflowsService
-      .removeWorkflowRole(this.workflow.full_workflow_path, entity, permission, this.entryType === EntryType.Service)
+      .removeWorkflowRole(this.workflow.full_workflow_path, email, permission, this.entryType === EntryType.Service)
       .subscribe(
         (userPermissions: Permission[]) => {
-          this.alertService.detailedSuccess('Removed permissions');
+          this.alertService.detailedSuccess(`Removed ${email}`);
           this.updating--;
           this.processResponse(userPermissions);
         },
@@ -69,16 +69,16 @@ export class PermissionsComponent implements OnInit {
 
   add(event: MatChipInputEvent, permission: RoleEnum): void {
     const input = event.input;
-    const value = event.value;
+    const email = event.value;
 
-    if ((value || '').trim()) {
+    if ((email || '').trim()) {
       this.updating++;
-      this.alertService.start('Updating permissions');
+      this.alertService.start(`Adding ${email}`);
       this.workflowsService
-        .addWorkflowPermission(this.workflow.full_workflow_path, { email: value, role: permission }, this.entryType === EntryType.Service)
+        .addWorkflowPermission(this.workflow.full_workflow_path, { email: email, role: permission }, this.entryType === EntryType.Service)
         .subscribe(
           (userPermissions: Permission[]) => {
-            this.alertService.detailedSuccess('Permissions updated');
+            this.alertService.detailedSuccess(`Added ${email}`);
             this.updating--;
             this.processResponse(userPermissions);
           },


### PR DESCRIPTION
**Description**
Stop never-ending indeterminate progress bar.

As long as there is an uncleared item, created by the
alertService.start, the progress bar will keep going.


**Issue**
#3975

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
