### PR TITLE
Replace cypress route() with intercept()

### DIFF
--- a/cypress/integration/group1/checkerWorkflowFromTools.ts
+++ b/cypress/integration/group1/checkerWorkflowFromTools.ts
@@ -34,8 +34,7 @@ describe('Checker workflow test from my-tools', () => {
 
   describe('Should be able to register and publish a checker workflow from a tool', () => {
     it('visit a tool and have the correct buttons and be able to register a checker workflow', () => {
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.wait('@getTool');
       goToB3();
 
@@ -56,8 +55,7 @@ describe('Checker workflow test from my-tools', () => {
       cy.get('#viewCheckerWorkflowButton').should('be.visible');
     });
     it('visit the tool and its checker workflow and have the correct buttons', () => {
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.wait('@getTool');
       goToB3();
       // In the parent tool right now
@@ -90,8 +88,7 @@ describe('Checker workflow test from my-tools', () => {
       cy.get('#viewCheckerWorkflowButton').should('be.visible');
     });
     it('visit the tool and have its publish/unpublish reflected in the checker workflow', () => {
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.wait('@getTool');
       goToB3();
       // In the parent tool right now

--- a/cypress/integration/group1/checkerWorkflowFromWorkflow.ts
+++ b/cypress/integration/group1/checkerWorkflowFromWorkflow.ts
@@ -37,7 +37,6 @@ describe('Checker workflow test from my-workflows', () => {
 
   describe('Should be able to register and publish a checker workflow from a workflow', () => {
     it('visit a tool and have the correct buttons and be able to register a checker workflow', () => {
-      cy.server();
       getWorkflow();
       cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
       cy.get('#viewCheckerWorkflowButton').should('not.exist');
@@ -50,7 +49,7 @@ describe('Checker workflow test from my-workflows', () => {
       cy.get('#checkerWorkflowPath').type('/Dockstore.cwl');
       cy.get('#checkerWorkflowTestParameterFilePath').type('/test.json');
       cy.fixture('refreshedChecker').then((json) => {
-        cy.route({
+        cy.intercept({
           method: 'GET',
           url: '/api/workflows/*/refresh',
           response: json,

--- a/cypress/integration/group1/checkerWorkflowFromWorkflow.ts
+++ b/cypress/integration/group1/checkerWorkflowFromWorkflow.ts
@@ -49,10 +49,8 @@ describe('Checker workflow test from my-workflows', () => {
       cy.get('#checkerWorkflowPath').type('/Dockstore.cwl');
       cy.get('#checkerWorkflowTestParameterFilePath').type('/test.json');
       cy.fixture('refreshedChecker').then((json) => {
-        cy.intercept({
-          method: 'GET',
-          url: '/api/workflows/*/refresh',
-          response: json,
+        cy.intercept('GET', '/api/workflows/*/refresh', {
+          body: json,
         });
         cy.get('#submitButton').click();
       });

--- a/cypress/integration/group1/hostedTools.ts
+++ b/cypress/integration/group1/hostedTools.ts
@@ -22,10 +22,7 @@ describe('Dockstore hosted tools', () => {
   beforeEach(() => {
     cy.visit('/my-tools');
 
-    cy.intercept({
-      method: 'GET',
-      url: /containers\/.+\/zip\/.+/,
-    }).as('downloadZip');
+    cy.intercept('GET', /containers\/.+\/zip\/.+/).as('downloadZip');
   });
 
   function getTool() {

--- a/cypress/integration/group1/hostedWorkflows.ts
+++ b/cypress/integration/group1/hostedWorkflows.ts
@@ -29,10 +29,7 @@ describe('Dockstore hosted workflows', () => {
   beforeEach(() => {
     cy.visit('/my-workflows');
 
-    cy.intercept({
-      method: 'GET',
-      url: /workflows\/.+\/zip\/.+/,
-    }).as('downloadZip');
+    cy.intercept('GET', /workflows\/.+\/zip\/.+/).as('downloadZip');
   });
 
   function getWorkflow() {

--- a/cypress/integration/group2/aliases.ts
+++ b/cypress/integration/group2/aliases.ts
@@ -22,31 +22,27 @@ describe('Dockstore aliases', () => {
 
   describe('Find workflow version by alias', () => {
     it('workflow version alias', () => {
-      cy.server();
-      cy.route({
-        url: '*/aliases/workflow-versions/w11wv13alias',
-        method: 'GET',
-        status: 200,
-        response: { fullWorkflowPath: 'github.com/A/l', tagName: 'master' },
+      cy.intercept('GET', '*/aliases/workflow-versions/w11wv13alias', {
+        body: {
+          fullWorkflowPath: 'github.com/A/l',
+          tagName: 'master',
+        },
+        statusCode: 200,
       });
       cy.visit('/aliases/workflow-versions/w11wv13alias');
       cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=info');
     });
 
     it('invalid workflow version alias type', () => {
-      cy.server();
       cy.visit('/aliases/foobar/fakeAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/aliases/foobar/fakeAlias');
       cy.contains('foobar is not a valid type');
     });
 
     it('workflow version alias incorrect', () => {
-      cy.server();
-      cy.route({
-        url: '*/aliases/workflow-versions/incorrectAlias',
-        method: 'GET',
-        status: 404,
-        response: {},
+      cy.intercept('GET', '*/aliases/workflow-versions/incorrectAlias', {
+        body: {},
+        statusCode: 404,
       });
       cy.visit('/aliases/workflow-versions/incorrectAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/aliases/workflow-versions/incorrectAlias');

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -398,22 +398,15 @@ describe('Dockstore my workflows', () => {
         path: 'foobar/doesNotExist',
       };
 
-      cy.server()
-        .route({
-          method: 'GET',
-          url: 'api/users/registries',
-          response: ['github.com', 'bitbucket.org'],
-        })
-        .route({
-          method: 'GET',
-          url: 'api/users/registries/github.com/organizations',
-          response: ['foobar', 'lorem'],
-        })
-        .route({
-          method: 'GET',
-          url: 'api/users/registries/github.com/organizations/foobar',
-          response: [canDeleteMe, cannotDeleteMe, doesNotExist],
-        });
+      cy.intercept('GET', 'api/users/registries', {
+        body: ['github.com', 'bitbucket.org'],
+      });
+      cy.intercept('GET', 'api/users/registries/github.com/organizations', {
+        body: ['foobar', 'lorem'],
+      });
+      cy.intercept('GET', 'api/users/registries/github.com/organizations/foobar', {
+        body: [canDeleteMe, cannotDeleteMe, doesNotExist],
+      });
 
       cy.visit('/my-workflows');
       cy.get('#registerWorkflowButton').should('be.visible').should('be.enabled').click();

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -34,9 +34,8 @@ describe('Dockstore my workflows', () => {
   });
 
   it('have action buttons which work', () => {
-    cy.server();
     cy.fixture('myWorkflows.json').then((json) => {
-      cy.route({
+      cy.intercept({
         url: '/api/users/1/workflows',
         method: 'PATCH',
         status: 200,
@@ -63,8 +62,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('Apps Logs').click();
       cy.contains('There were problems retrieving GitHub App logs for this organization.');
       cy.contains('Close').click();
-      cy.server();
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/lambdaEvents/**',
         response: [],
@@ -96,7 +94,7 @@ describe('Dockstore my workflows', () => {
           type: 'PUSH',
         },
       ];
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/lambdaEvents/**',
         response: realResponse,
@@ -260,10 +258,9 @@ describe('Dockstore my workflows', () => {
     });
 
     it('Should be able to request DOI and then export to ORCID', () => {
-      cy.server();
       // tokens.json indicates a Zenodo token and an ORCID token
       cy.fixture('tokens.json').then((json) => {
-        cy.route({
+        cy.intercept({
           url: '/api/users/1/tokens',
           method: 'GET',
           status: 200,
@@ -272,7 +269,7 @@ describe('Dockstore my workflows', () => {
       });
       // doiResponse.json has a workflow version with a DOI
       cy.fixture('doiResponse.json').then((json) => {
-        cy.route({
+        cy.intercept({
           url: '/api/**/requestDOI/*',
           method: 'PUT',
           status: 200,
@@ -281,7 +278,7 @@ describe('Dockstore my workflows', () => {
       });
       // orcidExportResponse.json has a workflow version with an ORCID put code
       cy.fixture('orcidExportResponse.json').then((json) => {
-        cy.route({
+        cy.intercept({
           url: '/api/entries/*/exportToOrcid?versionId=*',
           method: 'POST',
           status: 200,
@@ -353,9 +350,8 @@ describe('Dockstore my workflows', () => {
   });
 
   it('Should refresh individual repo when refreshing organization', () => {
-    cy.server();
     cy.fixture('refreshedAslashl').then((json) => {
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/workflows/11/refresh',
         response: json,
@@ -555,8 +551,7 @@ describe('Should handle no workflows correctly', () => {
   resetDB();
   setTokenUserViewPortCurator(); // Curator has no workflows
   beforeEach(() => {
-    cy.server();
-    cy.route({
+    cy.intercept({
       method: 'GET',
       url: /github.com\/organizations/,
       response: ['dockstore'],

--- a/cypress/integration/group2/myworkflows.ts
+++ b/cypress/integration/group2/myworkflows.ts
@@ -35,11 +35,9 @@ describe('Dockstore my workflows', () => {
 
   it('have action buttons which work', () => {
     cy.fixture('myWorkflows.json').then((json) => {
-      cy.intercept({
-        url: '/api/users/1/workflows',
-        method: 'PATCH',
-        status: 200,
-        response: json,
+      cy.intercept('PATCH', '/api/users/1/workflows', {
+        body: json,
+        statusCode: 200,
       });
     });
 
@@ -62,10 +60,8 @@ describe('Dockstore my workflows', () => {
       cy.contains('Apps Logs').click();
       cy.contains('There were problems retrieving GitHub App logs for this organization.');
       cy.contains('Close').click();
-      cy.intercept({
-        method: 'GET',
-        url: '/api/lambdaEvents/**',
-        response: [],
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: [],
       }).as('refreshWorkflow');
       cy.contains('Apps Logs').click();
       cy.contains('There are no GitHub App logs for this organization.');
@@ -94,10 +90,8 @@ describe('Dockstore my workflows', () => {
           type: 'PUSH',
         },
       ];
-      cy.intercept({
-        method: 'GET',
-        url: '/api/lambdaEvents/**',
-        response: realResponse,
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: realResponse,
       }).as('refreshWorkflow');
       cy.contains('Apps Logs').click();
       cy.contains('2020-02-20T02:20');
@@ -260,29 +254,23 @@ describe('Dockstore my workflows', () => {
     it('Should be able to request DOI and then export to ORCID', () => {
       // tokens.json indicates a Zenodo token and an ORCID token
       cy.fixture('tokens.json').then((json) => {
-        cy.intercept({
-          url: '/api/users/1/tokens',
-          method: 'GET',
-          status: 200,
-          response: json,
+        cy.intercept('GET', '/api/users/1/tokens', {
+          body: json,
+          statusCode: 200,
         });
       });
       // doiResponse.json has a workflow version with a DOI
       cy.fixture('doiResponse.json').then((json) => {
-        cy.intercept({
-          url: '/api/**/requestDOI/*',
-          method: 'PUT',
-          status: 200,
-          response: json,
+        cy.intercept('PUT', '/api/**/requestDOI/*', {
+          body: json,
+          statusCode: 200,
         });
       });
       // orcidExportResponse.json has a workflow version with an ORCID put code
       cy.fixture('orcidExportResponse.json').then((json) => {
-        cy.intercept({
-          url: '/api/entries/*/exportToOrcid?versionId=*',
-          method: 'POST',
-          status: 200,
-          response: json,
+        cy.intercept('POST', '/api/entries/*/exportToOrcid?versionId=*', {
+          body: json,
+          statusCode: 200,
         });
       });
 
@@ -351,10 +339,8 @@ describe('Dockstore my workflows', () => {
 
   it('Should refresh individual repo when refreshing organization', () => {
     cy.fixture('refreshedAslashl').then((json) => {
-      cy.intercept({
-        method: 'GET',
-        url: '/api/workflows/11/refresh',
-        response: json,
+      cy.intercept('GET', '/api/workflows/11/refresh', {
+        body: json,
       }).as('refreshWorkflow');
     });
     cy.visit('/my-workflows/github.com/A/l');
@@ -551,10 +537,8 @@ describe('Should handle no workflows correctly', () => {
   resetDB();
   setTokenUserViewPortCurator(); // Curator has no workflows
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: /github.com\/organizations/,
-      response: ['dockstore'],
+    cy.intercept('GET', /github.com\/organizations/, {
+      body: ['dockstore'],
     });
   });
   it('My workflows should prompt to register a workflow', () => {

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -44,10 +44,8 @@ describe('Dockstore Organizations', () => {
   describe('Should need to link two external accounts', () => {
     beforeEach(() => {
       const userTokens: Array<TokenUser> = [{ tokenSource: TokenSource.DOCKSTORE, id: 1, username: 'user_A' }];
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/1/tokens',
-        response: userTokens,
+      cy.intercept('GET', '*/users/1/tokens', {
+        body: userTokens,
       });
     });
 
@@ -218,10 +216,8 @@ describe('Dockstore Organizations', () => {
           organization: { id: 2, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe' },
         },
       ];
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: memberships,
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: memberships,
       });
     });
 

--- a/cypress/integration/group2/organizations.ts
+++ b/cypress/integration/group2/organizations.ts
@@ -449,43 +449,33 @@ describe('Dockstore Organizations', () => {
 
   describe('Find organization and collection by alias', () => {
     it('organization alias', () => {
-      cy.server();
-      cy.route({
-        url: '*/organizations/fakeAlias/aliases',
-        method: 'GET',
-        status: 200,
-        response: { name: 'Potatoe' },
+      cy.intercept('GET', '*/organizations/fakeAlias/aliases', {
+        body: { name: 'Potatoe' },
+        statusCode: 200,
       });
       cy.visit('/aliases/organizations/fakeAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe');
     });
 
     it('collection alias', () => {
-      cy.server();
-      cy.route({
-        url: '*/organizations/collections/fakeAlias/aliases',
-        method: 'GET',
-        status: 200,
-        response: { organizationName: 'Potatoe', name: 'veryFakeCollectionName' },
+      cy.intercept('GET', '*/organizations/collections/fakeAlias/aliases', {
+        body: { organizationName: 'Potatoe', name: 'veryFakeCollectionName' },
+        statusCode: 200,
       });
       cy.visit('/aliases/collections/fakeAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe/collections/veryFakeCollectionName');
     });
 
     it('invalid alias type', () => {
-      cy.server();
       cy.visit('/aliases/foobar/fakeAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/aliases/foobar/fakeAlias');
       cy.contains('foobar is not a valid type');
     });
 
     it('organization alias incorrect', () => {
-      cy.server();
-      cy.route({
-        url: '*/organizations/incorrectAlias/aliases',
-        method: 'GET',
-        status: 404,
-        response: {},
+      cy.intercept('GET', '*/organizations/incorrectAlias/aliases', {
+        body: {},
+        statusCode: 404,
       });
       cy.visit('/aliases/organizations/incorrectAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/aliases/organizations/incorrectAlias');
@@ -493,12 +483,9 @@ describe('Dockstore Organizations', () => {
     });
 
     it('collection alias incorrect', () => {
-      cy.server();
-      cy.route({
-        url: '*/organizations/collections/incorrectAlias/aliases',
-        method: 'GET',
-        status: 404,
-        response: {},
+      cy.intercept('GET', '*/organizations/collections/incorrectAlias/aliases', {
+        body: {},
+        statusCode: 404,
       });
       cy.visit('/aliases/collections/incorrectAlias');
       cy.url().should('eq', Cypress.config().baseUrl + '/aliases/collections/incorrectAlias');

--- a/cypress/integration/group2/sharedWorkflows.ts
+++ b/cypress/integration/group2/sharedWorkflows.ts
@@ -31,55 +31,40 @@ describe('Shared with me workflow test from my-workflows', () => {
   beforeEach(() => {
     // Mock the shared with me workflows and permissions
     // TODO: There is probably a better approach to this which would allow for deeper testing of shared workflows
-    cy.server();
 
-    cy.route({
-      method: 'GET',
-      url: /readertest\/actions/,
-      response: ['READ'],
+    cy.intercept('GET', /readertest\/actions/, {
+      body: ['READ'],
     }).as('readerActions');
 
-    cy.route({
-      method: 'GET',
-      url: /writertest\/actions/,
-      response: ['READ', 'WRITE'],
+    cy.intercept('GET', /writertest\/actions/, {
+      body: ['READ', 'WRITE'],
     }).as('writerActions');
 
-    cy.route({
-      method: 'GET',
-      url: /ownertest\/actions/,
-      response: ['READ', 'WRITE', 'SHARE', 'DELETE'],
+    cy.intercept('GET', /ownertest\/actions/, {
+      body: ['READ', 'WRITE', 'SHARE', 'DELETE'],
     }).as('ownerActions');
 
     const readerWorkflow = createHostedWorkflow('readertest', 200);
     const writerWorkflow = createHostedWorkflow('writertest', 201);
     const ownerWorkflow = createHostedWorkflow('ownertest', 202);
-    cy.route({
-      method: 'GET',
-      url: '*shared*',
-      response: [
+    cy.intercept('GET', '*shared*', {
+      body: [
         { role: 'READER', workflows: [readerWorkflow] },
         { role: 'WRITER', workflows: [writerWorkflow] },
         { role: 'OWNER', workflows: [ownerWorkflow] },
       ],
     }).as('getSharedWorkflows');
 
-    cy.route({
-      method: 'GET',
-      url: '*/workflows/200*',
-      response: readerWorkflow,
+    cy.intercept('GET', '*/workflows/200*', {
+      body: readerWorkflow,
     }).as('getReaderWorkflow');
 
-    cy.route({
-      method: 'GET',
-      url: '*/workflows/201*',
-      response: writerWorkflow,
+    cy.intercept('GET', '*/workflows/201*', {
+      body: writerWorkflow,
     }).as('getWriterWorkflow');
 
-    cy.route({
-      method: 'GET',
-      url: '*/workflows/202*',
-      response: ownerWorkflow,
+    cy.intercept('GET', '*/workflows/202*', {
+      body: ownerWorkflow,
     }).as('getOwnerWorkflow');
 
     // Visit my-worklfows page

--- a/cypress/integration/group2/usernameChangeRequired.ts
+++ b/cypress/integration/group2/usernameChangeRequired.ts
@@ -21,7 +21,6 @@ describe('Testing user with invalid username', () => {
             avatarURL: undefined,
             bio: undefined,
             company: undefined,
-            email: undefined,
             location: undefined,
             name: '',
             username: 'user_A',
@@ -32,16 +31,11 @@ describe('Testing user with invalid username', () => {
         canChangeUsername: true,
       };
 
-      cy.server();
-      cy.route({
-        method: 'GET',
-        url: '*/users/user',
-        response: invalidUsernameUser,
+      cy.intercept('GET', '*/users/user', {
+        body: invalidUsernameUser,
       });
-      cy.route({
-        method: 'GET',
-        url: '*/users/user/extended',
-        response: canChangeUsername,
+      cy.intercept('GET', '*/users/user/extended', {
+        body: canChangeUsername,
       });
 
       cy.visit('/');

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -51,8 +51,7 @@ describe('GitHub App Tools', () => {
       cy.contains('Apps Logs').click();
       cy.contains('There were problems retrieving GitHub App logs for this organization.');
       cy.contains('Close').click();
-      cy.server();
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/lambdaEvents/**',
         response: [],
@@ -74,7 +73,7 @@ describe('GitHub App Tools', () => {
           type: 'PUSH',
         },
       ];
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/lambdaEvents/**',
         response: realResponse,

--- a/cypress/integration/group3/githubAppTools.ts
+++ b/cypress/integration/group3/githubAppTools.ts
@@ -51,10 +51,8 @@ describe('GitHub App Tools', () => {
       cy.contains('Apps Logs').click();
       cy.contains('There were problems retrieving GitHub App logs for this organization.');
       cy.contains('Close').click();
-      cy.intercept({
-        method: 'GET',
-        url: '/api/lambdaEvents/**',
-        response: [],
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: [],
       }).as('lambdaEvents');
       cy.contains('Apps Logs').click();
       cy.contains('There are no GitHub App logs for this organization.');
@@ -73,10 +71,8 @@ describe('GitHub App Tools', () => {
           type: 'PUSH',
         },
       ];
-      cy.intercept({
-        method: 'GET',
-        url: '/api/lambdaEvents/**',
-        response: realResponse,
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: realResponse,
       }).as('lambdaEvents');
       cy.contains('Apps Logs').click();
       cy.contains('1 – 1 of 1');

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -505,10 +505,8 @@ describe('Dockstore my tools', () => {
   });
   it('Should refresh individual repo when refreshing organization', () => {
     cy.fixture('refreshedTool5').then((json) => {
-      cy.intercept({
-        method: 'GET',
-        url: '/api/containers/5/refresh',
-        response: json,
+      cy.intercept('GET', '/api/containers/5/refresh', {
+        body: json,
       }).as('refreshEntry');
     });
     cy.visit('/my-tools/quay.io/A2/a');
@@ -549,10 +547,8 @@ describe('Should handle no tools correctly', () => {
   resetDB();
   setTokenUserViewPortCurator(); // Curator has no tools
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: /github.com\/organizations/,
-      response: ['dockstore'],
+    cy.intercept('GET', /github.com\/organizations/, {
+      body: ['dockstore'],
     });
   });
   it('My tools should prompt to register a tool', () => {

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -52,8 +52,7 @@ describe('Dockstore my tools', () => {
   describe('Should contain extended DockstoreTool properties', () => {
     it('visit another page then come back', () => {
       // The seemingly unnecessary visits are due to a detached-from-dom error even using cy.get().click();
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.get('a#home-nav-button').click();
       cy.get('[data-cy=dropdown-main]:visible').should('be.visible').click();
       cy.get('[data-cy=my-tools-nav-button]').click();
@@ -115,8 +114,7 @@ describe('Dockstore my tools', () => {
       cy.get('[data-cy=saveLabelButton]').should('not.exist');
     });
     it('add and remove test parameter file', () => {
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.wait('@getTool');
       selectUnpublishedTab('A2');
       selectTool('b1');
@@ -149,8 +147,7 @@ describe('Dockstore my tools', () => {
 
   describe('publish a tool', () => {
     it('publish and unpublish', () => {
-      cy.server();
-      cy.route('api/containers/*?include=validations').as('getTool');
+      cy.intercept('api/containers/*?include=validations').as('getTool');
       cy.wait('@getTool');
       selectUnpublishedTab('A2');
       selectTool('b1');
@@ -193,8 +190,7 @@ describe('Dockstore my tools', () => {
       cy.get('#publishToolButton').should('contain', 'Publish').click().should('contain', 'Unpublish').click().should('contain', 'Publish');
     });
     it('Be able to add tag with test parameter file', () => {
-      cy.server();
-      cy.route({
+      cy.intercept({
         method: 'PUT',
         url: 'api/containers/1/testParameterFiles?testParameterPaths=/test.json*',
       }).as('putTestParameterFile');
@@ -508,9 +504,8 @@ describe('Dockstore my tools', () => {
     });
   });
   it('Should refresh individual repo when refreshing organization', () => {
-    cy.server();
     cy.fixture('refreshedTool5').then((json) => {
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '/api/containers/5/refresh',
         response: json,
@@ -554,8 +549,7 @@ describe('Should handle no tools correctly', () => {
   resetDB();
   setTokenUserViewPortCurator(); // Curator has no tools
   beforeEach(() => {
-    cy.server();
-    cy.route({
+    cy.intercept({
       method: 'GET',
       url: /github.com\/organizations/,
       response: ['dockstore'],

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -190,10 +190,7 @@ describe('Dockstore my tools', () => {
       cy.get('#publishToolButton').should('contain', 'Publish').click().should('contain', 'Unpublish').click().should('contain', 'Publish');
     });
     it('Be able to add tag with test parameter file', () => {
-      cy.intercept({
-        method: 'PUT',
-        url: 'api/containers/1/testParameterFiles?testParameterPaths=/test.json*',
-      }).as('putTestParameterFile');
+      cy.intercept('PUT', 'api/containers/1/testParameterFiles?testParameterPaths=/test.json*').as('putTestParameterFile');
       cy.visit('/my-tools/amazon.dkr.ecr.test.amazonaws.com/A/a');
       cy.contains('Versions').click();
       cy.get('#addTagButton').click();

--- a/cypress/integration/group3/mytools.ts
+++ b/cypress/integration/group3/mytools.ts
@@ -190,7 +190,7 @@ describe('Dockstore my tools', () => {
       cy.get('#publishToolButton').should('contain', 'Publish').click().should('contain', 'Unpublish').click().should('contain', 'Publish');
     });
     it('Be able to add tag with test parameter file', () => {
-      cy.intercept('PUT', 'api/containers/1/testParameterFiles?testParameterPaths=/test.json*').as('putTestParameterFile');
+      cy.intercept('PUT', 'api/containers/1/testParameterFiles?testParameterPaths=%2Ftest.json*').as('putTestParameterFile');
       cy.visit('/my-tools/amazon.dkr.ecr.test.amazonaws.com/A/a');
       cy.contains('Versions').click();
       cy.get('#addTagButton').click();
@@ -233,30 +233,21 @@ describe('Dockstore my tools', () => {
         tool_path: 'public.ecr.aws/testnamespace/testname',
         custom_docker_registry_path: 'public.ecr.aws',
       };
-      cy.server()
-        .route({
-          method: 'GET',
-          url: /refresh/,
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: 'containers/40000',
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: /dockerfile/,
-          response: { content: 'FROM ubuntu:16.10' },
-        })
-        .route({
-          method: 'GET',
-          url: /cwl/,
-          response: {
-            content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
-            path: '/Dockstore.cwl',
-          },
-        });
+      cy.intercept('GET', /refresh/, {
+        body: toolObject,
+      });
+      cy.intercept('GET', 'containers/40000', {
+        body: toolObject,
+      });
+      cy.intercept('GET', /dockerfile/, {
+        body: { content: 'FROM ubuntu:16.10' },
+      });
+      cy.intercept('GET', /cwl/, {
+        body: {
+          content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
+          path: '/Dockstore.cwl',
+        },
+      });
       // Make sure page is loaded first
       cy.get('#tool-path').should('be.visible');
       cy.get('#register_tool_button').click();
@@ -306,30 +297,21 @@ describe('Dockstore my tools', () => {
         tool_path: 'amazon.dkr.ecr.test-1.amazonaws.com/testnamespace/testname',
         custom_docker_registry_path: 'amazon.dkr.ecr.test-1.amazonaws.com',
       };
-      cy.server()
-        .route({
-          method: 'GET',
-          url: /refresh/,
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: 'containers/40000',
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: /dockerfile/,
-          response: { content: 'FROM ubuntu:16.10' },
-        })
-        .route({
-          method: 'GET',
-          url: /cwl/,
-          response: {
-            content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
-            path: '/Dockstore.cwl',
-          },
-        });
+      cy.intercept('GET', /refresh/, {
+        body: toolObject,
+      });
+      cy.intercept('GET', 'containers/40000', {
+        body: toolObject,
+      });
+      cy.intercept('GET', /dockerfile/, {
+        body: { content: 'FROM ubuntu:16.10' },
+      });
+      cy.intercept('GET', /cwl/, {
+        body: {
+          content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
+          path: '/Dockstore.cwl',
+        },
+      });
       // Make sure page is loaded first
       cy.get('#tool-path').should('be.visible');
       cy.get('#register_tool_button').click();
@@ -422,30 +404,21 @@ describe('Dockstore my tools', () => {
         tool_path: 'images.sbgenomics.com/testnamespace/testname',
         custom_docker_registry_path: 'images.sbgenomics.com',
       };
-      cy.server()
-        .route({
-          method: 'GET',
-          url: /refresh/,
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: 'containers/40000',
-          response: toolObject,
-        })
-        .route({
-          method: 'GET',
-          url: /dockerfile/,
-          response: { content: 'FROM ubuntu:16.10' },
-        })
-        .route({
-          method: 'GET',
-          url: /cwl/,
-          response: {
-            content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
-            path: '/Dockstore.cwl',
-          },
-        });
+      cy.intercept('GET', /refresh/, {
+        body: toolObject,
+      });
+      cy.intercept('GET', 'containers/40000', {
+        body: toolObject,
+      });
+      cy.intercept('GET', /dockerfile/, {
+        body: { content: 'FROM ubuntu:16.10' },
+      });
+      cy.intercept('GET', /cwl/, {
+        body: {
+          content: `#!/usr/bin/env cwl-runner\n\nclass: CommandLineTool\n\ndct:contributor:\n  foaf:name: Andy Yang\n  foaf:mbox: mailto:ayang@oicr.on.ca\ndct:creator:\n  '@id': http://orcid.org/0000-0001-9102-5681\n  foaf:name: Andrey Kartashov\n  foaf:mbox: mailto:Andrey.Kartashov@cchmc.org\ndct:description: 'Developed at Cincinnati Children’s Hospital Medical Center for the\n  CWL consortium http://commonwl.org/ Original URL: https://github.com/common-workflow-language/workflows'\ncwlVersion: v1.0\n\nrequirements:\n- class: DockerRequirement\n  dockerPull: quay.io/cancercollaboratory/dockstore-tool-samtools-rmdup:1.0\ninputs:\n  single_end:\n    type: boolean\n    default: false\n    doc: |\n      rmdup for SE reads\n  input:\n    type: File\n    inputBinding:\n      position: 2\n\n    doc: |\n      Input bam file.\n  output_name:\n    type: string\n    inputBinding:\n      position: 3\n\n  pairend_as_se:\n    type: boolean\n    default: false\n    doc: |\n      treat PE reads as SE in rmdup (force -s)\noutputs:\n  rmdup:\n    type: File\n    outputBinding:\n      glob: $(inputs.output_name)\n\n    doc: File with removed duplicates\nbaseCommand: [samtools, rmdup]\ndoc: |\n  Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. In the paired-end mode, this command ONLY works with FR orientation and requires ISIZE is correctly set. It does not work for unpaired reads (e.g. two ends mapped to different chromosomes or orphan reads).\n\n  Usage: samtools rmdup [-sS] <input.srt.bam> <out.bam>\n  Options:\n    -s       Remove duplicates for single-end reads. By default, the command works for paired-end reads only.\n    -S       Treat paired-end reads and single-end reads.\n\n`,
+          path: '/Dockstore.cwl',
+        },
+      });
       cy.get('#tool-path').should('be.visible');
       cy.get('#register_tool_button').click();
       cy.contains('Create tool with descriptor(s) on remote sites').should('be.visible').click();

--- a/cypress/integration/group3/sidebarAccordion.ts
+++ b/cypress/integration/group3/sidebarAccordion.ts
@@ -21,10 +21,8 @@ describe('Mock create a GitHub repository', () => {
   setTokenUserViewPort();
 
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: /github.com\/organizations/,
-      response: ['dockstore'],
+    cy.intercept('GET', /github.com\/organizations/, {
+      body: ['dockstore'],
     });
   });
 

--- a/cypress/integration/group3/sidebarAccordion.ts
+++ b/cypress/integration/group3/sidebarAccordion.ts
@@ -21,8 +21,7 @@ describe('Mock create a GitHub repository', () => {
   setTokenUserViewPort();
 
   beforeEach(() => {
-    cy.server();
-    cy.route({
+    cy.intercept({
       method: 'GET',
       url: /github.com\/organizations/,
       response: ['dockstore'],

--- a/cypress/integration/group3/starErrorMessage.ts
+++ b/cypress/integration/group3/starErrorMessage.ts
@@ -21,8 +21,7 @@ describe('Tool and workflow starring error messages', () => {
 
   function starringError(url: string, type: string, routePath: string, name: string) {
     cy.visit(url);
-    cy.server();
-    cy.route({
+    cy.intercept({
       url: routePath,
       method: 'PUT',
       status: 400,
@@ -43,8 +42,7 @@ describe('Tool and workflow starring error messages', () => {
 
     cy.get('#starringButtonIcon').click();
 
-    cy.server();
-    cy.route({
+    cy.intercept({
       url: routePath,
       method: 'PUT',
       status: 400,
@@ -62,9 +60,8 @@ describe('Tool and workflow starring error messages', () => {
 
   function starringServerError(url: string, routePath: string) {
     cy.visit(url);
-    cy.server();
 
-    cy.route({
+    cy.intercept({
       url: routePath,
       method: 'PUT',
       status: 500,

--- a/cypress/integration/group3/starErrorMessage.ts
+++ b/cypress/integration/group3/starErrorMessage.ts
@@ -21,11 +21,9 @@ describe('Tool and workflow starring error messages', () => {
 
   function starringError(url: string, type: string, routePath: string, name: string) {
     cy.visit(url);
-    cy.intercept({
-      url: routePath,
-      method: 'PUT',
-      status: 400,
-      response: 'You cannot star the ' + type + ' ' + name + ' because you have not unstarred it.',
+    cy.intercept('PUT', routePath, {
+      body: 'You cannot star the ' + type + ' ' + name + ' because you have not unstarred it.',
+      statusCode: 400,
     });
 
     cy.get('#starringButtonIcon').click();
@@ -42,11 +40,9 @@ describe('Tool and workflow starring error messages', () => {
 
     cy.get('#starringButtonIcon').click();
 
-    cy.intercept({
-      url: routePath,
-      method: 'PUT',
-      status: 400,
-      response: 'You cannot unstar the ' + type + ' ' + name + ' because you have not starred it.',
+    cy.intercept('PUT', routePath, {
+      body: 'You cannot unstar the ' + type + ' ' + name + ' because you have not starred it.',
+      statusCode: 400,
     });
 
     cy.get('#unstarringButtonIcon').click();
@@ -61,11 +57,9 @@ describe('Tool and workflow starring error messages', () => {
   function starringServerError(url: string, routePath: string) {
     cy.visit(url);
 
-    cy.intercept({
-      url: routePath,
-      method: 'PUT',
-      status: 500,
-      response: {},
+    cy.intercept('PUT', routePath, {
+      body: {},
+      statusCode: 500,
     });
 
     cy.get('#starringButtonIcon').click();

--- a/cypress/integration/immutableDatabaseTests/dropdown.ts
+++ b/cypress/integration/immutableDatabaseTests/dropdown.ts
@@ -20,10 +20,8 @@ describe('Dropdown test', () => {
   setTokenUserViewPortCurator();
 
   beforeEach(() => {
-    cy.server().route({
-      method: 'GET',
-      url: /extended/,
-      response: { canChangeUsername: true },
+    cy.intercept('GET', /extended/, {
+      body: { canChangeUsername: true },
     });
 
     cy.visit('');
@@ -98,10 +96,8 @@ describe('Dropdown test', () => {
         { id: 1001, name: 'OrgTwo', status: 'PENDING' },
       ];
 
-      cy.server().route({
-        method: 'GET',
-        url: '*/organizations/all?type=pending',
-        response: pendingOrganizations,
+      cy.intercept('GET', '*/organizations/all?type=pending', {
+        body: pendingOrganizations,
       });
 
       // Logged in user has two memberships, one is not accepted
@@ -125,10 +121,8 @@ describe('Dropdown test', () => {
           organization: { id: 1002, status: 'REJECTED', name: 'orgThree', displayName: 'orgThree' },
         },
       ];
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: memberships,
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: memberships,
       });
       // Choose dropdown
       cy.get('#dropdown-accounts').click();
@@ -137,10 +131,8 @@ describe('Dropdown test', () => {
 
     it('Should have one rejected org', () => {
       // Mock request re-review
-      cy.server().route({
-        method: 'POST',
-        url: '*/organizations/1002/request',
-        response: { id: 1002, name: 'OrgThree', status: 'PENDING' },
+      cy.intercept('POST', '*/organizations/1002/request', {
+        body: { id: 1002, name: 'OrgThree', status: 'PENDING' },
       });
 
       // Mock new pending orgs
@@ -150,10 +142,8 @@ describe('Dropdown test', () => {
         { id: 1002, name: 'OrgThree', status: 'PENDING' },
       ];
 
-      cy.server().route({
-        method: 'GET',
-        url: '*/organizations/all?type=pending',
-        response: pendingOrganizations,
+      cy.intercept('GET', '*/organizations/all?type=pending', {
+        body: pendingOrganizations,
       });
 
       // Mock new my pending orgs
@@ -162,10 +152,8 @@ describe('Dropdown test', () => {
         { id: 2, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
         { id: 3, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1002, status: 'PENDING', name: 'orgThree' } },
       ];
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: memberships,
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: memberships,
       });
 
       // Ensure that there is one org
@@ -189,17 +177,13 @@ describe('Dropdown test', () => {
     it('Should have two pending orgs', () => {
       // Endpoint should return only one pending organization after approval
       const pendingOrganizations = [{ id: 1001, name: 'OrgTwo', status: 'PENDING' }];
-      cy.server().route({
-        method: 'GET',
-        url: '*/organizations/all?type=pending',
-        response: pendingOrganizations,
+      cy.intercept('GET', '*/organizations/all?type=pending', {
+        body: pendingOrganizations,
       });
 
       // Stub approve response
-      cy.server().route({
-        method: 'POST',
-        url: '*/organizations/1000/approve',
-        response: [],
+      cy.intercept('POST', '*/organizations/1000/approve', {
+        body: [],
       });
 
       // Ensure that there are two orgs
@@ -218,10 +202,8 @@ describe('Dropdown test', () => {
 
     it('Should have a pending invite', () => {
       // Stub the accept invite response
-      cy.server().route({
-        method: 'POST',
-        url: '*/organizations/1000/invitation?accept=true',
-        response: [],
+      cy.intercept('POST', '*/organizations/1000/invitation?accept=true', {
+        body: [],
       });
 
       // Membership should have two accepted entries
@@ -229,10 +211,8 @@ describe('Dropdown test', () => {
         { id: 1, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1000, status: 'PENDING', name: 'orgOne' } },
         { id: 2, role: 'MAINTAINER', status: 'ACCEPTED', organization: { id: 1001, status: 'PENDING', name: 'orgTwo' } },
       ];
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: memberships,
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: memberships,
       });
 
       // One invite should be visible
@@ -278,17 +258,13 @@ describe('Dropdown test', () => {
       ];
 
       // Route all DELETE API calls to organizations respond with with an empty JSON object
-      cy.server().route({
-        method: 'DELETE',
-        url: '*/organizations/*',
-        response: [],
+      cy.intercept('DELETE', '*/organizations/*', {
+        body: [],
       });
 
       // Route GET API call to user/membership with the mocked membership JSON object after first deletion
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: membershipsAfterFirstDeletion,
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: membershipsAfterFirstDeletion,
       });
 
       // Delete the rejected organization
@@ -301,17 +277,13 @@ describe('Dropdown test', () => {
       cy.get('#my-rejected-org-card-0').should('not.exist');
 
       // Route GET API call to user/memberships to respond with the membership JSON object that the user is not affiliated with
-      cy.server().route({
-        method: 'GET',
-        url: '*/users/user/memberships',
-        response: [nonAffiliatedMembership],
+      cy.intercept('GET', '*/users/user/memberships', {
+        body: [nonAffiliatedMembership],
       });
 
       // Route all GET requests to organizations/all?type=pending to the non affiliated organization
-      cy.server().route({
-        method: 'GET',
-        url: '*/organizations/all?type=pending',
-        response: [nonAffiliatedMembership],
+      cy.intercept('GET', '*/organizations/all?type=pending', {
+        body: [nonAffiliatedMembership],
       });
 
       // Delete the pending organization
@@ -328,10 +300,8 @@ describe('Dropdown test', () => {
   describe('Go to enabled Dockstore Account & Preferences', () => {
     beforeEach(() => {
       // Select dropdown accounts
-      cy.server().route({
-        method: 'DELETE',
-        url: '*/users/user',
-        response: 'true',
+      cy.intercept('DELETE', '*/users/user', {
+        body: 'true',
       });
       cy.get('#dropdown-accounts').click();
       cy.contains('Dockstore Account & Preferences').click();

--- a/cypress/integration/immutableDatabaseTests/newsUpdates.ts
+++ b/cypress/integration/immutableDatabaseTests/newsUpdates.ts
@@ -20,9 +20,8 @@ describe('News and Updates Widget', () => {
   setTokenUserViewPort();
 
   it('News and updates widget appears on logged-in homepage', () => {
-    cy.server();
     cy.fixture('newsUpdates.json').then((json) => {
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '*/curation/notifications',
         response: json,

--- a/cypress/integration/immutableDatabaseTests/newsUpdates.ts
+++ b/cypress/integration/immutableDatabaseTests/newsUpdates.ts
@@ -21,10 +21,8 @@ describe('News and Updates Widget', () => {
 
   it('News and updates widget appears on logged-in homepage', () => {
     cy.fixture('newsUpdates.json').then((json) => {
-      cy.intercept({
-        method: 'GET',
-        url: '*/curation/notifications',
-        response: json,
+      cy.intercept('GET', '*/curation/notifications', {
+        body: json,
       });
     });
     cy.visit('/dashboard');

--- a/cypress/integration/immutableDatabaseTests/notifications.ts
+++ b/cypress/integration/immutableDatabaseTests/notifications.ts
@@ -27,10 +27,8 @@ describe('Notifications Banner', () => {
 
   beforeEach(() => {
     cy.fixture('notification1.json').then((json) => {
-      cy.intercept({
-        method: 'GET',
-        url: '*/curation/notifications',
-        response: json,
+      cy.intercept('GET', '*/curation/notifications', {
+        body: json,
       });
     });
 

--- a/cypress/integration/immutableDatabaseTests/notifications.ts
+++ b/cypress/integration/immutableDatabaseTests/notifications.ts
@@ -26,9 +26,8 @@ describe('Notifications Banner', () => {
   }
 
   beforeEach(() => {
-    cy.server();
     cy.fixture('notification1.json').then((json) => {
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '*/curation/notifications',
         response: json,

--- a/cypress/integration/immutableDatabaseTests/searchTable.ts
+++ b/cypress/integration/immutableDatabaseTests/searchTable.ts
@@ -22,11 +22,8 @@ describe('Dockstore tool/workflow search table', () => {
   // When elastic search is added to cypress testing, get rid of cy.intercepts, and uncomment the commented lines
   function starColumnSearch(url: string, type: string) {
     // Tools/worflows not starred in this response.
-    cy.intercept({
-      url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
-      method: 'POST',
-      status: 200,
-      response: {
+    cy.intercept('POST', '*' + ga4ghExtendedPath + '/tools/entry/_search', {
+      body: {
         took: 18,
         timed_out: false,
         _shards: { total: 5, successful: 5, skipped: 0, failed: 0 },
@@ -348,10 +345,8 @@ describe('Dockstore tool/workflow search table', () => {
 
     // First tool and workflow starred
     cy.fixture('searchTableResponse').then((json) => {
-      cy.intercept({
-        url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
-        method: 'POST',
-        response: json,
+      cy.intercept('POST', '*' + ga4ghExtendedPath + '/tools/entry/_search', {
+        body: json,
       });
     });
 
@@ -379,10 +374,8 @@ describe('search table items per page', () => {
   setTokenUserViewPort();
   beforeEach(() => {
     cy.fixture('searchTableResponse').then((json) => {
-      cy.intercept({
-        url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
-        method: 'POST',
-        response: json,
+      cy.intercept('POST', '*' + ga4ghExtendedPath + '/tools/entry/_search', {
+        body: json,
       });
     });
   });

--- a/cypress/integration/immutableDatabaseTests/searchTable.ts
+++ b/cypress/integration/immutableDatabaseTests/searchTable.ts
@@ -19,11 +19,10 @@ import { goToTab, setTokenUserViewPort } from '../../support/commands';
 describe('Dockstore tool/workflow search table', () => {
   setTokenUserViewPort();
 
-  // When elastic search is added to cypress testing, get rid of cy.routes, and uncomment the commented lines
+  // When elastic search is added to cypress testing, get rid of cy.intercepts, and uncomment the commented lines
   function starColumnSearch(url: string, type: string) {
-    cy.server();
     // Tools/worflows not starred in this response.
-    cy.route({
+    cy.intercept({
       url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
       method: 'POST',
       status: 200,
@@ -349,7 +348,7 @@ describe('Dockstore tool/workflow search table', () => {
 
     // First tool and workflow starred
     cy.fixture('searchTableResponse').then((json) => {
-      cy.route({
+      cy.intercept({
         url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
         method: 'POST',
         response: json,
@@ -379,9 +378,8 @@ describe('Dockstore tool/workflow search table', () => {
 describe('search table items per page', () => {
   setTokenUserViewPort();
   beforeEach(() => {
-    cy.server();
     cy.fixture('searchTableResponse').then((json) => {
-      cy.route({
+      cy.intercept({
         url: '*' + ga4ghExtendedPath + '/tools/entry/_search',
         method: 'POST',
         response: json,

--- a/cypress/integration/immutableDatabaseTests/toolDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/toolDetails.ts
@@ -170,11 +170,9 @@ describe('Dockstore Tool Details of quay.io/A2/b3', () => {
 
 describe('Find tool by alias', () => {
   it('tool alias', () => {
-    cy.intercept({
-      url: '*/containers/fakeAlias/aliases',
-      method: 'GET',
-      status: 200,
-      response: { tool_path: 'quay.io/A2/b3' },
+    cy.intercept('GET', '*/containers/fakeAlias/aliases', {
+      body: { tool_path: 'quay.io/A2/b3' },
+      statusCode: 200,
     });
     cy.visit('/aliases/tools/fakeAlias');
     cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/b3:latest?tab=info');

--- a/cypress/integration/immutableDatabaseTests/toolDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/toolDetails.ts
@@ -170,8 +170,7 @@ describe('Dockstore Tool Details of quay.io/A2/b3', () => {
 
 describe('Find tool by alias', () => {
   it('tool alias', () => {
-    cy.server();
-    cy.route({
+    cy.intercept({
       url: '*/containers/fakeAlias/aliases',
       method: 'GET',
       status: 200,

--- a/cypress/integration/immutableDatabaseTests/tosAndPrivacyPolicy.ts
+++ b/cypress/integration/immutableDatabaseTests/tosAndPrivacyPolicy.ts
@@ -104,7 +104,6 @@ describe('TOS Banner', () => {
             avatarURL: undefined,
             bio: undefined,
             company: undefined,
-            email: undefined,
             location: undefined,
             name: '',
             username: 'user_A',
@@ -113,10 +112,8 @@ describe('TOS Banner', () => {
         username: 'user_A',
       };
 
-      cy.intercept({
-        method: 'GET',
-        url: '*/users/user',
-        response: outOfDateUser,
+      cy.intercept('GET', '*/users/user', {
+        body: outOfDateUser,
       });
 
       cy.visit('');

--- a/cypress/integration/immutableDatabaseTests/tosAndPrivacyPolicy.ts
+++ b/cypress/integration/immutableDatabaseTests/tosAndPrivacyPolicy.ts
@@ -113,8 +113,7 @@ describe('TOS Banner', () => {
         username: 'user_A',
       };
 
-      cy.server();
-      cy.route({
+      cy.intercept({
         method: 'GET',
         url: '*/users/user',
         response: outOfDateUser,

--- a/cypress/integration/immutableDatabaseTests/verification.ts
+++ b/cypress/integration/immutableDatabaseTests/verification.ts
@@ -9,10 +9,8 @@ describe('See verification information and logs', () => {
       `curl -X POST "${Dockstore.API_URI}${ga4ghExtendedPath}/quay.io%2Fgaryluu%2Fdockstore-cgpmap%2Fcgpmap-cramOut/versions/3.0.0-rc8/CWL/tests/..%2Fexamples%2Fcgpmap%2FcramOut%2Ffastq_gz_input.json?platform=Dockstore%20CLI&platform_version=1.6.0&verified=true&metadata=Potato" -H "accept: application/json" -H "Authorization: Bearer imamafakedockstoretoken2"`
     );
     cy.fixture('toolTesterLogs').then((json) => {
-      cy.intercept({
-        url: `${Dockstore.API_URI}/toolTester/logs/**`,
-        method: 'GET',
-        response: json,
+      cy.intercept('GET', `${Dockstore.API_URI}/toolTester/logs/**`, {
+        body: json,
       });
     });
     cy.visit(Cypress.config().baseUrl + '/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8?tab=info');

--- a/cypress/integration/immutableDatabaseTests/verification.ts
+++ b/cypress/integration/immutableDatabaseTests/verification.ts
@@ -8,9 +8,8 @@ describe('See verification information and logs', () => {
     cy.exec(
       `curl -X POST "${Dockstore.API_URI}${ga4ghExtendedPath}/quay.io%2Fgaryluu%2Fdockstore-cgpmap%2Fcgpmap-cramOut/versions/3.0.0-rc8/CWL/tests/..%2Fexamples%2Fcgpmap%2FcramOut%2Ffastq_gz_input.json?platform=Dockstore%20CLI&platform_version=1.6.0&verified=true&metadata=Potato" -H "accept: application/json" -H "Authorization: Bearer imamafakedockstoretoken2"`
     );
-    cy.server();
     cy.fixture('toolTesterLogs').then((json) => {
-      cy.route({
+      cy.intercept({
         url: `${Dockstore.API_URI}/toolTester/logs/**`,
         method: 'GET',
         response: json,

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -118,11 +118,9 @@ describe('Dockstore Workflow Details', () => {
 
 describe('Find workflow by alias', () => {
   it('workflow alias', () => {
-    cy.intercept({
-      url: '*/workflows/fakeAlias/aliases',
-      method: 'GET',
-      status: 200,
-      response: { full_workflow_path: 'github.com/A/l' },
+    cy.intercept('GET', '*/workflows/fakeAlias/aliases', {
+      body: { full_workflow_path: 'github.com/A/l' },
+      statusCode: 200,
     });
     cy.visit('/aliases/workflows/fakeAlias');
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l');

--- a/cypress/integration/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/integration/immutableDatabaseTests/workflowDetails.ts
@@ -118,8 +118,7 @@ describe('Dockstore Workflow Details', () => {
 
 describe('Find workflow by alias', () => {
   it('workflow alias', () => {
-    cy.server();
-    cy.route({
+    cy.intercept({
       url: '*/workflows/fakeAlias/aliases',
       method: 'GET',
       status: 200,

--- a/cypress/integration/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/integration/smokeTests/sharedTests/auth-tests.ts
@@ -53,8 +53,7 @@ function unpublishTool() {
 function deleteTool() {
   it('delete the tool', () => {
     storeToken();
-    cy.server();
-    cy.route('delete', '**/containers/**').as('containers');
+    cy.intercept('delete', '**/containers/**').as('containers');
     cy.contains('#deregisterButton', 'Delete').should('be.visible').click();
     cy.contains('div', 'Are you sure you wish to delete this tool?').within(() => {
       cy.contains('button', 'Delete').should('be.visible').click();
@@ -70,13 +69,12 @@ function registerQuayTool(repo: string, name: string) {
     storeToken();
 
     // define routes to watch for
-    cy.server();
     // get quay.io organization/namespaces accessible to user
-    cy.route('/api/users/dockerRegistries/quay.io/organizations').as('orgs');
-    cy.route('**/tokens').as('tokens');
-    cy.route('**/repositories').as('repos');
-    cy.route('**/containers').as('containers');
-    cy.route('post', '**/publish').as('publish');
+    cy.intercept('/api/users/dockerRegistries/quay.io/organizations').as('orgs');
+    cy.intercept('**/tokens').as('tokens');
+    cy.intercept('**/repositories').as('repos');
+    cy.intercept('**/containers').as('containers');
+    cy.intercept('post', '**/publish').as('publish');
 
     cy.visit('/my-tools');
     cy.wait('@tokens');
@@ -111,9 +109,8 @@ function registerRemoteSitesTool(repo: string, name: string) {
   it('register and publish - create tool remote sites option', () => {
     storeToken();
     // define routes to watch for
-    cy.server();
-    cy.route('post', '**/publish').as('publish');
-    cy.route('**/tokens').as('tokens');
+    cy.intercept('post', '**/publish').as('publish');
+    cy.intercept('**/tokens').as('tokens');
 
     cy.visit('/my-tools');
     cy.wait('@tokens');
@@ -139,16 +136,15 @@ function registerToolOnDockstore(repo: string, name: string) {
     storeToken();
 
     // define routes to watch for
-    cy.server();
     // for some reason watching and waiting for all the responses is still flaky
-    cy.route('**/containers').as('containers');
-    cy.route('**/tokens').as('tokens');
-    cy.route('**/user').as('user');
-    cy.route('**/extended').as('extended');
-    cy.route('**/metadata').as('metadata');
-    cy.route('**/dockerRegistryList').as('docker');
-    cy.route('**/sourceControlList').as('sourceControl');
-    cy.route('**/notifications').as('notifications');
+    cy.intercept('**/containers').as('containers');
+    cy.intercept('**/tokens').as('tokens');
+    cy.intercept('**/user').as('user');
+    cy.intercept('**/extended').as('extended');
+    cy.intercept('**/metadata').as('metadata');
+    cy.intercept('**/dockerRegistryList').as('docker');
+    cy.intercept('**/sourceControlList').as('sourceControl');
+    cy.intercept('**/notifications').as('notifications');
 
     cy.visit('/my-tools');
     cy.wait('@containers');
@@ -233,19 +229,18 @@ function testWorkflow(registry: string, repo: string, name: string) {
       storeToken();
 
       // define routes to watch for
-      cy.server();
-      cy.route('**/tokens').as('tokens');
-      cy.route('**/workflows/path/workflow/**').as('workflow');
+      cy.intercept('**/tokens').as('tokens');
+      cy.intercept('**/workflows/path/workflow/**').as('workflow');
 
       cy.visit(`/my-workflows`);
       cy.wait('@tokens');
       cy.wait('@workflow');
 
       //  refresh stubbed workflow to full and publish
-      cy.route('**/refresh?hardRefresh=false').as('refresh');
+      cy.intercept('**/refresh?hardRefresh=false').as('refresh');
       cy.get('[data-cy=refreshButton]').click();
       cy.wait('@refresh');
-      cy.route('post', '**/publish').as('publish');
+      cy.intercept('post', '**/publish').as('publish');
       cy.contains('button', 'Publish').should('be.enabled').click();
       cy.wait('@publish');
     });
@@ -254,7 +249,6 @@ function testWorkflow(registry: string, repo: string, name: string) {
     // WARNING: don't actually snapshot since it can't be undone
     it('snapshot', () => {
       // define routes to watch for
-      cy.server();
 
       goToTab('Versions');
 
@@ -293,8 +287,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
     it('be able to add an entry to the collection', () => {
       storeToken();
       // define routes to watch for
-      cy.server();
-      cy.route('post', '**/collections/**').as('postToCollection');
+      cy.intercept('post', '**/collections/**').as('postToCollection');
       cy.visit(`/containers/quay.io/${repo}/${name}:develop?tab=info`);
       cy.get('#addToolToCollectionButton').should('be.visible').click();
       cy.get('#addEntryToCollectionButton').should('be.disabled');
@@ -311,7 +304,6 @@ function testCollection(org: string, collection: string, registry: string, repo:
 
     it('be able to remove an entry from a collection', () => {
       storeToken();
-      cy.server();
       cy.visit(`/organizations/${org}/collections/${collection}`);
       cy.contains(`quay.io/${repo}/${name}`);
       cy.get('#removeEntryButton').should('be.visible').click();
@@ -320,7 +312,7 @@ function testCollection(org: string, collection: string, registry: string, repo:
       cy.visit(`/organizations/${org}`);
       cy.contains('Members').should('be.visible');
 
-      cy.route('**/tokens').as('tokens');
+      cy.intercept('**/tokens').as('tokens');
       cy.visit('/my-tools');
       cy.wait('@tokens');
     });


### PR DESCRIPTION
**Description**
`cy.route()` is deprecated in Cypress 8, the version we currently use, and no longer present in Cypress 12, the version we aspire to. `cy.server` is also deprecated in 8, gone in 12. If you use `cy.intercept`, you don't need `cy.server`.

This is the first step towards migrating to Cypress 12.

**Review Instructions**
PR and smoke tests should be passing.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5091

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
