### PR TITLE
Don't show input errors when adding a tag

### DIFF
--- a/src/app/container/add-tag/add-tag.component.html
+++ b/src/app/container/add-tag/add-tag.component.html
@@ -28,6 +28,7 @@
         [pattern]="validationPatterns.versionTag"
         required
         placeholder="20.04"
+        [disabled]="!editMode"
       />
       <mat-hint>e.g. "20.04" is the tag name of "docker pull ubuntu:20.04" </mat-hint>
       <mat-error *ngIf="formErrors.versionTag">{{ formErrors.versionTag }}</mat-error>
@@ -43,6 +44,7 @@
         [pattern]="validationPatterns.reference"
         placeholder="develop"
         required
+        [disabled]="!editMode"
       />
       <mat-hint>e.g. "develop" is the branch name of "https://github.com/dockstore/dockstore/tree/develop"</mat-hint>
       <mat-error *ngIf="formErrors.reference">{{ formErrors.reference }}</mat-error>

--- a/src/app/container/add-tag/add-tag.component.ts
+++ b/src/app/container/add-tag/add-tag.component.ts
@@ -143,6 +143,7 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
 
   addTag() {
     this.alertService.start('Adding tag');
+    this.editMode = false;
     this.containertagsService.addTags(this.tool.id, [this.unsavedVersion]).subscribe(
       (tags: Tag[]) => {
         this.tool.workflowVersions = tags;
@@ -157,8 +158,6 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
         }
         const toAddCWLTestParameterFiles = this.unsavedCWLTestParameterFilePaths;
         const toAddWDLTestParameterFiles = this.unsavedCWLTestParameterFilePaths;
-        // Question: do we really want to clear the form?
-        this.initializeTag();
         // Using the string 'CWL' because this parameter only accepts 'CWL' or 'WDL' and not 'NFL'
         const addCWL: Observable<SourceFile[]> = this.containersService.addTestParameterFiles(
           id,
@@ -187,16 +186,21 @@ export class AddTagComponent extends Base implements OnInit, AfterViewChecked {
               (error: HttpErrorResponse) => {
                 this.containerService.setTool(this.tool);
                 this.alertService.detailedError(error);
+                this.editMode = true;
               }
             );
           },
           (error: HttpErrorResponse) => {
             this.containerService.setTool(this.tool);
             this.alertService.detailedError(error);
+            this.editMode = true;
           }
         );
       },
-      (error: HttpErrorResponse) => this.alertService.detailedError(error)
+      (error: HttpErrorResponse) => {
+        this.alertService.detailedError(error);
+        this.editMode = true;
+      }
     );
   }
 


### PR DESCRIPTION
**Description**
Problem was that we reinitialized the form before completing API
requests, and Angular will show errors, after editing has begun,
if an input is not valid (and empty is not valid).

Gary had left a question in the code about whether we should reinitialize the form. I think the answer is no. If action succeeds, the dialog goes away. If it fails, you have a chance to edit your values again, without having to re-enter from scratch. See screenshot (before this PR, all your inputs would be empty in the screenshot).

Finally, I noticed we never toggled editMode, and a couple of fields weren't even checking it. This will prevent the user from changing values while the requests are in flight.

Additional tests: it's tricky and I punted. It's hard to test for ephermal UI. There is an existing test for the dialog.

![Screen Shot 2022-08-18 at 4 17 00 PM](https://user-images.githubusercontent.com/1049340/185514698-8c17b7a1-6afc-460b-8081-09f55a9897e0.png)

**Issue**
dockstore/dockstore#4618

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
