### PR TITLE
Set size of hits to 0 for tag cloud query

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -34,7 +34,8 @@ export class QueryBuilderService {
   getTagCloudQuery(type: string): string {
     const tagCloudSize = 20;
     const index = type + 's';
-    let body = bodybuilder().size(tagCloudSize);
+    // Size to 0 here because https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#agg-caches
+    let body = bodybuilder().size(0);
     body = this.excludeContent(body);
     body = body.query('match', '_index', index);
     body = body.aggregation('significant_text', 'description', 'tagcloud', { size: tagCloudSize });


### PR DESCRIPTION
Note: Targeted for develop for now, but we could aim for a hotfix (upcoming one or the next) if preferred.

**Description**
Set a size parameter to 0 in the request to get ES tagcloud aggregations. It's confusing, but the number of aggregations returned is based on a different size parameter. And the UI only looks at the `aggregations` portion of the response.

Recommendation from here: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#agg-caches

Locally, with a prod snapshot, it makes a huge difference -- the ES response has a [took property](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-response-body) that indicates how long it takes for ES to process the request, and it went from about 1 second to 1 millisecond (yes, 1,000ms vs. 1ms).

The response is with the value set to 20:

```
"hits": {
    "total": {
      "value": 1832,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "workflows",
        "_type": "_doc",
        "_id": "99",
        "_score": 1
      },
... (and 19 more)
```

With it set to 0:

```
...
 "hits": {
    "total": {
      "value": 1832,
      "relation": "eq"
    },
    "max_score": null,
    "hits": [] // Empty!
  },
...
```

I verified that the `aggregations` part of the response, what the UI uses, is identical for both requests.

**Review Instructions**
Follow the instructions in dockstore/dockstore#5220. You should not see a turtle next to the request getting the aggregations.

**Issue**
dockstore/dockstore#5220

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
