### PR TITLE
Indicate open on versions table

### DIFF
--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -70,8 +70,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
     [
       'openData',
       new Map([
-        ['1', "doesn't need public test data"],
-        ['0', 'needs public test data'],
+        ['1', "doesn't need more data"],
+        ['0', 'needs more data'],
       ]),
     ],
     [

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -70,8 +70,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
     [
       'openData',
       new Map([
-        ['1', 'has public test data'],
-        ['0', 'no public test data'],
+        ['1', "doesn't need public test data"],
+        ['0', 'needs public test data'],
       ]),
     ],
     [

--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -70,8 +70,8 @@ export class MapFriendlyValuesPipe implements PipeTransform {
     [
       'openData',
       new Map([
-        ['1', "doesn't need more data"],
-        ['0', 'needs more data'],
+        ['1', 'open data'],
+        ['0', 'requires restricted data'],
       ]),
     ],
     [

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -534,7 +534,7 @@ export class SearchService {
       ['verified_platforms.keyword', 'Verified Platforms'],
       ['categories.name.keyword', 'Category'],
       ['descriptor_type_versions.keyword', 'Language Versions'],
-      ['openData', 'Open Data'],
+      ['openData', 'Open'],
     ]);
   }
 
@@ -555,7 +555,7 @@ export class SearchService {
         'descriptor_type_versions.keyword',
         'Indicates that the tool or workflow contains at least one version that is written with the workflow language version',
       ],
-      ['openData', 'Indicates whether an entry has a test parameter file with all publicly accessible data.'],
+      ['openData', 'Indicates whether an entry can be run with a provided test parameter file and no additional access permissions.'],
     ]);
   }
 

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -534,7 +534,7 @@ export class SearchService {
       ['verified_platforms.keyword', 'Verified Platforms'],
       ['categories.name.keyword', 'Category'],
       ['descriptor_type_versions.keyword', 'Language Versions'],
-      ['openData', 'Open'],
+      ['openData', 'Open Data'],
     ]);
   }
 
@@ -555,7 +555,10 @@ export class SearchService {
         'descriptor_type_versions.keyword',
         'Indicates that the tool or workflow contains at least one version that is written with the workflow language version',
       ],
-      ['openData', 'Indicates whether an entry can be run with a provided test parameter file and no additional access permissions.'],
+      [
+        'openData',
+        'Indicates whether an entry can be run with no additional access permissions, potentially via an included test parameter file referencing open data.',
+      ],
     ]);
   }
 

--- a/src/app/shared/versions.ts
+++ b/src/app/shared/versions.ts
@@ -38,6 +38,7 @@ export abstract class Versions extends EntryTab {
   dtOptions;
   displayedColumns: string[];
   readonly verifiedVersionTooltip = 'A version has a verified platform if it has been verified to work by a third party';
+  readonly openTooltip = 'A version is open if it provides everything to run it without requiring access to restricted data';
 
   abstract setNoOrderCols(): Array<number>;
   abstract setDisplayColumns(publicPage: boolean): void;

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -460,8 +460,8 @@
         {{ selectedVersion?.doiURL ? '' : 'n/a' }}
       </div>
       <div *ngIf="publicAccessibleTestParameterFile !== null && publicAccessibleTestParameterFile !== undefined">
-        <strong matTooltip="Version has a test parameter file where all URLs are publicly accessible"
-          >Test Parameter File With Open Data</strong
+        <strong matTooltip="Version either has a test parameter file where all URLs are publicly accessible or does not require test data"
+          >Open</strong
         >:
         {{ publicAccessibleTestParameterFile ? 'Yes' : 'No' }}
       </div>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -134,6 +134,15 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="openData">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="The version has a test parameter file with open data.">
+        Open Data
+      </th>
+      <td mat-cell *matCellDef="let version">
+        <mat-icon data-cy="openData" *ngIf="version?.versionMetadata?.publicAccessibleTestParameterFile">check</mat-icon>
+      </td>
+    </ng-container>
+
     <ng-container matColumnDef="verified">
       <th scope="col" mat-header-cell *matHeaderCellDef [matTooltip]="verifiedVersionTooltip">
         Verified Platforms

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -134,9 +134,22 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="openData">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="The version has a test parameter file with open data.">
-        Open Data
+    <ng-container matColumnDef="open" [matTooltip]="openTooltip">
+      <th
+        scope="col"
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        matTooltip="The version has a test parameter file with open data or requires no input files."
+      >
+        Open
+        <a
+          class="ds-green"
+          [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#what-is-an-open-tool-or-workflow'"
+          target="_blank"
+          rel="noopener noreferrer"
+          ><mat-icon>info</mat-icon></a
+        >
       </th>
       <td mat-cell *matCellDef="let version">
         <mat-icon data-cy="openData" *ngIf="version?.versionMetadata?.publicAccessibleTestParameterFile">check</mat-icon>

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -71,7 +71,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
 
   setDisplayColumns(publicPage: boolean) {
     if (publicPage) {
-      this.displayedColumns = ['name', 'last_modified', 'descriptorTypeVersions', 'valid', 'verified', 'openData', 'snapshot', 'actions'];
+      this.displayedColumns = ['name', 'last_modified', 'descriptorTypeVersions', 'valid', 'verified', 'open', 'snapshot', 'actions'];
     } else {
       this.displayedColumns = [
         'name',

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -38,7 +38,7 @@ import { Versions } from '../../shared/versions';
 export class VersionsWorkflowComponent extends Versions implements OnInit, OnChanges, AfterViewInit {
   faTag = faTag;
   faCodeBranch = faCodeBranch;
-  @Input() versions: Array<any>;
+  @Input() versions: Array<WorkflowVersion>;
   @Input() workflowId: number;
   @Input() verifiedVersionPlatforms: Array<VersionVerifiedPlatform>;
   zenodoUrl: string;
@@ -71,9 +71,19 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
 
   setDisplayColumns(publicPage: boolean) {
     if (publicPage) {
-      this.displayedColumns = ['name', 'last_modified', 'descriptorTypeVersions', 'valid', 'verified', 'snapshot', 'actions'];
+      this.displayedColumns = ['name', 'last_modified', 'descriptorTypeVersions', 'valid', 'verified', 'openData', 'snapshot', 'actions'];
     } else {
-      this.displayedColumns = ['name', 'last_modified', 'descriptorTypeVersions', 'valid', 'hidden', 'verified', 'snapshot', 'actions'];
+      this.displayedColumns = [
+        'name',
+        'last_modified',
+        'descriptorTypeVersions',
+        'valid',
+        'hidden',
+        'openData',
+        'verified',
+        'snapshot',
+        'actions',
+      ];
     }
   }
 

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -79,7 +79,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
         'descriptorTypeVersions',
         'valid',
         'hidden',
-        'openData',
+        'open',
         'verified',
         'snapshot',
         'actions',


### PR DESCRIPTION
**Description**
Adds an Open column to the versions table, and does corresponding renaming from Open Data to Open on the facets page.

***Background on the renaming***
* Initially, we were considering an open data version to be a workflow with a test parameter file with publicly accessible test data
* Now, we are considering an open version to be a version with publicly accessible test data, **OR**, a version that does not require any file inputs. The key point being that in both cases you don't need any additional permissions to run the version.

The versions table is getting crowded, although I think it might just be acceptable. Suggestions welcome.

Before:
![Screen Shot 2023-03-03 at 4 04 24 PM](https://user-images.githubusercontent.com/1049340/222857586-b3cabbd7-6ff3-455d-b1d0-c9c3be0e17bb.png)


After:
![Screen Shot 2023-03-03 at 3 45 15 PM](https://user-images.githubusercontent.com/1049340/222857722-59a7c443-9453-4c72-bc08-89a375c4749a.png)

***Facets***
Before
![Screen Shot 2023-03-03 at 4 02 40 PM](https://user-images.githubusercontent.com/1049340/222857473-c542bf10-17fa-4f65-b636-b2a3dac81759.png)

After
![Screen Shot 2023-03-03 at 4 01 46 PM](https://user-images.githubusercontent.com/1049340/222857491-e9515f16-a11f-4666-84e7-95dbc298cb0f.png)

**Review Instructions**
Verify that the Open column appears on the versions table in both the public and My workflows views. Verify that the facet looks good on the search page.

We only update public accessible when updating/creating a new version (it's not retroactive), so you'll need to push new versions to test this.

**Issue**
dockstore/dockstore#5340

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. dockstore/dockstore#5402
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
