### PR TITLE
Update entry-actions.service.ts

### DIFF
--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -111,7 +111,7 @@ export class EntryActionsService {
   openNoDefaultDialog(entry: Entry, entryType: string, showVersions: EventEmitter<void> | null): void {
     const informationDialogData: InformationDialogData = {
       title: 'Default Version Required',
-      message: `Your ${entryType} must have a default version to be published.  Please use the the Actions menu in the Versions tab to select a default version.`,
+      message: `Your ${entryType} must have a default version to be published.  Please use the Actions menu in the Versions tab to select a default version.`,
       closeButtonText: 'OK',
     };
     const observable = this.informationDialogService.openDialog(informationDialogData, bootstrap4mediumModalSize);


### PR DESCRIPTION
Fix typo in dialoge box informing the user that published entries need a default version

**Description**
Found while cleaning up branches for staging release

**Review Instructions**
Probably could just skip

**Issue**
n/a

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
