### PR TITLE
Feature/seab 5089/cypress12

### DIFF
--- a/THIRD-PARTY-LICENSES.csv
+++ b/THIRD-PARTY-LICENSES.csv
@@ -444,7 +444,7 @@
 "cssesc@3.0.0","MIT","https://github.com/mathiasbynens/cssesc"
 "custom-event@1.0.1","MIT","https://github.com/webmodules/custom-event"
 "cyclist@1.0.1","MIT","https://github.com/mafintosh/cyclist"
-"cypress@11.2.0","MIT","https://github.com/cypress-io/cypress"
+"cypress@12.3.0","MIT","https://github.com/cypress-io/cypress"
 "cytoscape-dagre@2.4.0","MIT","https://github.com/cytoscape/cytoscape.js-dagre"
 "cytoscape-popper@2.0.0","MIT","https://github.com/cytoscape/cytoscape.js-popper"
 "cytoscape@3.21.0","MIT","https://github.com/cytoscape/cytoscape.js"

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   projectId: '1ya4vj',
   viewportHeight: 900,
   viewportWidth: 1440,
-  defaultCommandTimeout: 45000,
-  requestTimeout: 45000,
+  defaultCommandTimeout: 30000,
+  requestTimeout: 30000,
   retries: {
     runMode: 3,
     openMode: 0,

--- a/cypress/e2e/group1/revokeDockstoreToken.ts
+++ b/cypress/e2e/group1/revokeDockstoreToken.ts
@@ -23,8 +23,7 @@ describe('Test revoke token button opens confirmation dialog successfully and lo
     cy.visit('/accounts?tab=accounts');
     cy.get('[data-cy=revoke-token-button]').should('be.visible').click();
     cy.get('[data-cy=confirm-revoke-token-button]').should('be.disabled');
-  });
-  it('Confirm button should log out user', () => {
+
     cy.get('[data-cy=revoke-token-username-input]').should('be.visible').clear().type('user_A');
     cy.get('[data-cy=confirm-revoke-token-button]').should('not.be.disabled').click();
     cy.get('[data-cy=header]').should('contain', 'Logged Out');

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -93,8 +93,12 @@ describe('Dockstore my workflows', () => {
         body: realResponse,
       }).as('refreshWorkflow');
       cy.contains('Apps Logs').click();
+      // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
       cy.contains('2020-02-20T02:20');
       cy.contains('2020-06-05T14:40');
+      // These next 2 values only work on the West Coast
+      // cy.contains('2020-02-19T18:20');
+      // cy.contains('2020-06-05T07:40');
       cy.contains('1 – 2 of 2');
       cy.contains('Close').click();
     });
@@ -315,7 +319,7 @@ describe('Dockstore my workflows', () => {
     cy.contains('/Dockstore.cwl');
     cy.contains('class: Workflow');
 
-    cy.get('mat-tab-body').within((tabBody) => {
+    cy.get('app-source-file-tabs').within((tabBody) => {
       cy.get('mat-select').click();
     });
 
@@ -465,7 +469,6 @@ describe('Dockstore my workflows', () => {
 
   describe('Should require default version to publish', () => {
     it('should not be able to publish with no default version', () => {
-      setTokenUserViewPort();
       cy.visit('/my-workflows/github.com/A/l');
       cy.get('#publishButton').should('contain', 'Unpublish').should('be.visible').click();
       cy.get('#publishButton').should('contain', 'Publish').should('be.visible').click();
@@ -477,11 +480,7 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=set-default-version-button]').should('be.visible').click();
       cy.wait(1000);
       cy.get('#publishButton').should('contain', 'Publish').should('be.visible').click();
-    });
-  });
 
-  describe('Look at a published workflow', () => {
-    it('Look at each tab', () => {
       const tabs = ['Info', 'Launch', 'Versions', 'Files', 'Tools', 'DAG'];
       cy.visit('/my-workflows/github.com/A/l');
       isActiveTab('Info');

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -55,8 +55,7 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=dropdown-main]:visible').should('be.visible').click();
       cy.get('[data-cy=my-workflows-nav-button]').click();
       cy.contains('github.com/A/l');
-    });
-    it('should be able to see GitHub Apps Logs dialog', () => {
+
       cy.contains('Apps Logs').click();
       cy.contains('There were problems retrieving GitHub App logs for this organization.');
       cy.contains('Close').click();
@@ -159,8 +158,7 @@ describe('Dockstore my workflows', () => {
       // .trigger('mouseover') doesn't work for some reason
       cy.contains('Mode').trigger('mouseenter');
       cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
-    });
-    it('should be able to add labels', () => {
+
       cy.contains('github.com/A/g');
       cy.get('button').contains('Manage labels').click();
       cy.get('[data-cy=workflowLabelInput]').type('potato');
@@ -467,13 +465,13 @@ describe('Dockstore my workflows', () => {
 
   describe('Should require default version to publish', () => {
     it('should not be able to publish with no default version', () => {
+      setTokenUserViewPort();
       cy.visit('/my-workflows/github.com/A/l');
       cy.get('#publishButton').should('contain', 'Unpublish').should('be.visible').click();
       cy.get('#publishButton').should('contain', 'Publish').should('be.visible').click();
       cy.get('[data-cy=close-dialog-button]').should('be.visible').click();
       cy.get('#publishButton').should('contain', 'Publish').should('be.visible');
-    });
-    it('should be able to publish after setting default version', () => {
+
       goToTab('Versions');
       cy.contains('button', 'Actions').should('be.visible').click();
       cy.get('[data-cy=set-default-version-button]').should('be.visible').click();

--- a/cypress/e2e/group2/notificationBadge.ts
+++ b/cypress/e2e/group2/notificationBadge.ts
@@ -37,20 +37,11 @@ describe('Test notification badge on navbar', () => {
     it('visit the organizations page from the home page', () => {
       cy.visit('/');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
-    });
 
-    it('create a new unapproved organization', () => {
       createOrganization('Test', 'Test Display', 'Testing Testing Testing', 'Lab', 'https://www.google.ca', 'asf@asdf.ca');
       cy.get('[data-cy=notification-button]').should('be.visible').click();
       cy.get('[data-cy=bell-icon]').should('contain.text', '1');
-    });
-  });
-  describe('Should have badge count of 1 with a rejected organization request', () => {
-    it('visit the requests page', () => {
       cy.get('[data-cy=notification-button]').should('be.visible').click();
-    });
-
-    it('reject a pending organization', () => {
       cy.contains('button', 'Reject').should('be.visible').click();
       cy.get('[data-cy=reject-pending-org-dialog]').should('be.visible').click();
       cy.reload();
@@ -63,9 +54,7 @@ describe('Test notification badge on navbar', () => {
     it('visit the organizations page from the home page', () => {
       cy.visit('/');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
-    });
 
-    it('create a new unapproved organization and invite user', () => {
       createOrganization(
         'Potato111',
         'Potato111',

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -64,9 +64,7 @@ describe('Dockstore Organizations', () => {
       cy.visit('/');
       cy.contains('a', 'Organizations').should('be.visible').should('have.attr', 'href', '/organizations').click();
       cy.contains('No organizations found');
-    });
 
-    it('create a new unapproved organization', () => {
       cy.contains('button', 'Create Organization Request').should('be.visible').click();
       cy.contains('button', 'Next').should('be.visible').click();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('be.disabled');
@@ -94,11 +92,7 @@ describe('Dockstore Organizations', () => {
       cy.get('[data-cy=image-url-input').clear();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potato');
-    });
-  });
 
-  describe('Should be able to view new unapproved organization', () => {
-    it('have the fields just entered in during registration', () => {
       cy.contains('Potato');
       cy.contains("Boil 'em, mash 'em, stick 'em in a stew");
       cy.contains('https://www.google.ca');
@@ -106,10 +100,9 @@ describe('Dockstore Organizations', () => {
       // Why does next line work in Cypress 8? Dangling DOM? I don't see it in screenshot; removing for Cypress 9
       // cy.contains('asdf@asdf.ca');
       cy.contains('No collections found');
-    });
-    it('be able to edit an unapproved organization', () => {
+
       cy.get('#editOrgInfo').should('be.visible').click();
-      cy.wait(5000);
+      cy.wait(2000);
       typeInInput('Name', 'Potatoe');
       typeInInput('Display Name', 'Potatoe');
       typeInInput('Topic', 'Boil them, mash them, stick them in a stew');
@@ -123,7 +116,7 @@ describe('Dockstore Organizations', () => {
       cy.get('#createOrUpdateOrganizationButton').should('not.exist');
       cy.get('#editOrgInfo').should('be.visible').click();
       // I don't even
-      cy.wait(5000);
+      cy.wait(2000);
       cy.get('[data-cy=image-url-input]').should('be.visible').clear();
       cy.get('[data-cy=image-url-input]').should('not.have.value', imageURL);
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
@@ -135,24 +128,18 @@ describe('Dockstore Organizations', () => {
       cy.get('[data-cy=image-url-input]').should('have.value', imageURL);
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/organizations/Potatoe');
-    });
 
-    it('have new fields reflected', () => {
       cy.contains('Potatoe');
       cy.contains('Boil them, mash them, stick them in a stew');
       cy.contains('https://www.google.com');
       cy.contains('UCSC Basement');
       // Why does next line work in Cypress 8? Dangling DOM? I don't see it in screenshot; removing for Cypress 9
       // cy.contains('asdf@asdf.ca');
-    });
 
-    it('have request shown on homepage', () => {
       cy.visit('/dashboard');
       cy.contains('1 organization request');
       cy.contains('1 organization request requiring action');
-    });
 
-    it('have organization shown on the homepage', () => {
       cy.visit('/dashboard');
       cy.contains('Potatoe');
       cy.contains('Find organizations');
@@ -174,11 +161,9 @@ describe('Dockstore Organizations', () => {
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('not.be.disabled').click();
       cy.contains('fakeCollectionName');
       cy.contains('fake collection topic');
-    });
 
-    it('be able to update a collection', () => {
       cy.get('#editCollection').click();
-      cy.wait(5000);
+      cy.wait(2000);
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('not.be.disabled');
       typeInInput('Name', 'veryFakeCollectionName');
       typeInInput('Display Name', 'veryFakeCollectionName');
@@ -187,14 +172,10 @@ describe('Dockstore Organizations', () => {
       cy.get('#createOrUpdateCollectionButton').should('not.exist');
       cy.contains('veryFakeCollectionName');
       cy.contains('very fake collection topic');
-    });
-  });
 
-  describe('Should be able to update description', () => {
-    it('be able to update an organization description with markdown', () => {
       cy.visit('/organizations/Potatoe');
       cy.get('#editOrgDescription').click();
-      cy.wait(5000);
+      cy.wait(2000);
       cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled');
       typeInTextArea('Description', '* fake organization description');
       cy.contains('Preview Mode').click();
@@ -235,12 +216,10 @@ describe('Dockstore Organizations', () => {
 
       // Should have no entries
       cy.contains('This collection has no associated entries');
-    });
 
-    it('be able to update a collection description', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.get('#editCollectionDescription').click();
-      cy.wait(5000);
+      cy.wait(2000);
       cy.get('#updateOrganizationDescriptionButton').should('be.visible').should('not.be.disabled');
       typeInTextArea('Description', '* fake collection description');
       cy.contains('Preview Mode').click();
@@ -250,12 +229,10 @@ describe('Dockstore Organizations', () => {
       cy.get('#updateOrganizationDescriptionButton').should('not.exist');
       cy.contains('fake collection description');
       cy.contains('* fake collection description').should('not.exist');
-    });
 
-    it('be able to edit collection information', () => {
       // Should be able to edit the collection topic and see the changes reflected
       cy.get('#editCollection').click();
-      cy.wait(5000);
+      cy.wait(2000);
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('not.be.disabled');
       typeInInput('Name', 'veryFakeCollectionName');
       typeInInput('Display Name', 'veryFakeCollectionName');
@@ -263,9 +240,7 @@ describe('Dockstore Organizations', () => {
       cy.get('#createOrUpdateCollectionButton').should('be.visible').should('not.be.disabled').click();
       cy.contains('veryFakeCollectionName');
       cy.contains('very fake collection topic2');
-    });
 
-    it('be able to add an entry to the collection', () => {
       cy.visit('/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8?tab=info');
       cy.get('#addToolToCollectionButton').should('be.visible').click();
       cy.get('#addEntryToCollectionButton').should('be.disabled');
@@ -278,9 +253,7 @@ describe('Dockstore Organizations', () => {
       cy.get('#addEntryToCollectionButton').should('not.be.disabled').click();
       cy.get('#addEntryToCollectionButton').should('not.exist');
       cy.get('mat-progress-bar').should('not.exist');
-    });
 
-    it('be able to add an entry with version to the collection', () => {
       cy.visit('/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8?tab=info');
       cy.get('#addToolToCollectionButton').should('be.visible').click();
       cy.get('#addEntryToCollectionButton').should('be.disabled');
@@ -295,16 +268,12 @@ describe('Dockstore Organizations', () => {
       cy.get('#addEntryToCollectionButton').should('not.be.disabled').click();
       cy.get('#addEntryToCollectionButton').should('not.exist');
       cy.get('mat-progress-bar').should('not.exist');
-    });
 
-    it('be able to see the two entries added to collection', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8');
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut');
-    });
 
-    // test the fix for DOCK-1945
-    it('stay on collections page when removing an entry', () => {
+      // test the fix for DOCK-1945
       const url: string = '/organizations/Potatoe/collections/veryFakeCollectionName';
       cy.visit(url);
       cy.url().should('include', url);
@@ -316,9 +285,7 @@ describe('Dockstore Organizations', () => {
       cy.url().should('include', url);
       cy.get('[data-cy=accept-remove-entry-from-org]').click();
       cy.url().should('include', url);
-    });
 
-    it('be able to remove an entry from a collection', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8');
       cy.get('#removeEntryButton').click();
@@ -327,18 +294,14 @@ describe('Dockstore Organizations', () => {
       cy.contains('This collection has no associated entries');
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').should('be.visible');
-    });
 
-    it('use default organization logo image', () => {
       approvePotatoOrganization();
       for (const url of ['/organizations', '/organizations/Potatoe', '/organizations/Potatoe/collections/veryFakeCollectionName']) {
         cy.visit(url);
         cy.wait(1000);
         cy.get('img[src*="default-org-logo"]').should('be.visible');
       }
-    });
 
-    it('be able to remove the collection', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.get('[data-cy=removeCollectionButton]').click();
       cy.get('[data-cy=cancel-remove-collection]').click();
@@ -352,18 +315,17 @@ describe('Dockstore Organizations', () => {
   });
 
   describe('Should be able to CRUD user', () => {
+    setTokenUserViewPort();
     beforeEach(() => {
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
     });
 
-    it('be able to Read organization user', () => {
+    it('be able to Read and create organization user', () => {
       cy.get('mat-progress-bar').should('not.exist');
       cy.get('#organization-member-0').should('be.visible').should('contain', 'user_A').should('contain', 'Admin');
       cy.get('#edit-user-role-0').should('not.exist');
-    });
 
-    it('be able to Create organization user', () => {
       createPotatoMembership();
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Pending Invitation');
       cy.get('#edit-user-role-1').should('exist').should('be.enabled');
@@ -373,15 +335,11 @@ describe('Dockstore Organizations', () => {
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Member');
-    });
 
-    it('be able to edit an approved organization', () => {
       cy.get('#editOrgInfo').should('be.visible').click();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
       cy.get('#createOrUpdateOrganizationButton').should('not.exist');
-    });
 
-    it('be able to Update organization user', () => {
       cy.get('#edit-user-role-1').should('not.be.disabled').click();
       cy.get('.mat-dialog-title').should('contain', 'Edit Member');
       cy.get('mat-select').click();
@@ -390,13 +348,11 @@ describe('Dockstore Organizations', () => {
       cy.get('#upsertUserDialogButton').should('be.visible').should('not.be.disabled').click();
       cy.get('#upsertUserDialogButton').should('not.exist');
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Maintainer');
-    });
 
-    it('be able to Delete organization user', () => {
       cy.get('#remove-user-1').should('not.be.disabled').click();
       cy.get('.mat-dialog-title').should('contain', 'Remove Member from Organization');
       cy.get('[data-cy=confirm-dialog-button]').should('not.be.disabled').click();
-      cy.get('#organization-member-1').contains('potato').should('not.exist');
+      cy.get('app-organization-members').contains('potato').should('not.exist');
     });
 
     it('Reject organization member invite', () => {
@@ -407,7 +363,7 @@ describe('Dockstore Organizations', () => {
       rejectPotatoMembership();
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
-      cy.get('#organization-member-1').should('contain', 'potato').should('contain', 'Rejected Invitation');
+      cy.get('app-organization-members').should('contain', 'potato').should('contain', 'Rejected Invitation');
       cy.get('#remove-user-1').should('exist').should('be.enabled');
     });
 
@@ -416,20 +372,20 @@ describe('Dockstore Organizations', () => {
       cy.get('.mat-dialog-title').should('contain', 'Resend Invitation');
       cy.get('#upsertUserDialogButton').should('be.visible').should('not.be.disabled').click();
       cy.get('#upsertUserDialogButton').should('not.exist');
-      cy.get('#organization-member-1').should('contain', 'potato').should('contain', 'Pending Invitation');
+      cy.get('app-organization-members').should('contain', 'potato').should('contain', 'Pending Invitation');
 
       // Reject membership again and reload for it to be visible
       rejectPotatoMembership();
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
-      cy.get('#organization-member-1').should('contain', 'potato').should('contain', 'Rejected Invitation');
+      cy.get('app-organization-members').should('contain', 'potato').should('contain', 'Rejected Invitation');
     });
 
     it('Delete rejected invitation', () => {
       cy.get('#remove-user-1').should('exist').should('be.enabled').click();
       cy.get('.mat-dialog-title').should('contain', 'Delete Invitation');
       cy.get('[data-cy=confirm-dialog-button]').should('not.be.disabled').click();
-      cy.get('#organization-member-1').contains('potato').should('not.exist');
+      cy.get('app-organization-members').contains('potato').should('not.exist');
     });
   });
 

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -321,11 +321,13 @@ describe('Dockstore Organizations', () => {
       cy.contains('Members').click();
     });
 
-    it('be able to Read and create organization user', () => {
+    it('be able to Read organization user', () => {
       cy.get('mat-progress-bar').should('not.exist');
       cy.get('#organization-member-0').should('be.visible').should('contain', 'user_A').should('contain', 'Admin');
       cy.get('#edit-user-role-0').should('not.exist');
+    });
 
+    it('be able to Create organization user', () => {
       createPotatoMembership();
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Pending Invitation');
       cy.get('#edit-user-role-1').should('exist').should('be.enabled');
@@ -335,11 +337,15 @@ describe('Dockstore Organizations', () => {
       cy.visit('/organizations/Potatoe');
       cy.contains('Members').click();
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Member');
+    });
 
+    it('be able to edit an approved organization', () => {
       cy.get('#editOrgInfo').should('be.visible').click();
       cy.get('#createOrUpdateOrganizationButton').should('be.visible').should('not.be.disabled').click();
       cy.get('#createOrUpdateOrganizationButton').should('not.exist');
+    });
 
+    it('be able to Update organization user', () => {
       cy.get('#edit-user-role-1').should('not.be.disabled').click();
       cy.get('.mat-dialog-title').should('contain', 'Edit Member');
       cy.get('mat-select').click();
@@ -348,7 +354,9 @@ describe('Dockstore Organizations', () => {
       cy.get('#upsertUserDialogButton').should('be.visible').should('not.be.disabled').click();
       cy.get('#upsertUserDialogButton').should('not.exist');
       cy.get('#organization-member-1').should('be.visible').should('contain', 'potato').should('contain', 'Maintainer');
+    });
 
+    it('be able to Delete organization user', () => {
       cy.get('#remove-user-1').should('not.be.disabled').click();
       cy.get('.mat-dialog-title').should('contain', 'Remove Member from Organization');
       cy.get('[data-cy=confirm-dialog-button]').should('not.be.disabled').click();

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -29,6 +29,7 @@ describe('GitHub App Tools', () => {
 
   function selectGitHubAppTool(tool: string) {
     cy.get('#workflow-path').should('be.visible');
+    cy.wait(5000);
     const alias = 'thetool';
     cy.contains('div .no-wrap', tool).should('be.visible').as(alias);
     // Cypress recommends using an alias like this to get around element being re-rendered

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -77,9 +77,7 @@ describe('GitHub App Tools', () => {
       cy.contains('Apps Logs').click();
       cy.contains('1 – 1 of 1');
       cy.contains('Close').click();
-    });
 
-    it('GitHub Tool Private View', () => {
       selectGitHubAppTool('test-github-app-tools/testing');
       cy.get('#publishButton').should('not.be.disabled');
       cy.get('#publishButton').contains('Unpublish');
@@ -137,9 +135,7 @@ describe('GitHub App Tools', () => {
 
       // Fix that the entry list on the left doesn't update without refreshing the page
       selectGitHubAppTool('test-github-app-tools/testing');
-    });
 
-    it('Public view', () => {
       selectGitHubAppTool('test-github-app-tools/md5sum');
       cy.get('[data-cy=viewPublicWorkflowButton]').click();
       cy.get('[data-cy=tool-icon]').should('exist');

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -29,7 +29,10 @@ describe('GitHub App Tools', () => {
 
   function selectGitHubAppTool(tool: string) {
     cy.get('#workflow-path').should('be.visible');
-    cy.contains('div .no-wrap', tool).should('be.visible').click();
+    const alias = 'thetool';
+    cy.contains('div .no-wrap', tool).should('be.visible').as(alias);
+    // Cypress recommends using an alias like this to get around element being re-rendered
+    cy.get('@' + alias).click();
     cy.get('#workflow-path').contains(tool);
   }
 

--- a/cypress/e2e/immutableDatabaseTests/services.ts
+++ b/cypress/e2e/immutableDatabaseTests/services.ts
@@ -135,11 +135,9 @@ describe('Dockstore Home', () => {
     cy.contains('README.md');
     cy.contains('# another-test-serviceaaaa');
 
-    cy.get('mat-tab-body')
-      .first()
-      .within((tabBody) => {
-        cy.get('mat-select').click();
-      });
+    cy.get('app-source-file-tabs').within((tabBody) => {
+      cy.get('mat-select').click();
+    });
     cy.get('mat-option').contains('docker-compose.yml').click();
     cy.contains('docker-compose.yml');
 

--- a/cypress/e2e/immutableDatabaseTests/services.ts
+++ b/cypress/e2e/immutableDatabaseTests/services.ts
@@ -135,9 +135,11 @@ describe('Dockstore Home', () => {
     cy.contains('README.md');
     cy.contains('# another-test-serviceaaaa');
 
-    cy.get('mat-tab-body').within((tabBody) => {
-      cy.get('mat-select').click();
-    });
+    cy.get('mat-tab-body')
+      .first()
+      .within((tabBody) => {
+        cy.get('mat-select').click();
+      });
     cy.get('mat-option').contains('docker-compose.yml').click();
     cy.contains('docker-compose.yml');
 

--- a/cypress/e2e/immutableDatabaseTests/toolsSearch.ts
+++ b/cypress/e2e/immutableDatabaseTests/toolsSearch.ts
@@ -20,8 +20,7 @@ describe('Dockstore tool list page', () => {
   describe('Select a tool', () => {
     it('Should be able to go to the tools search page', () => {
       cy.visit('/search-containers');
-    });
-    it('Should display the correct url', () => {
+
       cy.get('mat-cell')
         .find('a')
         .contains(/\ba\b/)
@@ -32,12 +31,10 @@ describe('Dockstore tool list page', () => {
         .contains('b3')
         .should('have.attr', 'href', '/containers/quay.io/A2/b3')
         .should('not.have.attr', 'href', '/containers/quay.io%20A2%20b3');
-    });
-    // a, b3, dockstore-cgpmap
-    it('Should have 3 tools', () => {
+
+      // a, b3, dockstore-cgpmap
       cy.get('mat-row').should('have.length', 3);
-    });
-    it('Should be able to go to the quay.io/A2/a tool', () => {
+
       cy.get('mat-cell').find('a').contains(/\ba\b/).first().click().get('#tool-path').should('contain', 'quay.io/A2/a');
     });
   });

--- a/cypress/e2e/immutableDatabaseTests/workflowsSearch.ts
+++ b/cypress/e2e/immutableDatabaseTests/workflowsSearch.ts
@@ -20,19 +20,15 @@ describe('Dockstore workflow list page', () => {
   describe('Select a workflow', () => {
     it('Should be able to go to the workflows search page', () => {
       cy.visit('/search-workflows');
-    });
-    it('Should display the correct url', () => {
+
       cy.get('mat-cell')
         .find('a')
         .contains(/^A\/l$/)
         .should('have.attr', 'href', '/workflows/github.com/A/l')
         .should('not.have.attr', 'href', '/workflows/github.com%20A%20l');
-    });
-    // 1 workflow A/l, no checkers from other tests added
-    it('Should have 1 workflow', () => {
+      // 1 workflow A/l, no checkers from other tests added
       cy.get('mat-row').should('have.length', 1);
-    });
-    it('Should be able to go to the github.com/A/l workflow', () => {
+
       cy.get('mat-cell')
         .find('a')
         .contains(/^A\/l$/)

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -101,8 +101,10 @@ describe('Test search page functionality', () => {
   });
   it('filters and unfilters by facets', () => {
     cy.visit('/search');
+    cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow').click();
     cy.get('[data-cy=workflowColumn] a');
+    cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
       cy.wrap($el).contains('NFL');

--- a/cypress/e2e/smokeTests/sharedTests/monitor.ts
+++ b/cypress/e2e/smokeTests/sharedTests/monitor.ts
@@ -71,6 +71,7 @@ describe('Monitor homepage links', () => {
   });
   describe('Test RSS feed', () => {
     it('access RSS feed', () => {
+      cy.visit('');
       cy.get('[data-cy=footer-rss-link]').then((t) => {
         cy.request(t.prop('href')).its('body').should('include', '<rss version="2.0">');
       });

--- a/cypress/e2e/smokeTests/sharedTests/search.ts
+++ b/cypress/e2e/smokeTests/sharedTests/search.ts
@@ -7,33 +7,23 @@ describe('Admin UI', () => {
   describe('Basic search functions', () => {
     it('should arrive on the correct page', () => {
       cy.url().should('include', '/search');
-    });
-    it('should be able to select facet', () => {
       cy.get('mat-checkbox').parent().contains('WDL').click();
       cy.contains('the Language is WDL');
       cy.url().should('include', '/search?descriptorType=WDL');
-    });
-    it('should be able to handle the back and forward buttons', () => {
       cy.go('back');
       cy.url().should('not.include', '/search?descriptorType=WDL');
       cy.contains('the Language is WDL').should('not.exist');
       cy.go('forward');
       cy.url().should('include', '/search?descriptorType=WDL');
       cy.contains('the Language is WDL').should('exist');
-    });
-    it('should be able to use basic search box and have suggestions', () => {
       cy.get('[data-cy=basic-search]').type('dockstore_i{enter}');
       cy.contains(' Sorry, no matches found for dockstore_i');
       cy.contains(/Do[ ]you[ ]mean:[ ].+/);
       cy.url().should('include', 'search=dockstore_i');
-    });
 
-    it('should reset filters', () => {
       cy.contains('Reset').click();
       cy.url().should('not.include', 'search=dockstore_i');
-    });
 
-    it('should remember paginator setting', () => {
       cy.contains('Items per page');
       cy.get('[data-cy=search-workflow-table-paginator]').within(() => {
         cy.get('.mat-paginator-range-label').contains('10 of');
@@ -44,8 +34,7 @@ describe('Admin UI', () => {
       cy.get('a').contains('Organizations').click();
       cy.go('back');
       cy.get('[data-cy=search-workflow-table-paginator]').contains(20);
-    });
-    it('should have basic search and advanced search mutually exclusive', () => {
+
       cy.get('[data-cy=basic-search]').type('dockstore_{enter}');
       cy.contains('Open Advanced Search').click();
       cy.contains('button', /^Advanced Search$/)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -21,9 +21,7 @@ const psqlInvocation: string = 'PASSWORD=dockstore psql';
 export function goToTab(tabName: string): void {
   // cypress tests run asynchronously, so if the DOM changes and an element-of-interest becomes detached while we're manipulating it, the test will fail.
   // our current (admittedly primitive) go-to solution is to wait (sleep) for long enough that the DOM "settles", thus avoiding the "detached element" bug.
-  cy.wait(500);
   cy.contains('.mat-tab-label', tabName).should('be.visible').click();
-  cy.wait(500);
 }
 
 export function assertVisibleTab(tabName: string): void {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -180,6 +180,8 @@ export function testNoGithubEntriesText(entryType: string, repository: string) {
     }
   });
   it('Should have no unpublished ' + entryType + 's in dockstore repository', () => {
+    cy.visit('/my-' + entryType + 's');
+    cy.get('mat-expansion-panel-header').contains(repository).click();
     cy.get('mat-expansion-panel-header')
       .contains(repository)
       .parentsUntil('mat-accordion')

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@types/node": "^15.12.2",
         "@typescript-eslint/eslint-plugin": "5.3.0",
         "@typescript-eslint/parser": "5.3.0",
-        "cypress": "^11.2.0",
+        "cypress": "^12.3.0",
         "eslint": "^8.2.0",
         "husky": "^7.0.0",
         "jasmine-core": "^3.7.1",
@@ -7024,9 +7024,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7077,7 +7077,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -22732,9 +22732,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/node": "^15.12.2",
     "@typescript-eslint/eslint-plugin": "5.3.0",
     "@typescript-eslint/parser": "5.3.0",
-    "cypress": "^11.2.0",
+    "cypress": "^12.3.0",
     "eslint": "^8.2.0",
     "husky": "^7.0.0",
     "jasmine-core": "^3.7.1",

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -12,8 +12,9 @@ fi
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar
-psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
-psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
-psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
-psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
-java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml
+#psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
+#psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
+#psql -h localhost -c 'drop database webservice_test;' -U postgres
+#psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
+#psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
+#java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -12,9 +12,8 @@ fi
 
 wget -O dockstore-webservice.jar --no-verbose --tries=10 ${JAR_PATH}
 chmod u+x dockstore-webservice.jar
-#psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
-#psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
-#psql -h localhost -c 'drop database webservice_test;' -U postgres
-#psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
-#psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
-#java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml
+psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
+psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
+psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
+psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
+java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0 test/web.yml


### PR DESCRIPTION
**Description**
Upgrade to Cypress 12.

The main migration issue is that in Cypress 12 tests are now isolated. This worked before:

```
it('Go to organizations page', () => {
   cy.visit('/organizations');
});
it('Go to an org from organizations page', () => {
  // Click UCSC org on /organizations page.
  cy.get('UCSC').click();
});
```

The second `it` relies on the state of the first `it`, on the user being on the `/organizations` page.

This no longer works in Cypress 12. At the start of each `it`, you're not on a page, and your local storage/cookies have been cleared.

There are 2 possible fixes. Fix 1, add the `cy.visit()` to each `it`, and, if authorization needed, set the token as well.

```
it('Go to organizations page', () => {
   cy.visit('/organizations');
});
it('Go to an org from organizations page', () => {
  cy.visit('/organizations');
  // Click UCSC org on /organizations page.
  cy.get('UCSC').click();
});
```

Fix 2, combine the two `it`'s into one:

```
it('Go to organizations page', () => {
   cy.visit('/organizations');
  // Click UCSC org on /organizations page.
  cy.get('UCSC').click();
});
```

I generally tried to prefer the first fix, but if the the state was even slightly complicated, then I went with the second fix.

I was also able to reduce some of the waits. I think we can eventually get rid of most of them, but one thing at a time.

There is also a small change in how `within` works, and other minor changes that were needed.

**Review Instructions**
Verify smoke tests continue to work (other tests will be tested by the PR itself).

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5089

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
