### PR TITLE
Fix s3 upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ jobs:
   upload_to_s3:
     working_directory: ~/repo
     docker:
-      - image: cimg/python:2.7
+      - image: cimg/python:3.11
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
**Description**
PR #1658 broke s3 uploads. This fixes it, hopefully.

We require Node 18, which doesn't run on Ubuntu 18. The `cimg/python:2.7` image is an Ubuntu 18 image.
I couldn't find an Ubuntu 20 image for python 2.x, so upgrade so go to 3.11.

How this slipped through:

1. The audit CI step failed because it was running node18 against the develop branch CircleCI. To get this working would have required a one time fix (run audits against develop on with node16, but then switch back to node 18 after PR merged).
2. So I manually ran `npm audit` to verify that audits were better with the PR and merged
3. But, s3_upload only works if audits pass.

**Review Instructions**
The s3_upload step in CircleCI should work.

**Issue**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
