### PR TITLE
Change tooltip position to fix a flaky test

### DIFF
--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.html
@@ -15,6 +15,7 @@
         [pattern]="descriptorPattern"
         required
         matTooltip="Default relative path to the descriptor in the Git repository."
+        matTooltipPosition="after"
         [placeholder]="descriptorPathPlaceholder"
       />
       <mat-error *ngIf="formErrors.workflow_path"> {{ formErrors.workflow_path }} </mat-error>
@@ -32,6 +33,7 @@
         [pattern]="validationDescriptorPatterns.testParameterFilePath"
         required
         matTooltip="Default relative path to the test parameter file in the Git repository."
+        matTooltipPosition="after"
         placeholder="e.g. /test.json"
       />
       <mat-error *ngIf="formErrors.testParameterFilePath"> {{ formErrors.testParameterFilePath }} </mat-error>


### PR DESCRIPTION
**Description**
Tooltip was sometimes covering the input during the integration tests, which led to a failure. I was able to reproduce intermittently locally, and unable to reproduce after this fix.

I picked position `after` because it's done fairly commonly already in the codebase.

**Review Instructions**
If the tests pass, it's fixed the flakiness. But go to the Register Checker Workflow dialog, and verify the tooltip for each input is still visible.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5217

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
