### PR TITLE
DOCK-2213: edit source code to link to primary descriptor

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -23,82 +23,82 @@ describe('Dockstore my workflows', () => {
   const cwlDescriptorType = 'CWL';
   const wdlDescriptorType = 'WDL';
   const nextflowDescriptorType = 'Nextflow';
-  // it('have entries shown on the homepage', () => {
-  //   cy.visit('/dashboard');
-  //   cy.contains(/^l$/);
-  //   cy.contains('Find entries');
-  //   cy.get('#mat-input-0').type('hosted');
-  //   cy.contains('hosted-workflow');
-  //   cy.get('#mat-input-0').type('potato');
-  //   cy.contains('No matching entries');
-  // });
-  //
-  // it('have action buttons which work', () => {
-  //   cy.fixture('myWorkflows.json').then((json) => {
-  //     cy.intercept('PATCH', '/api/users/1/workflows', {
-  //       body: json,
-  //       statusCode: 200,
-  //     });
-  //   });
-  //
-  //   cy.visit('/my-workflows');
-  //   cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
-  //   cy.get('[data-cy=addToExistingWorkflows]').should('be.visible').click();
-  //
-  //   cy.contains('addedthisworkflowviasync');
-  // });
+  it('have entries shown on the homepage', () => {
+    cy.visit('/dashboard');
+    cy.contains(/^l$/);
+    cy.contains('Find entries');
+    cy.get('#mat-input-0').type('hosted');
+    cy.contains('hosted-workflow');
+    cy.get('#mat-input-0').type('potato');
+    cy.contains('No matching entries');
+  });
+
+  it('have action buttons which work', () => {
+    cy.fixture('myWorkflows.json').then((json) => {
+      cy.intercept('PATCH', '/api/users/1/workflows', {
+        body: json,
+        statusCode: 200,
+      });
+    });
+
+    cy.visit('/my-workflows');
+    cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
+    cy.get('[data-cy=addToExistingWorkflows]').should('be.visible').click();
+
+    cy.contains('addedthisworkflowviasync');
+  });
 
   describe('Should contain extended Workflow properties', () => {
-    // it('visit another page then come back', () => {
-    //   cy.visit('/my-workflows');
-    //   cy.contains('github.com/A/l');
-    //
-    //   cy.contains('Apps Logs').click();
-    //   cy.contains('There were problems retrieving GitHub App logs for this organization.');
-    //   cy.contains('Close').click();
-    //   cy.intercept('GET', '/api/lambdaEvents/**', {
-    //     body: [],
-    //   }).as('refreshWorkflow');
-    //   cy.contains('Apps Logs').click();
-    //   cy.contains('There are no GitHub App logs for this organization.');
-    //   cy.contains('Close').click();
-    //   const realResponse = [
-    //     {
-    //       eventDate: 1582165220000,
-    //       githubUsername: 'boil',
-    //       id: 1,
-    //       message: 'HTTP 418 ',
-    //       organization: 'dockstore',
-    //       reference: 'refs/tag/1.03',
-    //       repository: 'hello_world',
-    //       success: false,
-    //       type: 'PUSH',
-    //     },
-    //     {
-    //       eventDate: 1591368041850,
-    //       githubUsername: 'em',
-    //       id: 2,
-    //       message: 'HTTP 418 ',
-    //       organization: 'dockstore',
-    //       reference: 'refs/tag/1.03',
-    //       repository: 'hello_world',
-    //       success: false,
-    //       type: 'PUSH',
-    //     },
-    //   ];
-    //   cy.intercept('GET', '/api/lambdaEvents/**', {
-    //     body: realResponse,
-    //   }).as('refreshWorkflow');
-    //   cy.contains('Apps Logs').click();
-    //   // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
-    //   cy.contains('2020-02-20T02:20');
-    //   cy.contains('2020-06-05T14:40');
-    //   // These next 2 values only work on the West Coast
-    //   // cy.contains('2020-02-19T18:20');
-    //   // cy.contains('2020-06-05T07:40');
-    //   cy.contains('1 – 2 of 2');
-    //   cy.contains('Close').click();
-    // });
+    it('visit another page then come back', () => {
+      cy.visit('/my-workflows');
+      cy.contains('github.com/A/l');
+
+      cy.contains('Apps Logs').click();
+      cy.contains('There were problems retrieving GitHub App logs for this organization.');
+      cy.contains('Close').click();
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: [],
+      }).as('refreshWorkflow');
+      cy.contains('Apps Logs').click();
+      cy.contains('There are no GitHub App logs for this organization.');
+      cy.contains('Close').click();
+      const realResponse = [
+        {
+          eventDate: 1582165220000,
+          githubUsername: 'boil',
+          id: 1,
+          message: 'HTTP 418 ',
+          organization: 'dockstore',
+          reference: 'refs/tag/1.03',
+          repository: 'hello_world',
+          success: false,
+          type: 'PUSH',
+        },
+        {
+          eventDate: 1591368041850,
+          githubUsername: 'em',
+          id: 2,
+          message: 'HTTP 418 ',
+          organization: 'dockstore',
+          reference: 'refs/tag/1.03',
+          repository: 'hello_world',
+          success: false,
+          type: 'PUSH',
+        },
+      ];
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: realResponse,
+      }).as('refreshWorkflow');
+      cy.contains('Apps Logs').click();
+      // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
+      cy.contains('2020-02-20T02:20');
+      cy.contains('2020-06-05T14:40');
+      // These next 2 values only work on the West Coast
+      // cy.contains('2020-02-19T18:20');
+      // cy.contains('2020-06-05T07:40');
+      cy.contains('1 – 2 of 2');
+      cy.contains('Close').click();
+    });
     it('Should contain the extended properties and be able to edit the info tab', () => {
       // The seemingly unnecessary visits are due to a detached-from-dom error even using cy.get().click();
       cy.visit('/my-workflows/github.com/A/l');
@@ -155,212 +155,212 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=viewPublicWorkflowButton]').should('be.visible').click();
       cy.contains('goodTopic').should('exist');
     });
-    // it('should have mode tooltip', () => {
-    //   cy.visit('/my-workflows/github.com/A/g');
-    //   // .trigger('mouseover') doesn't work for some reason
-    //   cy.contains('Mode').trigger('mouseenter');
-    //   cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
-    //
-    //   cy.contains('github.com/A/g');
-    //   cy.get('button').contains('Manage labels').click();
-    //   cy.get('[data-cy=workflowLabelInput]').type('potato');
-    //   // Adding force:true, appears to be a cypress issue, when clicking this button the event does not fire
-    //   // this will force submitWorkflowEdits() to fire
-    //   cy.get('[data-cy=saveLabelButton]').click({ force: true });
-    //   cy.get('[data-cy=saveLabelButton]').should('not.exist');
-    // });
-    // it('add and remove test parameter file', () => {
-    //   cy.visit('/my-workflows/github.com/A/l');
-    //   cy.contains('Versions').click();
-    //   cy.get('td').contains('Actions').click();
-    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-    //   // For some reason, it would type half in the correct input field, but the other half in the first field
-    //   cy.wait(2000);
-    //   cy.get('[data-cy=test-parameter-file-input]').click();
-    //   cy.get('[data-cy=test-parameter-file-input]').type('/test.wdl.json');
-    //   cy.get('[data-cy=save-version').click();
-    //   cy.get('[data-cy=save-version').should('not.exist');
-    //   cy.get('td').contains('Actions').click();
-    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-    //   cy.get('[data-cy=remove-test-parameter-file-button]').click();
-    //   cy.get('[data-cy=save-version').click();
-    //   cy.get('[data-cy=save-version').should('not.exist');
-    // });
-    // it('Should be able to hide/unhide', () => {
-    //   cy.visit('/my-workflows/github.com/A/l');
-    //   cy.contains('Versions').click();
-    //   cy.get('td').contains('Actions').should('exist').click();
-    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-    //   cy.get('[type="checkbox"]').check();
-    //   cy.contains('button', ' Save ').click();
-    //   // Check for hidden version and unhide
-    //   cy.get('[data-cy=hidden').should('exist');
-    //   cy.visit('/my-workflows/github.com/A/l');
-    //   cy.contains('Versions').click();
-    //   cy.get('td').contains('Actions').should('exist').click();
-    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-    //   cy.get('[type="checkbox"]').uncheck();
-    //   cy.contains('button', ' Save ').click();
-    // });
+    it('should have mode tooltip', () => {
+      cy.visit('/my-workflows/github.com/A/g');
+      // .trigger('mouseover') doesn't work for some reason
+      cy.contains('Mode').trigger('mouseenter');
+      cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
+
+      cy.contains('github.com/A/g');
+      cy.get('button').contains('Manage labels').click();
+      cy.get('[data-cy=workflowLabelInput]').type('potato');
+      // Adding force:true, appears to be a cypress issue, when clicking this button the event does not fire
+      // this will force submitWorkflowEdits() to fire
+      cy.get('[data-cy=saveLabelButton]').click({ force: true });
+      cy.get('[data-cy=saveLabelButton]').should('not.exist');
+    });
+    it('add and remove test parameter file', () => {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.contains('Versions').click();
+      cy.get('td').contains('Actions').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      // For some reason, it would type half in the correct input field, but the other half in the first field
+      cy.wait(2000);
+      cy.get('[data-cy=test-parameter-file-input]').click();
+      cy.get('[data-cy=test-parameter-file-input]').type('/test.wdl.json');
+      cy.get('[data-cy=save-version').click();
+      cy.get('[data-cy=save-version').should('not.exist');
+      cy.get('td').contains('Actions').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      cy.get('[data-cy=remove-test-parameter-file-button]').click();
+      cy.get('[data-cy=save-version').click();
+      cy.get('[data-cy=save-version').should('not.exist');
+    });
+    it('Should be able to hide/unhide', () => {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.contains('Versions').click();
+      cy.get('td').contains('Actions').should('exist').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      cy.get('[type="checkbox"]').check();
+      cy.contains('button', ' Save ').click();
+      // Check for hidden version and unhide
+      cy.get('[data-cy=hidden').should('exist');
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.contains('Versions').click();
+      cy.get('td').contains('Actions').should('exist').click();
+      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+      cy.get('[type="checkbox"]').uncheck();
+      cy.contains('button', ' Save ').click();
+    });
   });
 
-  // describe('Should be able to snapshot, request DOI, and export to ORCID', () => {
-  //   function gotoVersionsAndClickActions() {
-  //     cy.visit('/my-workflows/github.com/A/l');
-  //     cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-  //     goToTab('Versions');
-  //     cy.get('td').contains('Actions').click();
-  //   }
-  //
-  //   it('Should be able to snapshot', () => {
-  //     gotoVersionsAndClickActions();
-  //     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
-  //     // The buttons should be present
-  //     cy.get('[data-cy=dockstore-request-doi-button]').its('length').should('be.gt', 0);
-  //     cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
-  //
-  //     cy.get('[data-cy=dockstore-snapshot-unlocked]').its('length').should('be.gt', 0);
-  //
-  //     cy.get('[data-cy=dockstore-snapshot]').first().click();
-  //
-  //     cy.get('[data-cy=snapshot-button]').click();
-  //
-  //     cy.wait(250);
-  //     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 1);
-  //     cy.get('td').contains('Actions').click();
-  //     cy.get('[data-cy=dockstore-snapshot]').should('be.disabled');
-  //   });
-  //
-  //   it('Request DOI should require linked account', () => {
-  //     gotoVersionsAndClickActions();
-  //     cy.get('[data-cy=dockstore-request-doi-button]').click();
-  //
-  //     cy.get('[data-cy=zenodo-not-linked]').its('length').should('be.gt', 0);
-  //     cy.get('[data-cy=export-button').should('be.disabled');
-  //
-  //     cy.get('[data-cy=link-zenodo]').click();
-  //     cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
-  //   });
-  //
-  //   it('Export to ORCID should require linked account', () => {
-  //     gotoVersionsAndClickActions();
-  //     cy.get('[data-cy=dockstore-export-orcid-button]').click();
-  //     cy.get('[data-cy=orcid-not-linked]').its('length').should('be.gt', 0);
-  //     cy.get('[data-cy=export-button').should('be.disabled');
-  //     cy.get('[data-cy=link-orcid]').click();
-  //     cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
-  //   });
-  //
-  //   it('Should be able to request DOI and then export to ORCID', () => {
-  //     // tokens.json indicates a Zenodo token and an ORCID token
-  //     cy.fixture('tokens.json').then((json) => {
-  //       cy.intercept('GET', '/api/users/1/tokens', {
-  //         body: json,
-  //         statusCode: 200,
-  //       });
-  //     });
-  //     // doiResponse.json has a workflow version with a DOI
-  //     cy.fixture('doiResponse.json').then((json) => {
-  //       cy.intercept('PUT', '/api/**/requestDOI/*', {
-  //         body: json,
-  //         statusCode: 200,
-  //       });
-  //     });
-  //     // orcidExportResponse.json has a workflow version with an ORCID put code
-  //     cy.fixture('orcidExportResponse.json').then((json) => {
-  //       cy.intercept('POST', '/api/entries/*/exportToOrcid?versionId=*', {
-  //         body: json,
-  //         statusCode: 200,
-  //       });
-  //     });
-  //
-  //     cy.get('[data-cy=workflow-version-DOI-badge]').should('not.exist'); // Make sure there are no existing Zenodo badges
-  //     gotoVersionsAndClickActions();
-  //     // Request DOI
-  //     cy.get('[data-cy=dockstore-request-doi-button]').click();
-  //     cy.get('[data-cy=export-button').should('be.enabled');
-  //     cy.get('[data-cy=export-button').click();
-  //     cy.get('[data-cy=workflow-version-DOI-badge]').its('length').should('be.gt', 0); // Should have a DOI badge now
-  //     cy.get('td').contains('Actions').click();
-  //     cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
-  //
-  //     // Export to ORCID
-  //     cy.get('[data-cy=dockstore-export-orcid-button]').click();
-  //     cy.get('[data-cy=export-button').should('be.enabled');
-  //     cy.get('[data-cy=export-button').click();
-  //     cy.get('td').contains('Actions').click();
-  //     cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
-  //   });
-  // });
-  //
-  // it('Should be able to view a dockstore.yml workflow', () => {
-  //   cy.visit('/my-workflows/github.com/B/z');
-  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/B/z');
-  //   cy.contains('Automatically synced via GitHub App');
-  //
-  //   cy.get('#publishButton').should('not.be.disabled');
-  //   cy.get('[data-cy=refreshButton]').should('not.exist');
-  //
-  //   cy.contains('Workflow Path').should('not.exist');
-  //   cy.contains('Test File Path').should('not.exist');
-  //
-  //   // Should not be able to refresh a dockstore.yml workflow version
-  //   goToTab('Versions');
-  //   cy.contains('button', 'Actions').should('be.visible').click();
-  //   cy.contains('button', 'Refresh Version').should('be.disabled');
-  //
-  //   cy.get('body').type('{esc}');
-  //
-  //   // Test file content
-  //   goToTab('Files');
-  //
-  //   cy.contains('/Dockstore.cwl');
-  //   cy.contains('class: Workflow');
-  //
-  //   cy.get('app-source-file-tabs').within((tabBody) => {
-  //     cy.get('mat-select').click();
-  //   });
-  //
-  //   cy.get('mat-option').contains('md5sum-tool.cwl').click();
-  //   cy.contains('class: CommandLineTool');
-  //
-  //   goToTab('Configuration');
-  //   cy.contains('Configuration');
-  //   cy.contains('/.dockstore.yml');
-  // });
-  //
-  // it('Should be able to refresh a workflow version', () => {
-  //   cy.visit('/my-workflows/github.com/A/l');
-  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-  //   goToTab('Versions');
-  //   cy.contains('button', 'Actions').should('be.visible').click();
-  //   cy.contains('button', 'Refresh Version').should('not.be.disabled');
-  // });
-  //
-  // it('Should refresh individual repo when refreshing organization', () => {
-  //   cy.fixture('refreshedAslashl').then((json) => {
-  //     cy.intercept('GET', '/api/workflows/11/refresh', {
-  //       body: json,
-  //     }).as('refreshWorkflow');
-  //   });
-  //   cy.visit('/my-workflows/github.com/A/l');
-  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-  //   goToTab('Versions');
-  //   cy.get('table>tbody>tr').should('have.length', 2); // 2 Versions and no warning line
-  //   cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
-  //   cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
-  //   cy.wait('@refreshWorkflow');
-  //   goToTab('Versions');
-  //   cy.get('table>tbody>tr').should('have.length', 1); // 2 Versions and no warning line
-  // });
-  //
-  // describe('Look at an invalid workflow', () => {
-  //   it('Invalid workflow should not be publishable', () => {
-  //     cy.visit('/my-workflows/github.com/A/g');
-  //     cy.get('#publishButton').should('be.disabled');
-  //     cy.get('[data-cy=refreshButton]').should('not.be.disabled');
-  //   });
-  // });
+  describe('Should be able to snapshot, request DOI, and export to ORCID', () => {
+    function gotoVersionsAndClickActions() {
+      cy.visit('/my-workflows/github.com/A/l');
+      cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+      goToTab('Versions');
+      cy.get('td').contains('Actions').click();
+    }
+
+    it('Should be able to snapshot', () => {
+      gotoVersionsAndClickActions();
+      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+      // The buttons should be present
+      cy.get('[data-cy=dockstore-request-doi-button]').its('length').should('be.gt', 0);
+      cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
+
+      cy.get('[data-cy=dockstore-snapshot-unlocked]').its('length').should('be.gt', 0);
+
+      cy.get('[data-cy=dockstore-snapshot]').first().click();
+
+      cy.get('[data-cy=snapshot-button]').click();
+
+      cy.wait(250);
+      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 1);
+      cy.get('td').contains('Actions').click();
+      cy.get('[data-cy=dockstore-snapshot]').should('be.disabled');
+    });
+
+    it('Request DOI should require linked account', () => {
+      gotoVersionsAndClickActions();
+      cy.get('[data-cy=dockstore-request-doi-button]').click();
+
+      cy.get('[data-cy=zenodo-not-linked]').its('length').should('be.gt', 0);
+      cy.get('[data-cy=export-button').should('be.disabled');
+
+      cy.get('[data-cy=link-zenodo]').click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
+
+    it('Export to ORCID should require linked account', () => {
+      gotoVersionsAndClickActions();
+      cy.get('[data-cy=dockstore-export-orcid-button]').click();
+      cy.get('[data-cy=orcid-not-linked]').its('length').should('be.gt', 0);
+      cy.get('[data-cy=export-button').should('be.disabled');
+      cy.get('[data-cy=link-orcid]').click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
+
+    it('Should be able to request DOI and then export to ORCID', () => {
+      // tokens.json indicates a Zenodo token and an ORCID token
+      cy.fixture('tokens.json').then((json) => {
+        cy.intercept('GET', '/api/users/1/tokens', {
+          body: json,
+          statusCode: 200,
+        });
+      });
+      // doiResponse.json has a workflow version with a DOI
+      cy.fixture('doiResponse.json').then((json) => {
+        cy.intercept('PUT', '/api/**/requestDOI/*', {
+          body: json,
+          statusCode: 200,
+        });
+      });
+      // orcidExportResponse.json has a workflow version with an ORCID put code
+      cy.fixture('orcidExportResponse.json').then((json) => {
+        cy.intercept('POST', '/api/entries/*/exportToOrcid?versionId=*', {
+          body: json,
+          statusCode: 200,
+        });
+      });
+
+      cy.get('[data-cy=workflow-version-DOI-badge]').should('not.exist'); // Make sure there are no existing Zenodo badges
+      gotoVersionsAndClickActions();
+      // Request DOI
+      cy.get('[data-cy=dockstore-request-doi-button]').click();
+      cy.get('[data-cy=export-button').should('be.enabled');
+      cy.get('[data-cy=export-button').click();
+      cy.get('[data-cy=workflow-version-DOI-badge]').its('length').should('be.gt', 0); // Should have a DOI badge now
+      cy.get('td').contains('Actions').click();
+      cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
+
+      // Export to ORCID
+      cy.get('[data-cy=dockstore-export-orcid-button]').click();
+      cy.get('[data-cy=export-button').should('be.enabled');
+      cy.get('[data-cy=export-button').click();
+      cy.get('td').contains('Actions').click();
+      cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
+    });
+  });
+
+  it('Should be able to view a dockstore.yml workflow', () => {
+    cy.visit('/my-workflows/github.com/B/z');
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/B/z');
+    cy.contains('Automatically synced via GitHub App');
+
+    cy.get('#publishButton').should('not.be.disabled');
+    cy.get('[data-cy=refreshButton]').should('not.exist');
+
+    cy.contains('Workflow Path').should('not.exist');
+    cy.contains('Test File Path').should('not.exist');
+
+    // Should not be able to refresh a dockstore.yml workflow version
+    goToTab('Versions');
+    cy.contains('button', 'Actions').should('be.visible').click();
+    cy.contains('button', 'Refresh Version').should('be.disabled');
+
+    cy.get('body').type('{esc}');
+
+    // Test file content
+    goToTab('Files');
+
+    cy.contains('/Dockstore.cwl');
+    cy.contains('class: Workflow');
+
+    cy.get('app-source-file-tabs').within((tabBody) => {
+      cy.get('mat-select').click();
+    });
+
+    cy.get('mat-option').contains('md5sum-tool.cwl').click();
+    cy.contains('class: CommandLineTool');
+
+    goToTab('Configuration');
+    cy.contains('Configuration');
+    cy.contains('/.dockstore.yml');
+  });
+
+  it('Should be able to refresh a workflow version', () => {
+    cy.visit('/my-workflows/github.com/A/l');
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+    goToTab('Versions');
+    cy.contains('button', 'Actions').should('be.visible').click();
+    cy.contains('button', 'Refresh Version').should('not.be.disabled');
+  });
+
+  it('Should refresh individual repo when refreshing organization', () => {
+    cy.fixture('refreshedAslashl').then((json) => {
+      cy.intercept('GET', '/api/workflows/11/refresh', {
+        body: json,
+      }).as('refreshWorkflow');
+    });
+    cy.visit('/my-workflows/github.com/A/l');
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+    goToTab('Versions');
+    cy.get('table>tbody>tr').should('have.length', 2); // 2 Versions and no warning line
+    cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
+    cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
+    cy.wait('@refreshWorkflow');
+    goToTab('Versions');
+    cy.get('table>tbody>tr').should('have.length', 1); // 2 Versions and no warning line
+  });
+
+  describe('Look at an invalid workflow', () => {
+    it('Invalid workflow should not be publishable', () => {
+      cy.visit('/my-workflows/github.com/A/g');
+      cy.get('#publishButton').should('be.disabled');
+      cy.get('[data-cy=refreshButton]').should('not.be.disabled');
+    });
+  });
 
   function haveAlert() {
     cy.get('.mat-error').should('be.visible');

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -23,87 +23,88 @@ describe('Dockstore my workflows', () => {
   const cwlDescriptorType = 'CWL';
   const wdlDescriptorType = 'WDL';
   const nextflowDescriptorType = 'Nextflow';
-  it('have entries shown on the homepage', () => {
-    cy.visit('/dashboard');
-    cy.contains(/^l$/);
-    cy.contains('Find entries');
-    cy.get('#mat-input-0').type('hosted');
-    cy.contains('hosted-workflow');
-    cy.get('#mat-input-0').type('potato');
-    cy.contains('No matching entries');
-  });
-
-  it('have action buttons which work', () => {
-    cy.fixture('myWorkflows.json').then((json) => {
-      cy.intercept('PATCH', '/api/users/1/workflows', {
-        body: json,
-        statusCode: 200,
-      });
-    });
-
-    cy.visit('/my-workflows');
-    cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
-    cy.get('[data-cy=addToExistingWorkflows]').should('be.visible').click();
-
-    cy.contains('addedthisworkflowviasync');
-  });
+  // it('have entries shown on the homepage', () => {
+  //   cy.visit('/dashboard');
+  //   cy.contains(/^l$/);
+  //   cy.contains('Find entries');
+  //   cy.get('#mat-input-0').type('hosted');
+  //   cy.contains('hosted-workflow');
+  //   cy.get('#mat-input-0').type('potato');
+  //   cy.contains('No matching entries');
+  // });
+  //
+  // it('have action buttons which work', () => {
+  //   cy.fixture('myWorkflows.json').then((json) => {
+  //     cy.intercept('PATCH', '/api/users/1/workflows', {
+  //       body: json,
+  //       statusCode: 200,
+  //     });
+  //   });
+  //
+  //   cy.visit('/my-workflows');
+  //   cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
+  //   cy.get('[data-cy=addToExistingWorkflows]').should('be.visible').click();
+  //
+  //   cy.contains('addedthisworkflowviasync');
+  // });
 
   describe('Should contain extended Workflow properties', () => {
-    it('visit another page then come back', () => {
-      cy.visit('/my-workflows');
-      cy.contains('github.com/A/l');
-
-      cy.contains('Apps Logs').click();
-      cy.contains('There were problems retrieving GitHub App logs for this organization.');
-      cy.contains('Close').click();
-      cy.intercept('GET', '/api/lambdaEvents/**', {
-        body: [],
-      }).as('refreshWorkflow');
-      cy.contains('Apps Logs').click();
-      cy.contains('There are no GitHub App logs for this organization.');
-      cy.contains('Close').click();
-      const realResponse = [
-        {
-          eventDate: 1582165220000,
-          githubUsername: 'boil',
-          id: 1,
-          message: 'HTTP 418 ',
-          organization: 'dockstore',
-          reference: 'refs/tag/1.03',
-          repository: 'hello_world',
-          success: false,
-          type: 'PUSH',
-        },
-        {
-          eventDate: 1591368041850,
-          githubUsername: 'em',
-          id: 2,
-          message: 'HTTP 418 ',
-          organization: 'dockstore',
-          reference: 'refs/tag/1.03',
-          repository: 'hello_world',
-          success: false,
-          type: 'PUSH',
-        },
-      ];
-      cy.intercept('GET', '/api/lambdaEvents/**', {
-        body: realResponse,
-      }).as('refreshWorkflow');
-      cy.contains('Apps Logs').click();
-      // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
-      cy.contains('2020-02-20T02:20');
-      cy.contains('2020-06-05T14:40');
-      // These next 2 values only work on the West Coast
-      // cy.contains('2020-02-19T18:20');
-      // cy.contains('2020-06-05T07:40');
-      cy.contains('1 – 2 of 2');
-      cy.contains('Close').click();
-    });
+    // it('visit another page then come back', () => {
+    //   cy.visit('/my-workflows');
+    //   cy.contains('github.com/A/l');
+    //
+    //   cy.contains('Apps Logs').click();
+    //   cy.contains('There were problems retrieving GitHub App logs for this organization.');
+    //   cy.contains('Close').click();
+    //   cy.intercept('GET', '/api/lambdaEvents/**', {
+    //     body: [],
+    //   }).as('refreshWorkflow');
+    //   cy.contains('Apps Logs').click();
+    //   cy.contains('There are no GitHub App logs for this organization.');
+    //   cy.contains('Close').click();
+    //   const realResponse = [
+    //     {
+    //       eventDate: 1582165220000,
+    //       githubUsername: 'boil',
+    //       id: 1,
+    //       message: 'HTTP 418 ',
+    //       organization: 'dockstore',
+    //       reference: 'refs/tag/1.03',
+    //       repository: 'hello_world',
+    //       success: false,
+    //       type: 'PUSH',
+    //     },
+    //     {
+    //       eventDate: 1591368041850,
+    //       githubUsername: 'em',
+    //       id: 2,
+    //       message: 'HTTP 418 ',
+    //       organization: 'dockstore',
+    //       reference: 'refs/tag/1.03',
+    //       repository: 'hello_world',
+    //       success: false,
+    //       type: 'PUSH',
+    //     },
+    //   ];
+    //   cy.intercept('GET', '/api/lambdaEvents/**', {
+    //     body: realResponse,
+    //   }).as('refreshWorkflow');
+    //   cy.contains('Apps Logs').click();
+    //   // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
+    //   cy.contains('2020-02-20T02:20');
+    //   cy.contains('2020-06-05T14:40');
+    //   // These next 2 values only work on the West Coast
+    //   // cy.contains('2020-02-19T18:20');
+    //   // cy.contains('2020-06-05T07:40');
+    //   cy.contains('1 – 2 of 2');
+    //   cy.contains('Close').click();
+    // });
     it('Should contain the extended properties and be able to edit the info tab', () => {
       // The seemingly unnecessary visits are due to a detached-from-dom error even using cy.get().click();
-      cy.visit('/my-workflows/github.com/A/g');
+      cy.visit('/my-workflows/github.com/A/l');
       cy.contains('github.com');
-      cy.get('a#sourceRepository').contains('A/g').should('have.attr', 'href', 'https://github.com/A/g');
+      cy.get('[data-cy=sourceRepository]').should('contain.text', '1st-workflow.cwl');
+      cy.visit('/my-workflows/github.com/A/g');
       cy.contains('/Dockstore.cwl');
       // Change the file path
       cy.contains('button', ' Edit ').click();
@@ -154,212 +155,212 @@ describe('Dockstore my workflows', () => {
       cy.get('[data-cy=viewPublicWorkflowButton]').should('be.visible').click();
       cy.contains('goodTopic').should('exist');
     });
-    it('should have mode tooltip', () => {
-      cy.visit('/my-workflows/github.com/A/g');
-      // .trigger('mouseover') doesn't work for some reason
-      cy.contains('Mode').trigger('mouseenter');
-      cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
-
-      cy.contains('github.com/A/g');
-      cy.get('button').contains('Manage labels').click();
-      cy.get('[data-cy=workflowLabelInput]').type('potato');
-      // Adding force:true, appears to be a cypress issue, when clicking this button the event does not fire
-      // this will force submitWorkflowEdits() to fire
-      cy.get('[data-cy=saveLabelButton]').click({ force: true });
-      cy.get('[data-cy=saveLabelButton]').should('not.exist');
-    });
-    it('add and remove test parameter file', () => {
-      cy.visit('/my-workflows/github.com/A/l');
-      cy.contains('Versions').click();
-      cy.get('td').contains('Actions').click();
-      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-      // For some reason, it would type half in the correct input field, but the other half in the first field
-      cy.wait(2000);
-      cy.get('[data-cy=test-parameter-file-input]').click();
-      cy.get('[data-cy=test-parameter-file-input]').type('/test.wdl.json');
-      cy.get('[data-cy=save-version').click();
-      cy.get('[data-cy=save-version').should('not.exist');
-      cy.get('td').contains('Actions').click();
-      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-      cy.get('[data-cy=remove-test-parameter-file-button]').click();
-      cy.get('[data-cy=save-version').click();
-      cy.get('[data-cy=save-version').should('not.exist');
-    });
-    it('Should be able to hide/unhide', () => {
-      cy.visit('/my-workflows/github.com/A/l');
-      cy.contains('Versions').click();
-      cy.get('td').contains('Actions').should('exist').click();
-      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-      cy.get('[type="checkbox"]').check();
-      cy.contains('button', ' Save ').click();
-      // Check for hidden version and unhide
-      cy.get('[data-cy=hidden').should('exist');
-      cy.visit('/my-workflows/github.com/A/l');
-      cy.contains('Versions').click();
-      cy.get('td').contains('Actions').should('exist').click();
-      cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
-      cy.get('[type="checkbox"]').uncheck();
-      cy.contains('button', ' Save ').click();
-    });
+    // it('should have mode tooltip', () => {
+    //   cy.visit('/my-workflows/github.com/A/g');
+    //   // .trigger('mouseover') doesn't work for some reason
+    //   cy.contains('Mode').trigger('mouseenter');
+    //   cy.get('.mat-tooltip').contains('STUB: Basic metadata pulled from source control.');
+    //
+    //   cy.contains('github.com/A/g');
+    //   cy.get('button').contains('Manage labels').click();
+    //   cy.get('[data-cy=workflowLabelInput]').type('potato');
+    //   // Adding force:true, appears to be a cypress issue, when clicking this button the event does not fire
+    //   // this will force submitWorkflowEdits() to fire
+    //   cy.get('[data-cy=saveLabelButton]').click({ force: true });
+    //   cy.get('[data-cy=saveLabelButton]').should('not.exist');
+    // });
+    // it('add and remove test parameter file', () => {
+    //   cy.visit('/my-workflows/github.com/A/l');
+    //   cy.contains('Versions').click();
+    //   cy.get('td').contains('Actions').click();
+    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+    //   // For some reason, it would type half in the correct input field, but the other half in the first field
+    //   cy.wait(2000);
+    //   cy.get('[data-cy=test-parameter-file-input]').click();
+    //   cy.get('[data-cy=test-parameter-file-input]').type('/test.wdl.json');
+    //   cy.get('[data-cy=save-version').click();
+    //   cy.get('[data-cy=save-version').should('not.exist');
+    //   cy.get('td').contains('Actions').click();
+    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+    //   cy.get('[data-cy=remove-test-parameter-file-button]').click();
+    //   cy.get('[data-cy=save-version').click();
+    //   cy.get('[data-cy=save-version').should('not.exist');
+    // });
+    // it('Should be able to hide/unhide', () => {
+    //   cy.visit('/my-workflows/github.com/A/l');
+    //   cy.contains('Versions').click();
+    //   cy.get('td').contains('Actions').should('exist').click();
+    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+    //   cy.get('[type="checkbox"]').check();
+    //   cy.contains('button', ' Save ').click();
+    //   // Check for hidden version and unhide
+    //   cy.get('[data-cy=hidden').should('exist');
+    //   cy.visit('/my-workflows/github.com/A/l');
+    //   cy.contains('Versions').click();
+    //   cy.get('td').contains('Actions').should('exist').click();
+    //   cy.get('.cdk-overlay-connected-position-bounding-box').contains('Edit').click();
+    //   cy.get('[type="checkbox"]').uncheck();
+    //   cy.contains('button', ' Save ').click();
+    // });
   });
 
-  describe('Should be able to snapshot, request DOI, and export to ORCID', () => {
-    function gotoVersionsAndClickActions() {
-      cy.visit('/my-workflows/github.com/A/l');
-      cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-      goToTab('Versions');
-      cy.get('td').contains('Actions').click();
-    }
-
-    it('Should be able to snapshot', () => {
-      gotoVersionsAndClickActions();
-      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
-      // The buttons should be present
-      cy.get('[data-cy=dockstore-request-doi-button]').its('length').should('be.gt', 0);
-      cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
-
-      cy.get('[data-cy=dockstore-snapshot-unlocked]').its('length').should('be.gt', 0);
-
-      cy.get('[data-cy=dockstore-snapshot]').first().click();
-
-      cy.get('[data-cy=snapshot-button]').click();
-
-      cy.wait(250);
-      cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 1);
-      cy.get('td').contains('Actions').click();
-      cy.get('[data-cy=dockstore-snapshot]').should('be.disabled');
-    });
-
-    it('Request DOI should require linked account', () => {
-      gotoVersionsAndClickActions();
-      cy.get('[data-cy=dockstore-request-doi-button]').click();
-
-      cy.get('[data-cy=zenodo-not-linked]').its('length').should('be.gt', 0);
-      cy.get('[data-cy=export-button').should('be.disabled');
-
-      cy.get('[data-cy=link-zenodo]').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
-    });
-
-    it('Export to ORCID should require linked account', () => {
-      gotoVersionsAndClickActions();
-      cy.get('[data-cy=dockstore-export-orcid-button]').click();
-      cy.get('[data-cy=orcid-not-linked]').its('length').should('be.gt', 0);
-      cy.get('[data-cy=export-button').should('be.disabled');
-      cy.get('[data-cy=link-orcid]').click();
-      cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
-    });
-
-    it('Should be able to request DOI and then export to ORCID', () => {
-      // tokens.json indicates a Zenodo token and an ORCID token
-      cy.fixture('tokens.json').then((json) => {
-        cy.intercept('GET', '/api/users/1/tokens', {
-          body: json,
-          statusCode: 200,
-        });
-      });
-      // doiResponse.json has a workflow version with a DOI
-      cy.fixture('doiResponse.json').then((json) => {
-        cy.intercept('PUT', '/api/**/requestDOI/*', {
-          body: json,
-          statusCode: 200,
-        });
-      });
-      // orcidExportResponse.json has a workflow version with an ORCID put code
-      cy.fixture('orcidExportResponse.json').then((json) => {
-        cy.intercept('POST', '/api/entries/*/exportToOrcid?versionId=*', {
-          body: json,
-          statusCode: 200,
-        });
-      });
-
-      cy.get('[data-cy=workflow-version-DOI-badge]').should('not.exist'); // Make sure there are no existing Zenodo badges
-      gotoVersionsAndClickActions();
-      // Request DOI
-      cy.get('[data-cy=dockstore-request-doi-button]').click();
-      cy.get('[data-cy=export-button').should('be.enabled');
-      cy.get('[data-cy=export-button').click();
-      cy.get('[data-cy=workflow-version-DOI-badge]').its('length').should('be.gt', 0); // Should have a DOI badge now
-      cy.get('td').contains('Actions').click();
-      cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
-
-      // Export to ORCID
-      cy.get('[data-cy=dockstore-export-orcid-button]').click();
-      cy.get('[data-cy=export-button').should('be.enabled');
-      cy.get('[data-cy=export-button').click();
-      cy.get('td').contains('Actions').click();
-      cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
-    });
-  });
-
-  it('Should be able to view a dockstore.yml workflow', () => {
-    cy.visit('/my-workflows/github.com/B/z');
-    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/B/z');
-    cy.contains('Automatically synced via GitHub App');
-
-    cy.get('#publishButton').should('not.be.disabled');
-    cy.get('[data-cy=refreshButton]').should('not.exist');
-
-    cy.contains('Workflow Path').should('not.exist');
-    cy.contains('Test File Path').should('not.exist');
-
-    // Should not be able to refresh a dockstore.yml workflow version
-    goToTab('Versions');
-    cy.contains('button', 'Actions').should('be.visible').click();
-    cy.contains('button', 'Refresh Version').should('be.disabled');
-
-    cy.get('body').type('{esc}');
-
-    // Test file content
-    goToTab('Files');
-
-    cy.contains('/Dockstore.cwl');
-    cy.contains('class: Workflow');
-
-    cy.get('app-source-file-tabs').within((tabBody) => {
-      cy.get('mat-select').click();
-    });
-
-    cy.get('mat-option').contains('md5sum-tool.cwl').click();
-    cy.contains('class: CommandLineTool');
-
-    goToTab('Configuration');
-    cy.contains('Configuration');
-    cy.contains('/.dockstore.yml');
-  });
-
-  it('Should be able to refresh a workflow version', () => {
-    cy.visit('/my-workflows/github.com/A/l');
-    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-    goToTab('Versions');
-    cy.contains('button', 'Actions').should('be.visible').click();
-    cy.contains('button', 'Refresh Version').should('not.be.disabled');
-  });
-
-  it('Should refresh individual repo when refreshing organization', () => {
-    cy.fixture('refreshedAslashl').then((json) => {
-      cy.intercept('GET', '/api/workflows/11/refresh', {
-        body: json,
-      }).as('refreshWorkflow');
-    });
-    cy.visit('/my-workflows/github.com/A/l');
-    cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
-    goToTab('Versions');
-    cy.get('table>tbody>tr').should('have.length', 2); // 2 Versions and no warning line
-    cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
-    cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
-    cy.wait('@refreshWorkflow');
-    goToTab('Versions');
-    cy.get('table>tbody>tr').should('have.length', 1); // 2 Versions and no warning line
-  });
-
-  describe('Look at an invalid workflow', () => {
-    it('Invalid workflow should not be publishable', () => {
-      cy.visit('/my-workflows/github.com/A/g');
-      cy.get('#publishButton').should('be.disabled');
-      cy.get('[data-cy=refreshButton]').should('not.be.disabled');
-    });
-  });
+  // describe('Should be able to snapshot, request DOI, and export to ORCID', () => {
+  //   function gotoVersionsAndClickActions() {
+  //     cy.visit('/my-workflows/github.com/A/l');
+  //     cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+  //     goToTab('Versions');
+  //     cy.get('td').contains('Actions').click();
+  //   }
+  //
+  //   it('Should be able to snapshot', () => {
+  //     gotoVersionsAndClickActions();
+  //     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 0);
+  //     // The buttons should be present
+  //     cy.get('[data-cy=dockstore-request-doi-button]').its('length').should('be.gt', 0);
+  //     cy.get('[data-cy=dockstore-snapshot]').its('length').should('be.gt', 0);
+  //
+  //     cy.get('[data-cy=dockstore-snapshot-unlocked]').its('length').should('be.gt', 0);
+  //
+  //     cy.get('[data-cy=dockstore-snapshot]').first().click();
+  //
+  //     cy.get('[data-cy=snapshot-button]').click();
+  //
+  //     cy.wait(250);
+  //     cy.get('[data-cy=dockstore-snapshot-locked]').should('have.length', 1);
+  //     cy.get('td').contains('Actions').click();
+  //     cy.get('[data-cy=dockstore-snapshot]').should('be.disabled');
+  //   });
+  //
+  //   it('Request DOI should require linked account', () => {
+  //     gotoVersionsAndClickActions();
+  //     cy.get('[data-cy=dockstore-request-doi-button]').click();
+  //
+  //     cy.get('[data-cy=zenodo-not-linked]').its('length').should('be.gt', 0);
+  //     cy.get('[data-cy=export-button').should('be.disabled');
+  //
+  //     cy.get('[data-cy=link-zenodo]').click();
+  //     cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+  //   });
+  //
+  //   it('Export to ORCID should require linked account', () => {
+  //     gotoVersionsAndClickActions();
+  //     cy.get('[data-cy=dockstore-export-orcid-button]').click();
+  //     cy.get('[data-cy=orcid-not-linked]').its('length').should('be.gt', 0);
+  //     cy.get('[data-cy=export-button').should('be.disabled');
+  //     cy.get('[data-cy=link-orcid]').click();
+  //     cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+  //   });
+  //
+  //   it('Should be able to request DOI and then export to ORCID', () => {
+  //     // tokens.json indicates a Zenodo token and an ORCID token
+  //     cy.fixture('tokens.json').then((json) => {
+  //       cy.intercept('GET', '/api/users/1/tokens', {
+  //         body: json,
+  //         statusCode: 200,
+  //       });
+  //     });
+  //     // doiResponse.json has a workflow version with a DOI
+  //     cy.fixture('doiResponse.json').then((json) => {
+  //       cy.intercept('PUT', '/api/**/requestDOI/*', {
+  //         body: json,
+  //         statusCode: 200,
+  //       });
+  //     });
+  //     // orcidExportResponse.json has a workflow version with an ORCID put code
+  //     cy.fixture('orcidExportResponse.json').then((json) => {
+  //       cy.intercept('POST', '/api/entries/*/exportToOrcid?versionId=*', {
+  //         body: json,
+  //         statusCode: 200,
+  //       });
+  //     });
+  //
+  //     cy.get('[data-cy=workflow-version-DOI-badge]').should('not.exist'); // Make sure there are no existing Zenodo badges
+  //     gotoVersionsAndClickActions();
+  //     // Request DOI
+  //     cy.get('[data-cy=dockstore-request-doi-button]').click();
+  //     cy.get('[data-cy=export-button').should('be.enabled');
+  //     cy.get('[data-cy=export-button').click();
+  //     cy.get('[data-cy=workflow-version-DOI-badge]').its('length').should('be.gt', 0); // Should have a DOI badge now
+  //     cy.get('td').contains('Actions').click();
+  //     cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
+  //
+  //     // Export to ORCID
+  //     cy.get('[data-cy=dockstore-export-orcid-button]').click();
+  //     cy.get('[data-cy=export-button').should('be.enabled');
+  //     cy.get('[data-cy=export-button').click();
+  //     cy.get('td').contains('Actions').click();
+  //     cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
+  //   });
+  // });
+  //
+  // it('Should be able to view a dockstore.yml workflow', () => {
+  //   cy.visit('/my-workflows/github.com/B/z');
+  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/B/z');
+  //   cy.contains('Automatically synced via GitHub App');
+  //
+  //   cy.get('#publishButton').should('not.be.disabled');
+  //   cy.get('[data-cy=refreshButton]').should('not.exist');
+  //
+  //   cy.contains('Workflow Path').should('not.exist');
+  //   cy.contains('Test File Path').should('not.exist');
+  //
+  //   // Should not be able to refresh a dockstore.yml workflow version
+  //   goToTab('Versions');
+  //   cy.contains('button', 'Actions').should('be.visible').click();
+  //   cy.contains('button', 'Refresh Version').should('be.disabled');
+  //
+  //   cy.get('body').type('{esc}');
+  //
+  //   // Test file content
+  //   goToTab('Files');
+  //
+  //   cy.contains('/Dockstore.cwl');
+  //   cy.contains('class: Workflow');
+  //
+  //   cy.get('app-source-file-tabs').within((tabBody) => {
+  //     cy.get('mat-select').click();
+  //   });
+  //
+  //   cy.get('mat-option').contains('md5sum-tool.cwl').click();
+  //   cy.contains('class: CommandLineTool');
+  //
+  //   goToTab('Configuration');
+  //   cy.contains('Configuration');
+  //   cy.contains('/.dockstore.yml');
+  // });
+  //
+  // it('Should be able to refresh a workflow version', () => {
+  //   cy.visit('/my-workflows/github.com/A/l');
+  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+  //   goToTab('Versions');
+  //   cy.contains('button', 'Actions').should('be.visible').click();
+  //   cy.contains('button', 'Refresh Version').should('not.be.disabled');
+  // });
+  //
+  // it('Should refresh individual repo when refreshing organization', () => {
+  //   cy.fixture('refreshedAslashl').then((json) => {
+  //     cy.intercept('GET', '/api/workflows/11/refresh', {
+  //       body: json,
+  //     }).as('refreshWorkflow');
+  //   });
+  //   cy.visit('/my-workflows/github.com/A/l');
+  //   cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
+  //   goToTab('Versions');
+  //   cy.get('table>tbody>tr').should('have.length', 2); // 2 Versions and no warning line
+  //   cy.get('[data-cy=refreshOrganization]:visible').should('be.visible').click();
+  //   cy.get('[data-cy=confirm-dialog-button] > .mat-button-wrapper').contains('Refresh').click();
+  //   cy.wait('@refreshWorkflow');
+  //   goToTab('Versions');
+  //   cy.get('table>tbody>tr').should('have.length', 1); // 2 Versions and no warning line
+  // });
+  //
+  // describe('Look at an invalid workflow', () => {
+  //   it('Invalid workflow should not be publishable', () => {
+  //     cy.visit('/my-workflows/github.com/A/g');
+  //     cy.get('#publishButton').should('be.disabled');
+  //     cy.get('[data-cy=refreshButton]').should('not.be.disabled');
+  //   });
+  // });
 
   function haveAlert() {
     cy.get('.mat-error').should('be.visible');

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -45,9 +45,9 @@
             <a
               id="sourceRepository"
               data-cy="sourceRepository"
-              [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '')"
+              [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '') + '/' + sourceCodeFile"
             >
-              {{ workflow?.providerUrl | urlDeconstruct: (isPublic ? selectedVersion?.name : '') }}
+              {{ sourceCodeFile }}
             </a>
           </li>
         </span>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -47,7 +47,7 @@
               data-cy="sourceRepository"
               [href]="workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '') + '/' + sourceCodeFile"
             >
-              {{ sourceCodeFile }}
+              {{ workflow?.providerUrl | versionProviderUrl: (isPublic ? selectedVersion?.name : '') + '/' + sourceCodeFile }}
             </a>
           </li>
         </span>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -39,7 +39,7 @@
     <mat-divider></mat-divider>
     <mat-card-content class="p-3">
       <ul class="list-unstyled container-info" *ngIf="workflow">
-        <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED">
+        <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="truncate-text-1">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
             <strong matTooltip="Git repository for the associated descriptors">Source Code</strong>:
             <a

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -120,7 +120,11 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
         this.selectedVersion.workflow_path,
         this.sessionQuery.getValue().entryType
       );
-      this.sourceCodeFile = this.selectedVersion.workflow_path.slice(1); //removes first slash to prevent from displaying on text
+      if (this.selectedVersion.workflow_path.charAt(0) === '/') {
+        this.sourceCodeFile = this.selectedVersion.workflow_path.slice(1); //removes first slash to prevent from displaying on text
+      } else {
+        this.sourceCodeFile = this.selectedVersion.workflow_path;
+      }
       const found = this.validVersions.find((version: WorkflowVersion) => version.id === this.selectedVersion.id);
       this.isValidVersion = found ? true : false;
       this.downloadZipLink = Dockstore.API_URI + '/workflows/' + this.workflow.id + '/zip/' + this.currentVersion.id;

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -69,6 +69,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   topicEditing: boolean;
   isPublic: boolean;
   trsLink: string;
+  sourceCodeFile: string;
   displayTextForButton: string;
   displayedColumns: string[] = ['name', 'role', 'affiliation', 'email', 'orcid_id'];
   authors: (Author | OrcidAuthorInformation)[] = [];
@@ -150,6 +151,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .subscribe((entryType) => (this.displayTextForButton = this.infoTabService.getTRSId(this.workflow, entryType)));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
     this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
+    this.sourceCodeFile = this.selectedVersion.workflow_path.slice(1); //removes first slash to prevent from displaying on text
   }
   /**
    * Handle restubbing a workflow

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -120,6 +120,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
         this.selectedVersion.workflow_path,
         this.sessionQuery.getValue().entryType
       );
+      this.sourceCodeFile = this.selectedVersion.workflow_path.slice(1); //removes first slash to prevent from displaying on text
       const found = this.validVersions.find((version: WorkflowVersion) => version.id === this.selectedVersion.id);
       this.isValidVersion = found ? true : false;
       this.downloadZipLink = Dockstore.API_URI + '/workflows/' + this.workflow.id + '/zip/' + this.currentVersion.id;
@@ -151,7 +152,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .subscribe((entryType) => (this.displayTextForButton = this.infoTabService.getTRSId(this.workflow, entryType)));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
     this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
-    this.sourceCodeFile = this.selectedVersion.workflow_path.slice(1); //removes first slash to prevent from displaying on text
   }
   /**
    * Handle restubbing a workflow


### PR DESCRIPTION
**Description**
This PR changes the Source Code link to point to the primary descriptor file instead of pointing to the root of the repo. Also, some workflows had very long paths so the text of the link was changed to only display the file name.

**Review Instructions**
Verify the link is edited correctly

**Issue**
https://github.com/dockstore/dockstore/issues/5044

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
