### PR TITLE
Cancel workflow edit now reverts

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { contains } from 'cypress/types/jquery';
 import { Repository } from '../../../src/app/shared/openapi/model/repository';
 import { goToTab, isActiveTab, resetDB, setTokenUserViewPort } from '../../support/commands';
 
@@ -108,7 +107,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('1 – 2 of 2');
       cy.contains('Close').click();
     });
-    it('Should contain the extended properties and be able to edit the info tab', () => {
+    it.only('Should contain the extended properties and be able to edit the info tab', () => {
       // The seemingly unnecessary visits are due to a detached-from-dom error even using cy.get().click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('github.com');
@@ -116,16 +115,29 @@ describe('Dockstore my workflows', () => {
       cy.contains('/Dockstore.cwl');
       // Change the file path
       cy.contains('button', ' Edit ').click();
-      cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore2.cwl');
+      const workflowPathInput = '[data-cy=workflowPathInput]';
+      cy.get(workflowPathInput).clear().type('/Dockstore2.cwl');
       cy.contains('button', ' Save ').click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore2.cwl');
       // Change the file path back
       cy.contains('button', ' Edit ').click();
-      cy.get('[data-cy=workflowPathInput]').clear().type('/Dockstore.cwl');
+      const dockstoreCwlPath = '/Dockstore.cwl';
+      cy.get(workflowPathInput).clear().type(dockstoreCwlPath);
       cy.contains('button', ' Save ').click();
       cy.visit('/my-workflows/github.com/A/g');
-      cy.contains('/Dockstore.cwl');
+      const workflowPathSpan = '[data-cy=workflowPathSpan]';
+      cy.get(workflowPathSpan).contains(dockstoreCwlPath);
+
+      // Test Revert
+      cy.get('[data-cy=editWorkflowPathButton').click();
+      const sillyText = 'silly';
+      cy.get(workflowPathInput).clear().type(sillyText);
+      // Verify it took
+      cy.get(workflowPathInput).should('have.value', sillyText);
+      cy.get('[data-cy=cancelWorkflowPathButton').click();
+      // Input goes away, check that correct text displayed
+      cy.get(workflowPathSpan).contains(dockstoreCwlPath);
 
       // Topic Editing
       const privateEntryURI = '/my-workflows/github.com/A/l';

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -107,7 +107,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('1 – 2 of 2');
       cy.contains('Close').click();
     });
-    it.only('Should contain the extended properties and be able to edit the info tab', () => {
+    it('Should contain the extended properties and be able to edit the info tab', () => {
       // The seemingly unnecessary visits are due to a detached-from-dom error even using cy.get().click();
       cy.visit('/my-workflows/github.com/A/g');
       cy.contains('github.com');

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -76,7 +76,7 @@
               >
                 <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
                   <strong [matTooltip]="tooltip.workflowPath">Workflow Path: </strong>
-                  <span *ngIf="!workflowPathEditing" fxFlexOffset="4px"> {{ workflow.workflow_path }} </span>
+                  <span *ngIf="!workflowPathEditing" fxFlexOffset="4px" data-cy="workflowPathSpan"> {{ workflow.workflow_path }} </span>
                   <input
                     data-cy="workflowPathInput"
                     *ngIf="workflowPathEditing"
@@ -95,6 +95,7 @@
                 <div *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="btn-group" role="group" aria-label="Basic example">
                   <button
                     *ngIf="!isPublic && workflowPathEditing"
+                    data-cy="cancelWorkflowPathButton"
                     type="button"
                     mat-raised-button
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
@@ -104,6 +105,7 @@
                   </button>
                   <button
                     *ngIf="!isPublic"
+                    data-cy="editWorkflowPathButton"
                     type="button"
                     mat-raised-button
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -49,7 +49,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   // This should represent what's in the database
   @Input() extendedWorkflow: ExtendedWorkflow;
   // This is what the user is currently seeing/editing
-  public workflow: Workflow;
+  public workflow: ExtendedWorkflow;
   currentVersion: WorkflowVersion;
   downloadZipLink: string;
   publicAccessibleTestParameterFile: boolean | null;
@@ -107,7 +107,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
         this.hasHttpImports = sourceFiles.some((sourceFile) => this.fileService.hasHttpImport(sourceFile));
       });
     }
-    this.workflow = JSON.parse(JSON.stringify(this.extendedWorkflow));
+    this.workflow = this.deepCopy(this.extendedWorkflow);
     this.temporaryDescriptorType = this.workflow.descriptorType;
     if (this.selectedVersion && this.workflow) {
       this.currentVersion = this.selectedVersion;
@@ -233,6 +233,10 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
    */
   cancelEditing(): void {
     this.infoTabService.cancelEditing();
-    this.revertTopic();
+    this.workflow = this.deepCopy(this.extendedWorkflow);
+  }
+
+  private deepCopy(workflow: ExtendedWorkflow): ExtendedWorkflow {
+    return JSON.parse(JSON.stringify(this.extendedWorkflow));
   }
 }


### PR DESCRIPTION
**Description**
Cancel workflow edit now reverts

It was sort of confusing, code-wise. See [this comment](https://github.com/dockstore/dockstore/issues/4592#issuecomment-1221073554) for details.

TLDR; There was a workflow object in InfoTabService that was being reverted, but the object wasn't being used by the component, so no reversion happened in the UI. So I removed the object entirely from the service to avoid confusion, and I do the revert in the component.

**Issue**
dockstore/dockstore#4592

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
