### PR TITLE
Corrected typos in dockstore/dockstore-ui2

### DIFF
--- a/cypress/e2e/group1/checkerWorkflowFromTools.ts
+++ b/cypress/e2e/group1/checkerWorkflowFromTools.ts
@@ -156,7 +156,7 @@ describe('Should be able to see the checker workflow from a tool', () => {
     cy.get('#viewParentEntryButton').should('be.visible').click();
 
     // In the parent tool right now
-    // Accidentically allow the uri "tools" to work
+    // Accidentally allow the uri "tools" to work
     cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/b3:latest?tab=info');
     cy.get('#viewParentEntryButton').should('not.exist');
     cy.get('#addCheckerWorkflowButton').should('not.exist');

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -432,7 +432,7 @@ describe('Dockstore my workflows', () => {
   });
 
   describe('Test register workflow form validation', () => {
-    it('It should have 3 seperate descriptor path validation patterns', () => {
+    it('It should have 3 separate descriptor path validation patterns', () => {
       cy.visit('/my-workflows');
       cy.get('#registerWorkflowButton').should('be.visible').should('be.enabled').click();
       // TODO: Fix this.  When 'Next' is clicked too fast, the next step is empty

--- a/cypress/e2e/group2/notificationBadge.ts
+++ b/cypress/e2e/group2/notificationBadge.ts
@@ -49,7 +49,7 @@ describe('Test notification badge on navbar', () => {
       cy.get('[data-cy=bell-icon]').should('contain.text', '1');
     });
   });
-  describe('Should have badge count of 3 with one pending organiaztion, one invitation, and one rejected organization request', () => {
+  describe('Should have badge count of 3 with one pending organization, one invitation, and one rejected organization request', () => {
     setTokenUserViewPortCurator();
     it('visit the organizations page from the home page', () => {
       cy.visit('/');

--- a/cypress/e2e/immutableDatabaseTests/searchTable.ts
+++ b/cypress/e2e/immutableDatabaseTests/searchTable.ts
@@ -21,7 +21,7 @@ describe('Dockstore tool/workflow search table', () => {
 
   // When elastic search is added to cypress testing, get rid of cy.intercepts, and uncomment the commented lines
   function starColumnSearch(url: string, type: string) {
-    // Tools/worflows not starred in this response.
+    // Tools/workflows not starred in this response.
     cy.intercept('POST', '*' + ga4ghExtendedPath + '/tools/entry/_search', {
       body: {
         took: 18,

--- a/cypress/e2e/immutableDatabaseTests/services.ts
+++ b/cypress/e2e/immutableDatabaseTests/services.ts
@@ -86,7 +86,7 @@ describe('Dockstore Home', () => {
       cy.get('#workflow-path').contains('github.com/garyluu/another-test-service:1.3');
       checkTabs();
       checkInfoTab();
-      // TRS only visibile in public page
+      // TRS only visible in public page
       cy.contains('TRS: ').should('not.exist');
       checkVersionsTab();
       // Edit button only in my-services

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -277,7 +277,7 @@
             <!-- This looks different than the others ones because it's new and doesn't use bootstrap 3 classes -->
             <li>
               <form fxLayout="row" fxLayoutAlign="start center" class="w-100">
-                <span><strong matTooltip="Short descripton of the tool">Topic</strong>:&nbsp;</span>
+                <span><strong matTooltip="Short description of the tool">Topic</strong>:&nbsp;</span>
                 <span *ngIf="!topicEditing">{{ tool?.topicManual || 'n/a' }}</span>
                 <span fxFlex>
                   <input

--- a/src/app/loginComponents/accounts/controls/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/loginComponents/accounts/controls/delete-account-dialog/delete-account-dialog.component.ts
@@ -99,7 +99,7 @@ export class DeleteAccountDialogComponent implements OnDestroy {
   }
 
   /**
-   * What happens when deleteing the account has failed.
+   * What happens when deleting the account has failed.
    *
    * @private
    * @memberof DeleteAccountDialogComponent

--- a/src/app/my-sidebar/my-sidebar.component.html
+++ b/src/app/my-sidebar/my-sidebar.component.html
@@ -44,7 +44,7 @@
   <hr routerLink="/my-services" routerLinkActive="active" />
 
   <!-- Organizations page does not exist, framework is commented out for the time being -->
-  <!-- TO DO: Update routerLink (button and hr) with Org. page when avalible and uncomment to add to nav bar -->
+  <!-- TO DO: Update routerLink (button and hr) with Org. page when available and uncomment to add to nav bar -->
   <!-- <button mat-flat-button class="purple" routerLink="/organizations" routerLinkActive="active">
         <div><img src="../assets/svg/my-nav/organization.svg" class="pb-1" alt="my organizations"></div>
         Organizations

--- a/src/app/myworkflows/my-workflow/my-workflow.component.ts
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.ts
@@ -46,7 +46,7 @@ import { MyWorkflowsService } from '../myworkflows.service';
 /**
  * How the workflow selection works:
  * Each action is fully completed if 3 things are updated (URL, workflow$ and workflows$)
- * workflows$ is completely seperate from URL and workflow$ (none of them should update the other)
+ * workflows$ is completely separate from URL and workflow$ (none of them should update the other)
  * URL change is tied to workflow$ change
  *
  * To update (refresh, publish, etc) a currently selected workflow, update workflows$ first then

--- a/src/app/organizations/collections/state/create-collection.service.ts
+++ b/src/app/organizations/collections/state/create-collection.service.ts
@@ -148,16 +148,16 @@ export class CreateCollectionService {
    *
    * @param {FormsState['createOrUpdateCollection']} collectionFormState
    * @param {number} collectionID  ID of the collection to update
-   * @param {string} collectionDescripton The unedited description because formState isn't updating description and doesn't know it
+   * @param {string} collectionDescription The unedited description because formState isn't updating description and doesn't know it
    * @memberof CreateCollectionService
    */
-  updateCollection(collectionFormState: FormsState['createOrUpdateCollection'], collectionID: number, collectionDescripton: string) {
+  updateCollection(collectionFormState: FormsState['createOrUpdateCollection'], collectionID: number, collectionDescription: string) {
     let collection: Collection;
     collection = {
       name: collectionFormState.name,
       topic: collectionFormState.topic,
       displayName: collectionFormState.displayName,
-      description: collectionDescripton,
+      description: collectionDescription,
     };
     const organizationID = this.organizationQuery.getValue().organization.id;
     this.beforeCall();

--- a/src/app/organizations/registerOrganization/requireAccountsModal/require-accounts-modal.component.html
+++ b/src/app/organizations/registerOrganization/requireAccountsModal/require-accounts-modal.component.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>User Verification</h1>
 <p>
   For verification purposes, you are required to have at least two external accounts linked to your Dockstore account. However, it's
-  preferrable to have more than two because Dockstore curators will use that information to verify that your organization request is
+  preferable to have more than two because Dockstore curators will use that information to verify that your organization request is
   legitimate.
 </p>
 <p>You have {{ numLinkedAccounts$ | async | i18nPlural: messageMapping }} linked.</p>

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -48,7 +48,7 @@ describe('SearchService', () => {
   it('should be created', inject([SearchService], (service: SearchService) => {
     expect(service).toBeTruthy();
   }));
-  it('should get term from aggergation name', inject([SearchService], (service: SearchService) => {
+  it('should get term from aggregation name', inject([SearchService], (service: SearchService) => {
     expect(service.aggregationNameToTerm('agg_terms_type')).toEqual('type');
   }));
   it('should set observables', inject([SearchService], (service: SearchService) => {

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -211,7 +211,7 @@ export class SearchService {
   }
 
   /**
-   * Seperates the 'hits' object into 'toolHits' and 'workflowHits'
+   * Separates the 'hits' object into 'toolHits' and 'workflowHits'
    * Also sets up provider information
    * @param {Array<any>} hits
    * @param {number} query_size
@@ -543,7 +543,7 @@ export class SearchService {
       // Git hook auto fixes from single quotes with an escaped 's but linter complains about double quotes.
       /* eslint-disable-next-line quotes, @typescript-eslint/quotes */
       ['private_access', "A private tool requires authentication to view on Docker's registry website and to pull the Docker image."],
-      ['verified', 'Indicates that at least one version of a tool or workflow has been successfuly run by our team or an outside party.'],
+      ['verified', 'Indicates that at least one version of a tool or workflow has been successfully run by our team or an outside party.'],
       [SearchFields.VERIFIED_SOURCE, 'Indicates which party performed the verification process on a tool or workflow.'],
       [
         'has_checker',

--- a/src/app/shared/entry-wizard/entry-wizard.component.ts
+++ b/src/app/shared/entry-wizard/entry-wizard.component.ts
@@ -48,7 +48,7 @@ export class EntryWizardComponent implements OnInit {
 
   /**
    * Given an organization will retrieve all associated repositories for the logged in user
-   * @param selectedOrganization the seleceted organization
+   * @param selectedOrganization the selected organization
    */
   getRepositories(selectedOrganization: string) {
     this.entryWizardService.updateGitRepositoryStore(this.selectedGitRegistry, selectedOrganization);

--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -118,7 +118,7 @@ describe('Service: DescriptorLanguage', () => {
     placeholder = descriptorLanguageService.getDescriptorPattern(<ToolDescriptor.TypeEnum>'UnrecognizedType');
     expect(placeholder).toEqual('.*');
   });
-  it('should be able to get shortFriendlyName from Worfklow.DescriptorTypeEnum for workflow registration', () => {
+  it('should be able to get shortFriendlyName from Workflow.DescriptorTypeEnum for workflow registration', () => {
     const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);

--- a/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
+++ b/src/app/shared/entry/register-checker-workflow/register-checker-workflow.component.ts
@@ -107,7 +107,7 @@ export class RegisterCheckerWorkflowComponent extends Base implements OnInit, Af
    *
    * @private
    * @param {Entry} entry The current entry
-   * @param {string} descriptorType The descriptor type currnetly selected in the form
+   * @param {string} descriptorType The descriptor type currently selected in the form
    * @returns {string} The default test parameter file to populate the form
    * @memberof RegisterCheckerWorkflowComponent
    */

--- a/src/app/shared/entry/verified-display/verified-display.component.ts
+++ b/src/app/shared/entry/verified-display/verified-display.component.ts
@@ -46,7 +46,7 @@ export class VerifiedDisplayComponent implements OnInit, OnChanges {
   /**
    * Extracts the custom verification information object array from the sourcefiles
    *
-   * @param {number} versionid The versionid to get verfication information for
+   * @param {number} versionid The versionid to get verification information for
    * @param {Array<VersionVerifiedPlatform>} sourceFiles  The list of sourcefiles from an entry's version
    * @returns {Array<CustomVerificationInformationObject>}   Custom object array (that contains path, verifier, platform)
    * @memberof VerifiedDisplayComponent

--- a/src/app/shared/verified-by.service.ts
+++ b/src/app/shared/verified-by.service.ts
@@ -13,7 +13,7 @@ export class VerifiedByService {
    *
    * @param {Array<VersionVerifiedPlatform>} verifiedSources  The sourcesfiles of an entry's version
    * @param {number} versionid id of the version you want verified sources for.
-   * @returns {Array<string>}                    An array of strings to be displayed seperated by newlines
+   * @returns {Array<string>}                    An array of strings to be displayed separated by newlines
    * @memberof VerifiedByService
    */
 

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -233,7 +233,7 @@ export class SearchStubService {
       // Git hook auto fixes from single quotes with an escaped 's but linter complains about double quotes.
       /* eslint-disable-next-line quotes, @typescript-eslint/quotes */
       ['private_access', "A private tool requires authentication to view on Docker's registry website and to pull the Docker image."],
-      ['verified', 'Indicates that at least one version of a tool or workflow has been successfuly run by our team or an outside party.'],
+      ['verified', 'Indicates that at least one version of a tool or workflow has been successfully run by our team or an outside party.'],
       [SearchFields.VERIFIED_SOURCE, 'Indicates which party performed the verification process on a tool or workflow.'],
       [
         'has_checker',

--- a/src/app/workflow/dag/dag.component.ts
+++ b/src/app/workflow/dag/dag.component.ts
@@ -32,7 +32,7 @@ import { DagStore } from './state/dag.store';
  * This is the DAG tab
  * TODO: Not have a fixed 500px normal sized DAG in case people are using different height screens
  * TODO: Material tooltips to appear in fullscreen mode.
- * The matTooltip DOM is in a seperate div than the fullscreen element's div, that's why it doesn't show
+ * The matTooltip DOM is in a separate div than the fullscreen element's div, that's why it doesn't show
  * TODO: Performance improvements
  * @export
  * @class DagComponent

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -136,7 +136,7 @@
             matTooltip="Git Repository path."
             placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"
           />
-          <!-- TODO: Actually return 3 seperate sets of form error messages depending on the descriptor type selected -->
+          <!-- TODO: Actually return 3 separate sets of form error messages depending on the descriptor type selected -->
           <mat-error *ngIf="formErrors.gitPath">{{ formErrors.gitPath }}</mat-error>
         </mat-form-field>
         <mat-radio-group
@@ -167,7 +167,7 @@
             [matTooltip]="Tooltip.workflowPath"
             [placeholder]="workflowPathPlaceholder"
           />
-          <!-- TODO: Actually return 3 seperate sets of form error messages depending on the descriptor type selected -->
+          <!-- TODO: Actually return 3 separate sets of form error messages depending on the descriptor type selected -->
           <mat-error *ngIf="formErrors.workflow_path">{{ workflowPathError }}</mat-error>
         </mat-form-field>
         <mat-form-field class="w-100">

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -141,7 +141,7 @@ $kim-accent-4: (
 
 // main color is assumed to be 2 based on prevalence of it on the home page (buttons). It's also called default in zeplin
 // 1 is the darker version of it because it's the only one that's darker
-// 4 was arbitarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
+// 4 was arbitrarily chosen to be the lighter version because while looking at the progress bar, there wasn't enough contrast
 $dockstore-app-primary: mat.define-palette($kim-primary, 2, 4, 1);
 $dockstore-app-accent: mat.define-palette($kim-secondary, 2, 4, 1);
 $dockstore-app-error: mat.define-palette($kim-error, 2, 4, 1);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -344,7 +344,7 @@ h3.available-containers {
 
 // Globally allow any material tooltip to break the word if it's too long
 // Long sentences should still break on spaces if needed
-// Long continous words (without spaces and hyphens) will break at different points depending on browser
+// Long continuous words (without spaces and hyphens) will break at different points depending on browser
 .mat-tooltip {
   overflow-wrap: break-word;
 }
@@ -1120,7 +1120,7 @@ a.accent-1-dark-btn {
 }
 
 // Applied to mat-icons to make them smaller than Material defaults. 16px was chosen based on ORCID's recommended min logo size.
-// Typically acompanied with mat-btn-sm above.
+// Typically accompanied with mat-btn-sm above.
 // This is also the same size as site-icons-small
 mat-icon.mat-icon-sm {
   // These two override .mat-icon's default 24px height and width


### PR DESCRIPTION
Description
This PR corrects a lot of typos found in this repo. This PR is very similar to https://github.com/dockstore/dockstore-cli/pull/227.

Review Instructions
Ensure that all of my corrections are valid (ie. I didn't replace a typo with a typo)

Issue
[DOCK-2325](https://ucsc-cgl.atlassian.net/browse/DOCK-2325)
https://github.com/dockstore/dockstore/issues/5365
(These issues aren't directly related to this work)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2325]: https://ucsc-cgl.atlassian.net/browse/DOCK-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ