### PR TITLE
DOCK-2254 removed > character

### DIFF
--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -88,7 +88,6 @@
               (hasGroupGitHubAppToolEntriesObjects$ | async) === false
             "
           >
-            >
             <div fxFlex>
               <mat-card class="alert alert-info" role="alert">
                 <p>


### PR DESCRIPTION
**Description**
Removed the random '>' character in My Tools when there are no tools.

Before fix: 
![image](https://user-images.githubusercontent.com/61166764/195176800-80ff0e61-f1a9-4bed-8121-2e3bb49cc5a2.png)

After fix: 
![Screenshot from 2022-10-11 13-42-21](https://user-images.githubusercontent.com/61166764/195176845-df93a7b7-ed6d-4823-a329-b590657abcf8.png)


**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2254

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
