### PR TITLE
SEAB-5123: Verify notebooks can be added to collections/categories

### DIFF
--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -41,7 +41,7 @@ describe('Dockstore Categories', () => {
     cy.get('[data-cy=selectCollection]').click();
     cy.get('mat-option').contains(categoryDisplayName).click();
     cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
-    cy.get('[data-cy=collectionLink]').should('contain', categoryDisplayName);
+    cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
   }
 
   describe('Should be able to create a category', () => {

--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -41,6 +41,7 @@ describe('Dockstore Categories', () => {
     cy.get('[data-cy=selectCollection]').click();
     cy.get('mat-option').contains(categoryDisplayName).click();
     cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
+    cy.get('[data-cy=collectionLink]').should('contain', categoryDisplayName);
   }
 
   describe('Should be able to create a category', () => {

--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -48,14 +48,16 @@ describe('Dockstore Categories', () => {
 
   describe('Should be able to add a tool to a category', () => {
     it('be able to add tool to category', () => {
-      addToCollection(toolPath, categoryDisplayName);
+      addToCollection(toolPath, 'Dockstore', categoryDisplayName);
+      cy.visit(toolPath);
       cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });
 
   describe('Should be able to add a workflow to a category', () => {
     it('be able to add workflow to category', () => {
-      addToCollection(workflowPath, categoryDisplayName);
+      addToCollection(workflowPath, 'Dockstore', categoryDisplayName);
+      cy.visit(workflowPath);
       cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });
@@ -63,7 +65,8 @@ describe('Dockstore Categories', () => {
   describe('Should be able to add a notebook to a category', () => {
     insertNotebooks();
     it('be able to add notebook to category', () => {
-      addToCollection(notebookPath, categoryDisplayName);
+      addToCollection(notebookPath, 'Dockstore', categoryDisplayName);
+      cy.visit(notebookPath);
       cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });

--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { resetDB, setTokenUserViewPort, addOrganizationAdminUser } from '../../support/commands';
+import { resetDB, setTokenUserViewPort, insertNotebooks, addOrganizationAdminUser } from '../../support/commands';
 
 describe('Dockstore Categories', () => {
   const categoryName = 'foooo';
@@ -22,12 +22,25 @@ describe('Dockstore Categories', () => {
   const toolPath = '/containers/quay.io/garyluu/dockstore-cgpmap/cgpmap-cramOut:3.0.0-rc8?tab=info';
   const toolSnippet = 'cgpmap-cramOut';
   const workflowPath = '/workflows/github.com/A/l:master?tab=info';
+  const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
 
   resetDB();
   setTokenUserViewPort();
 
   function typeInInput(fieldName: string, text: string) {
     cy.contains('span', fieldName).parentsUntil('.mat-form-field-wrapper').find('input').first().should('be.visible').clear().type(text);
+  }
+
+  function addToCollection(path: string) {
+    cy.visit(path);
+    cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+    cy.get('[data-cy=selectOrganization]').click();
+    cy.get('mat-option').contains('Dockstore').click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+    cy.get('[data-cy=selectCollection]').click();
+    cy.get('mat-option').contains(categoryDisplayName).click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
   }
 
   describe('Should be able to create a category', () => {
@@ -47,29 +60,20 @@ describe('Dockstore Categories', () => {
 
   describe('Should be able to add a tool to a category', () => {
     it('be able to add tool to category', () => {
-      cy.visit(toolPath);
-      cy.get('#addToolToCollectionButton').should('be.visible').click();
-      cy.get('#addEntryToCollectionButton').should('be.disabled');
-      cy.get('#selectOrganization').click();
-      cy.get('mat-option').contains('Dockstore').click();
-      cy.get('#addEntryToCollectionButton').should('be.disabled');
-      cy.get('#selectCollection').click();
-      cy.get('mat-option').contains(categoryDisplayName).click();
-      cy.get('#addEntryToCollectionButton').should('not.be.disabled').click();
+      addToCollection(toolPath);
     });
   });
 
   describe('Should be able to add a workflow to a category', () => {
     it('be able to add workflow to category', () => {
-      cy.visit(workflowPath);
-      cy.get('#addToolToCollectionButton').should('be.visible').click();
-      cy.get('#addEntryToCollectionButton').should('be.disabled');
-      cy.get('#selectOrganization').click();
-      cy.get('mat-option').contains('Dockstore').click();
-      cy.get('#addEntryToCollectionButton').should('be.disabled');
-      cy.get('#selectCollection').click();
-      cy.get('mat-option').contains(categoryDisplayName).click();
-      cy.get('#addEntryToCollectionButton').should('not.be.disabled').click();
+      addToCollection(workflowPath);
+    });
+  });
+
+  describe('Should be able to add a notebook to a category', () => {
+    insertNotebooks();
+    it('be able to add notebook to category', () => {
+      addToCollection(notebookPath);
     });
   });
 

--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { resetDB, setTokenUserViewPort, insertNotebooks, addOrganizationAdminUser } from '../../support/commands';
+import { resetDB, setTokenUserViewPort, insertNotebooks, addOrganizationAdminUser, addToCollection } from '../../support/commands';
 
 describe('Dockstore Categories', () => {
   const categoryName = 'foooo';
@@ -29,19 +29,6 @@ describe('Dockstore Categories', () => {
 
   function typeInInput(fieldName: string, text: string) {
     cy.contains('span', fieldName).parentsUntil('.mat-form-field-wrapper').find('input').first().should('be.visible').clear().type(text);
-  }
-
-  function addToCollection(path: string) {
-    cy.visit(path);
-    cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
-    cy.get('[data-cy=selectOrganization]').click();
-    cy.get('mat-option').contains('Dockstore').click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
-    cy.get('[data-cy=selectCollection]').click();
-    cy.get('mat-option').contains(categoryDisplayName).click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
-    cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
   }
 
   describe('Should be able to create a category', () => {
@@ -61,20 +48,23 @@ describe('Dockstore Categories', () => {
 
   describe('Should be able to add a tool to a category', () => {
     it('be able to add tool to category', () => {
-      addToCollection(toolPath);
+      addToCollection(toolPath, categoryDisplayName);
+      cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });
 
   describe('Should be able to add a workflow to a category', () => {
     it('be able to add workflow to category', () => {
-      addToCollection(workflowPath);
+      addToCollection(workflowPath, categoryDisplayName);
+      cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });
 
   describe('Should be able to add a notebook to a category', () => {
     insertNotebooks();
     it('be able to add notebook to category', () => {
-      addToCollection(notebookPath);
+      addToCollection(notebookPath, categoryDisplayName);
+      cy.get('[data-cy=categoriesBubble]').should('contain', categoryDisplayName);
     });
   });
 

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -305,7 +305,8 @@ describe('Dockstore Organizations', () => {
       }
     });
     it('Should be able to add notebook to collection', () => {
-      const notebookPath = '/workflows/github.com/A/l:master?tab=info';
+      insertNotebooks();
+      const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
       addToCollection(notebookPath, 'Potatoe', 'veryFakeCollectionName');
       cy.get('[data-cy=collectionLink]').should('contain', 'veryFakeCollectionName');
     });

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -304,8 +304,8 @@ describe('Dockstore Organizations', () => {
         cy.get('img[src*="default-org-logo"]').should('be.visible');
       }
     });
+    insertNotebooks();
     it('Should be able to add notebook to collection', () => {
-      insertNotebooks();
       const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
       addToCollection(notebookPath, 'Potatoe', 'veryFakeCollectionName');
       cy.get('[data-cy=collectionLink]').should('contain', 'veryFakeCollectionName');

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -20,6 +20,8 @@ import {
   rejectPotatoMembership,
   resetDB,
   setTokenUserViewPort,
+  addToCollection,
+  insertNotebooks,
 } from '../../support/commands';
 import { TokenUser } from '../../../src/app/shared/swagger';
 import { TokenSource } from '../../../src/app/shared/enum/token-source.enum';
@@ -311,6 +313,16 @@ describe('Dockstore Organizations', () => {
       cy.get('[data-cy=accept-remove-collection]').click();
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('veryFakeCollectionName').should('not.exist');
+    });
+  });
+
+  describe('Should be able to add notebook to collection', () => {
+    it('add notebook to collection', () => {
+      setTokenUserViewPort();
+      insertNotebooks();
+      const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
+      addToCollection(notebookPath, 'Foooo');
+      cy.get('[data-cy=collectionLink]').should('contain', 'Foooo');
     });
   });
 

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -314,15 +314,13 @@ describe('Dockstore Organizations', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('veryFakeCollectionName').should('not.exist');
     });
-  });
 
-  describe('Should be able to add notebook to collection', () => {
     it('add notebook to collection', () => {
       setTokenUserViewPort();
       insertNotebooks();
       const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
-      addToCollection(notebookPath, 'Foooo');
-      cy.get('[data-cy=collectionLink]').should('contain', 'Foooo');
+      addToCollection(notebookPath, 'Potatoe', 'veryFakeCollectionName');
+      cy.get('[data-cy=collectionLink]').should('contain', 'veryFakeCollectionName');
     });
   });
 

--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -303,7 +303,14 @@ describe('Dockstore Organizations', () => {
         cy.wait(1000);
         cy.get('img[src*="default-org-logo"]').should('be.visible');
       }
+    });
+    it('Should be able to add notebook to collection', () => {
+      const notebookPath = '/workflows/github.com/A/l:master?tab=info';
+      addToCollection(notebookPath, 'Potatoe', 'veryFakeCollectionName');
+      cy.get('[data-cy=collectionLink]').should('contain', 'veryFakeCollectionName');
+    });
 
+    it('Should be able to remove collection', () => {
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.get('[data-cy=removeCollectionButton]').click();
       cy.get('[data-cy=cancel-remove-collection]').click();
@@ -313,14 +320,6 @@ describe('Dockstore Organizations', () => {
       cy.get('[data-cy=accept-remove-collection]').click();
       cy.visit('/organizations/Potatoe/collections/veryFakeCollectionName');
       cy.contains('veryFakeCollectionName').should('not.exist');
-    });
-
-    it('add notebook to collection', () => {
-      setTokenUserViewPort();
-      insertNotebooks();
-      const notebookPath = '/notebooks/github.com/dockstore-testing/simple-notebook';
-      addToCollection(notebookPath, 'Potatoe', 'veryFakeCollectionName');
-      cy.get('[data-cy=collectionLink]').should('contain', 'veryFakeCollectionName');
     });
   });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -204,13 +204,13 @@ export function testNoGithubEntriesText(entryType: string, repository: string) {
   });
 }
 
-export function addToCollection(path: string, collectionDisplayName: string) {
+export function addToCollection(path: string, organizationName: string, collectionDisplayName: string) {
   it('add to collection', () => {
     cy.visit(path);
     cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
     cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
     cy.get('[data-cy=selectOrganization]').click();
-    cy.get('mat-option').contains('Dockstore').click();
+    cy.get('mat-option').contains(organizationName).click();
     cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
     cy.get('[data-cy=selectCollection]').click();
     cy.get('mat-option').contains(collectionDisplayName).click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -205,15 +205,13 @@ export function testNoGithubEntriesText(entryType: string, repository: string) {
 }
 
 export function addToCollection(path: string, organizationName: string, collectionDisplayName: string) {
-  it('add to collection', () => {
-    cy.visit(path);
-    cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
-    cy.get('[data-cy=selectOrganization]').click();
-    cy.get('mat-option').contains(organizationName).click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
-    cy.get('[data-cy=selectCollection]').click();
-    cy.get('mat-option').contains(collectionDisplayName).click();
-    cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
-  });
+  cy.visit(path);
+  cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
+  cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+  cy.get('[data-cy=selectOrganization]').click();
+  cy.get('mat-option').contains(organizationName).click();
+  cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+  cy.get('[data-cy=selectCollection]').click();
+  cy.get('mat-option').contains(collectionDisplayName).click();
+  cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -203,3 +203,17 @@ export function testNoGithubEntriesText(entryType: string, repository: string) {
     }
   });
 }
+
+export function addToCollection(path: string, collectionDisplayName: string) {
+  it('add to collection', () => {
+    cy.visit(path);
+    cy.get('[data-cy=addToolToCollectionButton]').should('be.visible').click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+    cy.get('[data-cy=selectOrganization]').click();
+    cy.get('mat-option').contains('Dockstore').click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('be.disabled');
+    cy.get('[data-cy=selectCollection]').click();
+    cy.get('mat-option').contains(collectionDisplayName).click();
+    cy.get('[data-cy=addEntryToCollectionButton]').should('not.be.disabled').click();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9635/workflows/f87838ad-5937-4f1b-b600-275d7e543714/jobs/31636/artifacts",
-    "circle_build_id": "31636",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9644/workflows/7632e623-3db0-4f7a-9123-4df50a697da2/jobs/31720/artifacts",
+    "circle_build_id": "31720",
     "base_branch": "develop"
   },
   "scripts": {

--- a/src/app/categories/button/category-button.component.html
+++ b/src/app/categories/button/category-button.component.html
@@ -1,3 +1,11 @@
-<mat-chip class="bubble pointer" [routerLink]="routerLink" [queryParams]="queryParams" [ngClass]="[className]" [matTooltip]="category.topic" (click)="$event.stopPropagation(); $event.preventDefault()">
+<mat-chip
+  class="bubble pointer"
+  data-cy="categoriesBubble"
+  [routerLink]="routerLink"
+  [queryParams]="queryParams"
+  [ngClass]="[className]"
+  [matTooltip]="category.topic"
+  (click)="$event.stopPropagation(); $event.preventDefault()"
+>
   {{ category.displayName }}
 </mat-chip>

--- a/src/app/entry/current-collections/current-collections.component.html
+++ b/src/app/entry/current-collections/current-collections.component.html
@@ -60,6 +60,7 @@
             matTooltip="View the collection"
             [routerLink]="['/organizations', collectionOrganization.organizationName, 'collections', collectionOrganization.collectionName]"
             routerLinkActive="router-link-active"
+            data-cy="collectionLink"
             >{{ collectionOrganization.collectionDisplayName }}</a
           >
         </ng-template>

--- a/src/app/entry/current-collections/current-collections.component.html
+++ b/src/app/entry/current-collections/current-collections.component.html
@@ -23,6 +23,7 @@
         matTooltip="Add the entry to a collection"
         (click)="addEntryToCollection()"
         id="addToolToCollectionButton"
+        data-cy="addToolToCollectionButton"
       >
         <img src="../../../assets/svg/icons-plus.svg" class="pr-2 pb-1" alt="Add to my Collections" />
         <span fxHide.lt-lg>Add to my Collections</span>

--- a/src/app/organizations/collection/add-entry/add-entry.component.html
+++ b/src/app/organizations/collection/add-entry/add-entry.component.html
@@ -27,6 +27,7 @@
           <mat-label>Organization</mat-label>
           <mat-select
             id="selectOrganization"
+            data-cy="selectOrganization"
             placeholder="Organization"
             [(value)]="selectedOrganizationId"
             (selectionChange)="onOrganizationChange($event)"
@@ -43,7 +44,12 @@
             <mat-icon>info</mat-icon> The selected organization has no collections that can be added
           </mat-card>
         </ng-template>
-        <mat-form-field appearance="outline" id="selectCollection" *ngIf="collections && collections.length > 0; else noCollections">
+        <mat-form-field
+          appearance="outline"
+          id="selectCollection"
+          data-cy="selectCollection"
+          *ngIf="collections && collections.length > 0; else noCollections"
+        >
           <mat-label>Collection</mat-label>
           <mat-select placeholder="Collection" [(value)]="selectedCollectionId" [disabled]="!selectedOrganizationId">
             <mat-option *ngFor="let collection of collections" [value]="collection.id">
@@ -73,6 +79,7 @@
   <button
     mat-raised-button
     id="addEntryToCollectionButton"
+    data-cy="addEntryToCollectionButton"
     [mat-dialog-close]="selectedCollectionId"
     class="accent-1-dark-btn mat-elevation-z"
     [disabled]="!selectedOrganizationId || !selectedCollectionId"


### PR DESCRIPTION
**Description**
This PR verifies that notebooks can be added onto collections/categories.

**Review Instructions**
Verify that the new tests pass

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5123

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
