### PR TITLE
added notification badge

### DIFF
--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -44,30 +44,18 @@ describe('Test notification badge on navbar', () => {
       cy.contains('button', 'Create Organization Request').should('be.visible').click();
       cy.contains('button', 'Next').should('be.visible').click();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Name', 'Potato');
+      typeInInput('Name', 'Test');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Display Name', 'Potato');
+      typeInInput('Display Name', 'Test');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Topic', "Boil 'em, mash 'em, stick 'em in a stew");
+      typeInInput('Topic', 'Testing Testing Testing');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Email', 'fake@potato.com');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
-      typeInInput('Organization website', 'www.google.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Location', 'Basement');
-      cy.get('.mat-error').should('be.visible');
+      typeInInput('Location', 'Lab');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Organization website', 'https://www.google.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
-
-      cy.get('[data-cy=image-url-input').clear().type('https://via.placeholder.com/150');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-
       typeInInput('Contact Email Address', 'asdf@asdf.ca');
-      cy.get('.mat-error').should('be.visible');
-      cy.get('[data-cy=image-url-input').clear();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato');
+      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Test');
 
       cy.reload();
       cy.get('#notifButton').should('be.visible').click();
@@ -98,29 +86,12 @@ describe('Test notification badge on navbar', () => {
     it('create a new unapproved organization and invite user', () => {
       cy.contains('button', 'Create Organization Request').should('be.visible').click();
       cy.contains('button', 'Next').should('be.visible').click();
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Name', 'Potato111');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Display Name', 'Potato111');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Topic', "Boil 'em, mash 'em, stick 'em in a stew");
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-      typeInInput('Email', 'fake11@potato.com');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
-      typeInInput('Organization website', 'www.google.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Location', 'Basement');
-      cy.get('.mat-error').should('be.visible');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Organization website', 'https://www.google.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
-
-      cy.get('[data-cy=image-url-input').clear().type('https://via.placeholder.com/150');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
-
       typeInInput('Contact Email Address', 'a111sdf@asdf.ca');
-      cy.get('.mat-error').should('be.visible');
-      cy.get('[data-cy=image-url-input').clear();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato111');
 

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2018 OICR
+ *    Copyright 2022 OICR, UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -37,21 +37,15 @@ describe('Test notification badge on navbar', () => {
     it('visit the organizations page from the home page', () => {
       cy.visit('/');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
-      cy.contains('No organizations found');
     });
 
     it('create a new unapproved organization', () => {
       cy.contains('button', 'Create Organization Request').should('be.visible').click();
       cy.contains('button', 'Next').should('be.visible').click();
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Name', 'Test');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Display Name', 'Test');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Topic', 'Testing Testing Testing');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Location', 'Lab');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
       typeInInput('Organization website', 'https://www.google.ca');
       typeInInput('Contact Email Address', 'asdf@asdf.ca');
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
@@ -80,7 +74,6 @@ describe('Test notification badge on navbar', () => {
     it('visit the organizations page from the home page', () => {
       cy.visit('');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
-      cy.contains('No organizations found');
     });
 
     it('create a new unapproved organization and invite user', () => {

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { resetDB, setTokenUserViewPort, setTokenUserViewPortCurator } from '../../support/commands';
+import { createOrganization, resetDB, setTokenUserViewPort, setTokenUserViewPortCurator } from '../../support/commands';
 
 describe('Test notification badge on navbar', () => {
   function typeInInput(fieldName: string, text: string) {
@@ -40,18 +40,7 @@ describe('Test notification badge on navbar', () => {
     });
 
     it('create a new unapproved organization', () => {
-      cy.contains('button', 'Create Organization Request').should('be.visible').click();
-      cy.contains('button', 'Next').should('be.visible').click();
-      typeInInput('Name', 'Test');
-      typeInInput('Display Name', 'Test');
-      typeInInput('Topic', 'Testing Testing Testing');
-      typeInInput('Location', 'Lab');
-      typeInInput('Organization website', 'https://www.google.ca');
-      typeInInput('Contact Email Address', 'asdf@asdf.ca');
-      cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Test');
-
-      cy.reload();
+      createOrganization('Test', 'Test Display', 'Testing Testing Testing', 'Lab', 'https://www.google.ca', 'asf@asdf.ca');
       cy.get('[data-cy=notification-button]').should('be.visible').click();
       cy.get('[data-cy=bell-icon]').should('contain.text', '1');
     });
@@ -77,18 +66,14 @@ describe('Test notification badge on navbar', () => {
     });
 
     it('create a new unapproved organization and invite user', () => {
-      cy.contains('button', 'Create Organization Request').should('be.visible').click();
-      cy.contains('button', 'Next').should('be.visible').click();
-      typeInInput('Name', 'Potato111');
-      typeInInput('Display Name', 'Potato111');
-      typeInInput('Topic', "Boil 'em, mash 'em, stick 'em in a stew");
-      typeInInput('Location', 'Basement');
-      typeInInput('Organization website', 'https://www.google.ca');
-      typeInInput('Contact Email Address', 'a111sdf@asdf.ca');
-      cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato111');
-
-      cy.reload();
+      createOrganization(
+        'Potato111',
+        'Potato111',
+        "Boil 'em, mash 'em, stick 'em in a stew",
+        'Basement',
+        'https://www.google.ca',
+        'a111sdf@asdf.ca'
+      );
       cy.contains('span', 'Members').click();
       cy.contains('button', 'Add user').should('be.visible').click();
       typeInInput('Username', 'user_A');

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -1,0 +1,144 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import { resetDB, setTokenUserViewPort, setTokenUserViewPortCurator } from '../../support/commands';
+
+describe('Test notification badge on navbar', () => {
+  function typeInInput(fieldName: string, text: string) {
+    cy.contains('span', fieldName).parentsUntil('.mat-form-field-wrapper').find('input').first().should('be.visible').clear().type(text);
+  }
+  resetDB();
+  setTokenUserViewPort();
+
+  it('Notification button should link to requests page', () => {
+    cy.visit('');
+    cy.get('#notifButton').should('be.visible').click();
+    cy.url().should('contain', 'accounts?tab=requests');
+  });
+
+  it('Red badge should not be visible when there are no notifications', () => {
+    cy.visit('');
+    cy.get('mat-icon').should('have.class', 'mat-badge-hidden');
+  });
+
+  describe('Should have badge count of 1 with pending organization request', () => {
+    it('visit the organizations page from the home page', () => {
+      cy.visit('/');
+      cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
+      cy.contains('No organizations found');
+    });
+
+    it('create a new unapproved organization', () => {
+      cy.contains('button', 'Create Organization Request').should('be.visible').click();
+      cy.contains('button', 'Next').should('be.visible').click();
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Name', 'Potato');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Display Name', 'Potato');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Topic', "Boil 'em, mash 'em, stick 'em in a stew");
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Email', 'fake@potato.com');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
+      typeInInput('Organization website', 'www.google.ca');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Location', 'Basement');
+      cy.get('.mat-error').should('be.visible');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Organization website', 'https://www.google.ca');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
+
+      cy.get('[data-cy=image-url-input').clear().type('https://via.placeholder.com/150');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+
+      typeInInput('Contact Email Address', 'asdf@asdf.ca');
+      cy.get('.mat-error').should('be.visible');
+      cy.get('[data-cy=image-url-input').clear();
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato');
+
+      cy.reload();
+      cy.get('#notifButton').should('be.visible').click();
+      cy.get('mat-icon').should('contain.text', '1');
+    });
+  });
+  describe('Should have badge count of 1 with a rejected organization request', () => {
+    it('visit the requests page', () => {
+      cy.get('#notifButton').should('be.visible').click();
+    });
+
+    it('reject a pending organization', () => {
+      cy.contains('button', 'Reject').should('be.visible').click();
+      cy.get('#reject-pending-org-dialog').should('be.visible').click();
+      cy.reload();
+      cy.get('#notifButton').should('be.visible').click();
+      cy.get('mat-icon').should('contain.text', '1');
+    });
+  });
+  describe('Should have badge count of 3 with one pending organiaztion, one invitation, and one rejected organization request', () => {
+    setTokenUserViewPortCurator();
+    it('visit the organizations page from the home page', () => {
+      cy.visit('');
+      cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
+      cy.contains('No organizations found');
+    });
+
+    it('create a new unapproved organization and invite user', () => {
+      cy.contains('button', 'Create Organization Request').should('be.visible').click();
+      cy.contains('button', 'Next').should('be.visible').click();
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Name', 'Potato111');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Display Name', 'Potato111');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Topic', "Boil 'em, mash 'em, stick 'em in a stew");
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Email', 'fake11@potato.com');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
+      typeInInput('Organization website', 'www.google.ca');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Location', 'Basement');
+      cy.get('.mat-error').should('be.visible');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+      typeInInput('Organization website', 'https://www.google.ca');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled');
+
+      cy.get('[data-cy=image-url-input').clear().type('https://via.placeholder.com/150');
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
+
+      typeInInput('Contact Email Address', 'a111sdf@asdf.ca');
+      cy.get('.mat-error').should('be.visible');
+      cy.get('[data-cy=image-url-input').clear();
+      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato111');
+
+      cy.reload();
+      cy.get('#mat-tab-label-0-1').contains('Members').click();
+      cy.contains('button', 'Add user').should('be.visible').click();
+      typeInInput('Username', 'user_A');
+      cy.contains('button', 'Add User').should('be.visible').click();
+      cy.reload();
+    });
+
+    describe('Log back onto user_A', () => {
+      setTokenUserViewPort();
+      it('Badge count should be 3', () => {
+        cy.visit('');
+        cy.get('#notifButton').should('be.visible').click();
+        cy.get('mat-icon').should('contain.text', '3');
+      });
+    });
+  });
+});

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -23,14 +23,14 @@ describe('Test notification badge on navbar', () => {
   setTokenUserViewPort();
 
   it('Notification button should link to requests page', () => {
-    cy.visit('');
-    cy.get('#notifButton').should('be.visible').click();
+    cy.visit('/');
+    cy.get('[data-cy=notification-button]').should('be.visible').click();
     cy.url().should('contain', 'accounts?tab=requests');
   });
 
   it('Red badge should not be visible when there are no notifications', () => {
-    cy.visit('');
-    cy.get('mat-icon').should('have.class', 'mat-badge-hidden');
+    cy.visit('/');
+    cy.get('[data-cy=bell-icon]').should('have.class', 'mat-badge-hidden');
   });
 
   describe('Should have badge count of 1 with pending organization request', () => {
@@ -48,31 +48,31 @@ describe('Test notification badge on navbar', () => {
       typeInInput('Location', 'Lab');
       typeInInput('Organization website', 'https://www.google.ca');
       typeInInput('Contact Email Address', 'asdf@asdf.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Test');
 
       cy.reload();
-      cy.get('#notifButton').should('be.visible').click();
-      cy.get('mat-icon').should('contain.text', '1');
+      cy.get('[data-cy=notification-button]').should('be.visible').click();
+      cy.get('[data-cy=bell-icon]').should('contain.text', '1');
     });
   });
   describe('Should have badge count of 1 with a rejected organization request', () => {
     it('visit the requests page', () => {
-      cy.get('#notifButton').should('be.visible').click();
+      cy.get('[data-cy=notification-button]').should('be.visible').click();
     });
 
     it('reject a pending organization', () => {
       cy.contains('button', 'Reject').should('be.visible').click();
-      cy.get('#reject-pending-org-dialog').should('be.visible').click();
+      cy.get('[data-cy=reject-pending-org-dialog]').should('be.visible').click();
       cy.reload();
-      cy.get('#notifButton').should('be.visible').click();
-      cy.get('mat-icon').should('contain.text', '1');
+      cy.get('[data-cy=notification-button]').should('be.visible').click();
+      cy.get('[data-cy=bell-icon]').should('contain.text', '1');
     });
   });
   describe('Should have badge count of 3 with one pending organiaztion, one invitation, and one rejected organization request', () => {
     setTokenUserViewPortCurator();
     it('visit the organizations page from the home page', () => {
-      cy.visit('');
+      cy.visit('/');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
     });
 
@@ -85,11 +85,11 @@ describe('Test notification badge on navbar', () => {
       typeInInput('Location', 'Basement');
       typeInInput('Organization website', 'https://www.google.ca');
       typeInInput('Contact Email Address', 'a111sdf@asdf.ca');
-      cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
+      cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato111');
 
       cy.reload();
-      cy.get('#mat-tab-label-0-1').contains('Members').click();
+      cy.contains('span', 'Members').click();
       cy.contains('button', 'Add user').should('be.visible').click();
       typeInInput('Username', 'user_A');
       cy.contains('button', 'Add User').should('be.visible').click();
@@ -99,9 +99,9 @@ describe('Test notification badge on navbar', () => {
     describe('Log back onto user_A', () => {
       setTokenUserViewPort();
       it('Badge count should be 3', () => {
-        cy.visit('');
-        cy.get('#notifButton').should('be.visible').click();
-        cy.get('mat-icon').should('contain.text', '3');
+        cy.visit('/');
+        cy.get('[data-cy=notification-button]').should('be.visible').click();
+        cy.get('[data-cy=bell-icon]').should('contain.text', '3');
       });
     });
   });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -125,3 +125,18 @@ export function addOrganizationAdminUser(organization: string, user: string) {
       "'), true, 'ADMIN')"
   );
 }
+
+export function createOrganization(name: string, displayName: string, topic: string, location: string, website: string, email: string) {
+  cy.contains('button', 'Create Organization Request').should('be.visible').click();
+  cy.contains('button', 'Next').should('be.visible').click();
+  typeInInput('Name', name);
+  typeInInput('Display Name', displayName);
+  typeInInput('Topic', topic);
+  typeInInput('Location', location);
+  typeInInput('Organization website', website);
+  typeInInput('Contact Email Address', email);
+  cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
+  cy.url().should('eq', Cypress.config().baseUrl + '/organizations/' + name);
+
+  cy.reload();
+}

--- a/src/app/loginComponents/requests/organization-invite-confirm-dialog.html
+++ b/src/app/loginComponents/requests/organization-invite-confirm-dialog.html
@@ -10,9 +10,23 @@
   <div fxFlex></div>
   <button mat-button (click)="onNoClick()">No Thanks</button>
   <span *ngIf="data.approve; else rejectBlock">
-    <button mat-flat-button id="accept-pending-org-dialog" [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }">Accept</button>
+    <button
+      mat-flat-button
+      id="accept-pending-org-dialog"
+      data-cy="approve-pending-org-dialog"
+      [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }"
+    >
+      Accept
+    </button>
   </span>
   <ng-template #rejectBlock>
-    <button mat-flat-button id="reject-pending-org-dialog" [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }">Decline</button>
+    <button
+      mat-flat-button
+      id="reject-pending-org-dialog"
+      data-cy="reject-pending-org-dialog"
+      [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }"
+    >
+      Decline
+    </button>
   </ng-template>
 </div>

--- a/src/app/loginComponents/requests/organization-request-confirm-dialog.html
+++ b/src/app/loginComponents/requests/organization-request-confirm-dialog.html
@@ -11,6 +11,7 @@
       mat-raised-button
       class="accent-1-dark-btn mat-elevation-z"
       id="approve-pending-org-dialog"
+      data-cy="approve-pending-org-dialog"
       [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }"
     >
       Approve
@@ -21,6 +22,7 @@
       mat-raised-button
       class="accent-1-dark-btn mat-elevation-z"
       id="reject-pending-org-dialog"
+      data-cy="reject-pending-org-dialog"
       [mat-dialog-close]="{ 'id': data.id, 'approve': data.approve }"
     >
       Reject

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -51,6 +51,7 @@
         >
           <img src="../assets/svg/my-nav/dashboard.svg" alt="dashboard" /> My Dockstore
         </a>
+
         <div fxLayoutGap="1rem" *ngIf="!isLoggedIn">
           <a routerLink="/login">
             <button mat-raised-button color="accent">Login</button>
@@ -59,6 +60,40 @@
             <button mat-raised-button color="accent">Register</button>
           </a>
         </div>
+
+        <a
+          *ngIf="isLoggedIn"
+          mat-button
+          class="icon"
+          [routerLink]="['/accounts']"
+          [queryParams]="{ tab: 'requests' }"
+          routerLinkActive="icon-active"
+        >
+          <mat-icon
+            matBadge="{{
+              isAdminOrCurator
+                ? (myOrganizationInvites$ | async)?.length +
+                  (myRejectedOrganizationRequests$ | async)?.length +
+                  (allPendingOrganizations$ | async)?.length
+                : (myOrganizationInvites$ | async)?.length + (myRejectedOrganizationRequests$ | async)?.length
+            }}"
+            matBadgeHidden="{{
+              isAdminOrCurator
+                ? (myOrganizationInvites$ | async)?.length +
+                    (myRejectedOrganizationRequests$ | async)?.length +
+                    (allPendingOrganizations$ | async)?.length ===
+                  0
+                : (myOrganizationInvites$ | async)?.length + (myRejectedOrganizationRequests$ | async)?.length === 0
+            }}"
+            matBadgeColor="warn"
+            matBadgeSize="small"
+            matBadgeOverlap="true"
+            aria-label="requests button"
+            class="bell-icon"
+            >notifications</mat-icon
+          >
+        </a>
+
         <template [ngTemplateOutlet]="loginButton"></template>
         <mat-menu #menuLarge="matMenu">
           <button

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -70,21 +70,8 @@
           routerLinkActive="icon-active"
         >
           <mat-icon
-            matBadge="{{
-              isAdminOrCurator
-                ? (myOrganizationInvites$ | async)?.length +
-                  (myRejectedOrganizationRequests$ | async)?.length +
-                  (allPendingOrganizations$ | async)?.length
-                : (myOrganizationInvites$ | async)?.length + (myRejectedOrganizationRequests$ | async)?.length
-            }}"
-            matBadgeHidden="{{
-              isAdminOrCurator
-                ? (myOrganizationInvites$ | async)?.length +
-                    (myRejectedOrganizationRequests$ | async)?.length +
-                    (allPendingOrganizations$ | async)?.length ===
-                  0
-                : (myOrganizationInvites$ | async)?.length + (myRejectedOrganizationRequests$ | async)?.length === 0
-            }}"
+            matBadge="{{ (isAdminOrCurator$ | async) ? adminNotifCount : notifCount }}"
+            matBadgeHidden="{{ (isAdminOrCurator$ | async) ? adminNotifCount === 0 : notifCount === 0 }}"
             matBadgeColor="warn"
             matBadgeSize="small"
             matBadgeOverlap="true"

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -71,8 +71,8 @@
           routerLinkActive="icon-active"
         >
           <mat-icon
-            matBadge="{{ (isAdminOrCurator$ | async) ? adminNotifCount : notifCount }}"
-            matBadgeHidden="{{ (isAdminOrCurator$ | async) ? adminNotifCount === 0 : notifCount === 0 }}"
+            matBadge="{{ notifCount }}"
+            matBadgeHidden="{{ notifCount === 0 }}"
             matBadgeColor="warn"
             matBadgeSize="small"
             matBadgeOverlap="true"

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -64,6 +64,7 @@
         <a
           *ngIf="isLoggedIn"
           id="notifButton"
+          data-cy="notification-button"
           mat-button
           class="icon"
           [routerLink]="['/accounts']"
@@ -71,8 +72,9 @@
           routerLinkActive="icon-active"
         >
           <mat-icon
-            matBadge="{{ notifCount }}"
-            matBadgeHidden="{{ notifCount === 0 }}"
+            data-cy="bell-icon"
+            matBadge="{{ notificationCount$ | async }}"
+            matBadgeHidden="{{ (notificationCount$ | async) === 0 }}"
             matBadgeColor="warn"
             matBadgeSize="small"
             matBadgeOverlap="true"

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -63,6 +63,7 @@
 
         <a
           *ngIf="isLoggedIn"
+          id="notifButton"
           mat-button
           class="icon"
           [routerLink]="['/accounts']"

--- a/src/app/navbar/navbar.component.scss
+++ b/src/app/navbar/navbar.component.scss
@@ -76,6 +76,6 @@ mat-menu {
   filter: grayscale(100%);
 }
 .bell-icon {
-  color: #c5cae9;
+  color: mat.get-color-from-palette($kim-accent1-success, 4);
   transform: scale(1.25);
 }

--- a/src/app/navbar/navbar.component.scss
+++ b/src/app/navbar/navbar.component.scss
@@ -75,3 +75,7 @@ mat-menu {
 .icons {
   filter: grayscale(100%);
 }
+.bell-icon {
+  color: #c5cae9;
+  transform: scale(1.25);
+}

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -20,7 +20,9 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterTestingModule } from '@angular/router/testing';
+import { RequestsService } from '../loginComponents/state/requests.service';
 import { LogoutService } from '../shared/logout.service';
 import { PageInfo } from '../shared/models/PageInfo';
 import { PagenumberService } from '../shared/pagenumber.service';
@@ -36,12 +38,21 @@ describe('NavbarComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [NavbarComponent],
-        imports: [RouterTestingModule, MatMenuModule, MatButtonModule, MatIconModule, MatDividerModule, MatToolbarModule],
+        imports: [
+          RouterTestingModule,
+          MatMenuModule,
+          MatSnackBarModule,
+          MatButtonModule,
+          MatIconModule,
+          MatDividerModule,
+          MatToolbarModule,
+        ],
         schemas: [NO_ERRORS_SCHEMA],
         providers: [
           PagenumberService,
           { provide: TrackLoginService, useClass: TrackLoginStubService },
           { provide: LogoutService, useClass: LogoutStubService },
+          RequestsService,
         ],
       }).compileComponents();
     })

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -20,6 +20,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterTestingModule } from '@angular/router/testing';
 import { RequestsService } from '../loginComponents/state/requests.service';
@@ -46,6 +47,7 @@ describe('NavbarComponent', () => {
           MatIconModule,
           MatDividerModule,
           MatToolbarModule,
+          HttpClientTestingModule,
         ],
         schemas: [NO_ERRORS_SCHEMA],
         providers: [

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -61,7 +61,6 @@ export class NavbarComponent extends Logout implements OnInit {
     private requestsService: RequestsService
   ) {
     super(trackLoginService, logoutService, router);
-    this.adminNotifCount = 0;
     this.notifCount = 0;
     this.router.events
       .pipe(
@@ -86,14 +85,16 @@ export class NavbarComponent extends Logout implements OnInit {
     this.allPendingOrganizations$ = this.requestsQuery.allPendingOrganizations$;
     combineLatest([this.myOrganizationInvites$, this.myRejectedOrganizationRequests$, this.allPendingOrganizations$]).subscribe(
       ([invites, rejections, pendingOrgs]: [Array<OrganizationUser>, Array<OrganizationUser>, Array<Organization>]) => {
-        this.adminNotifCount = invites?.length + rejections?.length + pendingOrgs?.length;
-        this.notifCount = invites?.length + rejections?.length;
-        if (isNaN(this.adminNotifCount)) {
-          this.adminNotifCount = 0;
-        }
-        if (isNaN(this.notifCount)) {
-          this.notifCount = 0;
-        }
+        this.isAdminOrCurator$.subscribe((isAdminorCurator: boolean) => {
+          if (isAdminorCurator) {
+            this.notifCount = invites?.length + rejections?.length + pendingOrgs?.length;
+          } else {
+            this.notifCount = invites?.length + rejections?.length;
+          }
+          if (isNaN(this.notifCount)) {
+            this.notifCount = 0;
+          }
+        });
       }
     );
   }

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -16,7 +16,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
-import { filter, takeUntil, map } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 import { Logout } from '../loginComponents/logout';
 import { currentPrivacyPolicyVersion, currentTOSVersion } from '../shared/constants';
 import { Dockstore } from '../shared/dockstore.model';
@@ -88,7 +88,6 @@ export class NavbarComponent extends Logout implements OnInit {
       ([invites, rejections, pendingOrgs]: [Array<OrganizationUser>, Array<OrganizationUser>, Array<Organization>]) => {
         this.adminNotifCount = invites?.length + rejections?.length + pendingOrgs?.length;
         this.notifCount = invites?.length + rejections?.length;
-        console.log(invites?.length);
       }
     );
   }

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -16,7 +16,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { Logout } from '../loginComponents/logout';
 import { currentPrivacyPolicyVersion, currentTOSVersion } from '../shared/constants';
 import { Dockstore } from '../shared/dockstore.model';
@@ -48,8 +48,7 @@ export class NavbarComponent extends Logout implements OnInit {
   public myRejectedOrganizationRequests$: Observable<Array<OrganizationUser>>;
   public allPendingOrganizations$: Observable<Array<Organization>>;
   public isAdminOrCurator$: Observable<boolean>;
-  public adminNotifCount: number;
-  public notifCount: number;
+  public notificationCount$: Observable<number>;
 
   constructor(
     private pagenumberService: PagenumberService,
@@ -61,7 +60,6 @@ export class NavbarComponent extends Logout implements OnInit {
     private requestsService: RequestsService
   ) {
     super(trackLoginService, logoutService, router);
-    this.notifCount = 0;
     this.router.events
       .pipe(
         filter((event) => event instanceof NavigationEnd),
@@ -83,19 +81,33 @@ export class NavbarComponent extends Logout implements OnInit {
     this.myOrganizationInvites$ = this.requestsQuery.myOrganizationInvites$;
     this.myRejectedOrganizationRequests$ = this.requestsQuery.myRejectedOrganizationRequests$;
     this.allPendingOrganizations$ = this.requestsQuery.allPendingOrganizations$;
-    combineLatest([this.myOrganizationInvites$, this.myRejectedOrganizationRequests$, this.allPendingOrganizations$]).subscribe(
-      ([invites, rejections, pendingOrgs]: [Array<OrganizationUser>, Array<OrganizationUser>, Array<Organization>]) => {
-        this.isAdminOrCurator$.subscribe((isAdminorCurator: boolean) => {
-          if (isAdminorCurator) {
-            this.notifCount = invites?.length + rejections?.length + pendingOrgs?.length;
+    this.notificationCount$ = combineLatest([
+      this.myOrganizationInvites$,
+      this.myRejectedOrganizationRequests$,
+      this.allPendingOrganizations$,
+      this.isAdminOrCurator$,
+    ]).pipe(
+      takeUntil(this.ngUnsubscribe),
+      map(
+        ([invites, rejections, pendingOrganizations, isAdminOrCurator]: [
+          Array<OrganizationUser>,
+          Array<OrganizationUser>,
+          Array<Organization>,
+          boolean
+        ]) => {
+          if (isAdminOrCurator) {
+            if (isNaN(invites?.length + rejections?.length + pendingOrganizations?.length)) {
+              return 0;
+            }
+            return invites?.length + rejections?.length + pendingOrganizations?.length;
           } else {
-            this.notifCount = invites?.length + rejections?.length;
+            if (isNaN(invites?.length + rejections?.length)) {
+              return 0;
+            }
+            return invites?.length + rejections?.length;
           }
-          if (isNaN(this.notifCount)) {
-            this.notifCount = 0;
-          }
-        });
-      }
+        }
+      )
     );
   }
 

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -95,11 +95,11 @@ export class NavbarComponent extends Logout implements OnInit {
           Array<Organization>,
           boolean
         ]) => {
-          let count = invites?.length + rejections?.length;
+          let count = (invites?.length ?? 0) + (rejections?.length ?? 0);
           if (isAdminOrCurator) {
-            return isNaN(count + pendingOrganizations?.length) ? 0 : count + pendingOrganizations?.length;
+            return count + (pendingOrganizations?.length ?? 0);
           } else {
-            return isNaN(count) ? 0 : count;
+            return count;
           }
         }
       )

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -88,6 +88,12 @@ export class NavbarComponent extends Logout implements OnInit {
       ([invites, rejections, pendingOrgs]: [Array<OrganizationUser>, Array<OrganizationUser>, Array<Organization>]) => {
         this.adminNotifCount = invites?.length + rejections?.length + pendingOrgs?.length;
         this.notifCount = invites?.length + rejections?.length;
+        if (isNaN(this.adminNotifCount)) {
+          this.adminNotifCount = 0;
+        }
+        if (isNaN(this.notifCount)) {
+          this.notifCount = 0;
+        }
       }
     );
   }

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -95,12 +95,11 @@ export class NavbarComponent extends Logout implements OnInit {
           Array<Organization>,
           boolean
         ]) => {
+          let count = invites?.length + rejections?.length;
           if (isAdminOrCurator) {
-            return isNaN(invites?.length + rejections?.length + pendingOrganizations?.length)
-              ? 0
-              : invites?.length + rejections?.length + pendingOrganizations?.length;
+            return isNaN(count + pendingOrganizations?.length) ? 0 : count + pendingOrganizations?.length;
           } else {
-            return isNaN(invites?.length + rejections?.length) ? 0 : invites?.length + rejections?.length;
+            return isNaN(count) ? 0 : count;
           }
         }
       )

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -96,15 +96,11 @@ export class NavbarComponent extends Logout implements OnInit {
           boolean
         ]) => {
           if (isAdminOrCurator) {
-            if (isNaN(invites?.length + rejections?.length + pendingOrganizations?.length)) {
-              return 0;
-            }
-            return invites?.length + rejections?.length + pendingOrganizations?.length;
+            return isNaN(invites?.length + rejections?.length + pendingOrganizations?.length)
+              ? 0
+              : invites?.length + rejections?.length + pendingOrganizations?.length;
           } else {
-            if (isNaN(invites?.length + rejections?.length)) {
-              return 0;
-            }
-            return invites?.length + rejections?.length;
+            return isNaN(invites?.length + rejections?.length) ? 0 : invites?.length + rejections?.length;
           }
         }
       )

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Logout } from '../loginComponents/logout';
 import { currentPrivacyPolicyVersion, currentTOSVersion } from '../shared/constants';
@@ -27,6 +27,9 @@ import { PageInfo } from './../shared/models/PageInfo';
 import { PagenumberService } from './../shared/pagenumber.service';
 import { User } from './../shared/swagger/model/user';
 import { TrackLoginService } from './../shared/track-login.service';
+import { Organization, OrganizationUser } from '../shared/swagger';
+import { RequestsQuery } from '../loginComponents/state/requests.query';
+import { RequestsService } from '../loginComponents/state/requests.service';
 
 @Component({
   selector: 'app-navbar',
@@ -41,15 +44,23 @@ export class NavbarComponent extends Logout implements OnInit {
   protected ngUnsubscribe: Subject<{}> = new Subject();
   private readonly currentTOSVersion: User.TosversionEnum = currentTOSVersion;
   private readonly currentPrivacyPolicyVersion: User.PrivacyPolicyVersionEnum = currentPrivacyPolicyVersion;
+  public myOrganizationInvites$: Observable<Array<OrganizationUser>>;
+  public myRejectedOrganizationRequests$: Observable<Array<OrganizationUser>>;
+  public allPendingOrganizations$: Observable<Array<Organization>>;
+  public allPendingOrganizations: Array<Organization>;
+  public isAdminOrCurator: boolean;
 
   constructor(
     private pagenumberService: PagenumberService,
     trackLoginService: TrackLoginService,
     logoutService: LogoutService,
     router: Router,
-    private userQuery: UserQuery
+    private userQuery: UserQuery,
+    private requestsQuery: RequestsQuery,
+    private requestsService: RequestsService
   ) {
     super(trackLoginService, logoutService, router);
+
     this.router.events
       .pipe(
         filter((event) => event instanceof NavigationEnd),
@@ -58,13 +69,23 @@ export class NavbarComponent extends Logout implements OnInit {
       .subscribe(() => {
         this.isExtended = toExtendSite(this.router.url);
       });
+    this.userQuery.isAdminOrCurator$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isAdminOrCurator) => {
+      this.isAdminOrCurator = isAdminOrCurator;
+    });
   }
 
   ngOnInit() {
+    this.requestsService.updateMyMemberships();
+    this.requestsQuery.myOrganizationInvites$.subscribe((invites) => console.log(invites));
     this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((user) => {
       this.user = user;
+      this.requestsService.updateMyMemberships();
+      this.requestsService.updateCuratorOrganizations();
     });
     this.userQuery.extendedUserData$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((extendedUser) => (this.extendedUser = extendedUser));
+    this.myOrganizationInvites$ = this.requestsQuery.myOrganizationInvites$;
+    this.myRejectedOrganizationRequests$ = this.requestsQuery.myRejectedOrganizationRequests$;
+    this.allPendingOrganizations$ = this.requestsQuery.allPendingOrganizations$;
   }
 
   resetPageNumber() {

--- a/src/app/organizations/registerOrganization/register-organization.component.html
+++ b/src/app/organizations/registerOrganization/register-organization.component.html
@@ -72,6 +72,7 @@
   <button mat-flat-button class="secondary-1" mat-dialog-close>Cancel</button>
   <button
     id="createOrUpdateOrganizationButton"
+    data-cy="create-or-update-organization-button"
     [matTooltip]="title"
     mat-raised-button
     class="accent-1-dark-btn mat-elevation-z"


### PR DESCRIPTION
**Description**
Created a notification badge that links to their requests page. The badge will increment in count for organization invites, their rejected organizations, and any pending organization requests for admin/curators.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1918
https://github.com/dockstore/dockstore/issues/4477

When user has no notifications (no requests to approve , invitations, or rejected requests)
![Screenshot from 2022-09-22 15-52-01](https://user-images.githubusercontent.com/61166764/191839538-baa89a64-bf0d-4d35-9b6c-5046bfd9851f.png)

When a curator/admin has a organization request to approve
![Screenshot from 2022-09-22 15-53-01](https://user-images.githubusercontent.com/61166764/191839625-afff46da-089f-482b-8831-d6b702fc76c2.png)

When a user has organization invitations
![Screenshot from 2022-09-22 15-53-42](https://user-images.githubusercontent.com/61166764/191839722-2ded86cf-852a-4dab-a3bd-a9d3e0e5c61b.png)

When a user has their organization request rejected
![Screenshot from 2022-09-22 15-54-20](https://user-images.githubusercontent.com/61166764/191839807-89ba8d9b-f370-42d5-a4a7-9eff98e8d977.png)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
