### PR TITLE
Don't requests hits for sidebar ES query

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -43,8 +43,7 @@ export class QueryBuilderService {
     return toolQuery;
   }
 
-  getSidebarQuery(
-    query_size: number,
+  getSidebarAggregationQuery(
     values: string,
     advancedSearchObject: AdvancedSearchObject,
     searchTerm: boolean,
@@ -54,7 +53,8 @@ export class QueryBuilderService {
     index: 'workflows' | 'tools'
   ): string {
     const count = this.getNumberOfFilters(filters);
-    let sidebarBody = bodybuilder().size(query_size);
+    // Size to 0 here because https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#agg-caches
+    let sidebarBody = bodybuilder().size(0);
     sidebarBody = this.excludeContent(sidebarBody);
     sidebarBody = sidebarBody.query('match', '_index', index);
     sidebarBody = this.appendQuery(sidebarBody, values, advancedSearchObject, searchTerm);

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -434,8 +434,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     // The second query updates the result table
     const advancedSearchObject = this.advancedSearchQuery.getValue().advancedSearch;
     const values = this.advancedSearchQuery.getValue().searchText;
-    const sideBarQuery = this.queryBuilderService.getSidebarQuery(
-      this.query_size,
+    const sideBarQuery = this.queryBuilderService.getSidebarAggregationQuery(
       values,
       advancedSearchObject,
       this.searchTerm,


### PR DESCRIPTION
**Description**
Set the size of the sidebar query to 0. This will still return aggregations, which is all the UI processes, but it will not return the actual hits.

Since getSidebarQuery() is an aggregation query (see comment in search.component.ts two lines up from where it is invoked), rename the method to make that clearer.

**Review Instructions**
Go to the search page and click the facets. Make sure it works in general, and that the numbers are specifically make sense.  Compare qa with prod, where the databases are fairly similar.

In addition, make sure the query is faster. The `took` field should probably be a single digit (see dockstore/dockstore#5257).

**Issue**
dockstore/dockstore#5257

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
