### PR TITLE
DOCK-2309: moved badge out of dropdown and fixed bug in file tree

### DIFF
--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -62,7 +62,11 @@ export class FileTreeComponent {
     this.treeControl = new FlatTreeControl(this.getLevel, this.isExpandable);
     this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
     this.dataSource.data = this.convertSourceFilesToTree(data.files);
-    this.primaryDescriptorPath = '';
+    this.dataSource.data.forEach((fileNode) => {
+      if (this.isPrimaryDescriptor(fileNode.absolutePath)) {
+        this.primaryDescriptorPath = fileNode.absolutePath;
+      }
+    });
   }
 
   /** Transform the data to something the tree can read. */
@@ -116,9 +120,6 @@ export class FileTreeComponent {
             children: accumulator[pathSegment].result,
             absolutePath: '/' + array.slice(0, index + 1).join('/'),
           });
-          if (this.isPrimaryDescriptor(pathSegment)) {
-            this.primaryDescriptorPath = pathSegment;
-          }
         }
         return accumulator[pathSegment];
       }, level);
@@ -145,6 +146,6 @@ export class FileTreeComponent {
   }
 
   isPrimaryDescriptor(path: string): boolean {
-    return path == this.data.versionPath;
+    return path === this.data.versionPath;
   }
 }

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -62,11 +62,8 @@ export class FileTreeComponent {
     this.treeControl = new FlatTreeControl(this.getLevel, this.isExpandable);
     this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
     this.dataSource.data = this.convertSourceFilesToTree(data.files);
-    this.dataSource.data.forEach((fileNode) => {
-      if (this.isPrimaryDescriptor(fileNode.absolutePath)) {
-        this.primaryDescriptorPath = fileNode.absolutePath;
-      }
-    });
+    this.primaryDescriptorPath =
+      this.dataSource.data.find((fileNode) => this.isPrimaryDescriptor(fileNode.absolutePath))?.absolutePath || '';
   }
 
   /** Transform the data to something the tree can read. */

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -59,17 +59,10 @@
                     <mat-icon aria-hidden="false" aria-label="Navigate to Primary Descriptor file" fontIcon="home"></mat-icon>
                   </a>
                 </span>
-
                 <mat-form-field class="w-100" *ngIf="fileTab.value.length <= 10">
                   <mat-select [value]="currentFile" (selectionChange)="matSelectChange($event)">
                     <mat-select-trigger>
                       {{ currentFile.path }}
-                      <span
-                        *ngIf="isCurrentFilePrimary"
-                        class="bubble preview-bubble primary-bubble-header"
-                        data-cy="primary-descriptor-bubble"
-                        >Primary</span
-                      >
                     </mat-select-trigger>
                     <mat-option [value]="file" *ngFor="let file of fileTab.value">
                       {{ file.path }}
@@ -80,6 +73,13 @@
                   </mat-select>
                 </mat-form-field>
 
+                <span
+                  *ngIf="isCurrentFilePrimary && fileTab.value.length <= 10"
+                  class="bubble preview-bubble primary-bubble-header"
+                  data-cy="primary-descriptor-bubble"
+                >
+                  Primary
+                </span>
                 <a
                   color="secondary"
                   type="button"

--- a/src/app/source-file-tabs/source-file-tabs.component.scss
+++ b/src/app/source-file-tabs/source-file-tabs.component.scss
@@ -2,3 +2,6 @@
   font-size: 14px !important;
   padding: 0 1rem !important;
 }
+::ng-deep .mat-select-panel {
+  max-width: max-content !important;
+}


### PR DESCRIPTION
**Description**
This PR moves the primary descriptor indicator out of the dropdown. The badge is moved such that even if the file name is too long and truncated, the primary badge will still be shown. Also, this PR fixes the bug where the primary descriptor badge did not show in the file tree.

Before fix:
![Screenshot from 2023-02-02 18-04-12](https://user-images.githubusercontent.com/61166764/216471044-31e1e3be-f6d8-41fd-9955-16270613ed0c.png)
![Screenshot from 2023-02-03 15-28-01](https://user-images.githubusercontent.com/61166764/216704237-d09ab4e7-158b-403a-8069-0a8245131f78.png)
![Screenshot from 2023-02-02 18-04-32](https://user-images.githubusercontent.com/61166764/216471073-3d6bd45f-c3a3-4f6f-9a55-364f16ffce2b.png)

After fix:
![Screenshot from 2023-02-02 17-49-53](https://user-images.githubusercontent.com/61166764/216471107-b5fc720c-aba1-4924-97bc-fbf810bb0c32.png)
![Screenshot from 2023-02-03 15-27-38](https://user-images.githubusercontent.com/61166764/216704258-18f7ca85-ff3b-4298-8753-3abc31a464c1.png)
![Screenshot from 2023-02-02 17-49-26](https://user-images.githubusercontent.com/61166764/216471114-8194c922-dfba-4217-8d9e-76cd6ca99457.png)

**Review Instructions**
Verify that the integration tests still pass and the primary descriptor badge is not visible in files with long names. Also verify that the primary badge is shown when opening the file tree.

**Issue**
https://github.com/dockstore/dockstore/issues/5321

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
