### PR TITLE
Fix second revert not working in hosted workflows

### DIFF
--- a/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.spec.ts
@@ -1,7 +1,7 @@
-import { HttpClientModule } from '@angular/common/http';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { ClipboardModule } from '@angular/cdk/clipboard';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -13,6 +13,8 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
+import { SourceFile } from '../../shared/openapi';
 
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { CodeEditorListComponent } from './../../shared/code-editor-list/code-editor-list.component';
@@ -25,8 +27,6 @@ import { RefreshService } from './../../shared/refresh.service';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { ContainerStubService, HostedStubService, RefreshStubService, WorkflowStubService } from './../../test/service-stubs';
 import { ToolFileEditorComponent } from './tool-file-editor.component';
-import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ToolFileEditorComponent', () => {
   let component: ToolFileEditorComponent;
@@ -72,5 +72,29 @@ describe('ToolFileEditorComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should revert multiple times', () => {
+    const content = 'whatevs';
+    const newContent = 'new content';
+    const sourceFile: SourceFile = {
+      absolutePath: '/foo.cwl',
+      path: 'foo.cwl',
+      type: 'DOCKSTORE_CWL',
+      content: content,
+    };
+    component.originalSourceFiles = [sourceFile];
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
+    component.descriptorFiles[0].content = newContent;
+    // Modifying descriptor copy doesn't modify original:
+    expect(sourceFile.content).toBe(content);
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
+    component.descriptorFiles[0].content = newContent;
+    expect(sourceFile.content).toBe(content);
+    // One more revert
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
   });
 });

--- a/src/app/container/tool-file-editor/tool-file-editor.component.ts
+++ b/src/app/container/tool-file-editor/tool-file-editor.component.ts
@@ -16,11 +16,10 @@
 import { Component, Input } from '@angular/core';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileEditing } from '../../shared/file-editing';
-import { ContainertagsService } from '../../shared/openapi';
+import { ContainertagsService, SourceFile } from '../../shared/openapi';
 import { DockstoreTool, ToolDescriptor } from '../../shared/swagger';
 import { ContainerService } from './../../shared/container.service';
 import { HostedService } from './../../shared/swagger/api/hosted.service';
-import { SourceFile } from './../../shared/swagger/model/sourceFile';
 import { Tag } from './../../shared/swagger/model/tag';
 
 @Component({
@@ -75,10 +74,8 @@ export class ToolFileEditorComponent extends FileEditing {
    */
   loadVersionSourcefiles(): void {
     this.containerTagsService.getTagsSourcefiles(this.id, this.currentVersion.id).subscribe((sourcefiles: Array<SourceFile>) => {
-      this.originalSourceFiles = JSON.parse(JSON.stringify(sourcefiles));
-      this.descriptorFiles = JSON.parse(JSON.stringify(this.getDescriptorFiles(this.originalSourceFiles)));
-      this.testParameterFiles = JSON.parse(JSON.stringify(this.getTestFiles(this.originalSourceFiles)));
-      this.dockerFile = JSON.parse(JSON.stringify(this.getDockerFile(this.originalSourceFiles)));
+      this.originalSourceFiles = this.deepCopy(sourcefiles);
+      this.resetFiles();
     });
   }
 
@@ -138,9 +135,9 @@ export class ToolFileEditorComponent extends FileEditing {
    * Resets the files back to their original state
    */
   resetFiles(): void {
-    this.descriptorFiles = this.getDescriptorFiles(this.originalSourceFiles);
-    this.testParameterFiles = this.getTestFiles(this.originalSourceFiles);
-    this.dockerFile = this.getDockerFile(this.originalSourceFiles);
+    this.descriptorFiles = this.deepCopy(this.getDescriptorFiles(this.originalSourceFiles));
+    this.testParameterFiles = this.deepCopy(this.getTestFiles(this.originalSourceFiles));
+    this.dockerFile = this.deepCopy(this.getDockerFile(this.originalSourceFiles));
   }
 
   /**

--- a/src/app/shared/file-editing.ts
+++ b/src/app/shared/file-editing.ts
@@ -17,8 +17,8 @@
 import { Directive } from '@angular/core';
 import { AlertService } from './alert/state/alert.service';
 import { Files } from './files';
+import { SourceFile } from './openapi';
 import { Tag, WorkflowVersion } from './swagger';
-import { SourceFile } from './swagger/model/sourceFile';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
@@ -116,5 +116,9 @@ export class FileEditing extends Files {
 
   getNewestVersion(versions: Array<WorkflowVersion | Tag>): WorkflowVersion | Tag {
     return versions.reduce((p, c) => (p.id > c.id ? p : c));
+  }
+
+  deepCopy<T>(object: T): T {
+    return JSON.parse(JSON.stringify(object));
   }
 }

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.spec.ts
@@ -1,5 +1,6 @@
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -11,6 +12,8 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
+import { SourceFile } from '../../shared/openapi';
 
 import { WorkflowService } from '../../shared/state/workflow.service';
 import { CodeEditorListComponent } from './../../shared/code-editor-list/code-editor-list.component';
@@ -23,8 +26,6 @@ import { HostedService } from './../../shared/swagger/api/hosted.service';
 import { WorkflowsService } from './../../shared/swagger/api/workflows.service';
 import { HostedStubService, RefreshStubService, WorkflowsStubService, WorkflowStubService } from './../../test/service-stubs';
 import { WorkflowFileEditorComponent } from './workflow-file-editor.component';
-import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('WorkflowFileEditorComponent', () => {
   let component: WorkflowFileEditorComponent;
@@ -75,5 +76,29 @@ describe('WorkflowFileEditorComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should revert multiple times', () => {
+    const content = 'whatevs';
+    const newContent = 'new content';
+    const sourceFile: SourceFile = {
+      absolutePath: '/foo.cwl',
+      path: 'foo.cwl',
+      type: 'DOCKSTORE_CWL',
+      content: content,
+    };
+    component.originalSourceFiles = [sourceFile];
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
+    component.descriptorFiles[0].content = newContent;
+    // Modifying descriptor copy doesn't modify original:
+    expect(sourceFile.content).toBe(content);
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
+    component.descriptorFiles[0].content = newContent;
+    expect(sourceFile.content).toBe(content);
+    // One more revert
+    component.resetFiles();
+    expect(component.descriptorFiles[0].content).toBe(content);
   });
 });

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.ts
@@ -16,7 +16,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input } from '@angular/core';
 import { includesAuthors } from 'app/shared/constants';
-import { WorkflowsService as OpenApiWorkflowServices } from 'app/shared/openapi';
+import { SourceFile, WorkflowsService as OpenApiWorkflowServices } from 'app/shared/openapi';
 import { Observable } from 'rxjs';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { FileEditing } from '../../shared/file-editing';
@@ -34,9 +34,9 @@ import { WorkflowVersion } from './../../shared/swagger/model/workflowVersion';
   styleUrls: ['./workflow-file-editor.component.scss'],
 })
 export class WorkflowFileEditorComponent extends FileEditing {
-  descriptorFiles = [];
-  testParameterFiles = [];
-  originalSourceFiles = [];
+  descriptorFiles: Array<SourceFile> = [];
+  testParameterFiles: Array<SourceFile> = [];
+  originalSourceFiles: Array<SourceFile> = [];
   _selectedVersion: WorkflowVersion;
   isNewestVersion = false;
   public selectedDescriptorType$: Observable<ToolDescriptor.TypeEnum>;
@@ -81,9 +81,8 @@ export class WorkflowFileEditorComponent extends FileEditing {
    */
   loadVersionSourcefiles() {
     this.openapiWorkflowsService.getWorkflowVersionsSourcefiles(this.id, this._selectedVersion.id).subscribe((sourcefiles) => {
-      this.originalSourceFiles = JSON.parse(JSON.stringify(sourcefiles));
-      this.descriptorFiles = JSON.parse(JSON.stringify(this.getDescriptorFiles(this.originalSourceFiles)));
-      this.testParameterFiles = JSON.parse(JSON.stringify(this.getTestFiles(this.originalSourceFiles)));
+      this.originalSourceFiles = this.deepCopy(sourcefiles);
+      this.resetFiles();
     });
   }
 
@@ -151,8 +150,8 @@ export class WorkflowFileEditorComponent extends FileEditing {
    * Resets the files back to their original state
    */
   resetFiles() {
-    this.descriptorFiles = this.getDescriptorFiles(this.originalSourceFiles);
-    this.testParameterFiles = this.getTestFiles(this.originalSourceFiles);
+    this.descriptorFiles = this.deepCopy(this.getDescriptorFiles(this.originalSourceFiles));
+    this.testParameterFiles = this.deepCopy(this.getTestFiles(this.originalSourceFiles));
   }
 
   /**


### PR DESCRIPTION
**Description**
The problem was that a deep copy was made initially, so the first
revert worked, but the first revert used a shallow copy, so the
original data ended up being modified.

Did a little extra cleanup, removing some `any` types, and specifying
the correct imports (openapi vs swagger).

Tried to create a integration test, but ACE Editor and Cypress is not
a happy combination; seems safe/obvious enough, and added a unit test.

**Issue**
dockstore/dockstore#3800

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
