### PR TITLE
Fix multi galaxy custom URL bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.8.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.13.0-beta.3",
+    "webservice_version": "1.13.0-rc.1",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8331/workflows/81a1254f-c07b-4aa8-a4b1-42cc253dfb40/jobs/22925/artifacts",
-    "circle_build_id": "22925",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8588/workflows/7e19040e-70d9-416d-9acc-db7fd9c6639c/jobs/24582/artifacts",
+    "circle_build_id": "24582",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.spec.ts
@@ -33,6 +33,7 @@ describe('MultiCloudLaunchComponent', () => {
   it('Should construct url with https protocol', () => {
     expect(component.constructUrlWithHttpsProtocol('usegalaxy.ca')).toBe('https://usegalaxy.ca');
     expect(component.constructUrlWithHttpsProtocol('subdomain.usegalaxy.ca')).toBe('https://subdomain.usegalaxy.ca');
+    expect(component.constructUrlWithHttpsProtocol('https://usegalaxy.ca')).toBe('https://usegalaxy.ca');
     expect(() => component.constructUrlWithHttpsProtocol('http://foobar.com')).toThrow(); // NOSONAR suppress insecure http protocol analysis
     expect(() => component.constructUrlWithHttpsProtocol('foobar://foobar.com')).toThrow();
   });

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
@@ -125,8 +125,8 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
       localStorage.setItem('useCustomLaunch', 'false');
     }
 
-    // Create and save a user's custom launch entry to the db
-    if (this.presetLaunchWithOption === 'other' && this.user) {
+    // Construct custom URL
+    if (this.presetLaunchWithOption === 'other') {
       let url: URL;
       try {
         this.alertService.start('Constructing URL');
@@ -142,7 +142,8 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
         );
       }
 
-      if (url) {
+      // Create and save a user's custom launch entry to the db if URL is valid
+      if (url && this.user) {
         const newCustomInstance: CloudInstance = {
           url: this.launchWith.url,
           partner: this.languagePartner,
@@ -162,7 +163,7 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
             console.log(error.message);
           }
         );
-      } else {
+      } else if (!url) {
         // Remove link to prevent navigating to invalid URL
         document.getElementById('multiCloudLaunchButton').removeAttribute('href');
       }
@@ -183,7 +184,9 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
       }
     }
 
-    if (url.protocol !== 'https:') {
+    if (url.protocol === 'https:') {
+      return launchWithUrl;
+    } else {
       throw new Error('URL ' + launchWithUrl + ' does not start with https://');
     }
   }

--- a/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
+++ b/src/app/workflow/launch-third-party/multi-cloud-launch/multi-cloud-launch.component.ts
@@ -179,6 +179,7 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
     try {
       url = new URL(launchWithUrl);
     } catch (error) {
+      // URL has no protocol
       if (!launchWithUrl.toLowerCase().startsWith('https://')) {
         return 'https://' + launchWithUrl;
       }
@@ -187,6 +188,7 @@ export class MultiCloudLaunchComponent extends Base implements OnInit {
     if (url.protocol === 'https:') {
       return launchWithUrl;
     } else {
+      // URL has a protocol that is not HTTPS
       throw new Error('URL ' + launchWithUrl + ' does not start with https://');
     }
   }


### PR DESCRIPTION
**Description**
This PR fixes the bugs that Steve found while reviewing the ticket. Note that this is for 1.13. 

This PR:
- Constructs the https URL even if the user is logged out
- In `constructUrlWithHttpsProtocol`, returns the original url if it already contains the https protocol

**Issue**
[SEAB-3965](https://ucsc-cgl.atlassian.net/browse/SEAB-3965)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
