### PR TITLE
Show user-friendly Add Tool/Workflow button

### DIFF
--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 import { Repository } from '../../../src/app/shared/openapi/model/repository';
-import { goToTab, isActiveTab, resetDB, setTokenUserViewPort } from '../../support/commands';
+import { goToTab, isActiveTab, resetDB, setTokenUserViewPort, setTokenUserViewPortCurator } from '../../support/commands';
 
 describe('Dockstore my workflows', () => {
   resetDB();
@@ -550,4 +550,20 @@ describe('Dockstore my workflows', () => {
       cy.get('.error-output').should('not.be.visible');
     });
   }
+});
+describe('Should handle no workflows correctly', () => {
+  resetDB();
+  setTokenUserViewPortCurator(); // Curator has no workflows
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: /github.com\/organizations/,
+      response: ['dockstore'],
+    });
+  });
+  it('My tools should prompt to register a tool', () => {
+    cy.visit('/my-workflows');
+    cy.contains('Register Workflow');
+  });
 });

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -562,7 +562,7 @@ describe('Should handle no workflows correctly', () => {
       response: ['dockstore'],
     });
   });
-  it('My tools should prompt to register a tool', () => {
+  it('My workflows should prompt to register a workflow', () => {
     cy.visit('/my-workflows');
     cy.contains('Register Workflow');
   });

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -16,23 +16,6 @@
 import { DockstoreTool } from '../../../src/app/shared/openapi';
 import { goToTab, resetDB, setTokenUserViewPort, setTokenUserViewPortCurator, typeInInput } from '../../support/commands';
 
-describe('Should handle no tools correctly', () => {
-  resetDB();
-  setTokenUserViewPortCurator(); // Curator has no tools
-  beforeEach(() => {
-    cy.server();
-    cy.route({
-      method: 'GET',
-      url: /github.com\/organizations/,
-      response: ['dockstore'],
-    });
-  });
-  it('My tools should prompt to register a tool', () => {
-    cy.visit('/my-tools');
-    cy.contains('Add Tool');
-  });
-});
-
 describe('Dockstore my tools', () => {
   resetDB();
   setTokenUserViewPort();
@@ -564,6 +547,6 @@ describe('Should handle no tools correctly', () => {
   });
   it('My tools should prompt to register a tool', () => {
     cy.visit('/my-tools');
-    cy.contains('Add Tool');
+    cy.contains('Register Tool');
   });
 });

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -547,6 +547,6 @@ describe('Should handle no tools correctly', () => {
   });
   it('My tools should prompt to register a tool', () => {
     cy.visit('/my-tools');
-    cy.contains('Register Tool');
+    cy.contains('Add Tool');
   });
 });

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -14,7 +14,24 @@
  *     limitations under the License.
  */
 import { DockstoreTool } from '../../../src/app/shared/openapi';
-import { goToTab, resetDB, setTokenUserViewPort, typeInInput } from '../../support/commands';
+import { goToTab, resetDB, setTokenUserViewPort, setTokenUserViewPortCurator, typeInInput } from '../../support/commands';
+
+describe('Should handle no tools correctly', () => {
+  resetDB();
+  setTokenUserViewPortCurator(); // Curator has no tools
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: /github.com\/organizations/,
+      response: ['dockstore'],
+    });
+  });
+  it('My tools should prompt to register a tool', () => {
+    cy.visit('/my-tools');
+    cy.contains('Add Tool');
+  });
+});
 
 describe('Dockstore my tools', () => {
   resetDB();
@@ -532,4 +549,21 @@ describe('Dockstore my tools', () => {
       cy.get('#cdk-accordion-child-1 > .mat-action-row > .pull-right > [data-cy=refreshOrganization]').trigger('mouseenter');
     });
   }
+});
+
+describe('Should handle no tools correctly', () => {
+  resetDB();
+  setTokenUserViewPortCurator(); // Curator has no tools
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: /github.com\/organizations/,
+      response: ['dockstore'],
+    });
+  });
+  it('My tools should prompt to register a tool', () => {
+    cy.visit('/my-tools');
+    cy.contains('Add Tool');
+  });
 });

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -56,7 +56,7 @@ function deleteTool() {
     });
     cy.wait('@containers');
     // TODO: Revisit this -- with change to show GitHub orgs with no entries, this got broken
-    // cy.contains('There are currently no tools registered under this account');
+    cy.contains('There are currently no tools registered under this account');
   });
 }
 

--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -178,7 +178,8 @@ export class MyToolComponent extends MyEntry implements OnInit {
 
     this.hasGroupGitHubAppToolEntriesObjects$ = this.groupAppToolEntryObjects$.pipe(
       map((orgToolObjects: OrgWorkflowObject<Workflow>[]) => {
-        return orgToolObjects && orgToolObjects.length !== 0;
+        // Now that we have empty GitHub orgs showing up, check if they have any entries
+        return orgToolObjects && orgToolObjects.some((orgToolObject) => orgToolObject.unpublished.length || orgToolObject.published.length);
       })
     );
 

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -184,7 +184,8 @@ export class MyWorkflowComponent extends MyEntry implements OnInit {
 
     this.hasGroupEntriesObject$ = this.groupEntriesObject$.pipe(
       map((orgToolObjects: OrgWorkflowObject<Workflow>[]) => {
-        return orgToolObjects && orgToolObjects.length !== 0;
+        // Now that we have empty GitHub orgs showing up, check if they have any entries
+        return orgToolObjects && orgToolObjects.some((orgToolObject) => orgToolObject.unpublished.length || orgToolObject.published.length);
       })
     );
     this.hasGroupSharedEntriesObject$ = this.groupSharedEntriesObject$.pipe(


### PR DESCRIPTION
**Description**

The problem was that we now display your GitHub orgs even if you have no tools/workflows registered (so you can see the app logs). Now check also if there is a least one registered entry in one of the GitHub orgs.

Also restored commented out smoke test that this bug had broken.

**Issue**
dockstore/dockstore#5105

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
