### PR TITLE
Add note about fallback installation method

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -195,7 +195,7 @@ $ cwltool --version
 /usr/local/bin/cwltool ${this.cwltoolVersion}
 \`\`\`
 
-If you have issues installing cwltool using the above method try running \`pip3 install cwltool\`, which will install the latest released version from PyPi that is compatible with your Python version.
+Although Dockstore has only been tested with the above cwltool version, if you have issues installing cwltool please try running \`pip3 install cwltool\`. This will install the latest released version from PyPi that is compatible with your Python version.
 
 #### Part 6 - Install Nextflow (Optional)
 The Dockstore CLI does not run Nextflow workflows. Users can run them directly by using the Nextflow command line tool. For installation instructions, follow [Nextflow's documentation](https://github.com/nextflow-io/nextflow#download-the-package)

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -195,6 +195,8 @@ $ cwltool --version
 /usr/local/bin/cwltool ${this.cwltoolVersion}
 \`\`\`
 
+If you have issues installing cwltool using the above method try running \`pip3 install cwltool\`, which will install the latest released version from PyPi that is compatible with your Python version.
+
 #### Part 6 - Install Nextflow (Optional)
 The Dockstore CLI does not run Nextflow workflows. Users can run them directly by using the Nextflow command line tool. For installation instructions, follow [Nextflow's documentation](https://github.com/nextflow-io/nextflow#download-the-package)
 `;


### PR DESCRIPTION
**Description**
Adds a note for fallback when cwltool can't install using our provided method.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2187

https://github.com/dockstore/dockstore/issues/4961

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [n/a] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [n/a] Do due diligence on new 3rd party libraries, checking for CVEs
- [n/a] Don't allow user-uploaded images to be served from the Dockstore domain
