### PR TITLE
Redirect to same workflow after refresh if possible

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/services.ts
+++ b/cypress/e2e/immutableDatabaseTests/services.ts
@@ -28,16 +28,20 @@ describe('Dockstore Home', () => {
   describe('GitHub App Callback Routing', () => {
     setTokenUserViewPort();
     it('Redirects to my-tools', () => {
-      cy.visit('/githubCallback?state=tool');
-      cy.url().should('contain', '/my-tools');
+      cy.visit('/githubCallback?state=/my-tools/quay.io/A2/b1');
+      cy.url().should('contain', '/my-tools/quay.io/A2/b1');
     });
     it('Redirects to my-workflows', () => {
-      cy.visit('/githubCallback?state=workflow');
-      cy.url().should('contain', '/my-workflows');
+      cy.visit('/githubCallback?state=/my-workflows/github.com/A/l');
+      cy.url().should('contain', '/my-workflows/github.com/A/l');
     });
     it('Redirects to my-services', () => {
-      cy.visit('/githubCallback?state=service');
-      cy.url().should('contain', '/my-services');
+      cy.visit('/githubCallback?state=/services/github.com/garyluu/another-test-service');
+      cy.url().should('contain', '/services/github.com/garyluu/another-test-service');
+    });
+    it('Redirects to dashboard', () => {
+      cy.visit('githubCallback?state=/dashboard?newDashboard');
+      cy.url().should('contain', '/dashboard?newDashboard');
     });
   });
 

--- a/src/app/github-callback/github-callback.service.spec.ts
+++ b/src/app/github-callback/github-callback.service.spec.ts
@@ -2,7 +2,6 @@
 
 import { inject, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { EntryType } from 'app/shared/enum/entry-type';
 import { GithubCallbackService } from './github-callback.service';
 
 describe('Service: GithubCallback', () => {

--- a/src/app/github-callback/github-callback.service.spec.ts
+++ b/src/app/github-callback/github-callback.service.spec.ts
@@ -13,12 +13,7 @@ describe('Service: GithubCallback', () => {
     });
   });
 
-  it('should get the redirect URL', inject([GithubCallbackService], (service: GithubCallbackService) => {
+  it('should compile', inject([GithubCallbackService], (service: GithubCallbackService) => {
     expect(service).toBeTruthy();
-    expect(service.stateToUrl(EntryType.Tool)).toBe('/my-tools');
-    expect(service.stateToUrl(EntryType.BioWorkflow)).toBe('/my-workflows');
-    expect(service.stateToUrl(EntryType.Service)).toBe('/my-services');
-    expect(service.stateToUrl(null)).toBe('/');
-    expect(service.stateToUrl('potato')).toBe('/');
   }));
 });

--- a/src/app/github-callback/github-callback.service.ts
+++ b/src/app/github-callback/github-callback.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Params, Router } from '@angular/router';
-import { EntryType } from 'app/shared/enum/entry-type';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/github-callback/github-callback.service.ts
+++ b/src/app/github-callback/github-callback.service.ts
@@ -10,34 +10,9 @@ export class GithubCallbackService {
   public resolveQueryParam(queryParams: Params | null): void {
     if (queryParams) {
       const state: string | null = queryParams.state;
-      const url: string = this.stateToUrl(state);
-      this.router.navigateByUrl(url);
+      this.router.navigateByUrl(state);
     } else {
       this.router.navigateByUrl('/');
-    }
-  }
-
-  /**
-   * Given the state query param, determines what route to go to
-   *
-   * @param {(string | null)} state  The state query param
-   * @returns {(string)}  The route to redirect to
-   * @memberof GithubCallbackComponent
-   */
-  public stateToUrl(state: string | null): string {
-    if (state) {
-      switch (state) {
-        case EntryType.BioWorkflow:
-          return '/my-workflows';
-        case EntryType.Service:
-          return '/my-services';
-        case EntryType.Tool:
-          return '/my-tools';
-        default:
-          return '/';
-      }
-    } else {
-      return '/';
     }
   }
 }

--- a/src/app/mytools/mytools.service.ts
+++ b/src/app/mytools/mytools.service.ts
@@ -124,6 +124,22 @@ export class MytoolsService extends MyEntriesService<DockstoreTool, OrgToolObjec
     });
   }
 
+  matchingOrgEntryObjectByPath(
+    orgToolObjects: OrgToolObject<DockstoreTool>[],
+    toolPath: String
+  ): OrgToolObject<DockstoreTool> | undefined | null {
+    const toolPathComponents = toolPath.split('/');
+    if (toolPathComponents.length < 2) {
+      return null;
+    }
+
+    const registry = toolPathComponents[0];
+    const namespace = toolPathComponents[1];
+    return orgToolObjects.find((orgToolObject) => {
+      return orgToolObject.registry === registry && orgToolObject.namespace === namespace;
+    });
+  }
+
   getPath(entry: DockstoreTool | Workflow): string {
     if (MytoolsService.isWorkflowBasedObject(entry)) {
       return entry.full_workflow_path || '';

--- a/src/app/mytools/mytools.service.ts
+++ b/src/app/mytools/mytools.service.ts
@@ -126,7 +126,7 @@ export class MytoolsService extends MyEntriesService<DockstoreTool, OrgToolObjec
 
   matchingOrgEntryObjectByPath(
     orgToolObjects: OrgToolObject<DockstoreTool>[],
-    toolPath: String
+    toolPath: string
   ): OrgToolObject<DockstoreTool> | undefined | null {
     const toolPathComponents = toolPath.split('/');
     if (toolPathComponents.length < 2) {

--- a/src/app/myworkflows/myworkflows.service.ts
+++ b/src/app/myworkflows/myworkflows.service.ts
@@ -258,6 +258,22 @@ export class MyWorkflowsService extends MyEntriesService<Workflow, OrgWorkflowOb
     });
   }
 
+  matchingOrgEntryObjectByPath(
+    orgWorkflowObjects: OrgWorkflowObject<Workflow>[],
+    workflowPath: String
+  ): OrgWorkflowObject<Workflow> | undefined | null {
+    const workflowPathComponents = workflowPath.split('/');
+    if (workflowPathComponents.length < 2) {
+      return null;
+    }
+
+    const sourceControl = workflowPathComponents[0];
+    const organization = workflowPathComponents[1];
+    return orgWorkflowObjects.find((orgWorkflowObject) => {
+      return orgWorkflowObject.sourceControl === sourceControl && orgWorkflowObject.organization === organization;
+    });
+  }
+
   getPath(entry: Workflow): string {
     return entry.full_workflow_path || '';
   }

--- a/src/app/myworkflows/myworkflows.service.ts
+++ b/src/app/myworkflows/myworkflows.service.ts
@@ -260,7 +260,7 @@ export class MyWorkflowsService extends MyEntriesService<Workflow, OrgWorkflowOb
 
   matchingOrgEntryObjectByPath(
     orgWorkflowObjects: OrgWorkflowObject<Workflow>[],
-    workflowPath: String
+    workflowPath: string
   ): OrgWorkflowObject<Workflow> | undefined | null {
     const workflowPathComponents = workflowPath.split('/');
     if (workflowPathComponents.length < 2) {

--- a/src/app/shared/feature.service.ts
+++ b/src/app/shared/feature.service.ts
@@ -9,7 +9,8 @@ export class FeatureService {
 
   updateFeatureFlags(queryParams: string) {
     const urlSearchParams = new URLSearchParams(queryParams);
-    const newDashboard = urlSearchParams.has('newDashboard');
+    const gitHubAppCallBackToNewDashBoard = urlSearchParams.has('state') && urlSearchParams.get('state').includes('newDashboard');
+    const newDashboard = urlSearchParams.has('newDashboard') || gitHubAppCallBackToNewDashBoard;
     Dockstore.FEATURES.enableNewDashboard = newDashboard;
   }
 }

--- a/src/app/shared/myentries.service.ts
+++ b/src/app/shared/myentries.service.ts
@@ -23,16 +23,22 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
   protected constructor(protected urlResolverService: UrlResolverService) {}
 
   recomputeWhatEntryToSelect(entries: E[]): E | null {
-    const foundEntry = this.findEntryFromPath(this.urlResolverService.getEntryPathFromUrl(), entries);
+    const entryPath = this.urlResolverService.getEntryPathFromUrl();
+    const foundEntry = this.findEntryFromPath(entryPath, entries);
     if (foundEntry) {
       return foundEntry;
     } else {
-      const initialEntry = this.getInitialEntry(entries);
-      if (initialEntry) {
-        return initialEntry;
+      let initialEntry;
+      const orgEntryObjects = this.convertEntriesToOrgEntryObject(entries, null);
+      const foundOrgEntryObject = this.matchingOrgEntryObjectByPath(orgEntryObjects, entryPath);
+      if (foundOrgEntryObject) {
+        // If the entry from the URL doesn't exist, pick an entry from the same organization
+        initialEntry = this.getInitialEntry([...foundOrgEntryObject.published, ...foundOrgEntryObject.unpublished]);
       } else {
-        return null;
+        // Use the initial entry from all entries
+        initialEntry = this.getInitialEntry(entries);
       }
+      return initialEntry ? initialEntry : null;
     }
   }
 
@@ -54,7 +60,9 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
       }
     });
     this.recursiveSortOrgEntryObjects(orgEntryObjects);
-    this.setExpand(orgEntryObjects, selectedEntry);
+    if (selectedEntry) {
+      this.setExpand(orgEntryObjects, selectedEntry);
+    }
     return orgEntryObjects;
   }
 
@@ -81,6 +89,22 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
     }
     return entries.find((entry) => this.getPath(entry) === path);
   }
+
+  // protected findOrgEntryObjectFromPath(entryPath: string | null, orgEntryObjects: Array<O> | null): O | null | undefined {
+  //   if (!entryPath || !orgEntryObjects || orgEntryObjects.length === 0) {
+  //     return null;
+  //   }
+
+  //   const entryPathComponents = entryPath.split('/');
+  //   if (entryPathComponents.length < 2) {
+  //     return null;
+  //   }
+
+  //   const entryRegistryOrSourceControl = entryPathComponents[0];
+  //   const entryNamespaceOrOrganization = entryPathComponents[1];
+
+  //   return orgEntryObjects.find(orgEntryObject )
+  // }
 
   abstract getPath(entry: E): string;
 
@@ -131,4 +155,6 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
   }
 
   protected abstract matchingOrgEntryObject(orgEntryObjects: O[], selectedEntry: E): O | undefined;
+
+  protected abstract matchingOrgEntryObjectByPath(orgEntryObjects: O[], entryPath: String): O | undefined | null;
 }

--- a/src/app/shared/myentries.service.ts
+++ b/src/app/shared/myentries.service.ts
@@ -90,22 +90,6 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
     return entries.find((entry) => this.getPath(entry) === path);
   }
 
-  // protected findOrgEntryObjectFromPath(entryPath: string | null, orgEntryObjects: Array<O> | null): O | null | undefined {
-  //   if (!entryPath || !orgEntryObjects || orgEntryObjects.length === 0) {
-  //     return null;
-  //   }
-
-  //   const entryPathComponents = entryPath.split('/');
-  //   if (entryPathComponents.length < 2) {
-  //     return null;
-  //   }
-
-  //   const entryRegistryOrSourceControl = entryPathComponents[0];
-  //   const entryNamespaceOrOrganization = entryPathComponents[1];
-
-  //   return orgEntryObjects.find(orgEntryObject )
-  // }
-
   abstract getPath(entry: E): string;
 
   /**
@@ -156,5 +140,5 @@ export abstract class MyEntriesService<E extends DockstoreTool | Workflow, O ext
 
   protected abstract matchingOrgEntryObject(orgEntryObjects: O[], selectedEntry: E): O | undefined;
 
-  protected abstract matchingOrgEntryObjectByPath(orgEntryObjects: O[], entryPath: String): O | undefined | null;
+  protected abstract matchingOrgEntryObjectByPath(orgEntryObjects: O[], entryPath: string): O | undefined | null;
 }

--- a/src/app/shared/session/session.query.ts
+++ b/src/app/shared/session/session.query.ts
@@ -52,15 +52,15 @@ export class SessionQuery extends Query<SessionState> {
   /**
    * Generate the general GitHub App installation URL
    *
-   * @param {string} redirectUrl  The page to redirect to after installation is complete
+   * @param {string} redirectPath  The page to redirect to after installation is complete
    * @returns {string}
    * @memberof WorkflowQuery
    */
-  generateGitHubAppInstallationUrl(redirectUrl: string): string {
+  generateGitHubAppInstallationUrl(redirectPath: string): string {
     let queryParams = new HttpParams();
     // Can only provide a state query parameter
     // https://docs.github.com/en/apps/maintaining-github-apps/installing-github-apps#preserving-an-application-state-during-installation
-    queryParams = queryParams.set('state', redirectUrl);
+    queryParams = queryParams.set('state', redirectPath);
     return Dockstore.GITHUB_APP_INSTALLATION_URL + '/installations/new?' + queryParams.toString();
   }
 }

--- a/src/app/shared/session/session.query.ts
+++ b/src/app/shared/session/session.query.ts
@@ -15,6 +15,7 @@
  */
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { Query } from '@datorama/akita';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -41,23 +42,25 @@ export class SessionQuery extends Query<SessionState> {
   isService$: Observable<boolean> = this.entryType$.pipe(map((entryType) => entryType === EntryType.Service));
   isTool$: Observable<boolean> = this.entryType$.pipe(map((entryType) => entryType === EntryType.Tool));
   gitHubAppInstallationLink$: Observable<string> = this.entryType$.pipe(
-    map((entryType: EntryType) => (entryType ? this.generateGitHubAppInstallationUrl(entryType) : null))
+    map((entryType: EntryType) => (entryType ? this.generateGitHubAppInstallationUrl(this.route.url) : null))
   );
   loadingDialog$: Observable<boolean> = this.select((session) => session.loadingDialog);
-  constructor(protected store: SessionStore) {
+  constructor(protected store: SessionStore, private route: Router) {
     super(store);
   }
 
   /**
    * Generate the general GitHub App installation URL
    *
-   * @param {EntryType} entryType  To determine which page the user currently is on
+   * @param {string} redirectUrl  The page to redirect to after installation is complete
    * @returns {string}
    * @memberof WorkflowQuery
    */
-  generateGitHubAppInstallationUrl(entryType: EntryType): string {
+  generateGitHubAppInstallationUrl(redirectUrl: string): string {
     let queryParams = new HttpParams();
-    queryParams = queryParams.set('state', entryType);
+    // Can only provide a state query parameter
+    // https://docs.github.com/en/apps/maintaining-github-apps/installing-github-apps#preserving-an-application-state-during-installation
+    queryParams = queryParams.set('state', redirectUrl);
     return Dockstore.GITHUB_APP_INSTALLATION_URL + '/installations/new?' + queryParams.toString();
   }
 }


### PR DESCRIPTION
**Description**
The problem in the issue was that the My Workflows accordion changes after refreshing the page. I couldn't reproduce this locally or on QA.

I tried to fix other "refresh"/redirection problems that didn't align with the desired behaviour of this ticket, which was to return to the previous state the user was in after an action. 

This PR changes the behaviour of two scenarios:
1) When managing GItHub App installations on My Workflows, after the user clicks Save on GitHub, they're now redirected to the page they were previously on. If they were viewing a specific workflow, they would be redirected there. If they were on the new dashboard (which allows workflow registration), they would be directed back to the dashboard.

    The following videos demonstrate the old and new GitHub App callback behaviour. Previously, it just took you back to `/my-<entry>/` and the first published workflow was selected or the first unpublished.

    Before:
   
    https://user-images.githubusercontent.com/25287123/223787558-6cd0e365-fcd5-4907-850c-6eb33d87836d.mp4

    After:

    https://user-images.githubusercontent.com/25287123/223787593-c541060d-8172-460f-b044-e0135ad9365a.mp4







2) If the workflow that they're viewing does not exist anymore for whatever reason, when they refresh the page, the accordion that was previously opened will still be open. The entry selected is either the first published one in the organization, or the first unpublished one.

    The following videos demonstrate the deletion of the workflow that you're currently viewing and how you're redirected to a workflow in the same organization.

    Before:
   
    https://user-images.githubusercontent.com/25287123/223785885-5a385b41-6ab8-4130-9b05-3813fb6b11a0.mp4

    After:

    https://user-images.githubusercontent.com/25287123/223785978-bbf86891-ef8b-423d-9bb9-f21b32211c82.mp4 

**Review Instructions**
On QA,
Part 1:
1. If you don't already have a published hosted workflow, create one.
2. Go to My Workflows > Register a workflow > Quickly register remote workflows and register one of the workflows in your account by toggling one of the options.
3. Navigate to the workflow you just registered.
4. Go to My Workflows > Register a workflow > Quickly register remote workflows and toggle the **same** workflow that you toggled in step 1. This will delete the stub workflow that you registered in step 2.
5. Verify that you're redirected to a workflow within the same organization as the workflow that you just deleted. You should not be redirected to the published hosted workflow in step 1.

Part 2:
1. Go to My Workflows
5. Click on a workflow that is **not** the default selected workflow. Note which workflow it is
6. Click Register a Workflow > Register using GitHub Apps > Manage Dockstore Installations on GitHub
7. You'll be redirected to GitHub. Configure the GitHub App installation for one of your accounts then click Save
8. You should be redirected to the previous workflow page you were on in step 2
9. Go to the new dashboard (qa.dockstore.org/dashboard?newDashboard) and repeat steps 3 to 4 using the workflow box on the new dashboard.
10. You should be redirected back to the new dashboard after you're done on GitHub

**Issue**
dockstore/dockstore#4574
[DOCK-1987](https://ucsc-cgl.atlassian.net/browse/DOCK-1987)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-1987]: https://ucsc-cgl.atlassian.net/browse/DOCK-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ