### PR TITLE
DOCK-2061: Fix Weird Label Editing Behavior

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -151,7 +151,7 @@
               [formControl]="labelFormControl"
               [matChipInputFor]="chipList"
               [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-              [matChipInputAddOnBlur]="true"
+              [matChipInputAddOnBlur]="false"
               (matChipInputTokenEnd)="addToLabels($event)"
             />
             <mat-error *ngIf="labelFormControl.hasError('pattern')"

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -280,10 +280,15 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
       this.labelsEditMode = true;
       return;
     }
+    const value = this.labelFormControl.value;
+    if ((value || '').trim()) {
+      this.containerEditData.labels.push(value.trim());
+    }
     // the edit object should be recreated
-    if (this.containerEditData.labels !== 'undefined') {
+    if (this.containerEditData.labels !== undefined) {
       this.setContainerLabels();
     }
+    this.labelFormControl.setValue(null);
   }
 
   // TODO: Move most of this function to the service, sadly 'this.labelsEditMode' makes it more difficult
@@ -304,6 +309,7 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
   cancelLabelChanges(): void {
     this.containerEditData.labels = this.dockstoreService.getLabelStrings(this.tool.labels);
     this.labelsEditMode = false;
+    this.labelFormControl.setValue(null);
   }
 
   public toolCopyBtnClick(copyBtn: string): void {

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -375,6 +375,7 @@ export class ContainerComponent extends Entry implements AfterViewInit, OnInit {
     if (input) {
       input.value = '';
     }
+    this.labelFormControl.setValue(null);
   }
 
   removeLabel(label: any): void {

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -167,7 +167,7 @@
               [formControl]="labelFormControl"
               [matChipInputFor]="chipList"
               [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-              [matChipInputAddOnBlur]="true"
+              [matChipInputAddOnBlur]="false"
               (matChipInputTokenEnd)="addToLabels($event)"
             />
             <mat-error *ngIf="labelFormControl.hasError('pattern')"

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -485,6 +485,7 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
     if (input) {
       input.value = '';
     }
+    this.labelFormControl.setValue(null);
   }
 
   removeLabel(label: any): void {

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -413,15 +413,21 @@ export class WorkflowComponent extends Entry implements AfterViewInit, OnInit {
       this.labelsEditMode = true;
       return;
     }
+    const value = this.labelFormControl.value;
+    if ((value || '').trim()) {
+      this.workflowEditData.labels.push(value.trim());
+    }
     // the edit object should be recreated
-    if (this.workflowEditData.labels !== 'undefined') {
+    if (this.workflowEditData.labels !== undefined) {
       this.setWorkflowLabels();
     }
+    this.labelFormControl.setValue(null);
   }
 
   cancelLabelChanges(): void {
     this.workflowEditData.labels = this.dockstoreService.getLabelStrings(this.workflow.labels);
     this.labelsEditMode = false;
+    this.labelFormControl.setValue(null);
   }
 
   // TODO: Move most of this function to the service, sadly 'this.labelsEditMode' makes it more difficult


### PR DESCRIPTION
**Description**
This PR changes the entry label editing interface so that its behavior is more natural.  Both issues mentioned in the ticket are fixed.

Part of problem stemmed from the `matChipInputAddOnBlur` = `true` setting, which caused a new chip (label) to be added when the chip list lost focus.  This setting, when there were no labels, for reasons that I was not able to determine, prevented the "save"/"cancel" button handler from being fired when the button was clicked.  It would also trigger unexpected behavior, like adding a partially-typed label when, for example, you had to click on another window to look up how to spell the rest of it.

I also fixed some code that was likely a bug - `undefined` should probably not be quoted in that `if` statement.

Please try this out, because if we hotfix, it's important to user test as much as possible.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2061
https://github.com/dockstore/dockstore/issues/4719

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
