### PR TITLE
Updated Blue Banner Style

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -30,14 +30,14 @@
       (tool?.mode === ModeEnum.AUTODETECTQUAYTAGSAUTOMATEDBUILDS || tool?.mode === ModeEnum.AUTODETECTQUAYTAGSWITHMIXED) && !tool?.gitUrl
     "
   >
-    <mat-card class="alert alert-info" role="alert">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> This Quay.io tool does not have an associated Git repository. Please view the Quay.io repository and add
       a build trigger for a valid Git repository. Once the build has been added, refresh the tool.
     </mat-card>
   </div>
 
   <div class="row m-1" *ngIf="tool?.mode === ModeEnum.HOSTED && tool?.workflowVersions?.length === 0">
-    <mat-card class="alert alert-info" role="alert">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> Your manually added tool does not have any tags. Go to the versions tab to add one.
     </mat-card>
   </div>
@@ -443,7 +443,7 @@
 </div>
 <ng-template #noVersions>
   <div class="p-3">
-    <mat-card class="alert alert-info p-3" role="alert">
+    <mat-card class="alert alert-info mat-elevation-z p-3" role="alert">
       <mat-icon>info</mat-icon>
       <span *ngIf="tool?.mode === ModeEnum.HOSTED"> To see versions, please add a new version in the Files tab. </span>
       <span *ngIf="tool?.mode === ModeEnum.MANUALIMAGEPATH"> To see versions, click the Add Tag button below. </span>

--- a/src/app/container/files/files.component.html
+++ b/src/app/container/files/files.component.html
@@ -50,5 +50,7 @@
 </mat-tab-group>
 
 <div *ngIf="!versions">
-  <mat-card class="alert alert-info" role="alert"> <mat-icon>warning</mat-icon> No files will be shown for invalid versions. </mat-card>
+  <mat-card class="alert alert-info mat-elevation-z" role="alert">
+    <mat-icon>warning</mat-icon> No files will be shown for invalid versions.
+  </mat-card>
 </div>

--- a/src/app/home-page/new-dashboard/new-dashboard.component.html
+++ b/src/app/home-page/new-dashboard/new-dashboard.component.html
@@ -4,7 +4,7 @@
   <div fxFlex="calc(100vw - 11rem)">
     <app-header>My Dockstore: Dashboard</app-header>
     <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="2.5rem" class="p-4">
-      <mat-card class="alert alert-info mx-1 w-100" role="alert"> Major Release: TODO</mat-card>
+      <mat-card class="alert alert-info mat-elevation-z mx-1 w-100" role="alert"> Major Release: TODO</mat-card>
       <div fxFlex fxLayout fxLayout.lt-md="column" fxLayoutGap="2.5rem" class="w-100">
         <app-entry-box fxFlex="33" fxFlex.lt-md="100" class="entry-holder" entryType="WORKFLOW"></app-entry-box>
         <app-entry-box fxFlex="33" fxFlex.lt-md="100" class="entry-holder" entryType="TOOL"></app-entry-box>

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -1,6 +1,6 @@
 <app-loading [loading]="loading$ | async">
   <div *ngIf="noEvents$ | async">
-    <mat-card class="alert alert-info mx-1" role="alert">
+    <mat-card class="alert alert-info mat-elevation-z mx-1" role="alert">
       <mat-icon>info</mat-icon> No events found. Star entries or organizations to see events for them. Read
       <a [href]="starringDocUrl" target="_blank" rel="noopener noreferrer">Starring Tools and Workflows</a>
       to learn how to star entries.

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -7,7 +7,7 @@
   <div *ngIf="(isAdmin$ | async) || (isCurator$ | async)" class="p-3">
     <h3>Curator Requests</h3>
     <p>As a curator/admin, you can approve and reject organization requests.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(allPendingOrganizations$ | async)?.length === 0">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="(allPendingOrganizations$ | async)?.length === 0">
       <mat-icon>info</mat-icon> There are no organizations waiting for approval.
     </mat-card>
 
@@ -69,7 +69,7 @@
   <div class="p-3">
     <h3>My Requests</h3>
     <p>The following organizations that you have created are pending approval.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length === 0">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="(myPendingOrganizationRequests$ | async)?.length === 0">
       <mat-icon>info</mat-icon> You have no organizations pending approval.
     </mat-card>
 
@@ -102,7 +102,7 @@
     </div>
 
     <p class="pt-2">The following organizations that you have created are rejected.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(myRejectedOrganizationRequests$ | async)?.length === 0">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="(myRejectedOrganizationRequests$ | async)?.length === 0">
       <mat-icon>info</mat-icon> You have no rejected organizations.
     </mat-card>
     <div fxLayout="column" fxLayoutGap="32px">
@@ -150,7 +150,7 @@
   <div class="p-3">
     <h3>Organization Invites</h3>
     <p>Accept and decline invitations to join organizations.</p>
-    <mat-card class="alert alert-info" role="alert" *ngIf="(myOrganizationInvites$ | async)?.length === 0">
+    <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="(myOrganizationInvites$ | async)?.length === 0">
       <mat-icon>info</mat-icon> You have no pending organization invites.
     </mat-card>
 

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -83,7 +83,7 @@
             "
           >
             <div fxFlex>
-              <mat-card class="alert alert-info" role="alert">
+              <mat-card class="alert alert-info mat-elevation-z" role="alert">
                 <p>
                   <mat-icon>info</mat-icon>
                   There are currently no tools registered under this account, to add your first tool, do one of the following:

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -145,7 +145,7 @@
             fxLayout
           >
             <div fxFlex>
-              <mat-card class="alert alert-info" role="alert">
+              <mat-card class="alert alert-info mat-elevation-z" role="alert">
                 <p>
                   <mat-icon>info</mat-icon>
                   There are currently no {{ entryType$ | async }}s registered under this account. To add your first

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -4,7 +4,7 @@
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
       <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving GitHub App logs for this organization.
     </mat-card>
-    <mat-card *ngIf="showContent === 'empty'" class="alert alert-info" role="alert">
+    <mat-card *ngIf="showContent === 'empty'" class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> There are no GitHub App logs for this organization.
     </mat-card>
     <!-- *ngIf doesn't work with the sorting implementation, using hidden for now -->

--- a/src/app/organizations/collection/add-entry/add-entry.component.html
+++ b/src/app/organizations/collection/add-entry/add-entry.component.html
@@ -19,7 +19,7 @@
     <div fxLayout="column">
       <div fxFlex *ngIf="memberships$ | async as memberships">
         <ng-template #noMemberships>
-          <mat-card class="alert alert-info" role="alert">
+          <mat-card class="alert alert-info mat-elevation-z" role="alert">
             <mat-icon>info</mat-icon> You must be part of an organization to add to a collection
           </mat-card>
         </ng-template>
@@ -39,7 +39,7 @@
       </div>
       <div fxFlex *ngIf="selectedOrganizationId && collections$ | async as collections">
         <ng-template #noCollections>
-          <mat-card class="alert alert-info" role="alert">
+          <mat-card class="alert alert-info mat-elevation-z" role="alert">
             <mat-icon>info</mat-icon> The selected organization has no collections that can be added
           </mat-card>
         </ng-template>

--- a/src/app/organizations/collection/collection.component.html
+++ b/src/app/organizations/collection/collection.component.html
@@ -31,7 +31,7 @@
 <app-loading [loading]="(loadingCollection$ | async) || (loadingOrganization$ | async)">
   <div *ngIf="organization$ | async as organization">
     <div class="container mb-5" *ngIf="collection$ | async as collection" fxLayout="column">
-      <mat-card fxFlex class="my-3 alert alert-info" *ngIf="organization?.status === pendingEnum">
+      <mat-card fxFlex class="my-3 alert alert-info mat-elevation-z" *ngIf="organization?.status === pendingEnum">
         <mat-icon>info</mat-icon> This collection is part of an organization that is pending approval by a Dockstore curator.
         <span *ngIf="(isAdmin$ | async) || (isCurator$ | async); else notAdminOrCurator">
           You can approve/reject this pending organization request on the requests tab of the
@@ -43,7 +43,7 @@
         </ng-template>
       </mat-card>
 
-      <mat-card fxFlex class="my-3 alert alert-info" *ngIf="organization?.status === 'REJECTED'">
+      <mat-card fxFlex class="my-3 alert alert-info mat-elevation-z" *ngIf="organization?.status === 'REJECTED'">
         <mat-icon>info</mat-icon> This collection is part of an organization that has been rejected by a curator. Members can re-request
         approval on the <a [routerLink]="'/accounts'" style="text-decoration: underline">accounts page</a>.
       </mat-card>
@@ -90,7 +90,7 @@
           </button>
         </mat-card-actions>
       </div>
-      <mat-card class="alert alert-info" *ngIf="collection?.entries?.length === 0">
+      <mat-card class="alert alert-info mat-elevation-z" *ngIf="collection?.entries?.length === 0">
         <mat-icon>info</mat-icon> This collection has no associated entries. To add an entry, navigate to the public page of the tool or
         workflow you want to add and select `Add to collection`
       </mat-card>

--- a/src/app/organizations/collections/collections.component.html
+++ b/src/app/organizations/collections/collections.component.html
@@ -26,7 +26,7 @@
 </div>
 <app-loading [loading]="loading$ | async">
   <div *ngIf="(collections$ | async | json) === '{}'; else hasCollections">
-    <mat-card class="alert alert-info mx-1" role="alert"> <mat-icon>info</mat-icon> No collections found. </mat-card>
+    <mat-card class="alert alert-info mat-elevation-z mx-1" role="alert"> <mat-icon>info</mat-icon> No collections found. </mat-card>
   </div>
   <ng-template #hasCollections>
     <div class="pt-2" fxLayout="column" fxLayoutGap="1rem">

--- a/src/app/organizations/organization/organization.component.html
+++ b/src/app/organizations/organization/organization.component.html
@@ -37,7 +37,7 @@
   <!-- Organization header -->
   <div class="container mb-5" *ngIf="organization$ | async as org" fxLayout="column" fxLayoutGap="10px">
     <app-json-ld [json]="schema$ | async" class="m-0"></app-json-ld>
-    <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'PENDING'">
+    <mat-card fxFlex class="my-3 alert alert-info mat-elevation-z" *ngIf="org?.status === 'PENDING'">
       <mat-icon>info</mat-icon> This organization is pending approval by a Dockstore curator.
       <span *ngIf="(isAdmin$ | async) || (isCurator$ | async); else notAdminOrCurator">
         You can approve/reject this pending organization request on the requests tab of the
@@ -49,7 +49,7 @@
       </ng-template>
     </mat-card>
 
-    <mat-card fxFlex class="my-3 alert alert-info" *ngIf="org?.status === 'REJECTED'">
+    <mat-card fxFlex class="my-3 alert alert-info mat-elevation-z" *ngIf="org?.status === 'REJECTED'">
       <mat-icon>info</mat-icon> This organization has been rejected by a curator. Members can re-request approval on the
       <a [routerLink]="'/accounts'" [queryParams]="{ tab: 'requests' }">accounts page</a>.
     </mat-card>

--- a/src/app/organizations/organizations/organizations.component.html
+++ b/src/app/organizations/organizations/organizations.component.html
@@ -127,6 +127,6 @@
     ></mat-paginator>
   </div>
   <ng-template #noOrganizationsFound>
-    <mat-card class="alert alert-info"><mat-icon class="pr-5">info</mat-icon>No organizations found</mat-card>
+    <mat-card class="alert alert-info mat-elevation-z"><mat-icon class="pr-5">info</mat-icon>No organizations found</mat-card>
   </ng-template>
 </div>

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -247,7 +247,7 @@
         </mat-card>
 
         <div *ngIf="searchService.hasSearchText(advancedSearchObject, searchTerm, hits) || searchService.hasFilters(filters)">
-          <mat-card class="alert alert-info text-break">
+          <mat-card class="alert alert-info mat-elevation-z text-break">
             <button
               data-cy="share_button"
               mat-raised-button
@@ -302,7 +302,7 @@
           </mat-card>
         </div>
         <mat-card
-          class="alert alert-info"
+          class="alert alert-info mat-elevation-z"
           *ngIf="hits?.length > query_size - 1 && searchService.hasNarrowedSearch(advancedSearchObject, searchTerm, hits, filters)"
         >
           <p>

--- a/src/app/shared/code-editor-list/code-editor-list.component.html
+++ b/src/app/shared/code-editor-list/code-editor-list.component.html
@@ -1,5 +1,5 @@
 <div>
-  <mat-card class="alert alert-info" role="alert" *ngIf="sourcefiles?.length === 0"> No files exist. </mat-card>
+  <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="sourcefiles?.length === 0"> No files exist. </mat-card>
   <div *ngFor="let sourcefile of sourcefiles; let i = index" style="margin-top: 10px; margin-bottom: 10px">
     <div *ngIf="sourcefile?.content !== null && showSourcefile(sourcefile?.type)">
       <mat-toolbar color="primary">

--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -14,7 +14,7 @@
   ~    limitations under the License.
   -->
 
-<mat-card class="alert alert-info" data-cy="noStargazers" role="alert" *ngIf="starGazers?.length === 0">
+<mat-card class="alert alert-info mat-elevation-z" data-cy="noStargazers" role="alert" *ngIf="starGazers?.length === 0">
   <mat-card-header>
     <mat-card-title>Stargazers</mat-card-title>
   </mat-card-header>

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -46,8 +46,7 @@
               <span class="tab-display">{{ starredWorkflows?.length }}</span>
             </div>
           </ng-template>
-          <mat-card class="alert alert-info starred-header" role="alert" *ngIf="starredWorkflows?.length === 0">
-            <mat-icon>warning</mat-icon>
+          <mat-card class="alert alert-info mat-elevation-z starred-header" role="alert" *ngIf="starredWorkflows?.length === 0">
             You have no starred workflows.
           </mat-card>
           <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
@@ -66,8 +65,7 @@
             </div>
           </ng-template>
           <div>
-            <mat-card class="alert alert-info starred-header" role="alert" *ngIf="starredTools?.length === 0">
-              <mat-icon>warning</mat-icon>
+            <mat-card class="alert alert-info mat-elevation-z starred-header" role="alert" *ngIf="starredTools?.length === 0">
               You have no starred tools.
             </mat-card>
             <div fxLayout="column" fxLayoutGap="1rem" class="mb-2 mx-1">
@@ -191,10 +189,7 @@
               <span class="tab-display">0</span>
             </div>
           </ng-template>
-          <mat-card class="alert alert-info starred-header" role="alert">
-            <mat-icon>warning</mat-icon>
-            You have no starred services.
-          </mat-card>
+          <mat-card class="alert alert-info mat-elevation-z starred-header" role="alert"> You have no starred services. </mat-card>
         </mat-tab>
 
         <mat-tab>
@@ -205,8 +200,7 @@
               <span class="tab-display">{{ starredOrganizations?.length }}</span>
             </div>
           </ng-template>
-          <mat-card class="alert alert-info starred-header" role="alert" *ngIf="starredOrganizations?.length === 0">
-            <mat-icon>warning</mat-icon>
+          <mat-card class="alert alert-info mat-elevation-z starred-header" role="alert" *ngIf="starredOrganizations?.length === 0">
             You have no starred organizations.
           </mat-card>
           <div *ngIf="starredOrganizations?.length > 0">

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -15,7 +15,7 @@
   -->
 <div class="p-3">
   <mat-card
-    class="alert alert-info"
+    class="alert alert-info mat-elevation-z"
     *ngIf="
       !isPublic &&
       workflow?.source_control_provider === 'GITHUB' &&

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -27,7 +27,7 @@
     </div>
     <div *ngIf="_selectedVersion.valid" fxLayout="column" fxLayoutGap="1rem">
       <div fxLayout="column" fxLayoutGap="1rem">
-        <mat-card *ngIf="entryType === EntryType.Tool" class="alert alert-info" role="alert">
+        <mat-card *ngIf="entryType === EntryType.Tool" class="alert alert-info mat-elevation-z" role="alert">
           <mat-icon>info</mat-icon> GitHub App Tools are launched in workflow mode with the Dockstore CLI
         </mat-card>
         <mat-card *ngIf="(isNFL$ | async) === false" matTooltip="Commands for creating a runtime JSON template">

--- a/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
+++ b/src/app/workflow/workflow-file-editor/workflow-file-editor.component.html
@@ -40,7 +40,7 @@
         [entryType]="'workflow'"
         [entrypath]="entrypath"
       ></app-code-editor-list>
-      <mat-card class="alert alert-info" role="alert" *ngIf="isNFL$ | async">
+      <mat-card class="alert alert-info mat-elevation-z" role="alert" *ngIf="isNFL$ | async">
         <mat-icon>warning</mat-icon>
         &nbsp; Nextflow does not have the concept of a test parameter file.
       </mat-card>

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -277,19 +277,19 @@
             </div>
             <ng-template #noVersionsVersionTab>
               <div [ngSwitch]="workflow.mode" class="p-3">
-                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.HOSTED" class="alert alert-info" role="alert">
+                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.HOSTED" class="alert alert-info mat-elevation-z" role="alert">
                   <mat-icon>info</mat-icon> To see versions, please add a new version in the Files tab.
                 </mat-card>
-                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.STUB" class="alert alert-info" role="alert">
+                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.STUB" class="alert alert-info mat-elevation-z" role="alert">
                   <mat-icon>info</mat-icon> To see versions, please refresh the workflow.
                 </mat-card>
-                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML" class="alert alert-info" role="alert">
+                <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML" class="alert alert-info mat-elevation-z" role="alert">
                   <mat-icon>info</mat-icon> This {{ entryType }} does not have any versions because there are no GitHub branches or
                   releases/tags with a .dockstore.yml that references this {{ entryType }}. Create a valid .dockstore.yml on GitHub that
                   references this {{ entryType }} to add a new version.
                 </mat-card>
                 <!-- This also handles FULL -->
-                <mat-card *ngSwitchDefault class="alert alert-info" role="alert">
+                <mat-card *ngSwitchDefault class="alert alert-info mat-elevation-z" role="alert">
                   <mat-icon>info</mat-icon> This {{ entryType }} does not have any versions.
                 </mat-card>
               </div>
@@ -306,19 +306,19 @@
               </div>
               <ng-template #noVersionsFilesTab>
                 <div [ngSwitch]="workflow.mode" class="p-3">
-                  <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.STUB" class="alert alert-info" role="alert">
+                  <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.STUB" class="alert alert-info mat-elevation-z" role="alert">
                     <mat-icon>info</mat-icon> To see files, please refresh the {{ entryType }}.
                   </mat-card>
                   <div *ngSwitchCase="WorkflowModel.ModeEnum.HOSTED">
                     <ng-container *ngTemplateOutlet="hostedComponent"></ng-container>
                   </div>
-                  <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML" class="alert alert-info" role="alert">
+                  <mat-card *ngSwitchCase="WorkflowModel.ModeEnum.DOCKSTOREYML" class="alert alert-info mat-elevation-z" role="alert">
                     <mat-icon>info</mat-icon> This {{ entryType }} does not have any versions because there are no GitHub branches or
                     releases/tags with a .dockstore.yml that references this {{ entryType }}. Create a valid .dockstore.yml on GitHub that
                     references this {{ entryType }} to add a new version.
                   </mat-card>
                   <!-- This also handles FULL -->
-                  <mat-card *ngSwitchDefault class="alert alert-info" role="alert">
+                  <mat-card *ngSwitchDefault class="alert alert-info mat-elevation-z" role="alert">
                     <mat-icon>info</mat-icon> This {{ entryType }} does not have any versions.
                   </mat-card>
                 </div>

--- a/src/materialColorScheme.scss
+++ b/src/materialColorScheme.scss
@@ -102,6 +102,23 @@ $kim-accent1-success: (
   ),
 );
 
+$kim-accent2: (
+  1: #0277bd,
+  2: #29b6f6,
+  3: #81d4fa,
+  4: #b3e5fc,
+  5: #d0effd,
+  6: #e1f5fe,
+  contrast: (
+    1: white,
+    2: white,
+    3: black,
+    4: black,
+    5: black,
+    6: black,
+  ),
+);
+
 // Grayscale
 $kim-gray: (
   1: #212121,
@@ -147,6 +164,7 @@ $dockstore-app-accent: mat.define-palette($kim-secondary, 2, 4, 1);
 $dockstore-app-error: mat.define-palette($kim-error, 2, 4, 1);
 $dockstore-app-warn: mat.define-palette($kim-warn, 2, 4, 1);
 $dockstore-app-accent-1: mat.define-palette($kim-accent1-success, 2, 4, 1);
+$dockstore-app-accent-2: mat.define-palette($kim-accent2, 2, 4, 1);
 $dockstore-app-accent-4: mat.define-palette($kim-accent-4, 2, 4, 1);
 
 // 4 and 1 were chosen as darker and lighter versions, respectively, because those were used in styles.

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1329,9 +1329,11 @@ button.inline-text-btn {
 }
 
 .alert-info {
-  background-color: #d9edf7 !important;
-  border-color: #bce8f1 !important;
-  border: 0px !important;
+  background-color: mat.get-color-from-palette($dockstore-app-accent-2, 6) !important;
+  border: solid 1px mat.get-color-from-palette($dockstore-app-accent-2, 4) !important;
+  mat-icon {
+    color: mat.get-color-from-palette($dockstore-app-accent-2, 1);
+  }
 }
 
 .alert-danger {


### PR DESCRIPTION
**Description**
Updates the blue `alert-info` banner style following the zeplin mock-ups and creates a new palette for `Accent 2` as defined [here](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/5fc699d068c46f17551f745b).
New style has a blue border, light blue background and no box-shadow.
https://github.com/dockstore/dockstore-ui2/blob/cc245466e179fa7c0e80446f9f232fb26896854e/src/styles.scss#L1331-L1337
Zeplin mocks: [Dashboard](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/60229885ad1715098caf03e5), [Starred](https://app.zeplin.io/project/5fc690a2717ee9144814f190/screen/602c3030c7ca5718b6e37c1c)

**Dashboard:**
**Before:**
![image](https://user-images.githubusercontent.com/97123241/222573697-0cb574c3-909c-4cfa-a806-8fc528c2b3b1.png)
**After:**
![image](https://user-images.githubusercontent.com/97123241/222573578-cef1bcf2-c955-49a7-907e-5e0cabed9897.png)

**Starred:**
**Before:**
![image](https://user-images.githubusercontent.com/97123241/222571862-cdd5ac70-4a5c-4014-9a78-80000319c416.png)

**After:**
![image](https://user-images.githubusercontent.com/97123241/222571839-13768889-1e6c-45c2-be95-cb91dc7e1f26.png)
In this case, following the mocks, I removed the warning icon.

**Zeplin:**
![image](https://user-images.githubusercontent.com/97123241/222572498-7588b427-04b0-444f-a25c-50865ce268e7.png)

**General:**
For areas where we leave the icons, Zeplin didn't have any examples so I picked a matching blue from the new `Accent 2` colour palette:

**Before:**
![image](https://user-images.githubusercontent.com/97123241/222572987-312bc1b0-e147-4650-9408-04cf55a65768.png)

**After:**
![image](https://user-images.githubusercontent.com/97123241/222572967-0b3a05a3-1a16-47d8-b386-436d434f8791.png)

**Review Instructions**


**Issue**
SEAB-5201

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
