### PR TITLE
SEAB-5307: Retrieve entry type metadata at startup

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { CLIENT_ROUTER_PROVIDERS, routing } from './app.routing';
 import { BannerComponent } from './banner/banner.component';
 import { ChangeUsernameBannerComponent } from './changeUsernameBanner/changeUsernameBanner.component';
 import { ConfigurationService } from './configuration.service';
+import { EntryTypeMetadataService } from './entry/type-metadata/entry-type-metadata.service';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
 import { FileTreeComponent } from './file-tree/file-tree.component';
 import { FooterComponent } from './footer/footer.component';
@@ -127,8 +128,11 @@ export const myCustomSnackbarDefaults: MatSnackBarConfig = {
   verticalPosition: 'bottom',
 };
 
-export function configurationServiceFactory(configurationService: ConfigurationService): Function {
-  return () => configurationService.load();
+export function initializerFactory(
+  configurationService: ConfigurationService,
+  entryTypeMetadataService: EntryTypeMetadataService
+): Function {
+  return () => Promise.all([configurationService.load(), entryTypeMetadataService.load()]);
 }
 
 @NgModule({
@@ -234,11 +238,12 @@ export function configurationServiceFactory(configurationService: ConfigurationS
     ViewService,
     TosBannerService,
     ConfigurationService,
+    EntryTypeMetadataService,
     OrgLogoService,
     {
       provide: APP_INITIALIZER,
-      useFactory: configurationServiceFactory,
-      deps: [ConfigurationService],
+      useFactory: initializerFactory,
+      deps: [ConfigurationService, EntryTypeMetadataService],
       multi: true,
     },
     { provide: MAT_TOOLTIP_DEFAULT_OPTIONS, useValue: myCustomTooltipDefaults },

--- a/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
@@ -16,21 +16,22 @@ describe('EntryTypeMetadataService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('should return undefined if type is invalid', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
-    expect(service.get(undefined)).toBe(undefined);
-  }));
-
-  it('should return undefined at first', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+  it('should initially return undefined', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
     expect(service.get(EntryType.NOTEBOOK)).toBe(undefined);
   }));
 
-  it('should return correct value', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
-    const entryTypeMetadata: EntryTypeMetadata = {
+  it('should return the correct value', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+    const notebookMetadata: EntryTypeMetadata = {
       type: EntryType.NOTEBOOK,
       term: 'notebook',
     };
-    const blank: EntryTypeMetadata = {};
-    service.entryTypeMetadataList = [blank, entryTypeMetadata];
+    const workflowMetadata: EntryTypeMetadata = {
+      type: EntryType.WORKFLOW,
+      term: 'workflow',
+    };
+    service.entryTypeMetadataList = [notebookMetadata, workflowMetadata];
     expect(service.get(EntryType.NOTEBOOK).term).toBe('notebook');
+    expect(service.get(EntryType.WORKFLOW).term).toBe('workflow');
+    expect(service.get(EntryType.SERVICE)).toBe(undefined);
   }));
 });

--- a/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from 'ng2-ui-auth';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
 import { EntryTypeMetadataService } from './entry-type-metadata.service';
@@ -17,9 +18,10 @@ describe('EntryTypeMetadataService', () => {
 
   it('should initially return undefined', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
     expect(service.get(EntryType.NOTEBOOK)).toBe(undefined);
+    expect(service.getAll()).toBe(undefined);
   }));
 
-  it('should return the correct value', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+  it('should return the correct values', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
     const notebookMetadata: EntryTypeMetadata = {
       type: EntryType.NOTEBOOK,
       term: 'notebook',
@@ -32,5 +34,6 @@ describe('EntryTypeMetadataService', () => {
     expect(service.get(EntryType.NOTEBOOK).term).toBe('notebook');
     expect(service.get(EntryType.WORKFLOW).term).toBe('workflow');
     expect(service.get(EntryType.SERVICE)).toBe(undefined);
+    expect(service.getAll().length).toBe(2);
   }));
 });

--- a/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
@@ -1,0 +1,36 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import { ConfigService } from 'ng2-ui-auth';
+import { EntryTypeMetadataService } from './entry-type-metadata.service';
+import { EntryType, EntryTypeMetadata } from '../../shared/openapi';
+
+describe('EntryTypeMetadataService', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [EntryTypeMetadataService, { provide: ConfigService, useValue: {} }, { provide: Window, useValue: window }],
+    })
+  );
+
+  it('should be created', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should return undefined if type is invalid', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+    expect(service.get(undefined)).toBe(undefined);
+  }));
+
+  it('should return undefined at first', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+    expect(service.get(EntryType.NOTEBOOK)).toBe(undefined);
+  }));
+
+  it('should return correct value', inject([EntryTypeMetadataService], (service: EntryTypeMetadataService) => {
+    const entryTypeMetadata: EntryTypeMetadata = {
+      type: EntryType.NOTEBOOK,
+      term: 'notebook',
+    };
+    const blank: EntryTypeMetadata = {};
+    service.entryTypeMetadataList = [blank, entryTypeMetadata];
+    expect(service.get(EntryType.NOTEBOOK).term).toBe('notebook');
+  }));
+});

--- a/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
@@ -1,4 +1,3 @@
-import { ConfigService } from 'ng2-ui-auth';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
 import { EntryTypeMetadataService } from './entry-type-metadata.service';

--- a/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
-import { ConfigService } from 'ng2-ui-auth';
 import { EntryTypeMetadataService } from './entry-type-metadata.service';
 import { EntryType, EntryTypeMetadata } from '../../shared/openapi';
 
@@ -8,7 +7,7 @@ describe('EntryTypeMetadataService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [EntryTypeMetadataService, { provide: ConfigService, useValue: {} }, { provide: Window, useValue: window }],
+      providers: [EntryTypeMetadataService],
     })
   );
 

--- a/src/app/entry/type-metadata/entry-type-metadata.service.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { MetadataService, EntryType, EntryTypeMetadata } from '../../shared/openapi';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EntryTypeMetadataService {
+  constructor(private metadataService: MetadataService) {}
+
+  entryTypeMetadataList: EntryTypeMetadata[];
+
+  public load(): Promise<void> {
+    return this.metadataService
+      .getEntryTypeMetadataList()
+      .toPromise()
+      .then(
+        (entryTypeMetadataList: EntryTypeMetadata[]) => {
+          this.entryTypeMetadataList = entryTypeMetadataList;
+        },
+        (e) => {
+          this.entryTypeMetadataList = undefined;
+          // The following code is a direct adaptation of the "load failure" code in ConfigurationService
+          console.error('Error downloading entry type metadata list', e);
+          // Less than ideal, but just let the normal error handling in footer.component.ts kick in later.
+          Promise.resolve();
+        }
+      );
+  }
+
+  public get(type: EntryType): EntryTypeMetadata {
+    // If no metadata has been retrieved, log and return.
+    if (!this.entryTypeMetadataList) {
+      console.error('No metadata was retrieved.');
+      return undefined;
+    }
+    // Find the metadata for the specified entry type, log an error if it's not there, and return it.
+    const metadata = this.entryTypeMetadataList.find((metadata) => type == metadata.type);
+    if (metadata) {
+      return metadata;
+    } else {
+      console.error('No metadata exists for the specified entry type');
+      return undefined;
+    }
+  }
+}

--- a/src/app/entry/type-metadata/entry-type-metadata.service.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.ts
@@ -19,7 +19,7 @@ export class EntryTypeMetadataService {
         },
         (e) => {
           this.entryTypeMetadataList = undefined;
-          // The following code/comment is a direct adaptation/copy of the "load failure" code in ConfigurationService
+          // The following code/comment is a direct adaptation/copy of the "load failure" section in ConfigurationService
           console.error('Error downloading entry type metadata list', e);
           // Less than ideal, but just let the normal error handling in footer.component.ts kick in later.
           Promise.resolve();

--- a/src/app/entry/type-metadata/entry-type-metadata.service.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.ts
@@ -19,7 +19,7 @@ export class EntryTypeMetadataService {
         },
         (e) => {
           this.entryTypeMetadataList = undefined;
-          // The following code is a direct adaptation of the "load failure" code in ConfigurationService
+          // The following code/comment is a direct adaptation/copy of the "load failure" code in ConfigurationService
           console.error('Error downloading entry type metadata list', e);
           // Less than ideal, but just let the normal error handling in footer.component.ts kick in later.
           Promise.resolve();
@@ -30,7 +30,7 @@ export class EntryTypeMetadataService {
   public get(type: EntryType): EntryTypeMetadata {
     // If no metadata has been retrieved, log and return.
     if (!this.entryTypeMetadataList) {
-      console.error('No metadata was retrieved.');
+      console.error('No metadata was retrieved');
       return undefined;
     }
     // Find the metadata for the specified entry type, log an error if it's not there, and return it.

--- a/src/app/entry/type-metadata/entry-type-metadata.service.ts
+++ b/src/app/entry/type-metadata/entry-type-metadata.service.ts
@@ -42,4 +42,8 @@ export class EntryTypeMetadataService {
       return undefined;
     }
   }
+
+  public getAll(): EntryTypeMetadata[] {
+    return this.entryTypeMetadataList;
+  }
 }


### PR DESCRIPTION
**Description**
This PR modifies the UI to read metadata about each entry type (in the form of a list of `EntryTypeMetadata`) from the webservice at startup, and provides a new `Injectable` service `EntryTypeMetadataService` with methods to get the full list or the metadata for a particular entry type.

The new Service handles a load failure in the same manner as the current `ConfigurationService`, which means that it basically ignores it.  From what I gather from reading the source, the assumption is that soon afterwards, when the `FooterComponent` is rendered, if the server is down, the footer's TRS request will fail, and from there, we'll "redirect" to the `/maintenance` page.

This works if the server is actually down for the entire UI initialization process.  But, if requests are failing intermittently, or the server comes up during the initialization process, the UI could might continue to run "normally" but with incomplete information.  If there's not already a ticket to tighten up the failure semantics, maybe we should make one...  Once we do that, we might change `EntryTypeMetadataService.load()` to make sure the the webservice responds with a list that represents all values of `EntryType`.  If not, it could log/fail/maintenance-page via the new mechanism.

This ticket suggests that, as part of this PR, we should implement a UI refactor that uses the new service, but I'd prefer to save that for the upcoming notebook UI ticket, if that's ok...

**Review Instructions**
Make sure the tests pass, and that when the UI starts, it makes a request to the `getEntryTypeMetadataList` endpoint.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5307

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
