### PR TITLE
Fix CircleCI artifacts script

### DIFF
--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" -H "Circle-Token: ''" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
 
 echo "${ARTIFACT_URL}"


### PR DESCRIPTION
**Description**
UI builds have been failing because of the CircleCI artifacts script. This PR fixes the script by adding an empty `Circle-Token` header to the `curl` that the script makes to get the artifacts. 

The [docs](https://circleci.com/docs/api-developers-guide/#authentication-and-authorization) say that the API uses token-based authentication to manage access to the API server. Maybe they recently changed something so now the header is required :thinking:. The `getArtifacts` example [here](https://circleci.com/docs/api-developers-guide/#download-artifacts) also has the `Circle-Token` header. I just made the value an empty string and I think it works because the dockstore/dockstore project is public.

**EDIT:** accessibility_test_base runs the develop version of the script which doesn't have the Circle-Token header so it fails. It should pass once this PR merges into develop.

**Review Instructions**
Builds should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
