### PR TITLE
Added in test for hiding version

### DIFF
--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -256,6 +256,26 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('button', 'Restub').click();
       cy.contains('button', 'Publish').should('be.disabled');
     });
+    it('hide and un-hide a version', () => {
+      goToTab('Versions');
+      // hide
+      cy.get('[data-cy=refreshButton]').click();
+      cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
+      cy.contains('button', 'Edit').click();
+      cy.contains('div', 'Hidden:').within(() => {
+        cy.get('[name=checkbox]').click();
+      });
+      cy.contains('button', 'Save Changes').click();
+      cy.get('[data-cy=hidden]').should('have.length', 1);
+      // un-hide
+      cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
+      cy.contains('button', 'Edit').click();
+      cy.contains('div', 'Hidden:').within(() => {
+        cy.get('[name=checkbox]').click();
+      });
+      cy.contains('button', 'Save Changes').click();
+      cy.get('[data-cy=hidden]').should('not.exist');
+    });
   });
 }
 
@@ -300,7 +320,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
     deleteTool();
   });
 }
-
+//
 testCollection(collectionTuple[0], collectionTuple[1], toolTuple[0], toolTuple[1], toolTuple[2]);
 testTool(toolTuple[0], toolTuple[1], toolTuple[2]);
 testWorkflow(workflowTuple[0], workflowTuple[1], workflowTuple[2]);

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -170,6 +170,27 @@ function registerToolOnDockstore(repo: string, name: string) {
   });
 }
 
+function toggleHiddenToolVersion() {
+  cy.contains('button', 'Actions').should('be.visible');
+  cy.contains('td', 'Actions').first().click();
+  cy.contains('button', 'Edit').click();
+  cy.contains('div', 'Hidden:').within(() => {
+    cy.get('[name=checkbox]').click();
+  });
+  cy.contains('button', 'Save Changes').click();
+}
+
+function toggleHiddenWorkflowVersion() {
+  cy.get('[data-cy=refreshButton]').click();
+  cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
+  cy.contains('button', 'Edit').click();
+  // TODO: Use [data-cy=hiddenCheck] -- do after 1.14 deployed
+  cy.contains('div', 'Hidden:').within(() => {
+    cy.get('[name=checkbox]').click();
+  });
+  cy.contains('button', 'Save Changes').click();
+}
+
 function testTool(registry: string, repo: string, name: string) {
   describe('Register, publish, unpublish, and delete a tool', () => {
     registerQuayTool(repo, name);
@@ -184,25 +205,14 @@ function testTool(registry: string, repo: string, name: string) {
     deleteTool();
   });
 
-  // disable test until hiding versions for Tools are working on dev
-
   describe('Hide and un-hide a tool version', () => {
-    function toggleHidden() {
-      cy.contains('button', 'Actions').should('be.visible');
-      cy.contains('td', 'Actions').first().click();
-      cy.contains('button', 'Edit').click();
-      cy.contains('div', 'Hidden:').within(() => {
-        cy.get('[name=checkbox]').click();
-      });
-      cy.contains('button', 'Save Changes').click();
-    }
     registerQuayTool(repo, name);
     it('hide a version', () => {
       goToTab('Versions');
-      toggleHidden();
+      toggleHiddenToolVersion();
       cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
       // un-hide and verify
-      toggleHidden();
+      toggleHiddenToolVersion();
       cy.get('[data-cy=hiddenCheck]').should('not.exist');
     });
     it('refresh namespace', () => {
@@ -263,22 +273,12 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('button', 'Publish').should('be.disabled');
     });
     it('hide and un-hide a version', () => {
-      function toggleHidden() {
-        cy.get('[data-cy=refreshButton]').click();
-        cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
-        cy.contains('button', 'Edit').click();
-        // TODO: Use [data-cy=hiddenCheck] -- do after 1.13 deployed
-        cy.contains('div', 'Hidden:').within(() => {
-          cy.get('[name=checkbox]').click();
-        });
-        cy.contains('button', 'Save Changes').click();
-      }
       goToTab('Versions');
       // hide
-      toggleHidden();
+      toggleHiddenWorkflowVersion();
       cy.get('[data-cy=hidden]').should('have.length', 1);
       // un-hide
-      toggleHidden();
+      toggleHiddenWorkflowVersion();
       cy.get('[data-cy=hidden]').should('not.exist');
     });
   });

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -187,9 +187,7 @@ function testTool(registry: string, repo: string, name: string) {
   // disable test until hiding versions for Tools are working on dev
 
   describe('Hide and un-hide a tool version', () => {
-    registerQuayTool(repo, name);
-    it('hide a version', () => {
-      goToTab('Versions');
+    function toggleHidden() {
       cy.contains('button', 'Actions').should('be.visible');
       cy.contains('td', 'Actions').first().click();
       cy.contains('button', 'Edit').click();
@@ -197,7 +195,15 @@ function testTool(registry: string, repo: string, name: string) {
         cy.get('[name=checkbox]').click();
       });
       cy.contains('button', 'Save Changes').click();
+    }
+    registerQuayTool(repo, name);
+    it('hide a version', () => {
+      goToTab('Versions');
+      toggleHidden();
       cy.get('[data-cy=hiddenCheck]').should('have.length', 1);
+      // un-hide and verify
+      toggleHidden();
+      cy.get('[data-cy=hiddenCheck]').should('not.exist');
     });
     it('refresh namespace', () => {
       cy.contains('button', 'Refresh Namespace').first().click();
@@ -257,23 +263,22 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('button', 'Publish').should('be.disabled');
     });
     it('hide and un-hide a version', () => {
+      function toggleHidden() {
+        cy.get('[data-cy=refreshButton]').click();
+        cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
+        cy.contains('button', 'Edit').click();
+        // TODO: Use [data-cy=hiddenCheck] -- do after 1.13 deployed
+        cy.contains('div', 'Hidden:').within(() => {
+          cy.get('[name=checkbox]').click();
+        });
+        cy.contains('button', 'Save Changes').click();
+      }
       goToTab('Versions');
       // hide
-      cy.get('[data-cy=refreshButton]').click();
-      cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
-      cy.contains('button', 'Edit').click();
-      cy.contains('div', 'Hidden:').within(() => {
-        cy.get('[name=checkbox]').click();
-      });
-      cy.contains('button', 'Save Changes').click();
+      toggleHidden();
       cy.get('[data-cy=hidden]').should('have.length', 1);
       // un-hide
-      cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
-      cy.contains('button', 'Edit').click();
-      cy.contains('div', 'Hidden:').within(() => {
-        cy.get('[name=checkbox]').click();
-      });
-      cy.contains('button', 'Save Changes').click();
+      toggleHidden();
       cy.get('[data-cy=hidden]').should('not.exist');
     });
   });

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -181,8 +181,7 @@ function toggleHiddenToolVersion() {
 }
 
 function toggleHiddenWorkflowVersion() {
-  cy.get('[data-cy=refreshButton]').click();
-  cy.get('[data-cy=versionRow]').last().contains('button', 'Actions').should('be.visible').click();
+  cy.get('[data-cy=versionRow]').last().scrollIntoView().contains('button', 'Actions').should('be.visible').click();
   cy.contains('button', 'Edit').click();
   // TODO: Use [data-cy=hiddenCheck] -- do after 1.14 deployed
   cy.contains('div', 'Hidden:').within(() => {
@@ -273,6 +272,7 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.contains('button', 'Publish').should('be.disabled');
     });
     it('hide and un-hide a version', () => {
+      cy.get('[data-cy=refreshButton]').click();
       goToTab('Versions');
       // hide
       toggleHiddenWorkflowVersion();

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -325,7 +325,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
     deleteTool();
   });
 }
-//
+
 testCollection(collectionTuple[0], collectionTuple[1], toolTuple[0], toolTuple[1], toolTuple[2]);
 testTool(toolTuple[0], toolTuple[1], toolTuple[2]);
 testWorkflow(workflowTuple[0], workflowTuple[1], workflowTuple[2]);

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -175,6 +175,7 @@
               <div>
                 <label>
                   <input
+                    data-cy="hiddenCheck"
                     [disabled]="version.doiURL"
                     type="checkbox"
                     name="checkbox"


### PR DESCRIPTION
**Description**
This PR adds a test for hiding and un-hiding workflow versions. This PR is incomplete and regrettably I won't be able to see it through, so I am leaving some comments.

**Issue**
[DOCK-2202](https://ucsc-cgl.atlassian.net/browse/DOCK-2202)
https://github.com/dockstore/dockstore/issues/5017

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
