### PR TITLE
Add ".." at beginning of workerPath

### DIFF
--- a/src/app/shared/code-editor/code-editor.component.ts
+++ b/src/app/shared/code-editor/code-editor.component.ts
@@ -49,7 +49,7 @@ export class CodeEditorComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     const aceMode = 'ace/mode/' + this.mode;
-    ace.config.set('workerPath', '/assets/ace');
+    ace.config.set('workerPath', '../assets/ace');
     this.editor = ace.edit(this.aceId, {
       mode: aceMode,
       readOnly: this.readOnly,


### PR DESCRIPTION
**Description**
Follow up/fix to https://ucsc-cgl.atlassian.net/browse/SEAB-5240

The worker-json.js files were not being downloaded in qa, although they were in local tests. Because, in a deployment like qa, these files are served from gui.dockstore.org.

We need the ".." in front of the assets so that build in config.yml does the string substitution to add gui.dockstore.org.

**Review Instructions**
1. Open browser developer tools
2. Go to search, select WDL facet
3. Click first workflow
4. Go to files, then click test parameter files
5. Check that worker-json.js file is downloaded correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5240

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
