### PR TITLE
Add https to custom multi-cloud launch URLs without a protocol

### DIFF
--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.html
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.html
@@ -55,6 +55,7 @@
       Cancel
     </button>
     <a
+      id="multiCloudLaunchButton"
       mat-raised-button
       class="small-mat-btn-skin small-btn-structure"
       target="_blank"

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
@@ -33,7 +33,7 @@ describe('MultiCloudLaunchComponent', () => {
   it('Should construct url with https protocol', () => {
     expect(component.constructUrlWithHttpsProtocol('usegalaxy.ca')).toBe('https://usegalaxy.ca');
     expect(component.constructUrlWithHttpsProtocol('subdomain.usegalaxy.ca')).toBe('https://subdomain.usegalaxy.ca');
-    expect(() => component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow();
+    expect(() => component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow(); // NOSONAR suppress insecure http protocol analysis
     expect(() => component.constructUrlWithHttpsProtocol('foobar://foobar.com')).toThrow();
   });
 });

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
@@ -32,6 +32,8 @@ describe('MultiCloudLaunchComponent', () => {
 
   it('Should construct url with https protocol', () => {
     expect(component.constructUrlWithHttpsProtocol('usegalaxy.ca')).toBe('https://usegalaxy.ca');
-    expect(component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow();
+    expect(component.constructUrlWithHttpsProtocol('subdomain.usegalaxy.ca')).toBe('https://subdomain.usegalaxy.ca');
+    expect(() => component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow();
+    expect(() => component.constructUrlWithHttpsProtocol('foobar://foobar.com')).toThrow();
   });
 });

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
@@ -29,4 +29,9 @@ describe('MultiCloudLaunchComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('Should construct url with https protocol', () => {
+    expect(component.constructUrlWithHttpsProtocol('usegalaxy.ca')).toBe('https://usegalaxy.ca');
+    expect(component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow();
+  });
 });

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
@@ -130,6 +130,7 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
       let url: URL;
       try {
         this.alertService.start('Constructing URL');
+        this.launchWith.url = this.constructUrlWithHttpsProtocol(this.launchWith.url);
         url = new URL(this.launchWith.url);
         this.alertService.simpleSuccess();
       } catch (error) {
@@ -165,6 +166,21 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
 
   private updateLaunchWithUrl(): void {
     this.launchWith.url = this.presetLaunchWithOption === 'other' ? this.customLaunchWithOption : this.presetLaunchWithOption;
+  }
+
+  constructUrlWithHttpsProtocol(launchWithUrl: string): string {
+    let url;
+    try {
+      url = new URL(launchWithUrl);
+    } catch (error) {
+      if (!launchWithUrl.toLowerCase().startsWith('https://')) {
+        return 'https://' + launchWithUrl;
+      }
+    }
+
+    if (url.protocol !== 'https:') {
+      throw new Error('URL ' + launchWithUrl + ' does not start with https://');
+    }
   }
 
   closeMatMenu() {

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
@@ -142,25 +142,30 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
         );
       }
 
-      const newCustomInstance: CloudInstance = {
-        url: this.launchWith.url,
-        partner: this.languagePartner,
-        supportsFileImports: null,
-        supportsHttpImports: null,
-        supportedLanguages: new Array<Language>(),
-        displayName: url.hostname,
-      };
+      if (url) {
+        const newCustomInstance: CloudInstance = {
+          url: this.launchWith.url,
+          partner: this.languagePartner,
+          supportsFileImports: null,
+          supportsHttpImports: null,
+          supportedLanguages: new Array<Language>(),
+          displayName: url.hostname,
+        };
 
-      this.usersService.postUserCloudInstance(this.user.id, newCustomInstance).subscribe(
-        (usersCloudInstances: Array<CloudInstance>) => {
-          this.usersCloudInstances = usersCloudInstances;
-        },
-        (error: HttpErrorResponse) => {
-          // It's okay for the save to the db to fail for now. At this step, we only care about what URL's users
-          // are trying to use. Probably most of these failures will be the for violating the uniqueness constraint
-          console.log(error.message);
-        }
-      );
+        this.usersService.postUserCloudInstance(this.user.id, newCustomInstance).subscribe(
+          (usersCloudInstances: Array<CloudInstance>) => {
+            this.usersCloudInstances = usersCloudInstances;
+          },
+          (error: HttpErrorResponse) => {
+            // It's okay for the save to the db to fail for now. At this step, we only care about what URL's users
+            // are trying to use. Probably most of these failures will be the for violating the uniqueness constraint
+            console.log(error.message);
+          }
+        );
+      } else {
+        // Remove link to prevent navigating to invalid URL
+        document.getElementById('multiCloudLaunchButton').removeAttribute('href');
+      }
     }
   }
 


### PR DESCRIPTION
**Description**
This PR:
- Adds `https://` to URLs that don't specify a protocol so `usegalaxy.ca` becomes `https://usegalaxy.ca`.
- Validates that the URL uses https. If it doesn't, the URL is considered invalid and a warning message is displayed.
- Removes the `href` attribute for the `Launch` button if the URL is invalid so the user isn't directed to that URL.
- Performs a truthy check on `url` so we only add new user cloud instances to the DB if the url was created successfully. Without this check, we could get an `undefined` error for invalid URLs.

**Issue**
[SEAB-3965](https://ucsc-cgl.atlassian.net/browse/SEAB-3965)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
