### PR TITLE
SEAB-5270: Ensure UI builds/runs with new entry type information

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9439/workflows/5f79ee80-9510-4aaf-8596-07b5bd6fd2ae/jobs/30230/artifacts",
-    "circle_build_id": "30230",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9528/workflows/e0b89b73-fa17-4bc9-b405-13f630a8594b/jobs/30845/artifacts",
+    "circle_build_id": "30845",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9528/workflows/e0b89b73-fa17-4bc9-b405-13f630a8594b/jobs/30845/artifacts",
-    "circle_build_id": "30845",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9565/workflows/a734f7c7-fbfb-4f8d-8039-fc411937b3bf/jobs/31097/artifacts",
+    "circle_build_id": "31097",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9565/workflows/a734f7c7-fbfb-4f8d-8039-fc411937b3bf/jobs/31097/artifacts",
-    "circle_build_id": "31097",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9573/workflows/f6fb7f5b-294b-47e0-9bd1-1d60689db83d/jobs/31164/artifacts",
+    "circle_build_id": "31164",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/home-page/new-dashboard/new-dashboard.component.ts
+++ b/src/app/home-page/new-dashboard/new-dashboard.component.ts
@@ -5,6 +5,7 @@ import { RegisterToolService } from 'app/container/register-tool/register-tool.s
 import { MatDialog } from '@angular/material/dialog';
 import { RegisterToolComponent } from 'app/container/register-tool/register-tool.component';
 import { AlertService } from 'app/shared/alert/state/alert.service';
+import { EntryType } from 'app/shared/openapi';
 
 @Component({
   selector: 'app-new-dashboard',
@@ -12,6 +13,7 @@ import { AlertService } from 'app/shared/alert/state/alert.service';
   styleUrls: ['./new-dashboard.component.scss'],
 })
 export class NewDashboardComponent extends Base implements OnInit {
+  public entryType = EntryType;
   constructor(private registerToolService: RegisterToolService, private dialog: MatDialog, private alertService: AlertService) {
     super();
   }

--- a/src/app/home-page/widget/entries/entries.component.html
+++ b/src/app/home-page/widget/entries/entries.component.html
@@ -16,18 +16,18 @@
 
       <div *ngFor="let entry of myItems" class="w-100 no-wrap">
         <span [matTooltip]="entry.prettyPath">
-          <a *ngIf="entry.entryType === EntryType.TOOL" [routerLink]="'/my-tools/' + entry.path" routerLinkActive="router-link-active">{{
+          <a *ngIf="entry.entryType === entryType.TOOL" [routerLink]="'/my-tools/' + entry.path" routerLinkActive="router-link-active">{{
             entry.prettyPath
           }}</a>
 
           <a
-            *ngIf="entry.entryType === EntryType.WORKFLOW"
+            *ngIf="entry.entryType === entryType.WORKFLOW"
             [routerLink]="'/my-workflows/' + entry.path"
             routerLinkActive="router-link-active"
             >{{ entry.prettyPath }}</a
           >
           <a
-            *ngIf="entry.entryType === EntryType.SERVICE"
+            *ngIf="entry.entryType === entryType.SERVICE"
             [routerLink]="'/my-services/' + entry.path"
             routerLinkActive="router-link-active"
             >{{ entry.prettyPath }}</a

--- a/src/app/home-page/widget/entries/entries.component.html
+++ b/src/app/home-page/widget/entries/entries.component.html
@@ -16,21 +16,18 @@
 
       <div *ngFor="let entry of myItems" class="w-100 no-wrap">
         <span [matTooltip]="entry.prettyPath">
-          <a
-            *ngIf="entry.entryType === entryTypeEnum.TOOL"
-            [routerLink]="'/my-tools/' + entry.path"
-            routerLinkActive="router-link-active"
-            >{{ entry.prettyPath }}</a
-          >
+          <a *ngIf="entry.entryType === EntryType.TOOL" [routerLink]="'/my-tools/' + entry.path" routerLinkActive="router-link-active">{{
+            entry.prettyPath
+          }}</a>
 
           <a
-            *ngIf="entry.entryType === entryTypeEnum.WORKFLOW"
+            *ngIf="entry.entryType === EntryType.WORKFLOW"
             [routerLink]="'/my-workflows/' + entry.path"
             routerLinkActive="router-link-active"
             >{{ entry.prettyPath }}</a
           >
           <a
-            *ngIf="entry.entryType === entryTypeEnum.SERVICE"
+            *ngIf="entry.entryType === EntryType.SERVICE"
             [routerLink]="'/my-services/' + entry.path"
             routerLinkActive="router-link-active"
             >{{ entry.prettyPath }}</a

--- a/src/app/home-page/widget/entries/entries.component.ts
+++ b/src/app/home-page/widget/entries/entries.component.ts
@@ -14,7 +14,6 @@ import { FilteredList } from '../filtered-list';
 export class EntriesComponent extends FilteredList {
   Dockstore = Dockstore;
 
-  public entryTypeEnum = EntryUpdateTime.EntryTypeEnum;
   constructor(userQuery: UserQuery, usersService: UsersService, entriesService: EntriesService) {
     super(userQuery, entriesService, usersService);
   }

--- a/src/app/home-page/widget/entries/entries.component.ts
+++ b/src/app/home-page/widget/entries/entries.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Dockstore } from '../../../shared/dockstore.model';
+import { EntryType } from 'app/shared/openapi';
 import { EntryUpdateTime } from 'app/shared/openapi/model/entryUpdateTime';
 import { UserQuery } from 'app/shared/user/user.query';
 import { takeUntil } from 'rxjs/operators';
@@ -13,7 +14,7 @@ import { FilteredList } from '../filtered-list';
 })
 export class EntriesComponent extends FilteredList {
   Dockstore = Dockstore;
-
+  public entryType = EntryType;
   constructor(userQuery: UserQuery, usersService: UsersService, entriesService: EntriesService) {
     super(userQuery, entriesService, usersService);
   }

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -20,10 +20,10 @@
       <div id="workflow-number" fxLayout="row">
         <mat-card-header fxLayout="row">
           <mat-card-title>{{ entryTypeLowerCase | titlecase }}s</mat-card-title>
-          <span class="bubble workflow-background" *ngIf="entryType === entryTypeEnum.WORKFLOW">{{ totalEntries }}</span>
-          <span class="bubble container-background" *ngIf="entryType === entryTypeEnum.TOOL">{{ totalEntries }}</span>
-          <span class="bubble service-background" *ngIf="entryType === entryTypeEnum.SERVICE">{{ totalEntries }}</span>
-          <span class="bubble preview-bubble" *ngIf="entryType === entryTypeEnum.SERVICE">PREVIEW</span>
+          <span class="bubble workflow-background" *ngIf="entryType === newEntryType.WORKFLOW">{{ totalEntries }}</span>
+          <span class="bubble container-background" *ngIf="entryType === newEntryType.TOOL">{{ totalEntries }}</span>
+          <span class="bubble service-background" *ngIf="entryType === newEntryType.SERVICE">{{ totalEntries }}</span>
+          <span class="bubble preview-bubble" *ngIf="entryType === newEntryType.SERVICE">PREVIEW</span>
         </mat-card-header>
       </div>
       <button

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -16,6 +16,7 @@
 
 import { Component, Input, OnInit } from '@angular/core';
 import { EntryType } from 'app/shared/enum/entry-type';
+import { EntryType as NewEntryType } from 'app/shared/openapi';
 import { EntryUpdateTime, UsersService } from 'app/shared/openapi';
 import { debounceTime, finalize, takeUntil } from 'rxjs/operators';
 import { MyWorkflowsService } from 'app/myworkflows/myworkflows.service';
@@ -34,12 +35,9 @@ import { Observable } from 'rxjs';
 })
 export class EntryBoxComponent extends Base implements OnInit {
   Dockstore = Dockstore;
-  @Input() entryType:
-    | typeof EntryUpdateTime.EntryTypeEnum.TOOL
-    | typeof EntryUpdateTime.EntryTypeEnum.SERVICE
-    | typeof EntryUpdateTime.EntryTypeEnum.WORKFLOW;
+  public newEntryType = NewEntryType;
+  @Input() entryType: typeof NewEntryType.TOOL | typeof NewEntryType.SERVICE | typeof NewEntryType.WORKFLOW;
   entryTypeLowerCase: string;
-  public entryTypeEnum = EntryUpdateTime.EntryTypeEnum;
   filterText: string;
   listOfEntries: Array<EntryUpdateTime> = [];
   helpLink: string;
@@ -65,15 +63,15 @@ export class EntryBoxComponent extends Base implements OnInit {
     }
 
     //Get the links for the specified entryType
-    if (this.entryType === EntryUpdateTime.EntryTypeEnum.WORKFLOW) {
+    if (this.entryType === NewEntryType.WORKFLOW) {
       this.helpLink = Dockstore.DOCUMENTATION_URL + '/getting-started/dockstore-workflows.html';
       this.allEntriesLink = '/my-workflows/';
       this.entryTypeParam = 'WORKFLOWS';
-    } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.TOOL) {
+    } else if (this.entryType === NewEntryType.TOOL) {
       this.helpLink = Dockstore.DOCUMENTATION_URL + '/getting-started/dockstore-tools.html';
       this.allEntriesLink = '/my-tools/';
       this.entryTypeParam = 'TOOLS';
-    } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.SERVICE) {
+    } else if (this.entryType === NewEntryType.SERVICE) {
       this.helpLink = Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-services.html';
       this.allEntriesLink = '/my-services/';
       this.entryTypeParam = 'SERVICES';
@@ -108,13 +106,13 @@ export class EntryBoxComponent extends Base implements OnInit {
   }
 
   showRegisterEntryModal(): void {
-    if (this.entryType === EntryUpdateTime.EntryTypeEnum.WORKFLOW) {
+    if (this.entryType === NewEntryType.WORKFLOW) {
       this.sessionService.setEntryType(EntryType.BioWorkflow);
       this.myWorkflowsService.registerEntry(EntryType.BioWorkflow);
-    } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.TOOL) {
+    } else if (this.entryType === NewEntryType.TOOL) {
       this.sessionService.setEntryType(EntryType.Tool);
       this.registerToolService.setIsModalShown(true);
-    } else if (this.entryType === EntryUpdateTime.EntryTypeEnum.SERVICE) {
+    } else if (this.entryType === NewEntryType.SERVICE) {
       this.sessionService.setEntryType(EntryType.Service);
       this.myWorkflowsService.registerEntry(EntryType.Service);
     }


### PR DESCRIPTION
**Description**
This PR adjusts the UI for the extended type information (metadata) added to the openapi schema in https://github.com/dockstore/dockstore/pull/5403.

Two `EntryType`s are now defined: one in the schema (by the webservice), and the other by the UI code.  Eventually, we should probably completely replace the UI `EntryType` with the openapi `EntryType`, but until then, there will be occasional collisions.

The goal was to address these collisions with minimal changes, get the UI to build and run, and not break anything.  This PR makes none of the refactors that are enabled by the metadata, those will come later.

**Review Instructions**
Ensure the UI builds, starts, and passes the tests.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5270

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
