### PR TITLE
Organization invitation newline fix

### DIFF
--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -163,7 +163,7 @@
           <mat-card-subtitle> Requested on {{ membership.dbCreateDate | date }} </mat-card-subtitle>
         </mat-card-header>
         <mat-card-content class="px-4">
-          {{ membership.organization.topic }}
+          {{ membership.organization.topic }}<br />
           You have been invited to join the organization with the role <strong>{{ membership.role | lowercase }}</strong
           >.
         </mat-card-content>


### PR DESCRIPTION
**Description**
Adds a newline to the organization description on a member invitation

**Issue**
DOCK-2196 (https://ucsc-cgl.atlassian.net/browse/DOCK-2196)
GitHub issue #5002  (https://github.com/dockstore/dockstore/issues/5002)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
