### PR TITLE
Show more generic message when updating workflow

### DIFF
--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 <div>
-  <h4 mat-dialog-title>{{ isPublic || !canWrite ? 'View' : 'Edit' }} {{ entryTypeText }}</h4>
+  <h4 mat-dialog-title>{{ isPublic || !canWrite ? 'View' : 'Edit' }} {{ entryTypeText }} Version</h4>
   <div mat-dialog-content>
     <app-alert></app-alert>
     <fieldset [disabled]="!canWrite || isPublic">
@@ -79,7 +79,7 @@
             <div
               class="col-sm-9 col-md-9 col-lg-9 form-margin"
               [ngClass]="{ 'col-sm-offset-3': i > 0 }"
-              *ngFor="let item of testParameterFilePaths; let i = index; trackBy: trackByIndex"
+              *ngFor="let item of testParameterFilePaths; let i = index"
             >
               <div class="input-group">
                 <input


### PR DESCRIPTION
**Description**

When updating a workflow, we can't do it with one API request, we need to do it at least 2; one request for hidden and/or workflow path, then 1 or 2 more requests for adding/removing test parameter files. We were displaying the updating test parameter file success message last, which is what the user saw. Also, we displayed the updating test parameter files message, even if no request was made to update the test parameters.

The user shouldn't care about how many requests we are making underneath the hood, so now it's just a generic "Saving workflow version succeeded" message. I could have broken it apart, e.g., "Hiding version and adding one test parameter file", but it didn't seem worth the effort.

Also, if a refresh happens, a refresh message will be the last thing to display, but, oh well - I think you'd want to know that.

Also:

* Got rid of an `any`
* Changed the dialog title from `Edit Workfow` to `Edit Workflow Version`, because that's what it is doing
* Noticed a compiler error in WebStorm for the `trackByIndex` function (it doesn't exist), so just removed `trackBy`.

**Issue**
dockstore/dockstore#5014

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
