### PR TITLE
Position tooltip to the left in Actions menu dropdown

### DIFF
--- a/src/app/workflow/view/view.component.html
+++ b/src/app/workflow/view/view.component.html
@@ -51,6 +51,7 @@
       (click)="snapshotVersion()"
       data-cy="dockstore-snapshot"
       matTooltip="Snapshotting a version makes it read-only."
+      matTooltipPosition="left"
     >
       Snapshot
     </button>
@@ -63,6 +64,7 @@
       data-cy="dockstore-request-doi-button"
       *ngIf="version.referenceType !== 'BRANCH' && !version.doiURL && workflow?.is_published"
       matTooltip="Request a Digital Object Identifier (DOI) for this version."
+      matTooltipPosition="left"
     >
       Request DOI
     </button>
@@ -80,6 +82,7 @@
         workflow?.is_published
       "
       matTooltip="Export this version to ORCID."
+      matTooltipPosition="left"
     >
       Export to ORCID
     </button>
@@ -91,7 +94,10 @@
     >
       Set as Default Version
     </button>
-    <div matTooltip="Refresh an individual version. Disabled for GitHub App workflows, hosted workflows, and frozen versions.">
+    <div
+      matTooltip="Refresh an individual version. Disabled for GitHub App workflows, hosted workflows, and frozen versions."
+      matTooltipPosition="left"
+    >
       <button
         mat-menu-item
         color="accent"


### PR DESCRIPTION
**Description**
By default, the tooltip is positioned below the button. In the Actions menu, this can block other buttons. This PR sets the position of the tooltip to the left of the buttons in the Actions menu dropdown so that none of the tooltips are preventing users from pressing buttons under them. 

Before:

https://user-images.githubusercontent.com/25287123/223879359-5618a084-553b-44a4-aba0-58c7de28fc70.mp4



After:

https://user-images.githubusercontent.com/25287123/223879374-acfaf7b4-0a6b-46e7-b3a0-33bece08ab6d.mp4 

  
**Review Instructions**
On QA,
- Go to My Workflows and click on a workflow with more than one valid version (so that there's the option to snapshot). If the version is a tag, even better because the Actions menu dropdown for the version will have options to Snapshot, Request DOI, and Export to ORCID
- Click on the Versions tab and click the Actions dropdown for the valid version
- Hover over each button (at minimum, ensure there's the Snapshot button in order to verify this fix) and verify that the tooltip is positioned to the left of the button and each tooltip does not block the user from pressing buttons underneath it

**Issue**
https://github.com/dockstore/dockstore/issues/5258
[DOCK-2288](https://ucsc-cgl.atlassian.net/browse/DOCK-2288)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2288]: https://ucsc-cgl.atlassian.net/browse/DOCK-2288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ