### PR TITLE
DOCK-2271: fixed twitter widget width value

### DIFF
--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -17,7 +17,7 @@ import { approvePotatoMembership, approvePotatoOrganization, resetDB, setTokenUs
 import { TokenUser } from '../../../src/app/shared/swagger';
 import { TokenSource } from '../../../src/app/shared/enum/token-source.enum';
 
-const imageURL = 'https://fakeUrl.com/potato.png';
+const imageURL = 'https://superduperfakepotatourl.com/potato.png';
 describe('Dockstore Organizations', () => {
   resetDB();
   setTokenUserViewPort();

--- a/src/app/shared/twitter.service.ts
+++ b/src/app/shared/twitter.service.ts
@@ -73,6 +73,7 @@ export class TwitterService {
       .createTimeline({ sourceType: 'url', url: 'https://twitter.com/dockstoreOrg' }, nativeElement, {
         theme: 'light',
         tweetLimit: tweetLimit,
+        width: '100%',
       })
       .then((embed) => {
         // console.log(embed);


### PR DESCRIPTION
**Description**
This PR fixes the broken twitter widget on the homepage of Dockstore.

The cause of this issue was due to the widget's width being set to `1px`. This PR overrides this value and sets the width to `100%`.

Before fix:
![Screenshot from 2022-11-30 15-24-22](https://user-images.githubusercontent.com/61166764/204900768-eb08c053-94a7-4426-aa32-3fb86e423bf5.png)

After fix: 
![Screenshot from 2022-11-30 15-24-35](https://user-images.githubusercontent.com/61166764/204900783-cef11527-2712-4401-8aff-0e1aa266e580.png)

**Review Instructions**
Verify that the twitter feed correctly shows on local following this change.

**Issue**
https://github.com/dockstore/dockstore/issues/5217

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
