### PR TITLE
DOCK-2351: fixed spacing in launch tab

### DIFF
--- a/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.ts
+++ b/src/app/shared/entry/launch-checker-workflow/launch-checker-workflow.component.ts
@@ -38,7 +38,7 @@ export class LaunchCheckerWorkflowComponent {
           'dockstore workflow convert entry2json --entry ' +
           checkerWorkflowPath +
           (this.versionName ? ':' + this.versionName : '') +
-          '> checkparam.json'
+          ' > checkparam.json'
       )
     );
   }


### PR DESCRIPTION
**Description**
This PR fixes the inconsistent spacing in the launch tab of a workflow where on some of the commands we have a space before the >, and in others we don't. 

Before fix: 
![Screenshot from 2023-04-25 14-11-31](https://user-images.githubusercontent.com/61166764/234365482-a8edb9c7-75d4-4b0e-9150-2476714cc60a.png)

After fix: 
![Screenshot from 2023-04-25 14-11-16](https://user-images.githubusercontent.com/61166764/234365551-607ec500-603b-4109-9910-0ff4ebbc37ad.png)


**Review Instructions**
Review that all commands have a space before the `>` symbol.

**Issue**
https://github.com/dockstore/dockstore/issues/5422

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
