### PR TITLE
Update to the latest web service

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/8924/workflows/b7c31d89-45f9-4b02-a893-2f17f8224199/jobs/26631/artifacts",
-    "circle_build_id": "26631",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9018/workflows/2efa2b50-9cc1-4c36-b1de-c563bfa36d55/jobs/27233/artifacts",
+    "circle_build_id": "27233",
     "base_branch": "develop"
   },
   "scripts": {

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
 
 echo "${ARTIFACT_URL}"


### PR DESCRIPTION
**Description**
Updates to the latest web service.

Needed to update `get-circleci-artifact-url.sh` because of web service parallel unit test builds -- the openapi.yaml and swagger.yaml files are uploaded twice because of parallel builds; `https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts` now returns two urls for each artifact. So convert the result to an array and grab the first one -- should continue to work even if we turn off parallel builds, or if we have enough tests and the artifacts are uploaded 3 times. 

The first (brief) attempt was to get rid of two uploads in the web service, but it didn't work; there were dependencies on the uploaded artifacts within the web service.

**Review Instructions**
If it builds, it works.

**Issue**
No issue created -- just noticed it was out of date.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
