### PR TITLE
Update smoke tests and Ace editor

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,7 +19,12 @@
             "assets": [
               "src/assets",
               "src/favicon.ico",
-              "src/manifest.json"
+              "src/manifest.json",
+              {
+                "glob": "**/worker-*.js",
+                "input": "./node_modules/ace-builds/src-noconflict/",
+                "output": "/assets/ace"
+              }
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -204,6 +204,8 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     cy.url().should('contain', '?tab=files');
     cy.contains('Descriptor Files');
     cy.get('.ace_editor').should('be.visible');
+    cy.wait(1000); // https://ucsc-cgl.atlassian.net/browse/SEAB-5240 wait seems to fix; I think the import script needs to finish downloading
+    // before clicking away.
     goToTab('Test Parameter Files');
     if (type === ToolDescriptor.TypeEnum.NFL) {
       cy.contains('This version has no files of this type.');

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -240,9 +240,12 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     }
 
     if (type === 'WDL') {
-      cy.get('[data-cy=dnanexusLaunchWith] svg').should('exist');
-      cy.get('[data-cy=terraLaunchWith] svg').should('exist');
-      cy.get('[data-cy=anvilLaunchWith] svg').should('exist');
+      const launchSelectors = ['dnanexusLaunchWith', 'terraLaunchWith', 'anvilLaunchWith'];
+      launchSelectors
+        // In 1.13, launch button images are <svg>
+        // In 1.14, launch button images are <img>
+        .map((launchSelector) => `[data-cy=${launchSelector}] svg, [data-cy=${launchSelector}] img`)
+        .forEach((launchSelector) => cy.get(launchSelector).should('exist'));
     }
     if (type === 'CWL') {
       launchWithTuples = [

--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -49,7 +49,7 @@ export class CodeEditorComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     const aceMode = 'ace/mode/' + this.mode;
-    ace.config.set('workerPath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.4/');
+    ace.config.set('workerPath', '/assets/ace');
     this.editor = ace.edit(this.aceId, {
       mode: aceMode,
       readOnly: this.readOnly,


### PR DESCRIPTION
**Description**
This PR has 3 fixes, the first one is the actual JIRA issue, the second one was blocking the first one, and the third one was noticed while investigating.

1. The `cy.wait()` in basic-enduser.ts seems to fix the import error causing flaky tests; hard to tell for sure with flaky bugs, but it worked for me 10 times in a row locally. My theory is that the new, faster Cypress 12 was clicking away from the editor while the editor was still synchronously downloading a JS file, and the aborted download caused the tests to fail.
2. PR #1704 broke smoke tests on qa only because it changed `svg` to `img` for the launch with images. Changed the selector to look for either `svg` or `img`, so it will run on both qa and staging/prod. Created a followup ticket, dockstore/dockstore#5372 to remove the check for `svg` after 1.14 is released.
3. We are now bundling the [ACE editor](https://ace.c9.io/) worker files. This fixes a version mismatch I noticed -- the package-lock.json was bundling ACE editor 1.4.14, but our code was downloading the worker scripts from 1.4.4. Our files are on a CDN as well, so there's no real performance advantage to downloading them from CloudFlare, plus now we'll be certain the worker scripts are the same version as the core Ace editor.

***What are the Ace worker scripts?***
I'm hazy on the details, but they're JavaScript files that are downloaded synchronously by the editor itself. Since they are downloaded by name, I put them in the assets directory instead of putting them into one of the JavaScript bundles. In other words, ACE downloads, for example, worker-json.js. Now it will download it from Dockstore instead of CloudFlare.

**Review Instructions**
Nightly no_auth_tests on CircleCI should pass (auth_tests already passing).

Go to the editor (Files tab) for different file types, published and non-published entries, with browser tools open, and make sure there are no network errors nor errors in the console.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5240

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
