### PR TITLE
DOCK-2240 New dashboard add Preview button 

### DIFF
--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -3,9 +3,9 @@
     <div id="workflow-number" fxLayout="row">
       <mat-card-header fxLayout="row">
         <mat-card-title>{{ entryTypeLowerCase | titlecase }}s</mat-card-title>
-        <span class="bubble" id="bubble-green" *ngIf="entryTypeLowerCase === 'workflow'">{{ totalEntries }}</span>
-        <span class="bubble" id="bubble-blue" *ngIf="entryTypeLowerCase === 'tool'">{{ totalEntries }}</span>
-        <span class="bubble" id="bubble-orange" *ngIf="entryTypeLowerCase === 'service'">{{ totalEntries }}</span>
+        <span class="bubble workflow-background" *ngIf="entryType === entryTypeEnum.WORKFLOW">{{ totalEntries }}</span>
+        <span class="bubble container-background" *ngIf="entryType === entryTypeEnum.TOOL">{{ totalEntries }}</span>
+        <span class="bubble service-background" *ngIf="entryType === entryTypeEnum.SERVICE">{{ totalEntries }}</span>
       </mat-card-header>
     </div>
     <button

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -1,3 +1,19 @@
+<!--
+  ~    Copyright 2022 OICR, UCSC
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
 <mat-card class="h-100">
   <div id="header-bar" fxLayout="row" fxLayoutGap="5px" class="space-between">
     <div id="workflow-number" fxLayout="row">

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -3,7 +3,9 @@
     <div id="workflow-number" fxLayout="row">
       <mat-card-header fxLayout="row">
         <mat-card-title>{{ entryTypeLowerCase | titlecase }}s</mat-card-title>
-        <span class="bubble">{{ totalEntries }}</span>
+        <span class="bubble" id="bubble-green" *ngIf="entryTypeLowerCase === 'workflow'">{{ totalEntries }}</span>
+        <span class="bubble" id="bubble-blue" *ngIf="entryTypeLowerCase === 'tool'">{{ totalEntries }}</span>
+        <span class="bubble" id="bubble-orange" *ngIf="entryTypeLowerCase === 'service'">{{ totalEntries }}</span>
       </mat-card-header>
     </div>
     <button

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -22,6 +22,7 @@
         <span class="bubble workflow-background" *ngIf="entryType === entryTypeEnum.WORKFLOW">{{ totalEntries }}</span>
         <span class="bubble container-background" *ngIf="entryType === entryTypeEnum.TOOL">{{ totalEntries }}</span>
         <span class="bubble service-background" *ngIf="entryType === entryTypeEnum.SERVICE">{{ totalEntries }}</span>
+        <span class="bubble preview-bubble" *ngIf="entryType === entryTypeEnum.SERVICE">PREVIEW</span>
       </mat-card-header>
     </div>
     <button

--- a/src/app/home-page/widget/entry-box/entry-box.component.scss
+++ b/src/app/home-page/widget/entry-box/entry-box.component.scss
@@ -4,15 +4,3 @@
 .entries-container {
   height: 95%;
 }
-
-#bubble-green {
-  background-color: $workflow-selection-color;
-}
-
-#bubble-blue {
-  background-color: $tool-selection-color;
-}
-
-#bubble-orange {
-  background-color: $service-selection-color;
-}

--- a/src/app/home-page/widget/entry-box/entry-box.component.scss
+++ b/src/app/home-page/widget/entry-box/entry-box.component.scss
@@ -4,3 +4,15 @@
 .entries-container {
   height: 95%;
 }
+
+#bubble-green {
+  background-color: $workflow-selection-color;
+}
+
+#bubble-blue {
+  background-color: $tool-selection-color;
+}
+
+#bubble-orange {
+  background-color: $service-selection-color;
+}

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -22,6 +22,7 @@ export class EntryBoxComponent extends Base implements OnInit {
     | typeof EntryUpdateTime.EntryTypeEnum.SERVICE
     | typeof EntryUpdateTime.EntryTypeEnum.WORKFLOW;
   entryTypeLowerCase: string;
+  public entryTypeEnum = EntryUpdateTime.EntryTypeEnum;
   filterText: string;
   listOfEntries: Array<EntryUpdateTime> = [];
   helpLink: string;

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2022 OICR, UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License")
+ *    you may not use this file except in compliance with the License
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 import { Component, Input, OnInit } from '@angular/core';
 import { EntryType } from 'app/shared/enum/entry-type';
 import { EntryUpdateTime, UsersService } from 'app/shared/openapi';

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -1,6 +1,6 @@
 @use '@angular/material' as mat;
 /*
- *     Copyright 2018 OICR
+ *     Copyright 2022 OICR, UCSC
  *
  *     Licensed under the Apache License, Version 2.0 (the "License")
  *     you may not use this file except in compliance with the License

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -159,6 +159,7 @@ $workflow-background-color: #f6fefc;
 $workflow-selection-color: #d2fbf0;
 
 $service-color: #ff6c44;
+$service-selection-color: #ffdbcf;
 
 // Color used to indicate success in general (of an operation, verified badge, etc).
 $accent-3-dark: #00bfa5 !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -897,13 +897,19 @@ app-workflow-sidebar-accordion
 // Set the background to the color associated with containers (blue).
 // Used to set the background color in bubbles.
 .container-background {
-  background: #d0effd !important;
+  background: $tool-selection-color !important;
 }
 
 // Set the background to the color associated with workflows (green).
 // Used to set the background color in bubbles.
 .workflow-background {
-  background: #d2fbf0 !important;
+  background: $workflow-selection-color !important;
+}
+
+// Set the background to the color associated with services (orange).
+// Used to set the background color in bubbles.
+.service-background {
+  background: $service-selection-color !important;
 }
 
 // Styles an element as a "bubble", which is a small very-rounded rectangular element that typically contains a word or short phrase.

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -928,6 +928,12 @@ app-workflow-sidebar-accordion
   background: mat.get-color-from-palette($dockstore-app-gray, lighter);
 }
 
+.preview-bubble {
+  color: white !important;
+  background-color: mat.get-color-from-palette($kim-primary, 3);
+  margin: 0 1.25rem;
+}
+
 // Remove any default link styling from a bubble, and ensure the font-weight is correct.
 a.bubble,
 a.bubble:hover,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,5 @@
 /*!
- *    Copyright 2016 OICR
+ *    Copyright 2022 OICR, UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**
This PR adds a "PREVIEW" button shown on the zeplin mockups.

Before fix: 
![image](https://user-images.githubusercontent.com/61166764/204880628-02677780-263a-4804-a953-ae3ed9f3eea7.png)

After fix: 
![Screenshot from 2022-11-30 13-16-02](https://user-images.githubusercontent.com/61166764/204880680-c4199ca5-83e2-4f6c-85f5-1797734c5115.png)

**Review Instructions**
Verfify this button is present after these PR changes

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2240
https://github.com/dockstore/dockstore-ui2/pull/1638

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
