### PR TITLE
Don't make org membership requests if logged out

### DIFF
--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -74,8 +74,14 @@ export class NavbarComponent extends Logout implements OnInit {
   ngOnInit() {
     this.userQuery.user$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((user) => {
       this.user = user;
-      this.requestsService.updateMyMemberships();
-      this.requestsService.updateCuratorOrganizations();
+      if (user) {
+        // You may not be logged in
+        this.requestsService.updateMyMemberships();
+        this.requestsService.updateCuratorOrganizations();
+      } else {
+        // In case you went from logged in to logged out
+        this.requestsService.updateMyMembershipState(null, null, null, null);
+      }
     });
     this.userQuery.extendedUserData$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((extendedUser) => (this.extendedUser = extendedUser));
     this.myOrganizationInvites$ = this.requestsQuery.myOrganizationInvites$;


### PR DESCRIPTION
**Description**
We were requesting the user's organization memberships even if not logged in. Don't do it any more.

I think there might be a more generic place for handling the logged out case, e.g., logging out could clear all user state data, but I'm going to pass on that.

**Review Instructions**
1. Go to the home page
2. Log out if logged in
3. Open browser developer tools on network tab; clear network requests
4. Reload the page
5. Make sure there are no requests with 4xx responses.

**Issue**
dockstore/dockstore#2285

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
