### PR TITLE
fix height of tos banner mobile

### DIFF
--- a/src/app/changeUsernameBanner/changeUsernameBanner.component.html
+++ b/src/app/changeUsernameBanner/changeUsernameBanner.component.html
@@ -1,5 +1,5 @@
 <div class="tos-banner text-center" data-cy="changeUsernameBanner">
-  <div fxLayoutAlign="center center">
+  <div fxLayoutAlign="center center" fxFlex>
     <div>Your username contains one or more banned words. Some operations on Dockstore will be blocked until you change your username.</div>
   </div>
 </div>

--- a/src/app/tosBanner/tos-banner.component.html
+++ b/src/app/tosBanner/tos-banner.component.html
@@ -1,5 +1,5 @@
 <div class="container tos-banner text-center" data-cy="tos-banner">
-  <div class="container-fluid" fxLayout="" fxLayoutAlign="center center">
+  <div class="container-fluid" fxLayout fxLayoutAlign="center center" fxFlex>
     <div>
       {{ bannerText }}
       <a href="../assets/docs/Dockstore_Terms_of_Service.pdf" target="_blank" rel="noopener noreferrer">Terms of Service</a> and

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -550,12 +550,12 @@ td {
 
 @media (max-width: 992px) {
   .tos-banner {
-    height: 75px;
+    height: 11rem;
     line-height: 250%;
   }
 
   .push-tos {
-    height: 75px;
+    height: 11rem;
   }
 }
 


### PR DESCRIPTION
**Description**
At the time of addressing this ticket the "x" button to close the TOS banner is accesible on mobile but I noticed the text on the banner still gets cut off.

**Cut off text:**
![image](https://user-images.githubusercontent.com/97123241/213805772-94623475-fa35-444a-8db9-bf1bec22fef9.png)

**Solution:** change the banner height to fit the text and change the tos banner push.
![image](https://user-images.githubusercontent.com/97123241/213809390-280e2584-3d1d-46c4-a2e5-1ba83bab8061.png)

I also noticed that updating the height also fixes the text cut off for the change-username-banner.
![image](https://user-images.githubusercontent.com/97123241/213809486-da549e33-80f1-4344-acd3-444c6fe1aeb0.png)


**Review Instructions**
Remove your cookies to reveal the banner and ensure that the banner text isn't cut off when you resize to the smallest possible window size.


**Issue**
[DOCK-1780
](https://ucsc-cgl.atlassian.net/browse/DOCK-1780?atlOrigin=eyJpIjoiMTg2NzQ4NWI2OTA2NDcyMjhkNGExZmMzNTE5YTVkNDMiLCJwIjoiaiJ9)[github issue](https://github.com/dockstore/dockstore/issues/4223)

**Security**

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
