### PR TITLE
Dashboard Usability Fixes - SEAB-5348

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9644/workflows/7632e623-3db0-4f7a-9123-4df50a697da2/jobs/31720/artifacts",
-    "circle_build_id": "31720",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9680/workflows/f9d8c3a2-96ae-4796-af59-ba790194a662/jobs/31951/artifacts",
+    "circle_build_id": "31951",
     "base_branch": "develop"
   },
   "scripts": {

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" -H "Circle-Token: ''" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
 
 echo "${ARTIFACT_URL}"

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -20,7 +20,7 @@
       <mat-card-header>
         <mat-card-title>Tool Information</mat-card-title>
       </mat-card-header>
-      <mat-card-content class="p-3">
+      <mat-card-content class="p-2 pt-3">
         <ul class="list-unstyled container-info">
           <li *ngIf="tool?.providerUrl && tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
             <strong matTooltip="Source code repository for the associated tool descriptors and Dockerfile">Source Code</strong>:
@@ -365,7 +365,7 @@
         <mat-card-title class="m-0">Tag Information</mat-card-title>
         <mat-card-subtitle class="m-0">{{ selectedVersion?.name }}</mat-card-subtitle>
       </mat-card-header>
-      <mat-card-content class="p-3">
+      <mat-card-content class="p-2 pt-3">
         <div>
           <strong matTooltip="Author listed in descriptor">Author</strong>: {{ selectedVersion?.author ? selectedVersion?.author : 'n/a' }}
         </div>

--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -20,7 +20,7 @@
       <mat-card-header>
         <mat-card-title>Tool Information</mat-card-title>
       </mat-card-header>
-      <mat-card-content class="p-2 pt-3">
+      <mat-card-content class="p-1 pt-3">
         <ul class="list-unstyled container-info">
           <li *ngIf="tool?.providerUrl && tool?.mode !== DockstoreToolType.ModeEnum.HOSTED">
             <strong matTooltip="Source code repository for the associated tool descriptors and Dockerfile">Source Code</strong>:
@@ -365,7 +365,7 @@
         <mat-card-title class="m-0">Tag Information</mat-card-title>
         <mat-card-subtitle class="m-0">{{ selectedVersion?.name }}</mat-card-subtitle>
       </mat-card-header>
-      <mat-card-content class="p-2 pt-3">
+      <mat-card-content class="p-1 pt-3">
         <div>
           <strong matTooltip="Author listed in descriptor">Author</strong>: {{ selectedVersion?.author ? selectedVersion?.author : 'n/a' }}
         </div>

--- a/src/app/home-page/new-dashboard/new-dashboard.component.ts
+++ b/src/app/home-page/new-dashboard/new-dashboard.component.ts
@@ -35,6 +35,7 @@ export class NewDashboardComponent extends Base implements OnInit {
           .pipe(takeUntil(this.ngUnsubscribe))
           .subscribe(() => {
             this.alertService.clearEverything();
+            this.registerToolService.setIsModalShown(false);
           });
       } else {
         this.dialog.closeAll();

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -7,9 +7,17 @@
       fxLayoutAlign="space-between center"
     >
       <div fxLayout>
-        <a [routerLink]="'/users/' + event.initiatorUser?.username">
-          <img src="{{ event?.initiatorUser?.avatarUrl }}" alt="User avatar" />
-        </a>
+        <div *ngIf="event?.initiatorUser?.username; else defaultAvatar">
+          <a
+            *ngIf="event.type !== EventType.APPROVEORG && event.type !== EventType.REJECTORG && event.type"
+            [routerLink]="'/users/' + event.initiatorUser?.username"
+          >
+            <img *ngIf="event?.initiatorUser?.avatarUrl; else defaultAvatar" [src]="event?.initiatorUser?.avatarUrl" alt="User avatar" />
+          </a>
+        </div>
+        <ng-template #defaultAvatar>
+          <img [src]="gravatarService.gravatarUrlForMysteryPerson()" alt="User avatar" />
+        </ng-template>
         <div [ngSwitch]="event.type" class="my-3">
           <!-- Entries -->
           <div *ngSwitchCase="EventType.PUBLISHENTRY" class="truncate-text-2">
@@ -71,7 +79,7 @@
                 event.initiatorUser?.username
               }}</a></strong
             >
-            added {{ event.user.username }} to the organization
+            added <a [routerLink]="'/users/' + event.user?.username">{{ event.user?.username }}</a> to the organization
             <a [routerLink]="event | recentEvents: 'orgLink'">{{ event.organization?.displayName }}</a>
           </div>
           <div *ngSwitchCase="EventType.APPROVEORGINVITE" class="truncate-text-2">
@@ -100,7 +108,7 @@
               }}</a></strong
             >
             created the collection
-            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.name }}</a>
+            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.displayName }}</a>
             in organization
             <a [routerLink]="event | recentEvents: 'orgLink'">{{ event.organization?.displayName }}</a>
           </div>
@@ -111,7 +119,7 @@
                 event.initiatorUser?.username
               }}</a></strong
             >
-            removed the collection <strong>{{ event.collection?.name }}</strong> in organization
+            removed the collection <strong>{{ event.collection?.displayName }}</strong> in organization
             <a [routerLink]="event | recentEvents: 'orgLink'">{{ event.organization?.displayName }}</a>
           </div>
           <div *ngSwitchCase="EventType.ADDTOCOLLECTION" class="truncate-text-2">
@@ -123,7 +131,7 @@
             added the {{ event | recentEvents: 'entryType' }}
             <a [routerLink]="event | recentEvents: 'entryLink'">{{ event | recentEvents: 'displayName' }}</a>
             to the collection
-            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.name }}</a>
+            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.displayName }}</a>
             in organization
             <a [routerLink]="event | recentEvents: 'orgLink'">{{ event.organization?.displayName }}</a>
           </div>
@@ -134,7 +142,7 @@
               }}</a></strong
             >
             edited the collection
-            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.name }}</a>
+            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.displayName }}</a>
           </div>
           <div *ngSwitchCase="EventType.REMOVEFROMCOLLECTION" class="truncate-text-2">
             <strong
@@ -145,7 +153,7 @@
             removed the {{ event | recentEvents: 'entryType' }}
             <a [routerLink]="event | recentEvents: 'entryLink'">{{ event | recentEvents: 'displayName' }}</a>
             from the collection
-            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.name }}</a>
+            <a [routerLink]="event | recentEvents: 'collectionLink'">{{ event.collection?.displayName }}</a>
           </div>
           <div class="subtitle">{{ event.dbCreateDate | date: 'medium' }}</div>
         </div>

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -10,7 +10,7 @@
         <div *ngIf="event?.initiatorUser?.username; else defaultAvatar">
           <a
             *ngIf="event.type !== EventType.APPROVEORG && event.type !== EventType.REJECTORG && event.type"
-            [routerLink]="'/users/' + event.initiatorUser?.username"
+            [routerLink]="'/users/' + event.initiatorUser.username"
           >
             <img *ngIf="event?.initiatorUser?.avatarUrl; else defaultAvatar" [src]="event?.initiatorUser?.avatarUrl" alt="User avatar" />
           </a>

--- a/src/app/home-page/recent-events/recent-events.component.ts
+++ b/src/app/home-page/recent-events/recent-events.component.ts
@@ -12,6 +12,7 @@ import { finalize, takeUntil } from 'rxjs/operators';
 import { Base } from 'app/shared/base';
 import { Observable } from 'rxjs';
 import { OrgLogoService } from '../../shared/org-logo.service';
+import { GravatarService } from '../../gravatar/gravatar.service';
 
 /**
  * Shows recent events related to starred organization and entries or user organization events
@@ -85,7 +86,8 @@ export class RecentEventsComponent extends Base implements OnInit {
     private usersService: UsersService,
     private alertService: AlertService,
     private eventsService: EventsService,
-    private orgLogoService: OrgLogoService
+    private orgLogoService: OrgLogoService,
+    public gravatarService: GravatarService
   ) {
     super();
     this.username = this.activatedRoute.snapshot.paramMap.get('username');

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -19,7 +19,7 @@
     <div id="header-bar" fxLayout="row wrap" fxLayoutGap="0.5rem" class="space-between">
       <div id="workflow-number" fxLayout="row">
         <mat-card-header fxLayout="row">
-          <mat-card-title>{{ entryTypeLowerCase | titlecase }}s</mat-card-title>
+          <mat-card-title class="ml-2">{{ entryTypeLowerCase | titlecase }}s</mat-card-title>
           <span class="bubble {{ entryTypeLowerCase }}-background">{{ totalEntries }}</span>
           <span class="bubble preview-bubble" *ngIf="entryType === newEntryType.SERVICE || entryType === newEntryType.NOTEBOOK"
             >PREVIEW</span
@@ -78,19 +78,16 @@
           />
           <span>You have not registered any {{ entryTypeLowerCase }}s.</span>
           <div class="size-small">
-            <span>Use the</span>
-            <button
-              mat-button
-              class="inline-text-btn"
-              id="register{{ entryTypeLowerCase }}Button"
+            <span>Use the </span>
+            <a
+              class="size-small pointer mt-3"
               matTooltip="Register {{ entryTypeLowerCase }}"
               matTooltipPosition="after"
               (click)="showRegisterEntryModal()"
               data-cy="no-entry-register-modal"
+              >{{ entryTypeLowerCase }} registration wizard</a
             >
-              {{ entryTypeLowerCase }} registration wizard
-            </button>
-            <span>to register a {{ entryTypeLowerCase }}.</span>
+            <span> to register a {{ entryTypeLowerCase }}.</span>
           </div>
           <a class="size-small" target="_blank" rel="noopener noreferrer" [href]="helpLink" data-cy="help-link"
             >Learn more about {{ entryTypeLowerCase }}s.

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -40,7 +40,7 @@
       </button>
     </div>
     <mat-divider></mat-divider>
-    <mat-card-content class="p-3 h-100">
+    <mat-card-content class="mx-2 mt-3 h-100">
       <div *ngIf="totalEntries > 0 || isLoading; else noEntries">
         <mat-form-field appearance="outline" class="search-form-field w-100 pb-0">
           <mat-label>Search your {{ entryTypeLowerCase | titlecase }}s...</mat-label>

--- a/src/app/home-page/widget/news-box/news-box.component.html
+++ b/src/app/home-page/widget/news-box/news-box.component.html
@@ -1,7 +1,7 @@
 <mat-card class="h-100">
   <div fxLayout="column" fxLayoutAlign="start stretch" class="h-100">
     <mat-card-header>
-      <mat-card-title>News & Updates</mat-card-title>
+      <mat-card-title class="ml-2">News & Updates</mat-card-title>
       <span class="bubble">{{ newsUpdates.newsEntriesCount }}</span>
     </mat-card-header>
     <mat-divider></mat-divider>

--- a/src/app/home-page/widget/organization-box/my-organizations-dialog.component/my-organizations-dialog.component.html
+++ b/src/app/home-page/widget/organization-box/my-organizations-dialog.component/my-organizations-dialog.component.html
@@ -2,6 +2,10 @@
   <h1 mat-dialog-title>My Organizations</h1>
   <span class="bubble org-background ml-4">{{ data.length }}</span>
 </div>
+<div fxLayout fxLayoutAlign="space-between" class="date-display widget-list-items py-3">
+  <span>Organization</span>
+  <span>Date Created</span>
+</div>
 <div>
   <div *ngFor="let org of data" fxLayout="row" fxLayoutAlign="space-between center" class="widget-list-items w-100 py-3">
     <a class="pointer no-wrap" (click)="dialogNavigate(org.name)">
@@ -11,5 +15,5 @@
   </div>
 </div>
 <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" class="mt-4">
-  <button data-cy="close-dialog-button" mat-button mat-dialog-close color="primary" cdkFocusInitial>Close</button>
+  <button data-cy="close-dialog-button" mat-flat-button mat-dialog-close class="secondary-1" cdkFocusInitial>Close</button>
 </div>

--- a/src/app/home-page/widget/organization-box/organization-box.component.html
+++ b/src/app/home-page/widget/organization-box/organization-box.component.html
@@ -3,20 +3,32 @@
     <div id="header-bar" fxLayout="row wrap" fxLayoutGap="1rem" class="space-between">
       <div id="organization-number" fxLayout="row">
         <mat-card-header fxLayout="row">
-          <mat-card-title>Organizations</mat-card-title>
+          <mat-card-title class="ml-2">Organizations</mat-card-title>
           <span class="bubble org-background">{{ totalOrgs }}</span>
         </mat-card-header>
       </div>
       <div fxLayout="row wrap" fxLayoutGap="1rem">
         <div id="pending-requests" fxLayout="row" fxLayoutAlign="center center" class="mb-3">
           <mat-icon [class.disabled]="(pendingRequests$ | async)?.length === 0" class="pending-requests mr-1">pending_icon</mat-icon>
-          <a routerLink="/accounts" [queryParams]="{ tab: 'requests' }" class="size-small pending-links">
+          <a
+            routerLink="/accounts"
+            [queryParams]="{ tab: 'requests' }"
+            class="size-small pending-links"
+            matTooltip="See organizations you have created that are pending approval."
+            matTooltipPosition="above"
+          >
             {{ (pendingRequests$ | async)?.length }} Pending Request<span *ngIf="(pendingRequests$ | async)?.length !== 1">s</span>
           </a>
         </div>
         <div id="pending-invites" fxLayout="row" fxLayoutAlign="center center" class="mb-3">
           <mat-icon [class.disabled]="(pendingInvites$ | async)?.length === 0" class="pending-invites mr-1">error</mat-icon>
-          <a routerLink="/accounts" [queryParams]="{ tab: 'requests' }" class="size-small pending-links">
+          <a
+            routerLink="/accounts"
+            [queryParams]="{ tab: 'requests' }"
+            class="size-small pending-links"
+            matTooltip="Accept and decline invitations to join organizations."
+            matTooltipPosition="above"
+          >
             {{ (pendingInvites$ | async)?.length }} Pending Invitation<span *ngIf="(pendingInvites$ | async)?.length !== 1">s</span>
           </a>
         </div>
@@ -39,26 +51,20 @@
         <app-recent-events [eventType]="'SELF_ORGANIZATIONS'"></app-recent-events>
         <div class="weight-bold py-2">
           <a (click)="viewMyOrganizations()" class="pointer"
-            >View my Organizations<mat-icon class="mat-icon-sm">keyboard_double_arrow_right</mat-icon></a
+            >All Organizations<mat-icon class="mat-icon-sm">keyboard_double_arrow_right</mat-icon></a
           >
         </div>
       </div>
       <ng-template #noOrganizations>
         <div *ngIf="!isLoading" fxLayout="column" class="h-100" fxLayoutAlign="center center">
           <img src="../../../../assets/svg/organization-circle.svg" alt="my organizations" class="widget-box-type-logo mb-4" />
-          <span>You are not in any organizations </span>
+          <span>You are not in any organizations.</span>
           <div class="size-small text-align-center">
             <span>Use the </span>
-            <button
-              mat-button
-              class="inline-text-btn"
-              matTooltip="Request Organization"
-              matTooltipPosition="after"
-              (click)="requireAccounts()"
+            <a class="size-small pointer mt-3" matTooltip="Request Organization" matTooltipPosition="after" (click)="requireAccounts()"
+              >organization request wizard</a
             >
-              organization request wizard
-            </button>
-            to request an organization
+            <span> to request an organization</span>
           </div>
           <a
             class="size-small mt-3"

--- a/src/app/home-page/widget/starred-box/starred-box.component.html
+++ b/src/app/home-page/widget/starred-box/starred-box.component.html
@@ -2,7 +2,7 @@
   <div fxLayout="column" fxLayoutAlign="start stretch" class="h-100">
     <div id="header-bar" fxLayout="row wrap" fxLayoutAlign="space-between">
       <mat-card-header fxLayout="row">
-        <mat-card-title>Starred</mat-card-title>
+        <mat-card-title class="ml-2">Starred</mat-card-title>
       </mat-card-header>
       <div fxLayout="row wrap" fxLayoutGap="2rem" class="size-small pb-3">
         <div fxLayout fxLayoutAlign="center center">

--- a/src/app/loginComponents/accounts/external/accounts.component.html
+++ b/src/app/loginComponents/accounts/external/accounts.component.html
@@ -20,7 +20,7 @@
       <div class="h-100" fxLayout="column" fxLayoutAlign="space-between stretch">
         <div fxLayoutAlign="space-between">
           <mat-card-header>
-            <div mat-card-avatar matBadge="✓">
+            <div mat-card-avatar matBadge="✓" class="mr-4">
               <img src="../../../../assets/images/dockstore/dockstore.png" alt="Dockstore logo" class="w-100" />
             </div>
             <mat-card-title class="normal-line-height">Dockstore Account</mat-card-title>
@@ -93,7 +93,7 @@
         <div>
           <div fxLayoutAlign="space-between">
             <mat-card-header>
-              <div mat-card-avatar matBadge="✓" [matBadgeHidden]="!row.isLinked">
+              <div mat-card-avatar matBadge="✓" [matBadgeHidden]="!row.isLinked" class="mr-4">
                 <img src="../../../../assets/images/account-logos/{{ row.logo }}" alt="{{ row.name }} logo" class="w-100" />
               </div>
               <mat-card-title class="normal-line-height">{{ row.name }} Account&nbsp;</mat-card-title>

--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -128,6 +128,7 @@ export class MyToolComponent extends MyEntry implements OnInit {
           .pipe(takeUntil(this.ngUnsubscribe))
           .subscribe(() => {
             this.alertService.clearEverything();
+            this.registerToolService.setIsModalShown(false);
           });
       } else {
         this.dialog.closeAll();

--- a/src/app/shared/entry/recent-events.pipe.ts
+++ b/src/app/shared/entry/recent-events.pipe.ts
@@ -38,9 +38,9 @@ export class RecentEventsPipe implements PipeTransform {
         if (event.workflow) {
           return '/workflows/' + event.workflow.full_workflow_path;
         } else if (event.tool) {
-          return '/tools/' + event.tool.tool_path;
+          return '/containers/' + event.tool.tool_path;
         } else if (event.apptool) {
-          return '/tools/' + event.apptool.full_workflow_path;
+          return '/containers/' + event.apptool.full_workflow_path;
         }
         break;
       }

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -131,7 +131,7 @@
             </a>
             <app-starring class="pull-right" [workflow]="workflow" (starGazersChange)="starGazersChange()"></app-starring>
           </div>
-          <div class="ml-4 mr-2">
+          <div>
             <div class="truncate-text-3 mb-3">
               <app-markdown-wrapper
                 [data]="workflow?.description"
@@ -142,7 +142,7 @@
           </div>
           <div fxLayout="row" fxLayoutAlign="space-between stretch">
             <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-              <small class="spacing">Last updated {{ workflow?.lastUpdated | date }}</small>
+              <small>Last updated {{ workflow?.lastUpdated | date }}</small>
               <div fxLayout="row wrap" fxLayoutGap="1rem">
                 <span>
                   <mat-chip-list>
@@ -191,7 +191,7 @@
             <hr />
             <div fxLayout="row" fxLayoutAlign="space-between stretch">
               <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-                <small class="spacing">Last updated {{ tool?.lastUpdated | date }}</small>
+                <small>Last updated {{ tool?.lastUpdated | date }}</small>
                 <mat-chip-list>
                   <mat-chip class="bubble tool-background" *ngFor="let label of tool?.labels | slice: 0:3">{{ label.value }}</mat-chip>
                   <mat-chip *ngIf="tool?.versionVerified" matTooltip="Verified" class="bubble">

--- a/src/app/starredentries/starredentries.component.html
+++ b/src/app/starredentries/starredentries.component.html
@@ -116,7 +116,7 @@
         <ng-template #workflowSummary let-workflow="workflow" let-type="entryType">
           <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between">
             <a [routerLink]="type | routerLink: workflow" class="no-underline">
-              <mat-card-header>
+              <mat-card-header class="ml-2">
                 <mat-card-title fxLayoutAlign="space-between" fxLayoutGap="1rem">
                   <img
                     class="site-icons-small entryType-icons"
@@ -131,7 +131,7 @@
             </a>
             <app-starring class="pull-right" [workflow]="workflow" (starGazersChange)="starGazersChange()"></app-starring>
           </div>
-          <div>
+          <div class="ml-2">
             <div class="truncate-text-3 mb-3">
               <app-markdown-wrapper
                 [data]="workflow?.description"
@@ -142,7 +142,7 @@
           </div>
           <div fxLayout="row" fxLayoutAlign="space-between stretch">
             <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-              <small>Last updated {{ workflow?.lastUpdated | date }}</small>
+              <small class="mx-2">Last updated {{ workflow?.lastUpdated | date }}</small>
               <div fxLayout="row wrap" fxLayoutGap="1rem">
                 <span>
                   <mat-chip-list>
@@ -177,7 +177,7 @@
         <ng-template #toolSummary let-tool="tool">
           <div fxLayout="row" fxLayoutAlign="space-between">
             <a routerLink="/containers/{{ tool.tool_path }}" class="no-underline">
-              <mat-card-header>
+              <mat-card-header class="ml-2">
                 <mat-card-title fxLayoutAlign="flex-start" fxLayoutGap="1rem">
                   <img class="site-icons-small entryType-icons" src="../../../assets/svg/sub-nav/tool.svg" alt="tool logo" />
                   <h4>{{ tool?.namespace + '/' + tool?.name + (tool?.toolname ? '/' + tool?.toolname : '') }}</h4>
@@ -191,7 +191,7 @@
             <hr />
             <div fxLayout="row" fxLayoutAlign="space-between stretch">
               <div fxLayout="row" fxLayoutAlign="flex-start" fxLayoutGap="1rem">
-                <small>Last updated {{ tool?.lastUpdated | date }}</small>
+                <small class="mx-2">Last updated {{ tool?.lastUpdated | date }}</small>
                 <mat-chip-list>
                   <mat-chip class="bubble tool-background" *ngFor="let label of tool?.labels | slice: 0:3">{{ label.value }}</mat-chip>
                   <mat-chip *ngIf="tool?.versionVerified" matTooltip="Verified" class="bubble">

--- a/src/app/starredentries/starredentries.component.scss
+++ b/src/app/starredentries/starredentries.component.scss
@@ -8,11 +8,6 @@
   margin-right: 30px;
 }
 
-.spacing {
-  margin-left: 15px !important;
-  margin-right: 15px !important;
-}
-
 // Style for organization card.
 // The card size is unique compared to other cards (linked accounts) because <to be filled>
 .org-style {

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -29,7 +29,7 @@
       <mat-card *ngIf="gitHubProfile" fxLayout="column" fxLayoutAlign="space-between" class="h-100">
         <div fxLayout fxLayoutAlign="space-between">
           <mat-card-header>
-            <div mat-card-avatar matBadge="✓" class="mr-2">
+            <div mat-card-avatar matBadge="✓" class="mr-4">
               <img src="../../assets/images/account-logos/github.svg" alt="Github logo" class="w-100" />
             </div>
             <mat-card-title class="normal-line-height">GitHub Account</mat-card-title>
@@ -64,7 +64,7 @@
       <!-- ORCID -->
       <mat-card *ngIf="user?.orcid" class="h-100">
         <mat-card-header>
-          <div mat-card-avatar matBadge="✓" class="mr-2">
+          <div mat-card-avatar matBadge="✓" class="mr-4">
             <img src="../../assets/images/account-logos/orcid.svg" alt="ORCID logo" class="w-100" />
           </div>
           <mat-card-title class="normal-line-height">ORCID Account</mat-card-title>
@@ -79,7 +79,7 @@
       <mat-card *ngIf="googleProfile" fxLayout="column" fxLayoutAlign="space-between" class="h-100">
         <div fxLayout fxLayoutAlign="space-between">
           <mat-card-header>
-            <div mat-card-avatar matBadge="✓" class="mr-2">
+            <div mat-card-avatar matBadge="✓" class="mr-4">
               <img src="../../assets/images/account-logos/google.svg" alt="Google logo" class="w-100" />
             </div>
             <mat-card-title class="normal-line-height">Google Account</mat-card-title>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -37,7 +37,7 @@
       <mat-card-title>{{ entryType$ | async | titlecase }} Information</mat-card-title>
     </mat-card-header>
     <mat-divider></mat-divider>
-    <mat-card-content class="p-2 pt-3">
+    <mat-card-content class="p-1 pt-3">
       <ul class="list-unstyled container-info" *ngIf="workflow">
         <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="truncate-text-1">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
@@ -395,7 +395,7 @@
       <mat-card-title>{{ entryType$ | async | titlecase }} Version Information</mat-card-title>
     </mat-card-header>
     <mat-divider></mat-divider>
-    <mat-card-content class="p-2 pt-3">
+    <mat-card-content class="p-1 pt-3">
       <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="2rem">
         <span class="bubble">
           {{ selectedVersion?.name }}

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -37,7 +37,7 @@
       <mat-card-title>{{ entryType$ | async | titlecase }} Information</mat-card-title>
     </mat-card-header>
     <mat-divider></mat-divider>
-    <mat-card-content class="p-3">
+    <mat-card-content class="p-2 pt-3">
       <ul class="list-unstyled container-info" *ngIf="workflow">
         <span *ngIf="workflow?.mode !== WorkflowType.ModeEnum.HOSTED" class="truncate-text-1">
           <li *ngIf="workflow?.provider && workflow?.providerUrl">
@@ -395,7 +395,7 @@
       <mat-card-title>{{ entryType$ | async | titlecase }} Version Information</mat-card-title>
     </mat-card-header>
     <mat-divider></mat-divider>
-    <mat-card-content class="p-3">
+    <mat-card-content class="p-2 pt-3">
       <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="2rem">
         <span class="bubble">
           {{ selectedVersion?.name }}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1325,7 +1325,7 @@ button.inline-text-btn {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 3px 0 rgba(0, 0, 0, 0.08) !important;
   // Override mat-card-header margin
   .mat-card-header-text {
-    margin-left: 0rem !important;
+    margin-left: 0rem;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1323,6 +1323,10 @@ button.inline-text-btn {
 .mat-card:not([class*='mat-elevation-z']) {
   border: solid 1px mat.get-color-from-palette($dockstore-app-gray, 7);
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 3px 0 rgba(0, 0, 0, 0.08) !important;
+  // Override mat-card-header margin
+  .mat-card-header-text {
+    margin-left: 0rem !important;
+  }
 }
 
 // Alert and Warning styles


### PR DESCRIPTION
**Description**
Implements feedback following Dashboard [usability](https://docs.google.com/document/d/14QnlN-dL3bebsczPo-IAt8s2RNB1mASm2Licf43tA50/edit?usp=sharing) tests:

- Hide user avatar for admin/curator that approved/rejected an organization since we also don't display their name:

<p align=center>
<img src="https://user-images.githubusercontent.com/97123241/230173137-57b0580d-b1e9-46d6-883f-e2fda8daf588.png" width=600px>
</p>

- Provide link to invited user with org invitation events:

<p align=center>
<img src="https://user-images.githubusercontent.com/97123241/230173192-c570cc70-c699-498b-a4a0-8179e8408331.png" width=600px>
</p>

- Use the collection `displayName` instead of just collection `name`:

<p align=center>
<img src="https://user-images.githubusercontent.com/97123241/230173246-513ab8bd-82e4-4ea3-abb5-f54a6368e6a7.png" width=600px>
</p>

- Add missing period to `You are not in any organizations.`:

<p align=center>
<img src="https://user-images.githubusercontent.com/97123241/230908137-b0db2cfa-940f-4570-9be3-5113e260e990.png" width=300px>
</p>

- Add tool-tips to Pending Requests and Pending Invitations to provide more meaning:
  - `Pending Request` - "See organizations you have created that are pending approval."
  - `Pending Invitations` - "Accept and decline invitations to join organizations."

| Pending Request | Pending Invitations |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/97123241/230173732-b4a8b0d0-0f30-4e57-89db-27e9f99222c9.png) | ![image](https://user-images.githubusercontent.com/97123241/230173751-0fc2e9f0-ce03-436e-ae50-19a2c8f6a24e.png) |

- Updated link formatting (link colour and switch from using a `button` to `a`) for empty states:

| Before | After |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/97123241/230179759-63d0fbc2-a484-4148-a0ec-dcb0744180b0.png) | ![image](https://user-images.githubusercontent.com/97123241/230179781-352aee41-3c88-4834-bf2c-81f93a1da7a3.png) |

- Bug fix: `Register a Tool` dialog box is displayed when you navigate back to the new dashboard if you close the dialog box by clicking outside of it. Steps to reproduce:
  - Click on `Register a Tool`
  - Click outside of the dialog box to close it
  - Navigate to My Workflows by clicking on the sidebar
  - Either click on the Dashboard on the sidebar or click the back button to go back to the dashboard
  - See that the dialog box appears automatically
  
Problem actually existed with the `Register a Tool` dialog on the `my-tools` page as well, resolved both

- Bug fix: Page Not Found displayed if you click on a tool in the starred entries box then click Back. Clicking Back again takes you back to the dashboard (have to click twice)

Issue existed in the `recent-events.pipe`, forming the tool URL using `/tools/` instead of `/containers/`

 - Handle null users and users with no avatar image

**Lastly**
Updated the `mat-card` global style to remove the `mat-card-header` `margin-left`.  I've been looking at this for a while, but every `mat-card` with a `mat-card-header` has a large left margin which is inconsistent with the mocks and can look odd/not aligned with content (as with the case with the Dashboard). Resulting from this change, cleaned up and tightened extra padding for affected cards in a variety of places following the mocks.

| Before | After |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/97123241/230198709-db9737c9-5cae-4a81-a92a-9f0ce02d6de0.png) | ![image](https://user-images.githubusercontent.com/97123241/230198688-64dc17c6-26eb-4e35-913e-cbd5cbdab977.png) |

Before & After:
![image](https://user-images.githubusercontent.com/97123241/230199313-2b93b6c8-6a78-4896-b8c7-5aa896158e43.png)
![image](https://user-images.githubusercontent.com/97123241/230199358-220ecafb-ab30-477d-b17b-422cc8e9bd67.png)


**Review Instructions**
Issues stated above and in the usability doc should be resolved on the Dashboard.

**Issue**
SEAB-5348

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
