### PR TITLE
DOCK-2199: Added domain onto the copy block on Copy build info button

### DIFF
--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -31,6 +31,7 @@ import { versions } from './versions';
   styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent extends Base implements OnInit {
+  domain: string;
   version: string;
   tag: string;
   public prod = true;
@@ -62,6 +63,7 @@ export class FooterComponent extends Base implements OnInit {
   }
 
   ngOnInit() {
+    this.domain = window.location.href;
     this.year = new Date().getFullYear();
     this.tag = versions.tag;
     this.dsServerURI = Dockstore.API_URI;
@@ -78,6 +80,7 @@ export class FooterComponent extends Base implements OnInit {
               this.version = metadatum;
             }
             this.content = this.footerService.versionsToMarkdown(
+              this.domain,
               this.version,
               this.tag,
               Dockstore.COMPOSE_SETUP_VERSION,

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -63,7 +63,7 @@ export class FooterComponent extends Base implements OnInit {
   }
 
   ngOnInit() {
-    this.domain = window.location.href;
+    this.domain = Dockstore.HOSTNAME;
     this.year = new Date().getFullYear();
     this.tag = versions.tag;
     this.dsServerURI = Dockstore.API_URI;

--- a/src/app/footer/footer.service.spec.ts
+++ b/src/app/footer/footer.service.spec.ts
@@ -13,7 +13,7 @@ describe('FooterService', () => {
   it('should generate markdown', () => {
     // sanity test the method; don't want to look for the exact value as that would just be writing it all over again
     const markdown = service.versionsToMarkdown(
-      window.location.href,
+      'domainurl.com',
       '981edd1',
       '2.6.1-39-g597aeeed',
       '1.9.0',
@@ -24,7 +24,7 @@ describe('FooterService', () => {
       null,
       'potato'
     );
-    expect(markdown).toContain(window.location.href);
+    expect(markdown).toContain('domainurl.com');
     expect(markdown).toContain('981edd1');
     expect(markdown).toContain('potato');
     expect(markdown).toContain('checkUrlLambdaVersion');

--- a/src/app/footer/footer.service.spec.ts
+++ b/src/app/footer/footer.service.spec.ts
@@ -12,14 +12,26 @@ describe('FooterService', () => {
 
   it('should generate markdown', () => {
     // sanity test the method; don't want to look for the exact value as that would just be writing it all over again
-    const markdown = service.versionsToMarkdown('981edd1', '2.6.1-39-g597aeeed', '1.9.0', '3723b1a"', null, null, null, null, 'potato');
+    const markdown = service.versionsToMarkdown(
+      window.location.href,
+      '981edd1',
+      '2.6.1-39-g597aeeed',
+      '1.9.0',
+      '3723b1a"',
+      null,
+      null,
+      null,
+      null,
+      'potato'
+    );
+    expect(markdown).toContain(window.location.href);
     expect(markdown).toContain('981edd1');
     expect(markdown).toContain('potato');
     expect(markdown).toContain('checkUrlLambdaVersion');
   });
 
   it('should handle nulls', () => {
-    const markdown = service.versionsToMarkdown(null, null, null, null, null, null, null, null, null);
+    const markdown = service.versionsToMarkdown(null, null, null, null, null, null, null, null, null, null);
     expect(markdown.length).toBeGreaterThan(100);
     expect(markdown).not.toContain('compose_setup');
     expect(markdown).not.toContain('dockstore-deploy');

--- a/src/app/footer/footer.service.ts
+++ b/src/app/footer/footer.service.ts
@@ -14,6 +14,7 @@ export class FooterService {
   }
 
   versionsToMarkdown(
+    domain: string | null,
     webServiceVersion: string | null,
     uiVersion: string | null,
     composeSetupVersion: string | null,
@@ -24,7 +25,9 @@ export class FooterService {
     galaxyParsingLambdaVersion: string | null,
     checkUrlLambdaVersion: string | null
   ): string {
-    let baseBuildInfo = `[Webservice](${this.gitHubUrl('dockstore', webServiceVersion)}) - ${webServiceVersion}
+    let baseBuildInfo = `[Domain] - ${domain}
+
+[Webservice](${this.gitHubUrl('dockstore', webServiceVersion)}) - ${webServiceVersion}
 
 [UI](${this.gitHubUrl('dockstore-ui2', uiVersion)}) - ${uiVersion}`;
     if (composeSetupVersion) {


### PR DESCRIPTION
**Description**
This PR will now copy the domain when the Copy build info button is clicked. 

Before the fix, the Copy build info button copies all the build versions, but doesn't copy the domain, so you have to manually add the host/domain to that section of the issue.

**Review Instructions**
Verify that the Copy build info button down at the footer now copies the domain as well.

**Issue**
https://github.com/dockstore/dockstore/issues/5015
https://ucsc-cgl.atlassian.net/browse/DOCK-2199

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
