### PR TITLE
Allow organization admins to interact with invitations

### DIFF
--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -75,9 +75,9 @@ describe('Test notification badge on navbar', () => {
         'a111sdf@asdf.ca'
       );
       cy.contains('span', 'Members').click();
-      cy.contains('button', 'Add user').should('be.visible').click();
+      cy.contains('button', 'Invite a Member').should('be.visible').click();
       typeInInput('Username', 'user_A');
-      cy.contains('button', 'Add User').should('be.visible').click();
+      cy.contains('button', 'Send Invite').should('be.visible').click();
       cy.reload();
     });
 

--- a/cypress/integration/group2/notificationBadge.ts
+++ b/cypress/integration/group2/notificationBadge.ts
@@ -75,9 +75,9 @@ describe('Test notification badge on navbar', () => {
         'a111sdf@asdf.ca'
       );
       cy.contains('span', 'Members').click();
-      cy.contains('button', 'Invite a Member').should('be.visible').click();
+      cy.get('#addUserToOrgButton').should('be.visible').click();
       typeInInput('Username', 'user_A');
-      cy.contains('button', 'Send Invite').should('be.visible').click();
+      cy.get('#upsertUserDialogButton').should('be.visible').should('not.be.disabled').click();
       cy.reload();
     });
 

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -204,7 +204,12 @@ describe('Dockstore Organizations', () => {
   describe('should be able to view a collection', () => {
     beforeEach(() => {
       const memberships = [
-        { id: 1, role: 'MAINTAINER', accepted: true, organization: { id: 2, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe' } },
+        {
+          id: 1,
+          role: 'MAINTAINER',
+          status: 'ACCEPTED',
+          organization: { id: 2, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe' },
+        },
       ];
       cy.server().route({
         method: 'GET',

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -297,7 +297,7 @@ describe('Dockstore Organizations', () => {
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut');
     });
 
-    it.skip('be able to remove an entry from a collection', () => {
+    it('be able to remove an entry from a collection', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.wait(10000);
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8');
@@ -347,7 +347,7 @@ describe('Dockstore Organizations', () => {
     });
   });
 
-  describe.skip('Should be able to CRUD user', () => {
+  describe('Should be able to CRUD user', () => {
     beforeEach(() => {
       cy.contains('Members').click();
     });

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -24,7 +24,7 @@ import {
 import { TokenUser } from '../../../src/app/shared/swagger';
 import { TokenSource } from '../../../src/app/shared/enum/token-source.enum';
 
-const imageURL = 'https://fakeUrl.com/potato.png';
+const imageURL = 'https://superduperfakepotatourl.com/potato.png';
 describe('Dockstore Organizations', () => {
   resetDB();
   setTokenUserViewPort();

--- a/cypress/integration/immutableDatabaseTests/dropdown.ts
+++ b/cypress/integration/immutableDatabaseTests/dropdown.ts
@@ -109,19 +109,19 @@ describe('Dropdown test', () => {
         {
           id: 1,
           role: 'MAINTAINER',
-          accepted: false,
+          status: 'PENDING',
           organization: { id: 1000, status: 'PENDING', name: 'orgOne', displayName: 'orgOne' },
         },
         {
           id: 2,
           role: 'MAINTAINER',
-          accepted: true,
+          status: 'ACCEPTED',
           organization: { id: 1001, status: 'PENDING', name: 'orgTwo', displayName: 'orgTwo' },
         },
         {
           id: 3,
           role: 'MAINTAINER',
-          accepted: true,
+          status: 'ACCEPTED',
           organization: { id: 1002, status: 'REJECTED', name: 'orgThree', displayName: 'orgThree' },
         },
       ];
@@ -158,9 +158,9 @@ describe('Dropdown test', () => {
 
       // Mock new my pending orgs
       const memberships = [
-        { id: 1, role: 'MAINTAINER', accepted: false, organization: { id: 1000, status: 'PENDING', name: 'orgOne' } },
-        { id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
-        { id: 3, role: 'MAINTAINER', accepted: true, organization: { id: 1002, status: 'PENDING', name: 'orgThree' } },
+        { id: 1, role: 'MAINTAINER', status: 'PENDING', organization: { id: 1000, status: 'PENDING', name: 'orgOne' } },
+        { id: 2, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
+        { id: 3, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1002, status: 'PENDING', name: 'orgThree' } },
       ];
       cy.server().route({
         method: 'GET',
@@ -226,8 +226,8 @@ describe('Dropdown test', () => {
 
       // Membership should have two accepted entries
       const memberships = [
-        { id: 1, role: 'MAINTAINER', accepted: true, organization: { id: 1000, status: 'PENDING', name: 'orgOne' } },
-        { id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
+        { id: 1, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1000, status: 'PENDING', name: 'orgOne' } },
+        { id: 2, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
       ];
       cy.server().route({
         method: 'GET',
@@ -262,14 +262,19 @@ describe('Dropdown test', () => {
       const nonAffiliatedMembership = {
         id: 1,
         role: 'MAINTAINER',
-        accepted: false,
+        status: 'PENDING',
         organization: { id: 1000, status: 'PENDING', name: 'orgOne', displayName: 'orgOne' },
       };
 
       // New mocked memberships after deleting the rejected organization
       const membershipsAfterFirstDeletion = [
         nonAffiliatedMembership,
-        { id: 2, role: 'MAINTAINER', accepted: true, organization: { id: 1001, status: 'PENDING', name: 'orgTwo', displayName: 'orgTwo' } },
+        {
+          id: 2,
+          role: 'MAINTAINER',
+          status: 'ACCEPTED',
+          organization: { id: 1001, status: 'PENDING', name: 'orgTwo', displayName: 'orgTwo' },
+        },
       ];
 
       // Route all DELETE API calls to organizations respond with with an empty JSON object

--- a/cypress/integration/smokeTests/sharedTests/waf.ts
+++ b/cypress/integration/smokeTests/sharedTests/waf.ts
@@ -73,7 +73,7 @@ describe('Test AWS Managed Common Rule Set', () => {
   // clients shouldn't read or run. Example patterns include extensions like .log and .ini.
   it('Try a URL that would break if RestrictedExtensions_URIPATH were turned on', () => {
     const longUrl =
-      '/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Fnf-core%2Fhlatyping/versions/1.1.2/plain-NFL/descriptor//nextflow.config';
+      '/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Fnf-core%2Fhlatyping/versions/1.1.2/PLAIN_NFL/descriptor//nextflow.config';
     cy.request(longUrl).its('body').should('include', 'nfcore/hlatyping:1.1.2');
   });
   // RestrictedExtensions_QUERYARGUMENTS 	Inspects requests whose query arguments are system file extensions

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -109,7 +109,7 @@ export function invokeSql(sqlStatement: string) {
 }
 
 export function approvePotatoMembership() {
-  invokeSql('update organization_user set accepted=true where userid=2 and organizationid=1');
+  invokeSql("update organization_user set status='ACCEPTED' where userid=2 and organizationid=1");
 }
 
 export function approvePotatoOrganization() {
@@ -118,11 +118,11 @@ export function approvePotatoOrganization() {
 
 export function addOrganizationAdminUser(organization: string, user: string) {
   invokeSql(
-    "insert into organization_user (organizationid, userid, accepted, role) values ((select id from organization where name = '" +
+    "insert into organization_user (organizationid, userid, status, role) values ((select id from organization where name = '" +
       organization +
       "'), (select id from enduser where username = '" +
       user +
-      "'), true, 'ADMIN')"
+      "'), 'ACCEPTED', 'ADMIN')"
   );
 }
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -63,7 +63,7 @@ export function resetDB() {
     cy.exec('java -jar dockstore-webservice.jar db drop-all --confirm-delete-everything test/web.yml');
     cy.exec(psqlInvocation + ' -h localhost webservice_test -U dockstore < test/db_dump.sql');
     cy.exec(
-      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0 test/web.yml'
+      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml'
     );
   });
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -151,31 +151,6 @@ export function verifyGithubLinkNewDashboard(entryType: string) {
     .and('include', 'https://github.com/apps/dockstore-testing-application');
 }
 
-export function createOrganization(name: string, displayName: string, topic: string, location: string, website: string, email: string) {
-  cy.contains('button', 'Create Organization Request').should('be.visible').click();
-  cy.contains('button', 'Next').should('be.visible').click();
-  typeInInput('Name', name);
-  typeInInput('Display Name', displayName);
-  typeInInput('Topic', topic);
-  typeInInput('Location', location);
-  typeInInput('Organization website', website);
-  typeInInput('Contact Email Address', email);
-  cy.get('[data-cy=create-or-update-organization-button]').should('be.visible').should('not.be.disabled').click();
-  cy.url().should('eq', Cypress.config().baseUrl + '/organizations/' + name);
-
-  cy.reload();
-}
-
-export function verifyGithubLinkNewDashboard(entryType: string) {
-  cy.visit('/dashboard?newDashboard');
-  cy.get('[data-cy=register-entry-btn]').contains(entryType).should('be.visible').click();
-  cy.get('[data-cy=storage-type-choice]').contains('GitHub').click();
-  cy.contains('button', 'Next').should('be.visible').click();
-  cy.contains('a', 'Manage Dockstore installations on GitHub')
-    .should('have.attr', 'href')
-    .and('include', 'https://github.com/apps/dockstore-testing-application');
-}
-
 export function testNoGithubEntriesText(entryType: string, repository: string) {
   it('Should have no published ' + entryType + 's in ' + repository + ' repository', () => {
     cy.visit('/my-' + entryType + 's');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -108,8 +108,22 @@ export function invokeSql(sqlStatement: string) {
   cy.exec(psqlInvocation + ' -h localhost webservice_test -U dockstore -c "' + sqlStatement + '"');
 }
 
+export function createPotatoMembership() {
+  cy.get('#addUserToOrgButton').click();
+  typeInInput('Username', 'potato');
+  cy.get('mat-select').click();
+  cy.get('mat-option').contains('Member').click();
+  cy.get('.mat-select-panel').should('not.exist');
+  cy.get('#upsertUserDialogButton').should('be.visible').should('not.be.disabled').click();
+  cy.get('#upsertUserDialogButton').should('not.exist');
+}
+
 export function approvePotatoMembership() {
-  invokeSql("update organization_user set status='ACCEPTED' where userid=2 and organizationid=1");
+  invokeSql("update organization_user set status='ACCEPTED' where userid=2 and organizationid=2");
+}
+
+export function rejectPotatoMembership() {
+  invokeSql("update organization_user set status='REJECTED' where userid=2 and organizationid=2");
 }
 
 export function approvePotatoOrganization() {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.13.0",
-    "use_circle": false,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8588/workflows/7e19040e-70d9-416d-9acc-db7fd9c6639c/jobs/24582/artifacts",
-    "circle_build_id": "24582",
+    "use_circle": true,
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8858/workflows/1a20cf28-f539-4df6-8abf-086df408e846/jobs/26265/artifacts",
+    "circle_build_id": "26265",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8915/workflows/b5bd1db0-cc74-45e2-98f7-61192973abcb/jobs/26576/artifacts",
-    "circle_build_id": "26576",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8924/workflows/b7c31d89-45f9-4b02-a893-2f17f8224199/jobs/26631/artifacts",
+    "circle_build_id": "26631",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8901/workflows/25ab215e-9e9e-427d-ae4c-d893e2f8046e/jobs/26496/artifacts",
-    "circle_build_id": "26496",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8915/workflows/b5bd1db0-cc74-45e2-98f7-61192973abcb/jobs/26576/artifacts",
+    "circle_build_id": "26576",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8858/workflows/1a20cf28-f539-4df6-8abf-086df408e846/jobs/26265/artifacts",
-    "circle_build_id": "26265",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8901/workflows/25ab215e-9e9e-427d-ae4c-d893e2f8046e/jobs/26496/artifacts",
+    "circle_build_id": "26496",
     "base_branch": "develop"
   },
   "scripts": {

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -16,4 +16,4 @@ psql -h localhost -c "create user dockstore with password 'dockstore' createdb;"
 psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
 psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
 psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
-java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0 test/web.yml
+java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml

--- a/src/app/container/info-tab/info-tab.component.ts
+++ b/src/app/container/info-tab/info-tab.component.ts
@@ -193,7 +193,7 @@ export class InfoTabComponent extends Base implements OnInit, OnChanges {
   getTRSLink(path: string, versionName: string, descriptorType: ToolDescriptor.TypeEnum, relativePath: string): string {
     return (
       `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(path)}` +
-      `/versions/${encodeURIComponent(versionName)}/plain-` +
+      `/versions/${encodeURIComponent(versionName)}/PLAIN_` +
       descriptorType +
       `/descriptor/` +
       relativePath

--- a/src/app/container/launch/tool-launch.service.spec.ts
+++ b/src/app/container/launch/tool-launch.service.spec.ts
@@ -44,10 +44,10 @@ describe('ToolLaunchService', () => {
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).toContain('cwl-runner');
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).not.toContain('non-strict');
     expect(service.getCwlString('quay.io/a/b', 'c', '%2Fpotato')).toContain(
-      ga4ghPath + '/tools/quay.io%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/quay.io%2Fa%2Fb/versions/c/PLAIN_CWL/descriptor/%2Fpotato Dockstore.json'
     );
     expect(service.getCwlString('quay.io/a/b/d', 'c', '%2Fpotato')).toContain(
-      ga4ghPath + '/tools/quay.io%2Fa%2Fb%2Fd/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/quay.io%2Fa%2Fb%2Fd/versions/c/PLAIN_CWL/descriptor/%2Fpotato Dockstore.json'
     );
   }));
   it('should getConsonanceString', inject([ToolLaunchService], (service: ToolLaunchService) => {

--- a/src/app/container/launch/tool-launch.service.ts
+++ b/src/app/container/launch/tool-launch.service.ts
@@ -53,7 +53,7 @@ export class ToolLaunchService extends LaunchService {
     return (
       'cwl-runner ' +
       `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(path)}` +
-      `/versions/${encodeURIComponent(versionName)}/plain-CWL/descriptor/${mainDescriptor} Dockstore.json`
+      `/versions/${encodeURIComponent(versionName)}/PLAIN_CWL/descriptor/${mainDescriptor} Dockstore.json`
     );
   }
 

--- a/src/app/descriptor-languages/CWL.ts
+++ b/src/app/descriptor-languages/CWL.ts
@@ -12,7 +12,7 @@ export const extendedCWL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.CWL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.CWL,
   languageDocumentationURL: 'https://www.commonwl.org/',
-  plainTRS: 'PLAIN-CWL',
+  plainTRS: 'PLAIN_CWL',
   descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTORECWL],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',

--- a/src/app/descriptor-languages/Nextflow.ts
+++ b/src/app/descriptor-languages/Nextflow.ts
@@ -12,7 +12,7 @@ export const extendedNFL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.NFL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.NFL,
   languageDocumentationURL: 'https://www.nextflow.io/',
-  plainTRS: 'PLAIN-NFL',
+  plainTRS: 'PLAIN_NFL',
   descriptorFileTypes: [SourceFile.TypeEnum.NEXTFLOW, SourceFile.TypeEnum.NEXTFLOWCONFIG],
   toolTab: {
     rowIdentifier: 'process\xa0name',

--- a/src/app/descriptor-languages/Service.ts
+++ b/src/app/descriptor-languages/Service.ts
@@ -16,7 +16,7 @@ export const extendedService: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.SERVICE,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.Service,
   languageDocumentationURL: SERVICE_DOCUMENTATION_URL,
-  plainTRS: 'PLAIN-SERVICE',
+  plainTRS: null,
   descriptorFileTypes: [],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',

--- a/src/app/descriptor-languages/Snakemake.ts
+++ b/src/app/descriptor-languages/Snakemake.ts
@@ -14,7 +14,7 @@ export const extendedSMK: ExtendedDescriptorLanguageBean = {
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.SMK,
   languageDocumentationURL: 'https://snakemake.github.io/',
 
-  plainTRS: 'PLAIN-SMK',
+  plainTRS: 'PLAIN_SMK',
   descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTORESMK],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',

--- a/src/app/descriptor-languages/WDL.ts
+++ b/src/app/descriptor-languages/WDL.ts
@@ -12,7 +12,7 @@ export const extendedWDL: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.WDL,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.WDL,
   languageDocumentationURL: 'https://openwdl.org/',
-  plainTRS: 'PLAIN-WDL',
+  plainTRS: 'PLAIN_WDL',
   descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTOREWDL],
   toolTab: {
     rowIdentifier: 'task\xa0ID',

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -2,7 +2,7 @@ import { extendedGalaxy } from 'app/descriptor-languages/Galaxy';
 import { extendedNFL } from 'app/descriptor-languages/Nextflow';
 import { extendedService } from 'app/descriptor-languages/Service';
 import { extendedWDL } from 'app/descriptor-languages/WDL';
-import { DescriptorLanguageBean, SourceFile, ToolDescriptor, ToolVersion, Workflow } from 'app/shared/swagger';
+import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
 import { extendedCWL } from '../descriptor-languages/CWL';
 import { extendedSMK } from '../descriptor-languages/Snakemake';
 
@@ -72,4 +72,4 @@ export const extendedDescriptorLanguages: ExtendedDescriptorLanguageBean[] = [
 
 export type DescriptorLanguageEnum = 'SMK' | 'CWL' | 'WDL' | 'GXFORMAT2' | 'SWL' | 'NEXTFLOW' | 'SERVICE';
 
-export type PlainTRSDescriptorLanguageEnum = 'PLAIN_CWL' | 'PLAIN_WDL' | 'PLAIN_NFL' | 'PLAIN_GALAXY' | 'PLAIN_SMK';
+export type PlainTRSDescriptorLanguageEnum = 'PLAIN_SMK' | 'PLAIN_CWL' | 'PLAIN_WDL' | 'PLAIN_GALAXY' | 'PLAIN_NFL';

--- a/src/app/entry/extendedDescriptorLanguage.ts
+++ b/src/app/entry/extendedDescriptorLanguage.ts
@@ -2,7 +2,7 @@ import { extendedGalaxy } from 'app/descriptor-languages/Galaxy';
 import { extendedNFL } from 'app/descriptor-languages/Nextflow';
 import { extendedService } from 'app/descriptor-languages/Service';
 import { extendedWDL } from 'app/descriptor-languages/WDL';
-import { DescriptorLanguageBean, SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
+import { DescriptorLanguageBean, SourceFile, ToolDescriptor, ToolVersion, Workflow } from 'app/shared/swagger';
 import { extendedCWL } from '../descriptor-languages/CWL';
 import { extendedSMK } from '../descriptor-languages/Snakemake';
 
@@ -25,7 +25,7 @@ export interface ExtendedDescriptorLanguageBean extends DescriptorLanguageBean {
   toolDescriptorEnum: ToolDescriptor.TypeEnum;
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum;
   languageDocumentationURL: string;
-  plainTRS: string;
+  plainTRS: PlainTRSDescriptorLanguageEnum;
   descriptorFileTypes: SourceFile.TypeEnum[];
   toolTab: {
     // Example: If rowIdentifier is "tool ID", then the the first column of each row will say something like "tool ID: hello-world"
@@ -71,3 +71,5 @@ export const extendedDescriptorLanguages: ExtendedDescriptorLanguageBean[] = [
 ];
 
 export type DescriptorLanguageEnum = 'SMK' | 'CWL' | 'WDL' | 'GXFORMAT2' | 'SWL' | 'NEXTFLOW' | 'SERVICE';
+
+export type PlainTRSDescriptorLanguageEnum = 'PLAIN_CWL' | 'PLAIN_WDL' | 'PLAIN_NFL' | 'PLAIN_GALAXY' | 'PLAIN_SMK';

--- a/src/app/home-page/widget/requests/requests.component.ts
+++ b/src/app/home-page/widget/requests/requests.component.ts
@@ -55,10 +55,10 @@ export class RequestsComponent extends Base implements OnInit {
   getMyMemberships(): void {
     this.usersService.getUserMemberships().subscribe(
       (myMemberships: Array<OrganizationUser>) => {
-        this.myOrganizationInvites = myMemberships.filter((membership) => membership.status === 'PENDING');
+        this.myOrganizationInvites = myMemberships.filter((membership) => membership.status === OrganizationUser.StatusEnum.PENDING);
         this.myOrganizationRequests = myMemberships.filter(
           (membership) =>
-            membership.status === 'ACCEPTED' &&
+            membership.status === OrganizationUser.StatusEnum.ACCEPTED &&
             (membership.organization.status === Organization.StatusEnum.PENDING ||
               membership.organization.status === Organization.StatusEnum.REJECTED)
         );

--- a/src/app/home-page/widget/requests/requests.component.ts
+++ b/src/app/home-page/widget/requests/requests.component.ts
@@ -55,10 +55,10 @@ export class RequestsComponent extends Base implements OnInit {
   getMyMemberships(): void {
     this.usersService.getUserMemberships().subscribe(
       (myMemberships: Array<OrganizationUser>) => {
-        this.myOrganizationInvites = myMemberships.filter((membership) => !membership.accepted);
+        this.myOrganizationInvites = myMemberships.filter((membership) => membership.status === 'PENDING');
         this.myOrganizationRequests = myMemberships.filter(
           (membership) =>
-            membership.accepted &&
+            membership.status === 'ACCEPTED' &&
             (membership.organization.status === Organization.StatusEnum.PENDING ||
               membership.organization.status === Organization.StatusEnum.REJECTED)
         );

--- a/src/app/loginComponents/requests/organization-invite-confirm-dialog.html
+++ b/src/app/loginComponents/requests/organization-invite-confirm-dialog.html
@@ -8,7 +8,7 @@
 </div>
 <div mat-dialog-actions>
   <div fxFlex></div>
-  <button mat-button (click)="onNoClick()">No Thanks</button>
+  <button mat-button (click)="onNoClick()">Cancel</button>
   <span *ngIf="data.approve; else rejectBlock">
     <button
       mat-flat-button

--- a/src/app/loginComponents/requests/organization-request-confirm-dialog.html
+++ b/src/app/loginComponents/requests/organization-request-confirm-dialog.html
@@ -5,7 +5,7 @@
 </div>
 <div mat-dialog-actions>
   <div fxFlex></div>
-  <button mat-flat-button class="secondary-1" (click)="onNoClick()">No Thanks</button>
+  <button mat-flat-button class="secondary-1" (click)="onNoClick()">Cancel</button>
   <span *ngIf="data.approve; else rejectBlock">
     <button
       mat-raised-button

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -21,7 +21,9 @@
             <p>
               Requested by user(s)
               <span *ngFor="let user of org?.users; let last = last">
-                <strong *ngIf="user?.status === 'ACCEPTED'">{{ user.user.username }}<span *ngIf="!last">, </span></strong>
+                <strong *ngIf="user?.status === OrganizationUser.StatusEnum.ACCEPTED"
+                  >{{ user.user.username }}<span *ngIf="!last">, </span></strong
+                >
               </span>
               on {{ org.dbCreateDate | date }}
             </p>

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -21,7 +21,7 @@
             <p>
               Requested by user(s)
               <span *ngFor="let user of org?.users; let last = last">
-                <strong *ngIf="user?.accepted">{{ user.user.username }}<span *ngIf="!last">, </span></strong>
+                <strong *ngIf="user?.status === 'ACCEPTED'">{{ user.user.username }}<span *ngIf="!last">, </span></strong>
               </span>
               on {{ org.dbCreateDate | date }}
             </p>

--- a/src/app/loginComponents/requests/requests.component.ts
+++ b/src/app/loginComponents/requests/requests.component.ts
@@ -54,6 +54,7 @@ export class RequestsComponent extends Base implements OnInit {
   public myOrganizationInvites$: Observable<Array<OrganizationUser>>;
   public myPendingOrganizationRequests$: Observable<Array<OrganizationUser>>;
   public myRejectedOrganizationRequests$: Observable<Array<OrganizationUser>>;
+  public OrganizationUser = OrganizationUser;
   isLoading$: Observable<boolean>;
   isAdmin$: Observable<boolean>;
   isCurator$: Observable<boolean>;

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -110,7 +110,7 @@ export class RequestsService {
             (membership) => membership.organization.status === 'PENDING' && membership.status === 'ACCEPTED'
           );
           const myRejectedOrganizationRequests = myMemberships.filter(
-            (membership) => membership.organization.status === 'REJECTED' && membership.status === 'REJECTED'
+            (membership) => membership.organization.status === 'REJECTED' && membership.status === 'ACCEPTED'
           );
 
           this.updateMyMembershipState(myMemberships, myOrganizationInvites, myPendingOrganizationRequests, myRejectedOrganizationRequests);

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -105,12 +105,12 @@ export class RequestsService {
       .pipe(finalize(() => this.requestsStore.setLoading(false)))
       .subscribe(
         (myMemberships: Array<OrganizationUser>) => {
-          const myOrganizationInvites = myMemberships.filter((membership) => membership.status === 'PENDING');
+          const myOrganizationInvites = myMemberships.filter((membership) => membership.status === OrganizationUser.StatusEnum.PENDING);
           const myPendingOrganizationRequests = myMemberships.filter(
-            (membership) => membership.organization.status === 'PENDING' && membership.status === 'ACCEPTED'
+            (membership) => membership.organization.status === 'PENDING' && membership.status === OrganizationUser.StatusEnum.ACCEPTED
           );
           const myRejectedOrganizationRequests = myMemberships.filter(
-            (membership) => membership.organization.status === 'REJECTED' && membership.status === 'ACCEPTED'
+            (membership) => membership.organization.status === 'REJECTED' && membership.status === OrganizationUser.StatusEnum.ACCEPTED
           );
 
           this.updateMyMembershipState(myMemberships, myOrganizationInvites, myPendingOrganizationRequests, myRejectedOrganizationRequests);

--- a/src/app/loginComponents/state/requests.service.ts
+++ b/src/app/loginComponents/state/requests.service.ts
@@ -105,12 +105,12 @@ export class RequestsService {
       .pipe(finalize(() => this.requestsStore.setLoading(false)))
       .subscribe(
         (myMemberships: Array<OrganizationUser>) => {
-          const myOrganizationInvites = myMemberships.filter((membership) => !membership.accepted);
+          const myOrganizationInvites = myMemberships.filter((membership) => membership.status === 'PENDING');
           const myPendingOrganizationRequests = myMemberships.filter(
-            (membership) => membership.organization.status === 'PENDING' && membership.accepted
+            (membership) => membership.organization.status === 'PENDING' && membership.status === 'ACCEPTED'
           );
           const myRejectedOrganizationRequests = myMemberships.filter(
-            (membership) => membership.organization.status === 'REJECTED' && membership.accepted
+            (membership) => membership.organization.status === 'REJECTED' && membership.status === 'REJECTED'
           );
 
           this.updateMyMembershipState(myMemberships, myOrganizationInvites, myPendingOrganizationRequests, myRejectedOrganizationRequests);

--- a/src/app/organizations/collection/state/add-entry.service.ts
+++ b/src/app/organizations/collection/state/add-entry.service.ts
@@ -29,7 +29,8 @@ export class AddEntryService {
       .subscribe(
         (memberships: Array<OrganizationUser>) => {
           memberships = memberships.filter(
-            (membership) => membership.status === 'ACCEPTED' && membership.role !== OrganizationUser.RoleEnum.MEMBER
+            (membership) =>
+              membership.status === OrganizationUser.StatusEnum.ACCEPTED && membership.role !== OrganizationUser.RoleEnum.MEMBER
           );
           this.updateMembershipsState(memberships);
           this.addEntryStore.setError(false);

--- a/src/app/organizations/collection/state/add-entry.service.ts
+++ b/src/app/organizations/collection/state/add-entry.service.ts
@@ -28,7 +28,9 @@ export class AddEntryService {
       .pipe(finalize(() => this.addEntryStore.setLoading(false)))
       .subscribe(
         (memberships: Array<OrganizationUser>) => {
-          memberships = memberships.filter((membership) => membership.accepted && membership.role !== OrganizationUser.RoleEnum.MEMBER);
+          memberships = memberships.filter(
+            (membership) => membership.status === 'ACCEPTED' && membership.role !== OrganizationUser.RoleEnum.MEMBER
+          );
           this.updateMembershipsState(memberships);
           this.addEntryStore.setError(false);
         },

--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -13,13 +13,24 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
+<div *ngIf="canEdit$ | async" class="mt-3">
+  <button
+    mat-button
+    class="private-btn small-btn-structure"
+    matTooltip="Create a collection"
+    (click)="createCollection()"
+    id="createCollection"
+  >
+    <mat-icon class="info-icon accent-1-dark">add</mat-icon>Create a Collection
+  </button>
+</div>
 <app-loading [loading]="loading$ | async">
   <div *ngIf="(collections$ | async | json) === '{}'; else hasCollections">
     <mat-card class="alert alert-info mx-1" role="alert"> <mat-icon>info</mat-icon> No collections found. </mat-card>
   </div>
   <ng-template #hasCollections>
     <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">
-      <mat-card fxFlex *ngFor="let collection of collections$ | async | keyvalue" class="m-1 pb-3">
+      <mat-card fxFlex *ngFor="let collection of collections$ | async | keyvalue">
         <a
           class="no-underline"
           [routerLink]="['/organizations/', organizationName, 'collections', collection?.value?.name]"
@@ -75,9 +86,3 @@
     </div>
   </ng-template>
 </app-loading>
-<mat-action-row *ngIf="canEdit$ | async">
-  <div fxFlex></div>
-  <button mat-button class="my-2" (click)="createCollection()" id="createCollection" matTooltip="Create a new collection">
-    <mat-icon>add</mat-icon>Create collection
-  </button>
-</mat-action-row>

--- a/src/app/organizations/collections/collections.component.scss
+++ b/src/app/organizations/collections/collections.component.scss
@@ -1,9 +1,5 @@
 @import '/src/materialColorScheme.scss';
 
-.mat-action-row {
-  border: 0;
-}
-
 .mat-card-title,
 .mat-card-subtitle,
 h4 {

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -54,9 +54,9 @@
                     <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
                       <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
                     </a>
-                    <span class="bubble" [ngClass]="{ 'pending-bubble': organizationUser.status !== 'ACCEPTED' }">
+                    <span class="bubble" [ngClass]="{ 'pending-bubble': organizationUser.status !== OrganizationUser.StatusEnum.ACCEPTED }">
                       {{
-                        organizationUser.status === 'ACCEPTED'
+                        organizationUser.status === OrganizationUser.StatusEnum.ACCEPTED
                           ? (organizationUser.role | titlecase)
                           : (organizationUser.status | titlecase) + ' Invitation'
                       }}
@@ -85,19 +85,27 @@
                         <button
                           mat-button
                           class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                          [matTooltip]="organizationUser.status === 'REJECTED' ? 'Reinvite a user' : 'Edit member\'s role in organization'"
+                          [matTooltip]="
+                            organizationUser.status === OrganizationUser.StatusEnum.REJECTED
+                              ? 'Reinvite a user'
+                              : 'Edit member\'s role in organization'
+                          "
                           [id]="'edit-user-role-' + index"
                           (click)="editUser(organizationUser)"
                         >
                           <mat-icon class="info-icon accent-1-dark">{{
-                            organizationUser.status === 'REJECTED' ? 'sync' : 'edit'
+                            organizationUser.status === OrganizationUser.StatusEnum.REJECTED ? 'sync' : 'edit'
                           }}</mat-icon>
-                          {{ organizationUser.status === 'REJECTED' ? 'Resend Invite' : 'Edit' }}
+                          {{ organizationUser.status === OrganizationUser.StatusEnum.REJECTED ? 'Resend Invite' : 'Edit' }}
                         </button>
                         <button
                           mat-button
                           class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                          [matTooltip]="organizationUser.status === 'ACCEPTED' ? 'Remove member from organization' : 'Delete Invitation'"
+                          [matTooltip]="
+                            organizationUser.status === OrganizationUser.StatusEnum.ACCEPTED
+                              ? 'Remove member from organization'
+                              : 'Delete Invitation'
+                          "
                           [id]="'remove-user-' + index"
                           (click)="removeUserDialog(organizationUser)"
                         >

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -28,7 +28,7 @@
   <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">
     <!-- Setting to one column for the public view instead of two until we have a dedicated My Organizations page -->
     <div fxFlex="100" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
-      <mat-card fxFlex>
+      <mat-card [id]="'organization-member-' + index" fxFlex>
         <div fxLayout="column">
           <div fxLayout="row" fxLayoutAlign="space-between stretch">
             <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
@@ -44,10 +44,13 @@
                   <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
                     <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
                   </a>
-                  <span class="bubble" *ngIf="organizationUser.status === 'ACCEPTED'">{{ organizationUser.role | titlecase }}</span>
-                  <span class="bubble pending-bubble" *ngIf="organizationUser.status !== 'ACCEPTED'"
-                    >{{ organizationUser.status | titlecase }} Invitation</span
-                  >
+                  <span class="bubble" [ngClass]="{ 'pending-bubble': organizationUser.status !== 'ACCEPTED' }">
+                    {{
+                      organizationUser.status === 'ACCEPTED'
+                        ? (organizationUser.role | titlecase)
+                        : (organizationUser.status | titlecase) + ' Invitation'
+                    }}
+                  </span>
                 </div>
                 <div fxLayout="row" fxLayoutAlign="space-between">
                   <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row" fxLayoutAlign="start">
@@ -70,33 +73,20 @@
                       fxLayoutAlign="space-evenly"
                     >
                       <button
-                        *ngIf="organizationUser.status !== 'REJECTED'"
                         mat-button
                         class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                        matTooltip="Edit member's role in organization"
+                        [matTooltip]="organizationUser.status === 'REJECTED' ? 'Reinvite a user' : 'Edit member\'s role in organization'"
                         [id]="'edit-user-role-' + index"
-                        [disabled]="organizationUser.user.id === (userId$ | async)"
                         (click)="editUser(organizationUser)"
                       >
-                        <img src="../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit member" />Edit
-                      </button>
-                      <button
-                        *ngIf="organizationUser.status === 'REJECTED'"
-                        mat-button
-                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                        matTooltip="Re-invite a user"
-                        [id]="'re-invite-user-role-' + index"
-                        [disabled]="organizationUser.user.id === (userId$ | async)"
-                        (click)="reinviteUser(organizationUser)"
-                      >
-                        <mat-icon class="info-icon accent-1-dark">sync</mat-icon>Resend Invite
+                        <mat-icon class="info-icon accent-1-dark">{{ organizationUser.status === 'REJECTED' ? 'sync' : 'edit' }}</mat-icon>
+                        {{ organizationUser.status === 'REJECTED' ? 'Resend Invite' : 'Edit' }}
                       </button>
                       <button
                         mat-button
                         class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
                         [matTooltip]="organizationUser.status === 'ACCEPTED' ? 'Remove member from organization' : 'Delete Invitation'"
                         [id]="'remove-user-' + index"
-                        [disabled]="organizationUser.user.id === (userId$ | async)"
                         (click)="removeUserDialog(organizationUser)"
                       >
                         <img src="../assets/svg/icons-actions-trash.svg" class="pr-2" alt="Remove member" />

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -25,80 +25,93 @@
   </button>
 </div>
 <app-loading [loading]="loading$ | async">
-  <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">
-    <!-- Setting to one column for the public view instead of two until we have a dedicated My Organizations page -->
-    <div fxFlex="100" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
-      <mat-card [id]="'organization-member-' + index" fxFlex>
-        <div fxLayout="column">
-          <div fxLayout="row" fxLayoutAlign="space-between stretch">
-            <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
-              <img *ngIf="organizationUser.user?.avatarUrl" mat-card-avatar class="header-image" [src]="organizationUser.user?.avatarUrl" />
-              <img
-                *ngIf="!organizationUser.user?.avatarUrl"
-                mat-card-avatar
-                class="header-image"
-                src="https://via.placeholder.com/300x300?text=Avatar+Not+Found"
-              />
-              <div fxFlex="100" fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="0.5rem">
-                <div fxLayout="row" fxLayoutAlign="space-between center">
-                  <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
-                    <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
-                  </a>
-                  <span class="bubble" [ngClass]="{ 'pending-bubble': organizationUser.status !== 'ACCEPTED' }">
-                    {{
-                      organizationUser.status === 'ACCEPTED'
-                        ? (organizationUser.role | titlecase)
-                        : (organizationUser.status | titlecase) + ' Invitation'
-                    }}
-                  </span>
-                </div>
-                <div fxLayout="row" fxLayoutAlign="space-between">
-                  <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row" fxLayoutAlign="start">
-                    <div>
-                      ORCID
-                      <img
-                        src="../../../assets/images/account-logos/orcid.svg"
-                        alt="ORCID iD logo"
-                        class="orcid-id-logo site-icons-small mr-3"
-                      />
+  <!-- Need this external div with no-wrap so the fxLayoutGap grid doesn't add scrollbars -->
+  <div class="no-wrap">
+    <div class="pt-2" fxLayout="row wrap" fxLayoutGap="0.5rem grid">
+      <div
+        fxFlex="{{ (canEditMembership$ | async) ? '100' : '50' }}"
+        fxFlex.lt-lg="100"
+        *ngFor="let organizationUser of organizationMembers$ | async; let index = index"
+      >
+        <mat-card fxFlex [id]="'organization-member-' + index">
+          <div fxLayout="column">
+            <div fxLayout="row" fxLayoutAlign="space-between stretch">
+              <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
+                <img
+                  *ngIf="organizationUser.user?.avatarUrl"
+                  mat-card-avatar
+                  class="header-image"
+                  [src]="organizationUser.user?.avatarUrl"
+                />
+                <img
+                  *ngIf="!organizationUser.user?.avatarUrl"
+                  mat-card-avatar
+                  class="header-image"
+                  src="https://via.placeholder.com/300x300?text=Avatar+Not+Found"
+                />
+                <div fxFlex="100" fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="0.5rem">
+                  <div fxLayout="row" fxLayoutAlign="space-between center">
+                    <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
+                      <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
+                    </a>
+                    <span class="bubble" [ngClass]="{ 'pending-bubble': organizationUser.status !== 'ACCEPTED' }">
+                      {{
+                        organizationUser.status === 'ACCEPTED'
+                          ? (organizationUser.role | titlecase)
+                          : (organizationUser.status | titlecase) + ' Invitation'
+                      }}
+                    </span>
+                  </div>
+                  <div fxLayout="row" fxLayoutAlign="space-between">
+                    <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row" fxLayoutAlign="start">
+                      <div>
+                        ORCID
+                        <img
+                          src="../../../assets/images/account-logos/orcid.svg"
+                          alt="ORCID iD logo"
+                          class="orcid-id-logo site-icons-small mr-3"
+                        />
+                      </div>
+                      <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
+                    </span>
+                    <div fxLayout="row" fxLayoutAlign="end" *ngIf="canEditMembership$ | async" fxFlex="noshrink">
+                      <mat-card-content
+                        *ngIf="organizationUser.user.id !== (userId$ | async)"
+                        fxLayout="row"
+                        fxLayoutGap="1rem"
+                        class="m-0"
+                        fxLayoutAlign="space-evenly"
+                      >
+                        <button
+                          mat-button
+                          class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+                          [matTooltip]="organizationUser.status === 'REJECTED' ? 'Reinvite a user' : 'Edit member\'s role in organization'"
+                          [id]="'edit-user-role-' + index"
+                          (click)="editUser(organizationUser)"
+                        >
+                          <mat-icon class="info-icon accent-1-dark">{{
+                            organizationUser.status === 'REJECTED' ? 'sync' : 'edit'
+                          }}</mat-icon>
+                          {{ organizationUser.status === 'REJECTED' ? 'Resend Invite' : 'Edit' }}
+                        </button>
+                        <button
+                          mat-button
+                          class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+                          [matTooltip]="organizationUser.status === 'ACCEPTED' ? 'Remove member from organization' : 'Delete Invitation'"
+                          [id]="'remove-user-' + index"
+                          (click)="removeUserDialog(organizationUser)"
+                        >
+                          <img src="../assets/svg/icons-actions-trash.svg" class="pr-2" alt="Remove member" />
+                        </button>
+                      </mat-card-content>
                     </div>
-                    <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
-                  </span>
-                  <div fxLayout="row" fxLayoutAlign="end" *ngIf="canEditMembership$ | async" fxFlex="noshrink">
-                    <mat-card-content
-                      *ngIf="organizationUser.user.id !== (userId$ | async)"
-                      fxLayout="row"
-                      fxLayoutGap="1rem"
-                      class="m-0"
-                      fxLayoutAlign="space-evenly"
-                    >
-                      <button
-                        mat-button
-                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                        [matTooltip]="organizationUser.status === 'REJECTED' ? 'Reinvite a user' : 'Edit member\'s role in organization'"
-                        [id]="'edit-user-role-' + index"
-                        (click)="editUser(organizationUser)"
-                      >
-                        <mat-icon class="info-icon accent-1-dark">{{ organizationUser.status === 'REJECTED' ? 'sync' : 'edit' }}</mat-icon>
-                        {{ organizationUser.status === 'REJECTED' ? 'Resend Invite' : 'Edit' }}
-                      </button>
-                      <button
-                        mat-button
-                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                        [matTooltip]="organizationUser.status === 'ACCEPTED' ? 'Remove member from organization' : 'Delete Invitation'"
-                        [id]="'remove-user-' + index"
-                        (click)="removeUserDialog(organizationUser)"
-                      >
-                        <img src="../assets/svg/icons-actions-trash.svg" class="pr-2" alt="Remove member" />
-                      </button>
-                    </mat-card-content>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </mat-card>
+        </mat-card>
+      </div>
     </div>
   </div>
 </app-loading>

--- a/src/app/organizations/organization-members/organization-members.component.html
+++ b/src/app/organizations/organization-members/organization-members.component.html
@@ -13,10 +13,22 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
+<div *ngIf="canEditMembership$ | async" fxLayout="row" class="pt-3">
+  <button
+    mat-button
+    class="private-btn small-btn-structure"
+    matTooltip="Invite a member to the organization"
+    (click)="addUser()"
+    id="addUserToOrgButton"
+  >
+    <mat-icon class="info-icon accent-1-dark">email</mat-icon>Invite a Member
+  </button>
+</div>
 <app-loading [loading]="loading$ | async">
-  <div class="pt-2" fxLayout="row wrap">
-    <div fxFlex="50" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
-      <mat-card fxFlex class="m-2" *ngIf="organizationUser?.accepted">
+  <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">
+    <!-- Setting to one column for the public view instead of two until we have a dedicated My Organizations page -->
+    <div fxFlex="100" fxFlex.lt-sm="100" *ngFor="let organizationUser of organizationMembers$ | async; let index = index">
+      <mat-card fxFlex>
         <div fxLayout="column">
           <div fxLayout="row" fxLayoutAlign="space-between stretch">
             <div fxFlex fxLayout="row" fxLayoutGap="1rem" fxLayoutAlign="center center">
@@ -27,64 +39,76 @@
                 class="header-image"
                 src="https://via.placeholder.com/300x300?text=Avatar+Not+Found"
               />
-              <div fxFlex="80" fxLayout="column" fxLayoutAlign="start stretch">
+              <div fxFlex="100" fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="0.5rem">
                 <div fxLayout="row" fxLayoutAlign="space-between center">
                   <a class="no-underline" routerLink="/users/{{ organizationUser.user?.username }}">
                     <h5 class="weight-bold mt-0 mb-0" fxFlex>{{ organizationUser.user?.username }}</h5>
                   </a>
-                  <span class="bubble">{{ organizationUser.role | titlecase }}</span>
+                  <span class="bubble" *ngIf="organizationUser.status === 'ACCEPTED'">{{ organizationUser.role | titlecase }}</span>
+                  <span class="bubble pending-bubble" *ngIf="organizationUser.status !== 'ACCEPTED'"
+                    >{{ organizationUser.status | titlecase }} Invitation</span
+                  >
                 </div>
-                <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row wrap">
-                  <div>
-                    ORCID
-                    <img
-                      src="../../../assets/images/account-logos/orcid.svg"
-                      alt="ORCID iD logo"
-                      class="orcid-id-logo site-icons-small mr-3"
-                    />
+                <div fxLayout="row" fxLayoutAlign="space-between">
+                  <span class="orcid" *ngIf="organizationUser.user?.orcid" fxLayout="row" fxLayoutAlign="start">
+                    <div>
+                      ORCID
+                      <img
+                        src="../../../assets/images/account-logos/orcid.svg"
+                        alt="ORCID iD logo"
+                        class="orcid-id-logo site-icons-small mr-3"
+                      />
+                    </div>
+                    <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
+                  </span>
+                  <div fxLayout="row" fxLayoutAlign="end" *ngIf="canEditMembership$ | async" fxFlex="noshrink">
+                    <mat-card-content
+                      *ngIf="organizationUser.user.id !== (userId$ | async)"
+                      fxLayout="row"
+                      fxLayoutGap="1rem"
+                      class="m-0"
+                      fxLayoutAlign="space-evenly"
+                    >
+                      <button
+                        *ngIf="organizationUser.status !== 'REJECTED'"
+                        mat-button
+                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+                        matTooltip="Edit member's role in organization"
+                        [id]="'edit-user-role-' + index"
+                        [disabled]="organizationUser.user.id === (userId$ | async)"
+                        (click)="editUser(organizationUser)"
+                      >
+                        <img src="../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit member" />Edit
+                      </button>
+                      <button
+                        *ngIf="organizationUser.status === 'REJECTED'"
+                        mat-button
+                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+                        matTooltip="Re-invite a user"
+                        [id]="'re-invite-user-role-' + index"
+                        [disabled]="organizationUser.user.id === (userId$ | async)"
+                        (click)="reinviteUser(organizationUser)"
+                      >
+                        <mat-icon class="info-icon accent-1-dark">sync</mat-icon>Resend Invite
+                      </button>
+                      <button
+                        mat-button
+                        class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
+                        [matTooltip]="organizationUser.status === 'ACCEPTED' ? 'Remove member from organization' : 'Delete Invitation'"
+                        [id]="'remove-user-' + index"
+                        [disabled]="organizationUser.user.id === (userId$ | async)"
+                        (click)="removeUserDialog(organizationUser)"
+                      >
+                        <img src="../assets/svg/icons-actions-trash.svg" class="pr-2" alt="Remove member" />
+                      </button>
+                    </mat-card-content>
                   </div>
-                  <a href="https://orcid.org/{{ organizationUser.user?.orcid }}">{{ organizationUser.user?.orcid }}</a>
-                </span>
+                </div>
               </div>
             </div>
-          </div>
-          <div fxLayoutAlign="center" *ngIf="canEditMembership$ | async">
-            <mat-card-content
-              *ngIf="organizationUser.user.id !== (userId$ | async)"
-              fxLayout="row"
-              fxLayoutGap="35px"
-              class="m-0"
-              fxLayoutAlign="space-evenly"
-            >
-              <button
-                mat-button
-                class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                matTooltip="Edit user's role in organization"
-                [id]="'edit-user-role-' + index"
-                [disabled]="organizationUser.user.id === (userId$ | async)"
-                (click)="editUser(organizationUser)"
-              >
-                <img src="../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit member" />Edit
-              </button>
-              <button
-                mat-button
-                class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                matTooltip="Remove user from organization"
-                [id]="'remove-user-' + index"
-                [disabled]="organizationUser.user.id === (userId$ | async)"
-                (click)="removeUserDialog(organizationUser)"
-              >
-                <img src="../assets/svg/icons-actions-trash.svg" class="pr-2" alt="Remove member" />
-              </button>
-            </mat-card-content>
           </div>
         </div>
       </mat-card>
     </div>
   </div>
 </app-loading>
-<mat-action-row *ngIf="canEditMembership$ | async" fxLayout="row" fxLayoutAlign="end center">
-  <button matTooltip="Add user to organization" (click)="addUser()" id="addUserToOrgButton" mat-button>
-    <mat-icon>add</mat-icon>Add user
-  </button>
-</mat-action-row>

--- a/src/app/organizations/organization-members/organization-members.component.scss
+++ b/src/app/organizations/organization-members/organization-members.component.scss
@@ -24,14 +24,14 @@ h5 {
   line-height: none;
 }
 
-.mat-action-row {
-  border: 0;
-}
-
 a {
   color: mat.get-color-from-palette($kim-secondary, 2);
 }
 
 * {
   color: $header-color;
+}
+
+.pending-bubble {
+  background: mat.get-color-from-palette($dockstore-app-accent-4, 4);
 }

--- a/src/app/organizations/organization-members/organization-members.component.ts
+++ b/src/app/organizations/organization-members/organization-members.component.ts
@@ -16,7 +16,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ID } from '@datorama/akita';
-import { ConfirmationDialogData } from 'app/confirmation-dialog/confirmation-dialog.component';
 import { ConfirmationDialogService } from 'app/confirmation-dialog/confirmation-dialog.service';
 import { Base } from 'app/shared/base';
 import { bootstrap4mediumModalSize } from 'app/shared/constants';
@@ -81,31 +80,27 @@ export class OrganizationMembersComponent extends Base implements OnInit {
    * @memberof OrganizationMembersComponent
    */
   editUser(organizationUser: OrganizationUser) {
+    const editUserDialogData = {
+      mode: TagEditorMode.Edit,
+      username: organizationUser.user.username,
+      role: organizationUser.role,
+      title: 'Edit Member',
+      descriptionPrefix: "Edit the member's role in your organization.",
+      confirmationButtonText: 'Edit Member',
+    };
+    const resendInviteDialogData = {
+      mode: TagEditorMode.Edit,
+      username: organizationUser.user.username,
+      role: organizationUser.role,
+      title: 'Resend Invitation',
+      descriptionPrefix: `Resend an invitation to the user <strong>${organizationUser.user.username}</strong> 
+          who rejected the invitation to the organization <strong>${organizationUser.organization.displayName}</strong>. You may optionally edit the role.`,
+      confirmationButtonText: 'Resend Invitation',
+    };
+
     this.alertService.clearEverything();
     this.matDialog.open(UpsertOrganizationMemberComponent, {
-      data: {
-        mode: TagEditorMode.Edit,
-        username: organizationUser.user.username,
-        role: organizationUser.role,
-        title: 'Edit Member',
-        descriptionPrefix: "Edit the member's role in your organization.",
-        confirmationButtonText: 'Edit Member',
-      },
-      width: bootstrap4mediumModalSize,
-    });
-  }
-
-  reinviteUser(organizationUser: OrganizationUser) {
-    this.matDialog.open(UpsertOrganizationMemberComponent, {
-      data: {
-        mode: TagEditorMode.Edit,
-        username: organizationUser.user.username,
-        role: organizationUser.role,
-        title: 'Resend Invitation',
-        descriptionPrefix: `Resend an invitation to the user <strong>${organizationUser.user.username}</strong> 
-          who rejected the invitation to the organization <strong>${organizationUser.organization.displayName}</strong>. You may optionally edit the role.`,
-        confirmationButtonText: 'Resend Invitation',
-      },
+      data: organizationUser.status === 'REJECTED' ? resendInviteDialogData : editUserDialogData,
       width: bootstrap4mediumModalSize,
     });
   }
@@ -137,21 +132,24 @@ export class OrganizationMembersComponent extends Base implements OnInit {
    * @memberof OrganizationMembersComponent
    */
   removeUserDialog(organizationUser: OrganizationUser) {
-    const isAccepted = organizationUser.status === 'ACCEPTED';
-    const acceptedMessage = `Are you sure you want to <strong>remove</strong> the member <strong>${organizationUser.user.username}</strong>
-      from the organization <strong>${organizationUser.organization.displayName}</strong>?`;
-    const pendingOrRejectedMessage = `The member has a <strong>${organizationUser.status.toLowerCase()}</strong> invitation to the organization <strong>${
-      organizationUser.organization.displayName
-    }</strong>. 
-      Are you sure you want to <strong>delete</strong> the invitation to the member <strong>${organizationUser.user.username}</strong>?`;
-    const confirmationDialogData: ConfirmationDialogData = {
-      title: isAccepted ? 'Remove member from organization' : `Delete ${organizationUser.status.toLowerCase()} invitation`,
-      message: isAccepted ? acceptedMessage : pendingOrRejectedMessage,
+    const removeMemberDialogData = {
+      title: 'Remove Member from Organization',
+      message: `Are you sure you want to <strong>remove</strong> the member <strong>${organizationUser.user.username}</strong>
+        from the organization <strong>${organizationUser.organization.displayName}</strong>?`,
       cancelButtonText: 'Cancel',
-      confirmationButtonText: isAccepted ? 'Remove Member' : 'Delete Invitation',
+      confirmationButtonText: 'Remove Member',
+    };
+    const deleteInvitationDialogData = {
+      title: 'Delete Invitation',
+      message: `The member has a <strong>${organizationUser.status.toLowerCase()}</strong> invitation to the organization <strong>${
+        organizationUser.organization.displayName
+      }</strong>. 
+        Are you sure you want to <strong>delete</strong> the invitation to the member <strong>${organizationUser.user.username}</strong>?`,
+      cancelButtonText: 'Cancel',
+      confirmationButtonText: 'Delete Invitation',
     };
     this.confirmationDialogService
-      .openDialog(confirmationDialogData, bootstrap4mediumModalSize)
+      .openDialog(organizationUser.status === 'ACCEPTED' ? removeMemberDialogData : deleteInvitationDialogData, bootstrap4mediumModalSize)
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((result) => {
         if (result) {

--- a/src/app/organizations/organization-members/organization-members.component.ts
+++ b/src/app/organizations/organization-members/organization-members.component.ts
@@ -36,6 +36,7 @@ import { UpsertOrganizationMemberComponent } from '../upsert-organization-member
   styleUrls: ['./organization-members.component.scss'],
 })
 export class OrganizationMembersComponent extends Base implements OnInit {
+  OrganizationUser = OrganizationUser;
   organizationMembers$: Observable<OrganizationUser[]>;
   loading$: Observable<boolean>;
   canEdit$: Observable<boolean>;

--- a/src/app/organizations/organization-members/organization-members.component.ts
+++ b/src/app/organizations/organization-members/organization-members.component.ts
@@ -83,8 +83,30 @@ export class OrganizationMembersComponent extends Base implements OnInit {
   editUser(organizationUser: OrganizationUser) {
     this.alertService.clearEverything();
     this.matDialog.open(UpsertOrganizationMemberComponent, {
-      data: { mode: TagEditorMode.Edit, username: organizationUser.user.username, role: organizationUser.role },
-      width: '600px',
+      data: {
+        mode: TagEditorMode.Edit,
+        username: organizationUser.user.username,
+        role: organizationUser.role,
+        title: 'Edit Member',
+        descriptionPrefix: "Edit the member's role in your organization.",
+        confirmationButtonText: 'Edit Member',
+      },
+      width: bootstrap4mediumModalSize,
+    });
+  }
+
+  reinviteUser(organizationUser: OrganizationUser) {
+    this.matDialog.open(UpsertOrganizationMemberComponent, {
+      data: {
+        mode: TagEditorMode.Edit,
+        username: organizationUser.user.username,
+        role: organizationUser.role,
+        title: 'Resend Invitation',
+        descriptionPrefix: `Resend an invitation to the user <strong>${organizationUser.user.username}</strong> 
+          who rejected the invitation to the organization <strong>${organizationUser.organization.displayName}</strong>. You may optionally edit the role.`,
+        confirmationButtonText: 'Resend Invitation',
+      },
+      width: bootstrap4mediumModalSize,
     });
   }
 
@@ -96,8 +118,15 @@ export class OrganizationMembersComponent extends Base implements OnInit {
   addUser() {
     this.alertService.clearEverything();
     this.matDialog.open(UpsertOrganizationMemberComponent, {
-      data: { mode: TagEditorMode.Add, username: null, role: null },
-      width: '600px',
+      data: {
+        mode: TagEditorMode.Add,
+        username: null,
+        role: null,
+        title: 'Invite a Member',
+        descriptionPrefix: 'When you send this invite, the user will receive a request to join your organization.',
+        confirmationButtonText: 'Send Invite',
+      },
+      width: bootstrap4mediumModalSize,
     });
   }
 
@@ -108,13 +137,18 @@ export class OrganizationMembersComponent extends Base implements OnInit {
    * @memberof OrganizationMembersComponent
    */
   removeUserDialog(organizationUser: OrganizationUser) {
+    const isAccepted = organizationUser.status === 'ACCEPTED';
+    const acceptedMessage = `Are you sure you want to <strong>remove</strong> the member <strong>${organizationUser.user.username}</strong>
+      from the organization <strong>${organizationUser.organization.displayName}</strong>?`;
+    const pendingOrRejectedMessage = `The member has a <strong>${organizationUser.status.toLowerCase()}</strong> invitation to the organization <strong>${
+      organizationUser.organization.displayName
+    }</strong>. 
+      Are you sure you want to <strong>delete</strong> the invitation to the member <strong>${organizationUser.user.username}</strong>?`;
     const confirmationDialogData: ConfirmationDialogData = {
-      title: 'Remove user from organization',
-      message: `Are you sure you want to <strong>remove</strong> the user <strong>${organizationUser.user.username}</strong>
-      from the organization
-    <strong>${organizationUser.organization.displayName}?`,
-      cancelButtonText: 'NO THANKS',
-      confirmationButtonText: 'REMOVE',
+      title: isAccepted ? 'Remove member from organization' : `Delete ${organizationUser.status.toLowerCase()} invitation`,
+      message: isAccepted ? acceptedMessage : pendingOrRejectedMessage,
+      cancelButtonText: 'Cancel',
+      confirmationButtonText: isAccepted ? 'Remove Member' : 'Delete Invitation',
     };
     this.confirmationDialogService
       .openDialog(confirmationDialogData, bootstrap4mediumModalSize)

--- a/src/app/organizations/state/organization-members.service.ts
+++ b/src/app/organizations/state/organization-members.service.ts
@@ -96,24 +96,21 @@ export class OrganizationMembersService {
             const canEdit = organizationUsers.some(
               (user) =>
                 user.id.userId === currentUserId &&
-                user.status === 'ACCEPTED' &&
                 (user.role === OrganizationUser.RoleEnum.ADMIN || user.role === OrganizationUser.RoleEnum.MAINTAINER)
             );
             const canEditMembers = organizationUsers.some(
-              (user) => user.id.userId === currentUserId && user.status === 'ACCEPTED' && user.role === OrganizationUser.RoleEnum.ADMIN
+              (user) =>
+                user.id.userId === currentUserId &&
+                user.status === OrganizationUser.StatusEnum.ACCEPTED &&
+                user.role === OrganizationUser.RoleEnum.ADMIN
             );
             // If a user can edit the organization, allow them to delete a collection.
             const canDeleteCollection = canEdit;
             this.setCanModifyState(canEdit, canEditMembers, canDeleteCollection);
-            if (canEditMembers) {
-              this.updateAll(organizationUsers);
-            } else {
-              this.updateAll(organizationUsers.filter((organizationUser) => organizationUser.status === 'ACCEPTED'));
-            }
           } else {
             this.setCanModifyState(false, false, false);
-            this.updateAll(organizationUsers.filter((organizationUser) => organizationUser.status === 'ACCEPTED'));
           }
+          this.updateAll(organizationUsers);
           this.organizationMembersStore.setError(false);
         },
         (error: HttpErrorResponse) => {

--- a/src/app/organizations/state/organization-members.service.ts
+++ b/src/app/organizations/state/organization-members.service.ts
@@ -96,19 +96,24 @@ export class OrganizationMembersService {
             const canEdit = organizationUsers.some(
               (user) =>
                 user.id.userId === currentUserId &&
-                user.accepted &&
+                user.status === 'ACCEPTED' &&
                 (user.role === OrganizationUser.RoleEnum.ADMIN || user.role === OrganizationUser.RoleEnum.MAINTAINER)
             );
             const canEditMembers = organizationUsers.some(
-              (user) => user.id.userId === currentUserId && user.accepted && user.role === OrganizationUser.RoleEnum.ADMIN
+              (user) => user.id.userId === currentUserId && user.status === 'ACCEPTED' && user.role === OrganizationUser.RoleEnum.ADMIN
             );
             // If a user can edit the organization, allow them to delete a collection.
             const canDeleteCollection = canEdit;
             this.setCanModifyState(canEdit, canEditMembers, canDeleteCollection);
+            if (canEditMembers) {
+              this.updateAll(organizationUsers);
+            } else {
+              this.updateAll(organizationUsers.filter((organizationUser) => organizationUser.status === 'ACCEPTED'));
+            }
           } else {
             this.setCanModifyState(false, false, false);
+            this.updateAll(organizationUsers.filter((organizationUser) => organizationUser.status === 'ACCEPTED'));
           }
-          this.updateAll(organizationUsers);
           this.organizationMembersStore.setError(false);
         },
         (error: HttpErrorResponse) => {

--- a/src/app/organizations/state/upsert-organization-member.service.ts
+++ b/src/app/organizations/state/upsert-organization-member.service.ts
@@ -62,15 +62,24 @@ export class UpsertOrganizationMemberService {
   }
 
   /**
-   * Get the title based on the mode
+   * Get the description
    *
-   * @param {*} data
+   * @param {TagEditorMode} mode
    * @returns {string}
    * @memberof UpsertOrganizationMemberService
    */
-  getTitle(data: any): string {
-    const mode: TagEditorMode = data.mode;
-    return mode === TagEditorMode.Add ? 'Add User' : 'Edit User';
+  getDescription(mode: TagEditorMode, prefix: string): string {
+    const rolePermissions = ` Role permissions include:<br>
+      <strong>Admin:</strong> can update the organization, collections, and memberships.<br>
+      <strong>Maintainer:</strong> can update the organization and collections.<br>
+      <strong>Member:</strong> no editing permissions. Joins to show support for the organization.`;
+    let descriptionPrefix;
+    if (mode === TagEditorMode.Add) {
+      descriptionPrefix = 'When you send this invite, the user will receive a request to join your organization.';
+    } else {
+      descriptionPrefix = "Edit the member's role in your organization.";
+    }
+    return prefix + rolePermissions;
   }
 
   /**
@@ -86,7 +95,7 @@ export class UpsertOrganizationMemberService {
     } else {
       this.upsertOrganizationMemberStore.setLoading(true);
       this.upsertOrganizationMemberStore.setError(false);
-      this.alertService.start('Adding/updating user');
+      this.alertService.start('Inviting/updating member');
       const organizationId = this.organizationQuery.getValue().organization.id;
       // Have to grab the username from data because a disabled form value isn't recorded
       const username = formState.username ? formState.username : data.username;

--- a/src/app/organizations/state/upsert-organization-member.service.ts
+++ b/src/app/organizations/state/upsert-organization-member.service.ts
@@ -68,7 +68,7 @@ export class UpsertOrganizationMemberService {
    * @memberof UpsertOrganizationMemberService
    */
   getDescription(prefix: string): string {
-    const rolePermissions = ` Role permissions include:<br>
+    const rolePermissions = ` Role permissions are:<br>
       <strong>Admin:</strong> can update the organization, collections, and memberships.<br>
       <strong>Maintainer:</strong> can update the organization and collections.<br>
       <strong>Member:</strong> no editing permissions. Joins to show support for the organization.`;

--- a/src/app/organizations/state/upsert-organization-member.service.ts
+++ b/src/app/organizations/state/upsert-organization-member.service.ts
@@ -64,21 +64,14 @@ export class UpsertOrganizationMemberService {
   /**
    * Get the description
    *
-   * @param {TagEditorMode} mode
    * @returns {string}
    * @memberof UpsertOrganizationMemberService
    */
-  getDescription(mode: TagEditorMode, prefix: string): string {
+  getDescription(prefix: string): string {
     const rolePermissions = ` Role permissions include:<br>
       <strong>Admin:</strong> can update the organization, collections, and memberships.<br>
       <strong>Maintainer:</strong> can update the organization and collections.<br>
       <strong>Member:</strong> no editing permissions. Joins to show support for the organization.`;
-    let descriptionPrefix;
-    if (mode === TagEditorMode.Add) {
-      descriptionPrefix = 'When you send this invite, the user will receive a request to join your organization.';
-    } else {
-      descriptionPrefix = "Edit the member's role in your organization.";
-    }
     return prefix + rolePermissions;
   }
 

--- a/src/app/organizations/upsert-organization-member/upsert-organization-member.component.html
+++ b/src/app/organizations/upsert-organization-member/upsert-organization-member.component.html
@@ -1,15 +1,18 @@
 <h1 mat-dialog-title>{{ title }}</h1>
 <div mat-dialog-content>
   <app-alert></app-alert>
+  <p [innerHTML]="description"></p>
   <form [formGroup]="form">
     <div fxLayout="column">
-      <mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Username</mat-label>
         <input type="text" matInput formControlName="username" placeholder="Username" required />
         <mat-error *ngIf="name.hasError('required')">Name is required</mat-error>
         <mat-error *ngIf="name.hasError('minlength')">Name should be at least 3 characters long</mat-error>
         <mat-error *ngIf="name.hasError('maxlength')">Name should be at most 39 characters long</mat-error>
       </mat-form-field>
-      <mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Select a Role</mat-label>
         <mat-select formControlName="role" placeholder="Role">
           <mat-option *ngFor="let item of roleKeys" [value]="item">{{ item | titlecase }}</mat-option>
         </mat-select>
@@ -28,6 +31,6 @@
     (click)="upsertUser()"
     cdkFocusInitial
   >
-    {{ title }}
+    {{ confirmationButtonText }}
   </button>
 </div>

--- a/src/app/organizations/upsert-organization-member/upsert-organization-member.component.ts
+++ b/src/app/organizations/upsert-organization-member/upsert-organization-member.component.ts
@@ -6,6 +6,15 @@ import { TagEditorMode } from '../../shared/enum/tagEditorMode.enum';
 import { OrganizationUser } from '../../shared/swagger';
 import { FormsState, UpsertOrganizationMemberService } from '../state/upsert-organization-member.service';
 
+export interface UpsertOrganizationMemberComponentData {
+  mode: TagEditorMode;
+  username: string;
+  role: OrganizationUser.RoleEnum;
+  title: string;
+  descriptionPrefix: string;
+  confirmationButtonText: string;
+}
+
 @Component({
   selector: 'app-upsert-organization-member',
   templateUrl: './upsert-organization-member.component.html',
@@ -16,18 +25,24 @@ export class UpsertOrganizationMemberComponent implements OnInit, OnDestroy {
   constructor(
     private upsertOrganizationMemberService: UpsertOrganizationMemberService,
     private formsManager: NgFormsManager<FormsState>,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: UpsertOrganizationMemberComponentData
   ) {
     this.roleKeys = Object.keys(this.RoleEnum);
   }
   RoleEnum = OrganizationUser.RoleEnum;
   form: UntypedFormGroup;
-  public title: string;
   public TagEditorMode = TagEditorMode;
+  public mode: TagEditorMode;
+  public title: string;
+  public description: string;
+  public confirmationButtonText: string;
 
   ngOnInit() {
     this.form = this.upsertOrganizationMemberService.createForm(this.formsManager, this.data);
-    this.title = this.upsertOrganizationMemberService.getTitle(this.data);
+    this.mode = this.data.mode;
+    this.title = this.data.title;
+    this.description = this.upsertOrganizationMemberService.getDescription(this.mode, this.data.descriptionPrefix);
+    this.confirmationButtonText = this.data.confirmationButtonText;
   }
 
   upsertUser(): void {

--- a/src/app/organizations/upsert-organization-member/upsert-organization-member.component.ts
+++ b/src/app/organizations/upsert-organization-member/upsert-organization-member.component.ts
@@ -39,9 +39,8 @@ export class UpsertOrganizationMemberComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.form = this.upsertOrganizationMemberService.createForm(this.formsManager, this.data);
-    this.mode = this.data.mode;
     this.title = this.data.title;
-    this.description = this.upsertOrganizationMemberService.getDescription(this.mode, this.data.descriptionPrefix);
+    this.description = this.upsertOrganizationMemberService.getDescription(this.data.descriptionPrefix);
     this.confirmationButtonText = this.data.confirmationButtonText;
   }
 

--- a/src/app/shared/descriptor-type-compat.service.spec.ts
+++ b/src/app/shared/descriptor-type-compat.service.spec.ts
@@ -2,6 +2,7 @@
 
 import { inject, TestBed } from '@angular/core/testing';
 import { DescriptorTypeCompatService } from './descriptor-type-compat.service';
+import { ToolVersion } from './openapi';
 import { ToolDescriptor } from './swagger';
 
 describe('Service: DescriptorTypeCompat', () => {
@@ -15,13 +16,43 @@ describe('Service: DescriptorTypeCompat', () => {
     [DescriptorTypeCompatService],
     (service: DescriptorTypeCompatService) => {
       expect(service).toBeTruthy();
-      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.CWL)).toEqual('PLAIN-CWL');
-      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.WDL)).toEqual('PLAIN-WDL');
-      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.NFL)).toEqual('PLAIN-NFL');
-      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.SERVICE)).toEqual('PLAIN-SERVICE');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.CWL)).toEqual('PLAIN_CWL');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.WDL)).toEqual('PLAIN_WDL');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.NFL)).toEqual('PLAIN_NFL');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.GXFORMAT2)).toEqual('PLAIN_GALAXY');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.SMK)).toEqual('PLAIN_SMK');
+      expect(service.toolDescriptorTypeEnumToPlainTRS(ToolDescriptor.TypeEnum.SERVICE)).toEqual(null);
 
       expect(service.toolDescriptorTypeEnumToPlainTRS(<ToolDescriptor.TypeEnum>'potato')).toEqual(null);
       expect(service.toolDescriptorTypeEnumToPlainTRS(null)).toEqual(null);
+    }
+  ));
+
+  it('should be able to convert ToolDescriptor.TypeEnum to ToolVersion.DescriptorTypeEnum', inject(
+    [DescriptorTypeCompatService],
+    (service: DescriptorTypeCompatService) => {
+      expect(service).toBeTruthy();
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.CWL)).toEqual(
+        ToolVersion.DescriptorTypeEnum.CWL
+      );
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.WDL)).toEqual(
+        ToolVersion.DescriptorTypeEnum.WDL
+      );
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.NFL)).toEqual(
+        ToolVersion.DescriptorTypeEnum.NFL
+      );
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.GXFORMAT2)).toEqual(
+        ToolVersion.DescriptorTypeEnum.GALAXY
+      );
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.SMK)).toEqual(
+        ToolVersion.DescriptorTypeEnum.SMK
+      );
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(ToolDescriptor.TypeEnum.SERVICE)).toEqual(
+        ToolVersion.DescriptorTypeEnum.SERVICE
+      );
+
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(<ToolDescriptor.TypeEnum>'potato')).toEqual(null);
+      expect(service.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(null)).toEqual(null);
     }
   ));
 });

--- a/src/app/shared/descriptor-type-compat.service.ts
+++ b/src/app/shared/descriptor-type-compat.service.ts
@@ -14,7 +14,12 @@
  *     limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { extendedDescriptorLanguages, extendedUnknownDescriptor } from 'app/entry/extendedDescriptorLanguage';
+import {
+  extendedDescriptorLanguages,
+  extendedUnknownDescriptor,
+  PlainTRSDescriptorLanguageEnum,
+} from 'app/entry/extendedDescriptorLanguage';
+import { ToolVersion } from './openapi';
 import { ToolDescriptor, Workflow } from './swagger';
 
 /**
@@ -56,10 +61,10 @@ export class DescriptorTypeCompatService {
    * Converts the ToolDescriptor.TypeEnum to the plain text type
    *
    * @param {ToolDescriptor.TypeEnum} typeEnum  The ToolDescriptor.TypeEnum to convert
-   * @returns {string}  Plain type that the TRS accepts
+   * @returns {PlainTRSDescriptorLanguageEnum}  Plain type that the TRS accepts
    * @memberof DescriptorTypeCompatService
    */
-  public toolDescriptorTypeEnumToPlainTRS(typeEnum: ToolDescriptor.TypeEnum): string | null {
+  public toolDescriptorTypeEnumToPlainTRS(typeEnum: ToolDescriptor.TypeEnum): PlainTRSDescriptorLanguageEnum | null {
     const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
       (extendedDescriptorLanguage) => extendedDescriptorLanguage.toolDescriptorEnum === typeEnum
     );
@@ -67,6 +72,24 @@ export class DescriptorTypeCompatService {
       return foundExtendedDescriptorLanguage.plainTRS;
     }
     return extendedUnknownDescriptor.plainTRS;
+  }
+
+  /**
+   * Converts the ToolDescriptor.TypeEnum to ToolVersion.DescriptorLanguageEnum
+   */
+  public toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(typeEnum: ToolDescriptor.TypeEnum): ToolVersion.DescriptorTypeEnum | null {
+    // Special case for Galaxy because TRS uses 'GALAXY' and not 'GXFORMAT2'
+    if (typeEnum === ToolDescriptor.TypeEnum.GXFORMAT2) {
+      return ToolVersion.DescriptorTypeEnum.GALAXY;
+    }
+    const foundExtendedDescriptorLanguage = extendedDescriptorLanguages.find(
+      (extendedDescriptorLanguage) => extendedDescriptorLanguage.toolDescriptorEnum === typeEnum
+    );
+    if (foundExtendedDescriptorLanguage) {
+      // Cast to ToolVersion.DescriptorTypeEnum because for other languages, the ToolDescriptor.TypeEnum value is the same as ToolVersion.DescriptorTypeEnum
+      return <ToolVersion.DescriptorTypeEnum>foundExtendedDescriptorLanguage.toolDescriptorEnum;
+    }
+    return <ToolVersion.DescriptorTypeEnum>extendedUnknownDescriptor.toolDescriptorEnum;
   }
 }
 

--- a/src/app/shared/descriptor-type-compat.service.ts
+++ b/src/app/shared/descriptor-type-compat.service.ts
@@ -75,7 +75,7 @@ export class DescriptorTypeCompatService {
   }
 
   /**
-   * Converts the ToolDescriptor.TypeEnum to ToolVersion.DescriptorLanguageEnum
+   * Converts the ToolDescriptor.TypeEnum to ToolVersion.DescriptorTypeEnum
    */
   public toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(typeEnum: ToolDescriptor.TypeEnum): ToolVersion.DescriptorTypeEnum | null {
     // Special case for Galaxy because TRS uses 'GALAXY' and not 'GXFORMAT2'

--- a/src/app/shared/descriptor-type-compat.service.ts
+++ b/src/app/shared/descriptor-type-compat.service.ts
@@ -69,3 +69,15 @@ export class DescriptorTypeCompatService {
     return extendedUnknownDescriptor.plainTRS;
   }
 }
+
+export type DescriptorTypeWithPlain =
+  | 'CWL'
+  | 'WDL'
+  | 'NFL'
+  | 'GALAXY'
+  | 'SMK'
+  | 'PLAIN_CWL'
+  | 'PLAIN_WDL'
+  | 'PLAIN_NFL'
+  | 'PLAIN_GALAXY'
+  | 'PLAIN_SMK';

--- a/src/app/shared/file.service.spec.ts
+++ b/src/app/shared/file.service.spec.ts
@@ -47,20 +47,20 @@ describe('FileService', () => {
     const descriptorType = ToolDescriptor.TypeEnum.CWL;
     const entryType = 'tool';
     const url = fileService.getDescriptorPath('quay.io/org/repo', tag, sourceFile, descriptorType, entryType);
-    expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN-CWL/descriptor/%2Fcwl.json');
+    expect(url).toEqual(Dockstore.API_URI + ga4ghPath + '/tools/quay.io%2Forg%2Frepo/versions/sampleName/PLAIN_CWL/descriptor/%2Fcwl.json');
   }));
 
   it('should get downloadFilePath', inject([FileService], (fileService: FileService) => {
     const id = '#workflow/github.com/HumanCellAtlas/skylab/HCA_SmartSeq2';
     const versionId = 'dockstore';
-    const type = 'PLAIN-WDL';
+    const type = 'PLAIN_WDL';
     const relativePath = 'HISAT2.wdl';
     const downloadFilePath = fileService.getDownloadFilePath(id, versionId, type, relativePath);
     expect(downloadFilePath).toEqual(
       Dockstore.API_URI +
         ga4ghPath +
         // eslint-disable-next-line max-len
-        '/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN-WDL/descriptor/HISAT2.wdl'
+        '/tools/%23workflow%2Fgithub.com%2FHumanCellAtlas%2Fskylab%2FHCA_SmartSeq2/versions/dockstore/PLAIN_WDL/descriptor/HISAT2.wdl'
     );
   }));
 

--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -16,10 +16,10 @@
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
 import { FilesService } from '../../workflow/files/state/files.service';
-import { GA4GHV20Service, ToolVersion } from '../openapi';
-import { ToolDescriptor } from '../swagger';
+import { GA4GHV20Service } from '../openapi';
 import { GA4GHFilesStore } from './ga4gh-files.store';
 import { DescriptorLanguageService } from '../entry/descriptor-language.service';
+import { DescriptorTypeCompatService } from '../descriptor-type-compat.service';
 
 @Injectable({
   providedIn: 'root',
@@ -29,7 +29,8 @@ export class GA4GHFilesService {
     private ga4ghFilesStore: GA4GHFilesStore,
     private ga4ghService: GA4GHV20Service,
     private filesService: FilesService,
-    private descriptorLanguageService: DescriptorLanguageService
+    private descriptorLanguageService: DescriptorLanguageService,
+    private descriptorTypeCompatService: DescriptorTypeCompatService
   ) {}
 
   /**
@@ -53,7 +54,10 @@ export class GA4GHFilesService {
     }
     this.injectAuthorizationToken(this.ga4ghService);
     descriptorTypes.forEach((descriptorType) => {
-      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(id, <ToolVersion.DescriptorTypeEnum>descriptorType, version).subscribe(
+      const type = this.descriptorTypeCompatService.toolDescriptorTypeEnumToToolVersionDescriptorTypeEnum(
+        this.descriptorTypeCompatService.stringToDescriptorType(descriptorType)
+      );
+      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(id, type, version).subscribe(
         (files) => {
           this.ga4ghFilesStore.setError(null);
           this.ga4ghFilesStore.upsert(descriptorType, { toolFiles: files });

--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -16,7 +16,8 @@
 import { Injectable } from '@angular/core';
 import { transaction } from '@datorama/akita';
 import { FilesService } from '../../workflow/files/state/files.service';
-import { GA4GHV20Service } from '../openapi';
+import { GA4GHV20Service, ToolVersion } from '../openapi';
+import { ToolDescriptor } from '../swagger';
 import { GA4GHFilesStore } from './ga4gh-files.store';
 import { DescriptorLanguageService } from '../entry/descriptor-language.service';
 
@@ -52,7 +53,7 @@ export class GA4GHFilesService {
     }
     this.injectAuthorizationToken(this.ga4ghService);
     descriptorTypes.forEach((descriptorType) => {
-      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(id, descriptorType, version).subscribe(
+      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(id, <ToolVersion.DescriptorTypeEnum>descriptorType, version).subscribe(
         (files) => {
           this.ga4ghFilesStore.setError(null);
           this.ga4ghFilesStore.upsert(descriptorType, { toolFiles: files });

--- a/src/app/shared/ga4gh-files/ga4gh-files.service.ts
+++ b/src/app/shared/ga4gh-files/ga4gh-files.service.ts
@@ -52,7 +52,7 @@ export class GA4GHFilesService {
     }
     this.injectAuthorizationToken(this.ga4ghService);
     descriptorTypes.forEach((descriptorType) => {
-      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(descriptorType, id, version).subscribe(
+      this.ga4ghService.toolsIdVersionsVersionIdTypeFilesGet(id, descriptorType, version).subscribe(
         (files) => {
           this.ga4ghFilesStore.setError(null);
           this.ga4ghFilesStore.upsert(descriptorType, { toolFiles: files });

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -24,7 +24,7 @@ import { ga4ghWorkflowIdPrefix } from '../constants';
 import { DescriptorTypeWithPlain } from '../descriptor-type-compat.service';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
-import { EntriesService, GA4GHV20Service, ToolVersion } from '../openapi';
+import { EntriesService, GA4GHV20Service } from '../openapi';
 import { FileWrapper, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
 
 /**

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -21,9 +21,10 @@ import { FilesQuery } from '../../workflow/files/state/files.query';
 import { FilesService } from '../../workflow/files/state/files.service';
 import { AlertService } from '../alert/state/alert.service';
 import { ga4ghWorkflowIdPrefix } from '../constants';
+import { DescriptorTypeWithPlain } from '../descriptor-type-compat.service';
 import { FileService } from '../file.service';
 import { GA4GHFilesService } from '../ga4gh-files/ga4gh-files.service';
-import { EntriesService, GA4GHV20Service } from '../openapi';
+import { EntriesService, GA4GHV20Service, ToolVersion } from '../openapi';
 import { FileWrapper, Tag, ToolDescriptor, ToolFile, WorkflowVersion } from '../swagger';
 
 /**
@@ -160,7 +161,7 @@ export abstract class EntryFileSelector implements OnDestroy {
       this.gA4GHService
         .toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(
           this.entryType === 'workflow' ? ga4ghWorkflowIdPrefix + this.entrypath : this.entrypath,
-          this.currentDescriptor,
+          <DescriptorTypeWithPlain>this.currentDescriptor,
           this._selectedVersion.name,
           this.currentFile.path
         )

--- a/src/app/shared/selectors/entry-file-selector.ts
+++ b/src/app/shared/selectors/entry-file-selector.ts
@@ -159,8 +159,8 @@ export abstract class EntryFileSelector implements OnDestroy {
     } else {
       this.gA4GHService
         .toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(
-          this.currentDescriptor,
           this.entryType === 'workflow' ? ga4ghWorkflowIdPrefix + this.entrypath : this.entrypath,
+          this.currentDescriptor,
           this._selectedVersion.name,
           this.currentFile.path
         )

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -46,7 +46,7 @@ describe('ValueService', () => {
     expect(service.getTRSLink(path, versionName, descriptorType, descriptorPath, entryType)).toContain(
       ga4ghPath +
         // eslint-disable-next-line max-len
-        '/tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FMetaphlan-ISBCGC/versions/master/plain-CWL/descriptor//metaphlan_wfl.cwl'
+        '/tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FMetaphlan-ISBCGC/versions/master/PLAIN_CWL/descriptor//metaphlan_wfl.cwl'
     );
     // TODO: service test
   });

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -218,7 +218,7 @@ export class InfoTabService {
   getTRSLink(path: string, versionName: string, descriptorType: string, descriptorPath: string, entryType: EntryType): string {
     return (
       `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(this.getTRSIDFromPath(path, entryType))}` +
-      `/versions/${encodeURIComponent(versionName)}/plain-` +
+      `/versions/${encodeURIComponent(versionName)}/PLAIN_` +
       descriptorType.toUpperCase() +
       `/descriptor/` +
       descriptorPath

--- a/src/app/workflow/launch/workflow-launch.service.spec.ts
+++ b/src/app/workflow/launch/workflow-launch.service.spec.ts
@@ -48,7 +48,7 @@ describe('WorkflowLaunchService', () => {
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).toContain('cwl-runner');
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).not.toContain('non-strict');
     expect(service.getCwlString('a/b', 'c', '%2Fpotato')).toContain(
-      ga4ghPath + '/tools/%23workflow%2Fa%2Fb/versions/c/plain-CWL/descriptor/%2Fpotato Dockstore.json'
+      ga4ghPath + '/tools/%23workflow%2Fa%2Fb/versions/c/PLAIN_CWL/descriptor/%2Fpotato Dockstore.json'
     );
   }));
   it('should getConsonanceString', inject([WorkflowLaunchService], (service: WorkflowLaunchService) => {

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -60,7 +60,7 @@ export class WorkflowLaunchService extends LaunchService {
     const id = encodeURIComponent(ga4ghWorkflowIdPrefix + path);
     return (
       `cwl-runner ${Dockstore.API_URI}${ga4ghPath}/tools/${id}` +
-      `/versions/${encodeURIComponent(versionName)}/plain-CWL/descriptor/${mainDescriptor} Dockstore.json`
+      `/versions/${encodeURIComponent(versionName)}/PLAIN_CWL/descriptor/${mainDescriptor} Dockstore.json`
     );
   }
 

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -122,6 +122,23 @@ $kim-gray: (
   ),
 );
 
+$kim-accent-4: (
+  1: #f4511e,
+  2: #ff6e40,
+  3: #ff9370,
+  4: #ffbea9,
+  5: #ffdbcf,
+  6: #fff0eb,
+  contrast: (
+    1: white,
+    2: white,
+    3: black,
+    4: black,
+    5: black,
+    6: black,
+  ),
+);
+
 // main color is assumed to be 2 based on prevalence of it on the home page (buttons). It's also called default in zeplin
 // 1 is the darker version of it because it's the only one that's darker
 // 4 was arbitarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
@@ -130,6 +147,7 @@ $dockstore-app-accent: mat.define-palette($kim-secondary, 2, 4, 1);
 $dockstore-app-error: mat.define-palette($kim-error, 2, 4, 1);
 $dockstore-app-warn: mat.define-palette($kim-warn, 2, 4, 1);
 $dockstore-app-accent-1: mat.define-palette($kim-accent1-success, 2, 4, 1);
+$dockstore-app-accent-4: mat.define-palette($kim-accent-4, 2, 4, 1);
 
 // 4 and 1 were chosen as darker and lighter versions, respectively, because those were used in styles.
 // Main color was chosen arbitrarily to be between darker and lighter.

--- a/test/db_dump.sql
+++ b/test/db_dump.sql
@@ -1536,7 +1536,7 @@ steps:
     run: wc.cwl
     in:
       infiles: grep/outfile
-out: [outfile]
+    out: [outfile]
 ', 'grep-and-count.cwl', 'DOCKSTORE_CWL', NULL, NULL);
 INSERT INTO public.sourcefile (id, content, path, type, dbcreatedate, dbupdatedate) VALUES (31, 'cwlVersion: v1.0
 class: CommandLineTool


### PR DESCRIPTION
**Description**
This PR allows organization admins to interact with pending and rejected invitations. It relies on this webservice PR https://github.com/dockstore/dockstore/pull/5243. 

The UI closely follows this [mock-up](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c28cebb6cf41a28cc204e), but there's some deviations based on what I thought made the most sense for us.
- Pending invitations don't have a `Resend Invite` button because I don't think that makes sense for us. Instead, they have the `Edit` button so an admin can edit the invitation role
- There was no mock-up for rejected invites, but I made them look like pending invitations, except instead of an `Edit` button, it has a `Resend Invite` button 

Functionality changes:
- Organization admins can view pending and rejected invitations.
- For pending invitations, they can:
  - Edit the member role
  - Delete the invitation
- For rejected invitations, they can:
  - Resend the invite (the requested user will see it in their requests tab)
  - Delete the invitation. Rejected invitations do not go away on their own. The admin must delete it to remove the organization user.
- The functionality of accepted members remains the same. Admins can edit their roles or remove them from the organization
- The members count displayed in the Members tab includes pending and rejected invitations for the admin. The public view only shows accepted members
- The members are displayed in one column if the user can edit membership so that the buttons can fit without overlapping in the card. This also matches the mock-up
- Updated the Add User button to Invite a Member to match the mock-up. Also updated the dialog to match this [mock-up](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c2802942e481ec7cb7d63).

Other changes:
- Noticed some tests in organization.ts were being skipped, so I removed `.skip` and updated them so they pass
- Remove duplicate function declarations in constants.ts
- Updated some related dialog button texts to match the other re-designed dialogs we have
  - Ex: `No thanks` -> `Cancel`
- Updated the Add Collection button so it matches the mock-up because I also updated the Member's Add User button to match the mock-up
- Made a small change in a CWL workflow file in the db dump because it was causing two tests to fail. It wasn't revealed before because the UI tests were using the 1.13.0 webservice artifact and not what's latest in develop.
  - This workflow was causing a `Unprocessable Entity: Unable to parse CWL workflow` when getting the tools json table. The fix was to fix the indentation of one line in the workflow file

I attached some screenshots and videos to show the UI and the functionality. The videos don't work for me in Firefox so if the same happens to you, try Chrome.

Organization admin view before:
![Screenshot 2022-11-17 at 13-18-23 Dockstore Organization](https://user-images.githubusercontent.com/25287123/202526558-f4b46e77-da49-4236-a105-08ec629db0e3.png)

Organization admin view after:
![image](https://user-images.githubusercontent.com/25287123/202527262-cca0a525-16c9-4509-ad23-a77d7090ad59.png)

Admin interacting with pending invitation:

https://user-images.githubusercontent.com/25287123/202487052-9f92c777-94eb-4dc1-8520-470c0e0b6fca.mp4

Admin resending invite for rejected invitation:

https://user-images.githubusercontent.com/25287123/202485656-add5a7b4-8383-4687-842f-78be720fedb7.mp4

Admin deleting rejected invitation:

https://user-images.githubusercontent.com/25287123/202485728-9421a355-2b8a-44b3-943b-98a582a48fd6.mp4

Admin interacting with accepted invitation:

https://user-images.githubusercontent.com/25287123/202485788-097419f9-2545-4cbd-8555-ca300421012d.mp4

I'll update the CircleCI jar to one off the develop branch after I merge the webservice PR

**Review Instructions**
- Create an organization and invite users to it. Verify that users who haven't accepted the invite yet are displayed in the Members tab and that you can edit the member's role and delete the invitation.
- Invite a user then have that user reject the invite. Verify that the user shows up in the Members tab and that you can resend an invitation to the user. This should update the invitation from Rejected Invitation to Pending Invitation.

**Issue**
https://github.com/dockstore/dockstore/issues/4226 
[DOCK-1781](https://ucsc-cgl.atlassian.net/browse/DOCK-1781)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
  - Might be better to wait for the new dashboard My Organizations to be implemented before updating the docs
