### PR TITLE
Fix Broken Smoke Test for Staging/Prod  - SEAB-5269

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -107,7 +107,9 @@ describe('Test search page functionality', () => {
     cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
-      cy.wrap($el).contains('Nextflow');
+      // In 1.13, the Nextflow badge displays as 'NFL'
+      // In 1.14, the Nextflow badge displays as 'Nextflow'
+      expect($el.text()).to.be.oneOf(['Nextflow', 'NFL']);
     });
     cy.url().should('contain', 'descriptorType=NFL');
     cy.url().should('contain', 'searchMode=files');


### PR DESCRIPTION
**Description**
Previously updated the smoke tests in this [pr](https://github.com/dockstore/dockstore-ui2/pull/1707/files#diff-0e83ac8adb043831f00e87fd557c3cbe8a82257c2ca3d5772e2a31d01dbc77feR110) to look for `Nextflow` instead of `NFL` since we switched to the friendly names, however the change in smoke test does not accommodate for staging/develop where these changes from develop are not present.  Updated the test to handle both cases of `NFL` and `Nextflow`, tested locally with `NFL` and `Nextflow` and appears to be passing well.

Added an additional note [here](https://github.com/dockstore/dockstore/issues/5372#issuecomment-1439116907) to remove the check for "NFL" after the 1.14 release.

**Review Instructions**

**Issue**
SEAB-5269

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
