### PR TITLE
Update Entry Box Search - SEAB-5268

### DIFF
--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -58,8 +58,8 @@
           </a>
           <div class="date-display">{{ entry.lastUpdateDate | date: 'MMM d, yyyy' }}</div>
         </div>
-        <div *ngIf="listOfEntries.length === 0" class="mt-2">No matching {{ entryTypeLowerCase }}s</div>
-        <div class="weight-bold py-2">
+        <div *ngIf="listOfEntries.length === 0" class="text-align-center date-display mt-5">No matching {{ entryTypeLowerCase }}s.</div>
+        <div *ngIf="listOfEntries.length > 0" class="weight-bold py-2">
           <a [routerLink]="allEntriesLink" data-cy="all-entries-btn">
             All {{ entryTypeLowerCase | titlecase }}s<mat-icon class="mat-icon-sm">keyboard_double_arrow_right</mat-icon>
           </a>

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -48,6 +48,7 @@ export class EntryBoxComponent extends Base implements OnInit {
   public isLoading = true;
   userEntries$: Observable<EntryUpdateTime[]>;
   entryTypeParam: any;
+  firstCall: boolean = true;
 
   constructor(
     private registerToolService: RegisterToolService,
@@ -91,10 +92,11 @@ export class EntryBoxComponent extends Base implements OnInit {
       )
       .subscribe(
         (myEntries: Array<EntryUpdateTime>) => {
-          myEntries.forEach(() => {
-            this.listOfEntries = myEntries.slice(0, 7);
+          this.listOfEntries = myEntries.slice(0, 7);
+          if (this.firstCall) {
             this.totalEntries = myEntries.length;
-          });
+            this.firstCall = false;
+          }
         },
         (error: HttpErrorResponse) => {
           this.alertService.detailedError(error);


### PR DESCRIPTION
**Description**
Updates search on `entry-box.component` to handle empty search results.

**Before:**

https://user-images.githubusercontent.com/97123241/221948529-f5616d21-16aa-4ffd-a5ec-3bf73806f855.mp4


**After:**

https://user-images.githubusercontent.com/97123241/221948545-acaa1221-f85d-48ae-94ce-1a3b33036e21.mp4


**Review Instructions**
Empty search results should display message.

**Issue**
SEAB-5268

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
