### PR TITLE
SEAB-5435: Fix mathjax notebooks font url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
             # TODO: https://gui.dockstore.org/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7) can probably be made into a bash/circle-ci variable.
             - run:
                 name: Swap for CDN paths
-                command: bash -i -c "find src \( -iname '*.html' -o -iname '*.ts' -o -iname '*.json' \) -exec sed -i 's~\(\.\./\)\+assets/~https://gui\.dockstore\.org/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/assets/~g' {} +"
+                command: bash -i -c "find src \( -iname '*.html' -o -iname '*.ts' -o -iname '*.js' -o -iname '*.json' \) -exec sed -i 's~\(\.\./\)\+assets/~https://gui\.dockstore\.org/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/assets/~g' {} +"
             - run:
                 name: Build
                 command: NODE_OPTIONS="--max-old-space-size=1610" bash -i -c 'npm run build.prod -- --deploy-url https://gui.dockstore.org/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/'

--- a/src/app/notebook/mathjax-config.js
+++ b/src/app/notebook/mathjax-config.js
@@ -8,7 +8,7 @@ window.MathJax = {
     processEscapes: true,
   },
   chtml: {
-    fontURL: '/assets/fonts/mathjax',
+    fontURL: '../../../../assets/fonts/mathjax',
   },
   options: {
     // values adapted from https://docs.mathjax.org/en/latest/options/safe.html


### PR DESCRIPTION
**Description**
Fix mathjax font url, cherry pick of https://github.com/dockstore/dockstore-ui2/commit/b551eb927f11a241dcfacfc36c1cf3bb7d6c6ab9 to release/1.14

**Review Instructions**
None, will be verified on develop and during deploy-related user testing.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5435

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
