### PR TITLE
Handle backend change to for source file metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9018/workflows/2efa2b50-9cc1-4c36-b1de-c563bfa36d55/jobs/27673/artifacts",
-    "circle_build_id": "27673",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9193/workflows/2a111e94-802c-49bd-9d8f-235236b85b8a/jobs/28416/artifacts",
+    "circle_build_id": "28416",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9193/workflows/2a111e94-802c-49bd-9d8f-235236b85b8a/jobs/28416/artifacts",
-    "circle_build_id": "28416",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9200/workflows/9699a9a9-55c1-4820-a4ee-5a04d86e870e/jobs/28468/artifacts",
+    "circle_build_id": "28468",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -107,7 +107,7 @@
       <td mat-cell *matCellDef="let version">
         <!-- Only display descriptor type versions if there's one descriptor type otherwise we can't tell which version belongs to which type without looking at the source files -->
         <span *ngIf="tool?.descriptorType.length === 1">{{
-          tool.descriptorType[0] | descriptorLanguageVersions: version.descriptorTypeVersions
+          tool.descriptorType[0] | descriptorLanguageVersions: version.versionMetadata?.descriptorTypeVersions
         }}</span>
       </td>
     </ng-container>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -100,7 +100,7 @@
         Language Versions
       </th>
       <td mat-cell *matCellDef="let version">
-        <span>{{ this.workflow.descriptorType | descriptorLanguageVersions: version.descriptorTypeVersions }}</span>
+        <span>{{ this.workflow.descriptorType | descriptorLanguageVersions: version.versionMetadata?.descriptorTypeVersions }}</span>
       </td>
     </ng-container>
 


### PR DESCRIPTION
**Description**
A companion to dockstore/dockstore#5035 -- SourceFile language descriptor version is now in a nested SourceFileMetadata object.

**Review Instructions**
Verify that that language descriptor versions show up correctly on the versions tab of workflows and tools.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5162

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
