### PR TITLE
Organization Search Clears After Enter - DOCK-2308

### DIFF
--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -45,7 +45,7 @@
         <mat-form-field appearance="outline" class="search-form-field">
           <mat-label>Search Organizations</mat-label>
           <input #search matInput formControlName="name" />
-          <button mat-button *ngIf="search.value" matSuffix mat-icon-button (click)="clearSearch()">
+          <button mat-button *ngIf="search.value" matSuffix mat-icon-button (click)="clearSearch()" type="button">
             <mat-icon>close</mat-icon>
           </button>
         </mat-form-field>


### PR DESCRIPTION
**Description**
After hitting `enter` in the organization search box the form would clear, loosing the search results.  Small fix found [here](https://github.com/angular/angular/issues/12643#issuecomment-257620559) and now it behaves as expected.

**Left is QA and right is with changes:**
(Pretend that you can see I'm pressing `enter` after typing in "broad")

https://user-images.githubusercontent.com/97123241/217320548-a05f14a3-39b9-45e7-bc28-8d262a76235b.mp4

**Review Instructions**
Test it out and ensure search doesn't clear after `enter`.

**Issue**
[DOCK-2308
](https://ucsc-cgl.atlassian.net/browse/DOCK-2308)[GitHub issue](https://github.com/dockstore/dockstore/issues/5318)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
