### PR TITLE
Migrating from CircleCI's scheduled workflow to schedules pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,9 +418,20 @@ jobs:
           name: Build
           command: NODE_OPTIONS="--max-old-space-size=1610" bash -i -c 'npm run build.prod'
 
+parameters:
+  run_nightly_auth:
+    type: boolean
+    default: false
+  run_nightly_no_auth:
+    type: boolean
+    default: false
+
 workflows:
   version: 2
   everything:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       # Add the tags filter to all jobs so they will run before upload_to_s3
       - audit:
@@ -513,13 +524,7 @@ workflows:
             - dockerhub
 
   nightly_no_auth:
-    triggers:
-      - schedule:
-          cron: "0 10 * * *" # This is 3am PDT / 2am PST
-          filters:
-            branches:
-              only:
-                - develop
+    when: << pipeline.parameters.run_nightly_no_auth >>
     jobs:
       - no_auth_smoke_tests:
           name: "no_auth_smoke_tests_dev"
@@ -541,13 +546,7 @@ workflows:
             - oicr-slack
 
   nightly_auth:
-    triggers:
-      - schedule:
-          cron: "0 11 * * *" # This is 4am PDT / 3am PST
-          filters:
-            branches:
-              only:
-                - develop
+    when: << pipeline.parameters.run_nightly_auth >>
     jobs:
       - auth_smoke_tests:
           name: "auth_smoke_tests_dev"


### PR DESCRIPTION
**Description**
CircleCI is phasing out scheduled workflows such as the ones that we use for the nightly no auth and nightly auth tests. 
This PR migrates our existing scheduled workflows to scheduled pipeline format, with pipeline triggers created at https://app.circleci.com/settings/project/github/dockstore/dockstore-ui2/triggers. 

More information can be found https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

**Review Instructions**
Verify that the filtering correctly triggers each test. Also, verify that the "everything" workflow is not being triggered during these scheduled pipelines.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4702

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
