### PR TITLE
fixed github app link on new dashboard

### DIFF
--- a/cypress/integration/group1/dashboard.ts
+++ b/cypress/integration/group1/dashboard.ts
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 import { resetDB, setTokenUserViewPort } from '../../support/commands';
+import { Dockstore } from '../../../src/app/shared/dockstore.model';
 
 describe('Dockstore dashboard', () => {
   resetDB();
@@ -42,5 +43,15 @@ describe('Dockstore dashboard', () => {
       .contains('Learn more about services')
       .should('have.attr', 'href')
       .and('include', 'getting-started-with-services');
+  });
+  it('Registering new tool through Github redirects correctly', () => {
+    cy.visit('/dashboard?newDashboard');
+    cy.contains('Tools');
+    cy.get('#registerToolButton').should('be.visible').click();
+    cy.get('#3-register-workflow-option').should('be.visible').click();
+    cy.contains('button', 'Next').should('be.visible').click();
+    cy.contains('a', 'Manage Dockstore installations on GitHub')
+      .should('have.attr', 'href')
+      .and('include', 'https://github.com/apps/dockstore-testing-application');
   });
 });

--- a/cypress/integration/group1/dashboard.ts
+++ b/cypress/integration/group1/dashboard.ts
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 import { resetDB, setTokenUserViewPort } from '../../support/commands';
-import { Dockstore } from '../../../src/app/shared/dockstore.model';
 
 describe('Dockstore dashboard', () => {
   resetDB();
@@ -49,6 +48,16 @@ describe('Dockstore dashboard', () => {
     cy.contains('Tools');
     cy.get('#registerToolButton').should('be.visible').click();
     cy.get('#3-register-workflow-option').should('be.visible').click();
+    cy.contains('button', 'Next').should('be.visible').click();
+    cy.contains('a', 'Manage Dockstore installations on GitHub')
+      .should('have.attr', 'href')
+      .and('include', 'https://github.com/apps/dockstore-testing-application');
+  });
+  it('Registering new workflow through Github redirects correctly', () => {
+    cy.visit('/dashboard?newDashboard');
+    cy.contains('Workflows');
+    cy.get('#registerWorkflowButton').should('be.visible').click();
+    cy.get('#0-register-workflow-option').should('be.visible').click();
     cy.contains('button', 'Next').should('be.visible').click();
     cy.contains('a', 'Manage Dockstore installations on GitHub')
       .should('have.attr', 'href')

--- a/cypress/integration/group1/dashboard.ts
+++ b/cypress/integration/group1/dashboard.ts
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { resetDB, setTokenUserViewPort } from '../../support/commands';
+import { resetDB, setTokenUserViewPort, verifyGithubLinkNewDashboard } from '../../support/commands';
 
 describe('Dockstore dashboard', () => {
   resetDB();
@@ -44,23 +44,9 @@ describe('Dockstore dashboard', () => {
       .and('include', 'getting-started-with-services');
   });
   it('Registering new tool through Github redirects correctly', () => {
-    cy.visit('/dashboard?newDashboard');
-    cy.contains('Tools');
-    cy.get('#registerToolButton').should('be.visible').click();
-    cy.get('#3-register-workflow-option').should('be.visible').click();
-    cy.contains('button', 'Next').should('be.visible').click();
-    cy.contains('a', 'Manage Dockstore installations on GitHub')
-      .should('have.attr', 'href')
-      .and('include', 'https://github.com/apps/dockstore-testing-application');
+    verifyGithubLinkNewDashboard('Tool');
   });
   it('Registering new workflow through Github redirects correctly', () => {
-    cy.visit('/dashboard?newDashboard');
-    cy.contains('Workflows');
-    cy.get('#registerWorkflowButton').should('be.visible').click();
-    cy.get('#0-register-workflow-option').should('be.visible').click();
-    cy.contains('button', 'Next').should('be.visible').click();
-    cy.contains('a', 'Manage Dockstore installations on GitHub')
-      .should('have.attr', 'href')
-      .and('include', 'https://github.com/apps/dockstore-testing-application');
+    verifyGithubLinkNewDashboard('Workflow');
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -125,3 +125,12 @@ export function addOrganizationAdminUser(organization: string, user: string) {
       "'), true, 'ADMIN')"
   );
 }
+export function verifyGithubLinkNewDashboard(entryType: string) {
+  cy.visit('/dashboard?newDashboard');
+  cy.get('[data-cy=register-entry-btn]').contains(entryType).should('be.visible').click();
+  cy.get('[data-cy=storage-type-choice]').contains('GitHub').click();
+  cy.contains('button', 'Next').should('be.visible').click();
+  cy.contains('a', 'Manage Dockstore installations on GitHub')
+    .should('have.attr', 'href')
+    .and('include', 'https://github.com/apps/dockstore-testing-application');
+}

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -34,6 +34,7 @@
             *ngFor="let option of options"
             [value]="option"
             [id]="option.value + '-register-workflow-option'"
+            data-cy="storage-type-choice"
           >
             <span class="text-wrap">
               {{ option.label }}

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -9,7 +9,6 @@ import { Dockstore } from 'app/shared/dockstore.model';
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { SessionService } from '../../../shared/session/session.service';
-import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-entry-box',
@@ -35,8 +34,7 @@ export class EntryBoxComponent extends Base implements OnInit {
     private myWorkflowsService: MyWorkflowsService,
     private usersService: UsersService,
     private alertService: AlertService,
-    private sessionService: SessionService,
-    private route: ActivatedRoute
+    private sessionService: SessionService
   ) {
     super();
   }

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -8,6 +8,8 @@ import { Base } from 'app/shared/base';
 import { Dockstore } from 'app/shared/dockstore.model';
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { SessionService } from '../../../shared/session/session.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-entry-box',
@@ -32,7 +34,9 @@ export class EntryBoxComponent extends Base implements OnInit {
     private registerToolService: RegisterToolService,
     private myWorkflowsService: MyWorkflowsService,
     private usersService: UsersService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private sessionService: SessionService,
+    private route: ActivatedRoute
   ) {
     super();
   }
@@ -95,10 +99,13 @@ export class EntryBoxComponent extends Base implements OnInit {
 
   showRegisterEntryModal(): void {
     if (this.entryType === EntryUpdateTime.EntryTypeEnum.WORKFLOW) {
+      this.sessionService.setEntryType(EntryType.BioWorkflow);
       this.myWorkflowsService.registerEntry(EntryType.BioWorkflow);
     } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.TOOL) {
+      this.sessionService.setEntryType(EntryType.Tool);
       this.registerToolService.setIsModalShown(true);
     } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.SERVICE) {
+      this.sessionService.setEntryType(EntryType.Service);
       this.myWorkflowsService.registerEntry(EntryType.Service);
     }
   }

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -28,7 +28,12 @@
       </p>
       <div class="modal-body">
         <mat-radio-group [(ngModel)]="selectedOption">
-          <mat-radio-button *ngFor="let option of options" [value]="option" [id]="option.value + '-register-workflow-option'">
+          <mat-radio-button
+            *ngFor="let option of options"
+            [value]="option"
+            [id]="option.value + '-register-workflow-option'"
+            data-cy="storage-type-choice"
+          >
             <span class="text-wrap">
               {{ option.label }}
               <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">

--- a/test/web.yml
+++ b/test/web.yml
@@ -25,8 +25,6 @@ orcidClientSecret: <fill me in>
 gitHubAppPrivateKeyFile: <fill me in>
 gitHubAppId: <fill me in>
 
-orcidClientID: <fill me in>
-orcidClientSecret: <fill me in>
 
 authorizerType: inmemory
 
@@ -97,6 +95,7 @@ uiConfig:
   gitlabAuthUrl: https://gitlab.com/oauth/authorize
   gitlabRedirectPath: /auth/gitlab.com
   gitlabScope: api
+  gitHubAppInstallationUrl: https://github.com/apps/dockstore-testing-application
 
   zenodoAuthUrl: https://zenodo.org/oauth/authorize
   zenodoRedirectPath: /auth/zenodo.org

--- a/test/web.yml
+++ b/test/web.yml
@@ -87,6 +87,7 @@ uiConfig:
   gitHubAuthUrl: https://github.com/login/oauth/authorize
   gitHubRedirectPath: /auth/github.com
   gitHubScope: read:org,user:email
+  gitHubAppInstallationUrl: https://github.com/apps/dockstore-testing-application
 
   quayIoAuthUrl: https://quay.io/oauth/authorize
   quayIoRedirectPath: /auth/quay.io

--- a/test/web.yml
+++ b/test/web.yml
@@ -25,6 +25,8 @@ orcidClientSecret: <fill me in>
 gitHubAppPrivateKeyFile: <fill me in>
 gitHubAppId: <fill me in>
 
+orcidClientID: <fill me in>
+orcidClientSecret: <fill me in>
 
 authorizerType: inmemory
 
@@ -95,7 +97,6 @@ uiConfig:
   gitlabAuthUrl: https://gitlab.com/oauth/authorize
   gitlabRedirectPath: /auth/gitlab.com
   gitlabScope: api
-  gitHubAppInstallationUrl: https://github.com/apps/dockstore-testing-application
 
   zenodoAuthUrl: https://zenodo.org/oauth/authorize
   zenodoRedirectPath: /auth/zenodo.org
@@ -108,4 +109,3 @@ uiConfig:
   googleScope: profile email
 
   cwlVisualizerUri: https://view.commonwl.org
-


### PR DESCRIPTION
**Description**
Fixes the github app link when registering  workflows, tools, and services on the new dashboard.

The changes specifically fixes the issue where the 'Manage Dockstore Installations on GitHub' button would redirect to the homepage instead of to github. This issue was caused due to the new dashboard not having an EntryType set in its session.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2239
https://github.com/dockstore/dockstore/issues/5123


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
