### PR TITLE
Collapse Search Panels - Dock 2317

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -74,7 +74,6 @@
         ></app-basic-search>
         <mat-expansion-panel
           *ngFor="let key of getKeys(orderedBuckets)"
-          #bucket
           [expanded]="expandedPanels.get(key)"
           (afterExpand)="updateExpandedPanels(key, true)"
           (afterCollapse)="updateExpandedPanels(key, false)"

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -58,7 +58,7 @@
             fxFlex="1 0 auto"
             class="m-1 private-btn mat-accent small-btn-structure"
             mat-button
-            (click)="resetFilters()"
+            (click)="resetFilters(); resetExpansionPanels()"
             type="button"
           >
             <img src="../assets/svg/reset.svg" alt="Reset filters" class="pb-1 pr-1" />
@@ -72,7 +72,13 @@
           (changedDebounced)="handleChangedDebounced($event)"
           (submitted)="handleSubmitted($event)"
         ></app-basic-search>
-        <mat-expansion-panel *ngFor="let key of getKeys(orderedBuckets)" #bucket expanded>
+        <mat-expansion-panel
+          *ngFor="let key of getKeys(orderedBuckets)"
+          #bucket
+          [expanded]="expandedPanels.get(key)"
+          (afterExpand)="updateExpandedPanels(key, true)"
+          (afterCollapse)="updateExpandedPanels(key, false)"
+        >
           <mat-expansion-panel-header>
             {{ friendlyNames.get(key) }}
             <img

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -129,6 +129,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   public friendlyNames: Map<string, string>;
   public toolTips: Map<string, string>;
   private entryOrder: Map<string, SubBucket>;
+  private expandedPanels: Map<string, Boolean>;
   public basicSearchText$: Observable<string>;
   private advancedSearchOptions = ['ANDSplitFilter', 'ANDNoSplitFilter', 'ORFilter', 'NOTFilter', 'searchMode'];
   public filterKeys$: Observable<Array<string>>;
@@ -163,6 +164,8 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.friendlyNames = this.searchService.initializeFriendlyNames();
     this.entryOrder = this.searchService.initializeEntryOrder();
     this.toolTips = this.searchService.initializeToolTips();
+    this.expandedPanels = this.searchService.initializeExpandedPanels();
+
     this.clearFacetSearches();
   }
 
@@ -541,6 +544,11 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.searchService.setPageSizeAndIndex(this.searchQuery.getValue().pageSize, 0);
   }
 
+  resetExpansionPanels() {
+    this.clearExpandedPanelsState();
+    this.expandedPanels = this.searchService.initializeExpandedPanels();
+  }
+
   /**===============================================
    *                Event Functions
    * ==============================================
@@ -658,6 +666,20 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.searchService.setFacetAutocompleteTerms(filteredItems);
   }
 
+  /**
+   * Updates the state of the expansion panels on expand or collapse events
+   * Saves state to local storage
+   *
+   * @param {string} key
+   * @param {Boolean} expanded
+   * @memberof SearchComponent
+   */
+  updateExpandedPanels(key: string, expanded: Boolean) {
+    this.expandedPanels.set(key, expanded);
+    this.clearExpandedPanelsState();
+    this.saveExpandedPanelsState();
+  }
+
   /**===============================================
    *                Helper Functions
    * ===============================================
@@ -666,5 +688,13 @@ export class SearchComponent implements OnInit, OnDestroy {
 
   getBucketKeys(key: string) {
     return Array.from(this.orderedBuckets.get(key).SelectedItems.keys());
+  }
+
+  saveExpandedPanelsState() {
+    localStorage.setItem(this.searchService.expandedPanelsStorageKey, JSON.stringify(Array.from(this.expandedPanels.entries())));
+  }
+
+  clearExpandedPanelsState() {
+    localStorage.removeItem(this.searchService.expandedPanelsStorageKey);
   }
 }

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -586,7 +586,7 @@ export class SearchService {
    */
   initializeExpandedPanels() {
     if (localStorage.getItem(this.expandedPanelsStorageKey)) {
-      return new Map<string, Boolean>(JSON.parse(localStorage.getItem(this.expandedPanelsStorageKey)));
+      return new Map<string, boolean>(JSON.parse(localStorage.getItem(this.expandedPanelsStorageKey)));
     } else {
       return new Map([
         ['descriptorType', true],

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -65,6 +65,7 @@ export class SearchService {
   public toSaveSearch$ = new BehaviorSubject<boolean>(false);
   public searchTerm$ = new BehaviorSubject<boolean>(false);
   public tagClicked$ = new BehaviorSubject<boolean>(false);
+  public readonly expandedPanelsStorageKey = 'expandedPanels';
   searchInfo$ = this.searchInfoSource.asObservable();
 
   /**
@@ -578,6 +579,35 @@ export class SearchService {
       ['has_checker', new SubBucket()],
       ['openData', new SubBucket()],
     ]);
+  }
+
+  /**
+   * Initialize expanded panels to default state or restore previous state from local storage
+   */
+  initializeExpandedPanels() {
+    if (localStorage.getItem(this.expandedPanelsStorageKey)) {
+      return new Map<string, Boolean>(JSON.parse(localStorage.getItem(this.expandedPanelsStorageKey)));
+    } else {
+      return new Map([
+        ['descriptorType', true],
+        ['registry', true],
+        ['source_control_provider.keyword', true],
+        ['private_access', false],
+        ['verified', true],
+        ['author', false],
+        ['namespace', true],
+        ['labels.value.keyword', false],
+        ['input_file_formats.value.keyword', false],
+        ['output_file_formats.value.keyword', false],
+        [SearchFields.VERIFIED_SOURCE, false],
+        ['has_checker', false],
+        ['organization', true],
+        ['verified_platforms.keyword', false],
+        ['categories.name.keyword', true],
+        ['descriptor_type_versions.keyword', false],
+        ['openData', false],
+      ]);
+    }
   }
 
   // Functions called from HTML

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -155,6 +155,7 @@ export class GA4GHV20StubService {
 }
 
 export class SearchStubService {
+  public readonly expandedPanelsStorageKey = 'expandedPanels';
   workflowhit$ = observableOf([]);
   toolhit$ = observableOf([]);
   searchInfo$ = observableOf({});
@@ -254,6 +255,32 @@ export class SearchStubService {
       ['verified', new SubBucket()],
       ['verifiedSource', new SubBucket()],
     ]);
+  }
+
+  initializeExpandedPanels() {
+    if (localStorage.getItem(this.expandedPanelsStorageKey)) {
+      return new Map<string, Boolean>(JSON.parse(localStorage.getItem(this.expandedPanelsStorageKey)));
+    } else {
+      return new Map([
+        ['descriptorType', true],
+        ['registry', true],
+        ['source_control_provider.keyword', true],
+        ['private_access', false],
+        ['verified', true],
+        ['author', false],
+        ['namespace', true],
+        ['labels.value.keyword', false],
+        ['input_file_formats.value.keyword', false],
+        ['output_file_formats.value.keyword', false],
+        [SearchFields.VERIFIED_SOURCE, false],
+        ['has_checker', false],
+        ['organization', true],
+        ['verified_platforms.keyword', false],
+        ['categories.name.keyword', true],
+        ['descriptor_type_versions.keyword', false],
+        ['openData', false],
+      ]);
+    }
   }
 
   initializeFriendlyValueNames() {


### PR DESCRIPTION
**Description**
Following the [mocks](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc690e874e0c807afeb299b), the search sidebar has a new default state in which about half of the panels are collapsed.  A nice little change which avoids that long scroll to the bottom of the page.  As Charles suggested in the [ticket](https://ucsc-cgl.atlassian.net/browse/DOCK-2317), the state of the panels is saved to local storage, so upon page reload or navigation, the panels that have been collapsed or expanded by the user is remembered.

The tools search looks identical, collapsed panels follow the tools search [mocks](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc7ceb4fd8d340926d62d6d):
| Workflows | Tools |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/97123241/219801381-9240f2a9-71f7-4bb3-b1b7-54a596cc36e2.png) | ![image](https://user-images.githubusercontent.com/97123241/219801262-8023de4d-39ad-4d29-8644-6cb56730b909.png) |

**Before:**
Very simple, all panels begin expanded, no state is saved, if you collapsed any panels on page refresh they will be expanded again.

https://user-images.githubusercontent.com/97123241/219798551-ed3d54a0-fb80-4efb-8644-75e4e2d711a9.mp4

**After:**
Half of the panels begin collapsed, when a user collapses or expands any panels it's state is remembered upon refresh and navigation. I also set the `reset` button to clear local storage of the panel's state and reset them back to their default (half collapsed) state.

https://user-images.githubusercontent.com/97123241/219798880-0ebbca57-99e7-41c7-9cc2-3cd94925eb5e.mp4


Also created a few spin-off tickets to update some of the search UI: SEAB-5258, SEAB-5257

**Review Instructions**
Check out the search panels, ensure some are collapsed by default and state is saved.

**Issue**
DOCK-2317

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
