### PR TITLE
DOCK-2240: added preview button

### DIFF
--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -17,7 +17,7 @@ import { approvePotatoMembership, approvePotatoOrganization, resetDB, setTokenUs
 import { TokenUser } from '../../../src/app/shared/swagger';
 import { TokenSource } from '../../../src/app/shared/enum/token-source.enum';
 
-const imageURL = 'https://fakeUrl.com/potato.png';
+const imageURL = 'https://superduperfakepotatourl.com/potato.png';
 describe('Dockstore Organizations', () => {
   resetDB();
   setTokenUserViewPort();

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -22,6 +22,7 @@
         <span class="bubble workflow-background" *ngIf="entryType === entryTypeEnum.WORKFLOW">{{ totalEntries }}</span>
         <span class="bubble container-background" *ngIf="entryType === entryTypeEnum.TOOL">{{ totalEntries }}</span>
         <span class="bubble service-background" *ngIf="entryType === entryTypeEnum.SERVICE">{{ totalEntries }}</span>
+        <span class="bubble preview-bubble" *ngIf="entryType === entryTypeEnum.SERVICE">PREVIEW</span>
       </mat-card-header>
     </div>
     <button

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -928,6 +928,12 @@ app-workflow-sidebar-accordion
   background: mat.get-color-from-palette($dockstore-app-gray, lighter);
 }
 
+.preview-bubble {
+  color: white !important;
+  background-color: mat.get-color-from-palette($kim-primary, 3);
+  margin: 0 1.25rem;
+}
+
 // Remove any default link styling from a bubble, and ensure the font-weight is correct.
 a.bubble,
 a.bubble:hover,


### PR DESCRIPTION
**Description**
This PR adds a "PREVIEW" button onto the new dashboard as shown in the zeplin mockups.

Before fix: 
![image](https://user-images.githubusercontent.com/61166764/204883591-cc636ee9-0347-456d-822e-c553064ea7c3.png)

After fix: 
![Screenshot from 2022-11-30 13-16-02](https://user-images.githubusercontent.com/61166764/204883647-9560daaf-64ac-458c-9d99-50f2b7169da2.png)

**Review Instructions**
Review the newly added bubble matches the zeplin mockup correctly

**Issue**
https://github.com/dockstore/dockstore/issues/5124

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
