### PR TITLE
SEAB-5438: Display old Jupyter notebooks

### DIFF
--- a/src/app/notebook/notebook-types.ts
+++ b/src/app/notebook/notebook-types.ts
@@ -16,10 +16,8 @@ export interface Cell {
   cell_type?: string;
   metadata?: CellMetadata;
   source?: string | string[];
-  input?: string | string[];
   attachments?: Attachments;
   execution_count?: number | null;
-  prompt_number?: number | null;
   outputs?: Output[];
 }
 

--- a/src/app/notebook/notebook-types.ts
+++ b/src/app/notebook/notebook-types.ts
@@ -16,8 +16,10 @@ export interface Cell {
   cell_type?: string;
   metadata?: CellMetadata;
   source?: string | string[];
+  input?: string | string[];
   attachments?: Attachments;
   execution_count?: number | null;
+  prompt_number?: number | null;
   outputs?: Output[];
 }
 

--- a/src/app/notebook/notebook.component.spec.ts
+++ b/src/app/notebook/notebook.component.spec.ts
@@ -184,4 +184,12 @@ describe('NotebookComponent', () => {
     expect(element.querySelector('.output img').getAttribute('height')).toBe('480');
     confirmSuccess();
   });
+
+  it('should do a reasonable job of displaying a format 3 notebook', () => {
+    const cell = '{"cell_type": "code", "input": "some input", "outputs": [{"output_type": "display_data", "html": "<p>some html</p>"}]}';
+    const notebook = `{"nbformat": 3, "worksheets": [{ "cells": [${cell}] }]}`;
+    format(notebook);
+    expect(element.querySelector('.source').textContent).toContain('some input');
+    expect(element.querySelector('.output').textContent).toContain('some html');
+  });
 });

--- a/src/app/notebook/notebook.component.ts
+++ b/src/app/notebook/notebook.component.ts
@@ -120,7 +120,7 @@ export class NotebookComponent implements OnChanges {
       if (this.isArray(cell.outputs)) {
         cell.outputs.forEach(
           (output) =>
-            // Map the previous representation of rich outputs to a "mime bundle'.
+            // Map the old representation of rich outputs to a "mime bundle'.
             (output.data ??= {
               'text/plain': output['text'],
               'text/html': output['html'],

--- a/src/app/notebook/notebook.component.ts
+++ b/src/app/notebook/notebook.component.ts
@@ -63,7 +63,7 @@ export class NotebookComponent implements OnChanges {
                 // Parse the JSON content of the notebook file.
                 const json = JSON.parse(sourceFile.content);
                 // Find the cells and, if necessary, convert them to a representation that approximates nbformat 4.
-                const cells = json?.nbformat >= 4 ? json?.cells : this.cellsToNbformat4(json?.worksheets[0]?.cells);
+                const cells = json?.nbformat < 4 ? this.cellsToNbformat4(json?.worksheets[0]?.cells) : json?.cells;
                 // If the `cells` property is an array, filter spam and "pass" the cells to the template.
                 if (this.isArray(cells)) {
                   this.cells = this.filterSpam(cells);


### PR DESCRIPTION
**Description**
This PR modifies the UI to do a better job of displaying Jupyter notebooks with major nbformat (version) less than 4.

The transition from format format 3 to format 4 appears to have happened approximately 8 years ago.  It's rare, but occasionally, I do see a format 3 notebook, enough so that it seemed important enough to support them.   

The important differences between a format 3 and format 4 Jupyter notebook include:

* In format 3, the a root-level `worksheets` field contains a list of worksheets, each of which contains a `cells` field.  The first contains the notebook cells.  In format 4, `cells` is a root-level field, and `worksheets` has been removed.
* In format 3, rich outputs are embedded directly as fields in the output, denoted by shorthand like `text` and `png`.    In format 4, these outputs are stored in a mime bundle, to which the `data` field is set.
* Various field names and values have changed.

After parsing a pre-format-4 notebook, this code converts the resulting object to a form that vaguely resembles the equivalent format-4 notebook object, which is then processed as before.   The conversion is not perfect or complete, but since the preview code is written to fail gracefully, it works pretty well.  This approach has the advantage of concentrating the pre-format-4 processing in one spot, instead of scattered it piecemeal all over the place. 
 
**Review Instructions**
Register a notebook with nbformat < 4, view its Preview, and confirm that it looks fine.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5438

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
