### PR TITLE
re-order and recommend github apps for tools

### DIFF
--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -40,7 +40,7 @@ describe('GitHub App Tools', () => {
       // Registration
       cy.get('#register_tool_button').click();
       cy.contains('Register using GitHub Apps');
-      cy.get('#3-register-workflow-option').click();
+      cy.get('#GitHubApps-register-workflow-option').click();
       cy.contains('Install our GitHub App on your');
       cy.get('.modal-footer').contains('Next').first().click();
       cy.contains('Navigate to GitHub to install our GitHub app');

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -52,10 +52,10 @@
     </mat-step>
     <mat-step>
       <ng-template matStepLabel>Create a tool</ng-template>
-      <div *ngIf="selectedOption?.value === 0">
+      <div *ngIf="selectedOption?.value === OptionChoice.QuayAuto">
         <app-refresh-wizard></app-refresh-wizard>
       </div>
-      <div *ngIf="selectedOption?.value === 3">
+      <div *ngIf="selectedOption?.value === OptionChoice.GitHubApps">
         <p>
           Navigate to GitHub to install our GitHub app on your repositories/organizations. See our
           <a
@@ -79,7 +79,7 @@
         </div>
       </div>
       <form
-        *ngIf="selectedOption?.value === 1"
+        *ngIf="selectedOption?.value === OptionChoice.Remote"
         #registerToolForm="ngForm"
         name="registerToolForm"
         class="form-horizontal"
@@ -372,7 +372,7 @@
         </div>
       </form>
       <form
-        *ngIf="selectedOption?.value === 2"
+        *ngIf="selectedOption?.value === OptionChoice.Hosted"
         #registerHostedToolForm="ngForm"
         name="registerHostedToolForm"
         class="form-horizontal"

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -33,7 +33,7 @@
             class="radio-button"
             *ngFor="let option of options"
             [value]="option"
-            [id]="option.value + '-register-workflow-option'"
+            [id]="OptionChoice[option.value] + '-register-workflow-option'"
             data-cy="storage-type-choice"
           >
             <span class="text-wrap">

--- a/src/app/container/register-tool/register-tool.component.ts
+++ b/src/app/container/register-tool/register-tool.component.ts
@@ -32,6 +32,13 @@ interface HostedTool {
   entryName?: string;
 }
 
+enum OptionChoice {
+  GitHubApps,
+  Hosted,
+  QuayAuto,
+  Remote,
+}
+
 @Component({
   selector: 'app-register-tool',
   templateUrl: './register-tool.component.html',
@@ -56,31 +63,37 @@ export class RegisterToolComponent implements OnInit, AfterViewChecked, OnDestro
     registryProvider: 'Quay.io',
     entryName: undefined,
   };
+
+  public get OptionChoice() {
+    return OptionChoice;
+  }
+
   public options = [
     {
-      label: 'Quickly register Quay.io tools',
-      extendedLabel: 'Select repositories from Quay.io to quickly create tools on Dockstore.',
-      value: 0,
-    },
-    {
-      label: 'Create tool with descriptor(s) on remote sites',
+      label: 'Register using GitHub Apps (Recommended)',
       extendedLabel:
-        'Manually add individual tools with descriptor(s) from sites like GitHub, BitBucket, and GitLab. Docker images are stored on sites like Quay.io and DockerHub.',
-      value: 1,
+        'Install our GitHub App on your repository/organization to automatically sync tools with GitHub. Allows you to register a tool descriptor without linking to a Docker image you own.',
+      value: OptionChoice.GitHubApps,
     },
     {
       label: 'Create tool with descriptor(s) on Dockstore.org',
       extendedLabel:
         'Manually add individual tools with descriptor(s) stored on Dockstore.org. Docker images are stored on sites like Quay.io and DockerHub.',
-      value: 2,
+      value: OptionChoice.Hosted,
     },
     {
-      label: 'Register using GitHub Apps',
+      label: 'Quickly register Quay.io tools',
+      extendedLabel: 'Select repositories from Quay.io to quickly create tools on Dockstore.',
+      value: OptionChoice.QuayAuto,
+    },
+    {
+      label: 'Create tool with descriptor(s) on remote sites',
       extendedLabel:
-        'Install our GitHub App on your repository/organization to automatically sync tools with GitHub. Allows you to register a tool descriptor without linking to a Docker image you own.',
-      value: 3,
+        'Manually add individual tools with descriptor(s) from sites like GitHub, BitBucket, and GitLab. Docker images are stored on sites like Quay.io and DockerHub.',
+      value: OptionChoice.Remote,
     },
   ];
+
   public selectedOption = this.options[0];
   private ngUnsubscribe: Subject<{}> = new Subject();
   Dockstore = Dockstore;


### PR DESCRIPTION
**Description**
Recommend GitHub app registration for tools

**Review Instructions**
GitHub apps is now the recommended tool (not just workflow) registration type.
Dialog box should work when trying different options

**Issue**
https://github.com/dockstore/dockstore/issues/4857

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
