### PR TITLE
Updated Dashboard Starred Box - SEAB-5197

### DIFF
--- a/src/app/home-page/widget/starred-box/starred-box.component.html
+++ b/src/app/home-page/widget/starred-box/starred-box.component.html
@@ -1,192 +1,204 @@
 <mat-card class="h-100">
-  <div id="header-bar" fxLayout="row" fxLayoutAlign="space-between">
-    <mat-card-header fxLayout="row">
-      <mat-card-title>Starred</mat-card-title>
-    </mat-card-header>
-    <div id="total-starred" fxLayout="row" fxLayoutGap="1rem" class="size-small pb-3">
-      <div [ngPlural]="totalStarredWorkflows" id="starred-workflows" fxLayout="row" fxLayoutAlign="start center">
-        <ng-template ngPluralCase="=0"> <img src="../assets/svg/star-off.svg" alt="star" class="mr-1" />0 Workflows</ng-template>
-        <ng-template ngPluralCase="=1"> <img src="../assets/svg/star-on.svg" alt="star" class="mr-1" />1 Workflow</ng-template>
-        <ng-template ngPluralCase="other">
-          <img src="../assets/svg/star-on.svg" class="mr-1 site-icons-small" />{{ totalStarredWorkflows }} Workflows</ng-template
-        >
-      </div>
-      <div [ngPlural]="totalStarredTools" id="starred-tools" fxLayout="-mediumrow" fxLayoutAlign="start center">
-        <ng-template ngPluralCase="=0"> <img src="../assets/svg/star-off.svg" alt="star" class="mr-1" />0 Tools</ng-template>
-        <ng-template ngPluralCase="=1"> <img src="../assets/svg/star-on.svg" alt="star" class="mr-1" />1 Tool</ng-template>
-        <ng-template ngPluralCase="other">
-          <img src="../assets/svg/star-on.svg" class="mr-1 site-icons-small" />{{ totalStarredTools }} Tools</ng-template
-        >
-      </div>
-      <div [ngPlural]="totalStarredServices" id="starred-services" fxLayout="row" fxLayoutAlign="start center">
-        <ng-template ngPluralCase="=0"> <img src="../assets/svg/star-off.svg" alt="star" class="mr-1" />0 Services</ng-template>
-        <ng-template ngPluralCase="=1"> <img src="../assets/svg/star-on.svg" alt="star" class="mr-1" />1 Service</ng-template>
-        <ng-template ngPluralCase="other">
-          <img src="../assets/svg/star-on.svg" class="mr-1 site-icons-small" />{{ totalStarredServices }} Services</ng-template
-        >
-      </div>
-      <div [ngPlural]="totalStarredOrganizations" id="starred-orgs" fxLayout="row" fxLayoutAlign="start center">
-        <ng-template ngPluralCase="=0"> <img src="../assets/svg/star-off.svg" alt="star" class="mr-1" />0 Organizations</ng-template>
-        <ng-template ngPluralCase="=1"> <img src="../assets/svg/star-on.svg" alt="star" class="mr-1" />1 Organization</ng-template>
-        <ng-template ngPluralCase="other">
-          <img src="../assets/svg/star-on.svg" class="mr-1 site-icons-small" />{{ totalStarredOrganizations }} Organizations</ng-template
-        >
+  <div fxLayout="column" fxLayoutAlign="start stretch" class="h-100">
+    <div id="header-bar" fxLayout="row wrap" fxLayoutAlign="space-between">
+      <mat-card-header fxLayout="row">
+        <mat-card-title>Starred</mat-card-title>
+      </mat-card-header>
+      <div fxLayout="row wrap" fxLayoutGap="2rem" class="size-small pb-3">
+        <div fxLayout fxLayoutAlign="center center">
+          <mat-icon *ngIf="totalStarredWorkflows" class="mat-icon-sm">star</mat-icon>
+          <mat-icon *ngIf="!totalStarredWorkflows" class="mat-icon-sm">star_border</mat-icon>
+          <a [routerLink]="['/starred']" [queryParams]="{ tab: 'workflows' }">
+            {{ totalStarredWorkflows }} Workflow<span *ngIf="totalStarredWorkflows === 0 || totalStarredWorkflows > 1">s</span>
+          </a>
+        </div>
+        <div fxLayout fxLayoutAlign="center center">
+          <mat-icon *ngIf="totalStarredTools" class="mat-icon-sm">star</mat-icon>
+          <mat-icon *ngIf="!totalStarredTools" class="mat-icon-sm">star_border</mat-icon>
+          <a [routerLink]="['/starred']" [queryParams]="{ tab: 'tools' }">
+            {{ totalStarredTools }} Tool<span *ngIf="totalStarredTools === 0 || totalStarredTools > 1">s</span>
+          </a>
+        </div>
+        <!-- TO DO: uncomment when starred services are implemented -->
+        <!-- <div fxLayout fxLayoutAlign="center center">
+          <mat-icon *ngIf="totalStarredServices" class="mat-icon-sm">star</mat-icon>
+          <mat-icon *ngIf="!totalStarredServices" class="mat-icon-sm">star_border</mat-icon>
+          <a [routerLink]="['/starred']" [queryParams]="{ tab:'services' }">
+            {{ totalStarredServices }} Service<span *ngIf="totalStarredServices === 0 || totalStarredServices > 1">s</span>
+          </a>
+        </div> -->
+        <div fxLayout fxLayoutAlign="center center">
+          <mat-icon *ngIf="totalStarredOrganizations" class="mat-icon-sm">star</mat-icon>
+          <mat-icon *ngIf="!totalStarredOrganizations" class="mat-icon-sm">star_border</mat-icon>
+          <a [routerLink]="['/starred']" [queryParams]="{ tab: 'organizations' }">
+            {{ totalStarredOrganizations }} Organization<span *ngIf="totalStarredOrganizations === 0 || totalStarredOrganizations > 1"
+              >s</span
+            >
+          </a>
+        </div>
       </div>
     </div>
-  </div>
-  <mat-divider></mat-divider>
-  <mat-card-content class="p-3 h-100">
-    <div *ngIf="events.length !== 0 || isLoading; else noEvents">
-      <h5 class="weight-bold">Recent Activity</h5>
-      <div class="size-small widget-list-items" *ngFor="let event of events" fxLayout="row" fxLayoutAlign="space-between center">
-        <div fxLayout="row">
-          <img src="{{ event?.initiatorUser?.avatarUrl }}" alt="User avatar" />
-          <div [ngSwitch]="event.type">
-            <div *ngSwitchCase="EventType.ADDVERSIONTOENTRY" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser?.username }}</strong> created the {{ event.version?.referenceType | lowercase }}
-                <strong>{{ event.version?.name }}</strong> in {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
-                <a
-                  [routerLink]="
-                    event?.apptool
-                      ? '/tools/' + event?.apptool.full_workflow_path
-                      : event?.tool
-                      ? '/tools/' + event?.tool.tool_path
-                      : '/workflows/' + event?.workflow.full_workflow_path
-                  "
-                  >{{
-                    (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
-                  }}</a
-                >
+    <mat-divider></mat-divider>
+    <mat-card-content class="p-3 h-100">
+      <div *ngIf="events.length !== 0 || isLoading; else noEvents">
+        <h5 class="weight-bold">Recent Activity</h5>
+        <div class="size-small widget-list-items" *ngFor="let event of events" fxLayout="row" fxLayoutAlign="space-between center">
+          <div fxLayout="row">
+            <img src="{{ event?.initiatorUser?.avatarUrl }}" alt="User avatar" />
+            <div [ngSwitch]="event.type">
+              <div *ngSwitchCase="EventType.ADDVERSIONTOENTRY" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser?.username }}</strong> created the {{ event.version?.referenceType | lowercase }}
+                  <strong>{{ event.version?.name }}</strong> in {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+                  <a
+                    [routerLink]="
+                      event?.apptool
+                        ? '/tools/' + event?.apptool.full_workflow_path
+                        : event?.tool
+                        ? '/tools/' + event?.tool.tool_path
+                        : '/workflows/' + event?.workflow.full_workflow_path
+                    "
+                    >{{
+                      (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+                    }}</a
+                  >
+                </div>
+                <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+                <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
               </div>
-              <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
-              <mat-divider *ngIf="!last" class="custom-margin"></mat-divider>
+              <div *ngSwitchCase="EventType.CREATECOLLECTION" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser?.username }}</strong> created the collection
+                  <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
+                    >{{ event.collection?.name }}
+                  </a>
+                  in organization
+                  <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
+                </div>
+                <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.ADDTOCOLLECTION" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser.username }}</strong> added the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+                  <a
+                    [routerLink]="
+                      event?.apptool
+                        ? '/tools/' + event?.apptool.full_workflow_path
+                        : event?.tool
+                        ? '/tools/' + event?.tool.tool_path
+                        : '/workflows/' + event?.workflow.full_workflow_path
+                    "
+                    >{{ event?.apptool ? event?.apptool.workflowName : event?.tool ? event?.tool.name : event?.workflow.workflowName }}</a
+                  >
+                  to the collection
+                  <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
+                    >{{ event.collection?.name }}
+                  </a>
+                  in organization
+                  <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
+                </div>
+                <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.ADDUSERTOORG" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser.username }}</strong> added {{ event.user.username }} to the organization
+                  <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
+                </div>
+                <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.MODIFYCOLLECTION" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser.username }}</strong> edited the collection
+                  <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
+                    >{{ event.collection?.name }}
+                  </a>
+                </div>
+                <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.REMOVEFROMCOLLECTION" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.initiatorUser.username }}</strong> removed the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+                  <a
+                    [routerLink]="
+                      event?.apptool
+                        ? '/tools/' + event?.apptool.full_workflow_path
+                        : event?.tool
+                        ? '/tools/' + event?.tool.tool_path
+                        : '/workflows/' + event?.workflow.full_workflow_path
+                    "
+                    >{{ event?.apptool ? event?.apptool.workflowName : event?.tool ? event?.tool.name : event?.workflow.workflowName }}</a
+                  >
+                  from the collection
+                  <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
+                    >{{ event.collection?.name }}
+                  </a>
+                </div>
+                <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.PUBLISHENTRY" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.user.username }}</strong> published the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+                  <a
+                    [routerLink]="
+                      event?.apptool
+                        ? '/tools/' + event?.apptool.full_workflow_path
+                        : event?.tool
+                        ? '/tools/' + event?.tool.tool_path
+                        : '/workflows/' + event?.workflow.full_workflow_path
+                    "
+                    >{{
+                      (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+                    }}</a
+                  >
+                </div>
+                <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+              </div>
+              <div *ngSwitchCase="EventType.UNPUBLISHENTRY" class="my-3">
+                <div class="truncate-text-2">
+                  <strong>{{ event.user.username }}</strong> unpublished the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
+                  <a
+                    [routerLink]="
+                      event?.apptool
+                        ? '/tools/' + event?.apptool.full_workflow_path
+                        : event?.tool
+                        ? '/tools/' + event?.tool.tool_path
+                        : '/workflows/' + event?.workflow.full_workflow_path
+                    "
+                    >{{
+                      (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
+                    }}</a
+                  >
+                </div>
+                <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+              </div>
             </div>
-            <div *ngSwitchCase="EventType.CREATECOLLECTION" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser?.username }}</strong> created the collection
-                <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
-                  >{{ event.collection?.name }}
-                </a>
-                in organization
-                <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
-              </div>
-              <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.ADDTOCOLLECTION" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser.username }}</strong> added the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
-                <a
-                  [routerLink]="
-                    event?.apptool
-                      ? '/tools/' + event?.apptool.full_workflow_path
-                      : event?.tool
-                      ? '/tools/' + event?.tool.tool_path
-                      : '/workflows/' + event?.workflow.full_workflow_path
-                  "
-                  >{{ event?.apptool ? event?.apptool.workflowName : event?.tool ? event?.tool.name : event?.workflow.workflowName }}</a
-                >
-                to the collection
-                <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
-                  >{{ event.collection?.name }}
-                </a>
-                in organization
-                <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
-              </div>
-              <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.ADDUSERTOORG" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser.username }}</strong> added {{ event.user.username }} to the organization
-                <a [routerLink]="'/organizations/' + event.organization?.name">{{ event.organization?.displayName }}</a>
-              </div>
-              <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.MODIFYCOLLECTION" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser.username }}</strong> edited the collection
-                <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
-                  >{{ event.collection?.name }}
-                </a>
-              </div>
-              <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.REMOVEFROMCOLLECTION" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.initiatorUser.username }}</strong> removed the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
-                <a
-                  [routerLink]="
-                    event?.apptool
-                      ? '/tools/' + event?.apptool.full_workflow_path
-                      : event?.tool
-                      ? '/tools/' + event?.tool.tool_path
-                      : '/workflows/' + event?.workflow.full_workflow_path
-                  "
-                  >{{ event?.apptool ? event?.apptool.workflowName : event?.tool ? event?.tool.name : event?.workflow.workflowName }}</a
-                >
-                from the collection
-                <a [routerLink]="'/organizations/' + event.organization?.name + '/collections/' + event.collection?.name"
-                  >{{ event.collection?.name }}
-                </a>
-              </div>
-              <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.PUBLISHENTRY" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.user.username }}</strong> published the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
-                <a
-                  [routerLink]="
-                    event?.apptool
-                      ? '/tools/' + event?.apptool.full_workflow_path
-                      : event?.tool
-                      ? '/tools/' + event?.tool.tool_path
-                      : '/workflows/' + event?.workflow.full_workflow_path
-                  "
-                  >{{
-                    (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
-                  }}</a
-                >
-              </div>
-              <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
-            </div>
-            <div *ngSwitchCase="EventType.UNPUBLISHENTRY" class="my-3">
-              <div class="truncate-text-2">
-                <strong>{{ event.user.username }}</strong> unpublished the {{ event?.tool || event?.apptool ? 'tool' : 'workflow' }}
-                <a
-                  [routerLink]="
-                    event?.apptool
-                      ? '/tools/' + event?.apptool.full_workflow_path
-                      : event?.tool
-                      ? '/tools/' + event?.tool.tool_path
-                      : '/workflows/' + event?.workflow.full_workflow_path
-                  "
-                  >{{
-                    (event?.tool | entryToDisplayName) || (event?.workflow | entryToDisplayName) || (event?.apptool | entryToDisplayName)
-                  }}</a
-                >
-              </div>
-              <div class="subtitle">{{ 'on ' + (event.dbCreateDate | date: 'medium') }}</div>
+          </div>
+          <img class="mx-2" src="{{ event?.organization?.avatarUrl }}" alt="Org avatar" />
+        </div>
+        <div class="weight-bold py-2">
+          <a [routerLink]="'/starred'">All Starred<mat-icon class="mat-icon-sm">keyboard_double_arrow_right</mat-icon> </a>
+        </div>
+      </div>
+      <ng-template #noEvents>
+        <div *ngIf="!isLoading" fxLayout="column" fxLayoutAlign="center center" class="h-100 text-align-center">
+          <img src="../assets/svg/star-circle.svg" alt="starred" class="widget-box-type-logo mb-4" />
+          <span>You do not have any starred entries or organizations.</span>
+          <div class="size-small mt-3">
+            <div>Star entries or organizations to follow updates for them.</div>
+            <div>
+              Read
+              <a
+                class="size-small mt-3"
+                target="_blank"
+                rel="noopener noreferrer"
+                [href]="Dockstore.DOCUMENTATION_URL + '/end-user-topics/starring.html'"
+                >Starring Tools and Workflows</a
+              >
+              to learn how to become a stargazer.
             </div>
           </div>
         </div>
-        <img class="mx-2" src="{{ event?.organization?.avatarUrl }}" alt="Org avatar" />
-      </div>
-      <div class="weight-bold py-2">
-        <a [routerLink]="'/starred'">All Starred<mat-icon class="mat-icon-sm">keyboard_double_arrow_right</mat-icon> </a>
-      </div>
-    </div>
-    <ng-template #noEvents>
-      <div *ngIf="!isLoading" fxLayout="column" class="h-100" fxLayoutAlign="center center">
-        <img src="../assets/svg/star-on.svg" alt="starred" class="widget-box-type-logo mb-4" />
-        <span>You do not have any starred events</span>
-        <a
-          class="size-small mt-3"
-          target="_blank"
-          rel="noopener noreferrer"
-          [href]="Dockstore.DOCUMENTATION_URL + '/end-user-topics/starring.html'"
-          >Learn more about starring</a
-        >
-      </div>
-    </ng-template>
-  </mat-card-content>
+      </ng-template>
+    </mat-card-content>
+  </div>
 </mat-card>

--- a/src/app/home-page/widget/starred-box/starred-box.component.scss
+++ b/src/app/home-page/widget/starred-box/starred-box.component.scss
@@ -11,5 +11,15 @@ img[alt='User avatar'] {
 
 img[alt='Org avatar'] {
   width: 6rem;
-  height: 6rem;
+  max-height: 6rem;
+  object-fit: scale-down;
+}
+
+.size-small mat-icon {
+  color: mat.get-color-from-palette($dockstore-app-accent-1, darker);
+}
+
+// Overide mat-card padding to extend mat-divider to edges
+mat-divider {
+  margin: 0 -16px;
 }

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -26,20 +26,22 @@
     </div>
 
     <div class="container">
+      <!-- TO DO: When services are implemented add:'service-tab-group': selected.value === 2,' -->
+      <!-- TO DO: And change the purple-tab-group to:'purple-tab-group': selected.value === 3' -->
       <mat-tab-group
         mat-stretch-tabs
         class="container"
         *ngIf="!starGazersClicked && !organizationStarGazersClicked"
         [selectedIndex]="selected.value"
-        (selectedTabChange)="onTabChange($event)"
+        (selectedIndexChange)="selected.setValue($event)"
+        (selectedTabChange)="selectedTabChange($event)"
         [ngClass]="{
           'workflow-tab-group': selected.value === 0,
           'tool-tab-group': selected.value === 1,
-          'service-tab-group': selected.value === 2,
-          'purple-tab-group': selected.value === 3
+          'purple-tab-group': selected.value === 2
         }"
       >
-        <mat-tab *ngIf="starredWorkflows">
+        <mat-tab>
           <ng-template mat-tab-label>
             <div fxLayoutGap="0.5rem">
               <img class="site-icons-tab" src="../../../assets/svg/sub-nav/workflow.svg" alt="workflow logo" />
@@ -58,7 +60,7 @@
           </div>
         </mat-tab>
 
-        <mat-tab *ngIf="starredTools">
+        <mat-tab>
           <ng-template mat-tab-label>
             <div fxLayoutGap="0.5rem">
               <img src="../../../assets/svg/sub-nav/tool.svg" alt="tool logo" />
@@ -183,6 +185,7 @@
         </ng-template>
 
         <!-- Services not done -->
+        <!-- TO DO: remove *ngIf when implemented to allow for routing of tabs -->
         <mat-tab *ngIf="starredServices">
           <ng-template mat-tab-label>
             <div fxLayoutGap="0.5rem">
@@ -197,7 +200,7 @@
           </mat-card>
         </mat-tab>
 
-        <mat-tab *ngIf="starredOrganizations">
+        <mat-tab>
           <ng-template mat-tab-label>
             <div fxLayoutGap="0.5rem">
               <img src="../../../assets/svg/sub-nav/organization.svg" alt="organization logo" />

--- a/src/app/starredentries/starredentries.component.spec.ts
+++ b/src/app/starredentries/starredentries.component.spec.ts
@@ -1,6 +1,6 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { ImageProviderService } from '../shared/image-provider.service';
 import { ProviderService } from './../shared/provider.service';
 import { StarentryService } from './../shared/starentry.service';
@@ -23,6 +23,7 @@ describe('StarredEntriesComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
         declarations: [StarredEntriesComponent],
         schemas: [NO_ERRORS_SCHEMA],
         providers: [

--- a/src/assets/svg/star-circle.svg
+++ b/src/assets/svg/star-circle.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <g>
+                    <g>
+                        <g>
+                            <g>
+                                <g>
+                                    <path fill="#7986CB" d="M50 25c0 13.807-11.193 25-25 25S0 38.807 0 25 11.193 0 25 0s25 11.193 25 25" transform="translate(-393 -694) translate(0 62) translate(115.187 140) translate(.813 372) translate(102 120) translate(175)"/>
+                                    <path fill="#FFF" d="M28.538 22L25.5 12 22.462 22 13 22 20.725 27.513 17.788 37 25.5 31.138 33.225 37 30.288 27.513 38 22z" transform="translate(-393 -694) translate(0 62) translate(115.187 140) translate(.813 372) translate(102 120) translate(175)"/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
**Description**
Added routing to the starred page and some UI fixes to the `starred-box.component` on the dashboard to match the zeplin mocks ([empty](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/60229885ad1715098caf03e5) and [full](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/6022ab2d42df9f2c57c20982)).

**Before:**
<p align="center">
  <img src="https://user-images.githubusercontent.com/97123241/215852990-41dc2a03-4126-4bfc-a5f0-40632c5e1028.png" width="75%">
<img src="https://user-images.githubusercontent.com/97123241/215852737-84ec864c-bcac-48cf-aca4-f04292df6465.png" width="75%">
</p>

**After:**
<p align="center">
  <img src="https://user-images.githubusercontent.com/97123241/215854395-b31a3832-767c-4e20-81a9-3acca122962b.png" width="75%">
<img src="https://user-images.githubusercontent.com/97123241/215854171-4c910d32-0165-4b1e-93a0-ad656e1471f8.png" width="75%">
</p>

You will notice the starred "services" star has been removed since there is no starred services page for users to go to. The work has been commented out for when we are ready.

The links on the top right of the card route to individual tabs on the "Starred Entries" page, it follows the same logic as the tabs on the "My Account" page.  Instead of defaulting to the `organizations` tab I changed the default to `workflows` so it follows other pages where you start at the tab to the far left.

![image](https://user-images.githubusercontent.com/97123241/215855261-70570903-ac33-49e9-b12c-ca6f411d9c6c.png)

Other small fixes:
- org logos being compressed
- star icons colour and sizing
- updated empty card text and icon

**Review Instructions**
In relation to the dashboard resizing [ticket](https://ucsc-cgl.atlassian.net/browse/SEAB-5212), I'm containing the mat-card contents in a `div` to help prevent the overflow issues that will soon be addressed, as a result, the actual changes in `starred-box.component.html` are hard to see.  Essentially line 2 is for the new div, lines 3-38 are the updated stars and routing, and lines 182-203 are for the updated empty card. Everything else should just have a new indentation.

**Issue**
[SEAB-5197
](https://ucsc-cgl.atlassian.net/browse/SEAB-5197)
**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
