### PR TITLE
SEAB-5511: Make all "launch with" button tooltips appear to the left

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -37,11 +37,13 @@
               [className]="'partner-launch'"
               [disabled]="(hasContent$ | async) === false"
               [matTooltip]="(hasContent$ | async) ? '' : 'The WDL workflow has no content.'"
+              matTooltipPosition="left"
             ></app-multi-cloud-launch>
             <a
               mat-button
               class="launch-with-button private-btn"
               [matTooltip]="(hasContent$ | async) ? '' : 'The WDL workflow has no content.'"
+              matTooltipPosition="left"
               target="_blank"
               rel="noopener"
               [attr.href]="config.DNANEXUS_IMPORT_URL + '?source=' + trsUrl"
@@ -53,6 +55,7 @@
               mat-button
               class="launch-with-button private-btn"
               [matTooltip]="terraTooltip$ | async"
+              matTooltipPosition="left"
               target="_blank"
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
@@ -64,6 +67,7 @@
               mat-button
               class="launch-with-button private-btn"
               [matTooltip]="elwaziToolTip$ | async"
+              matTooltipPosition="left"
               target="_blank"
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
@@ -75,6 +79,7 @@
               mat-button
               class="launch-with-button private-btn"
               [matTooltip]="anvilTooltip$ | async"
+              matTooltipPosition="left"
               target="_blank"
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
@@ -86,6 +91,7 @@
               mat-button
               class="launch-with-button private-btn"
               [matTooltip]="bdCatalystTerraTooltip$ | async"
+              matTooltipPosition="left"
               target="_blank"
               rel="noopener"
               [disabled]="disableTerraPlatform$ | async"
@@ -113,6 +119,7 @@
                 mat-button
                 class="launch-with-button private-btn"
                 [matTooltip]="(hasContent$ | async) ? '' : 'The WDL workflow has no content.'"
+                matTooltipPosition="left"
                 target="_blank"
                 rel="noopener"
                 [attr.href]="config.DNANEXUS_IMPORT_URL + '?source=' + trsUrl"
@@ -124,6 +131,7 @@
                 mat-button
                 class="launch-with-button private-btn"
                 [matTooltip]="terraTooltip$ | async"
+                matTooltipPosition="left"
                 target="_blank"
                 rel="noopener"
                 [disabled]="disableTerraPlatform$ | async"
@@ -135,6 +143,7 @@
                 mat-button
                 class="launch-with-button private-btn"
                 [matTooltip]="elwaziToolTip$ | async"
+                matTooltipPosition="left"
                 target="_blank"
                 rel="noopener"
                 [disabled]="disableTerraPlatform$ | async"
@@ -146,6 +155,7 @@
                 mat-button
                 class="launch-with-button private-btn"
                 [matTooltip]="anvilTooltip$ | async"
+                matTooltipPosition="left"
                 target="_blank"
                 rel="noopener"
                 [disabled]="disableTerraPlatform$ | async"
@@ -157,6 +167,7 @@
                 mat-button
                 class="launch-with-button private-btn"
                 [matTooltip]="bdCatalystTerraTooltip$ | async"
+                matTooltipPosition="left"
                 target="_blank"
                 rel="noopener"
                 [disabled]="disableTerraPlatform$ | async"
@@ -177,6 +188,7 @@
             mat-button
             class="launch-with-button private-btn"
             [matTooltip]="cgcTooltip$ | async"
+            matTooltipPosition="left"
             target="_blank"
             rel="noopener"
             [attr.href]="config.CGC_IMPORT_URL + '?trs=' + trsUrl"
@@ -188,6 +200,7 @@
             mat-button
             class="launch-with-button private-btn"
             [matTooltip]="bdCatalystSevenBridgesTooltip$ | async"
+            matTooltipPosition="left"
             target="_blank"
             rel="noopener"
             [attr.href]="config.BD_CATALYST_SEVEN_BRIDGES_IMPORT_URL + '?trs=' + trsUrl"
@@ -199,6 +212,7 @@
             mat-button
             class="launch-with-button private-btn"
             [matTooltip]="cavaticaTooltip$ | async"
+            matTooltipPosition="left"
             target="_blank"
             rel="noopener"
             [attr.href]="config.CAVATICA_IMPORT_URL + '?trs=' + trsUrl"
@@ -218,6 +232,7 @@
             [className]="'galaxy-launch'"
             [disabled]="(hasContent$ | async) === false"
             [matTooltip]="(hasContent$ | async) ? '' : 'The Galaxy workflow has no content.'"
+            matTooltipPosition="left"
             data-cy="galaxyLaunchWith"
           ></app-multi-cloud-launch>
         </div>
@@ -226,6 +241,7 @@
             mat-button
             class="launch-with-button private-btn"
             [matTooltip]="(hasContent$ | async) ? 'Export this workflow to Nextflow Tower' : 'The Nextflow workflow has no content.'"
+            matTooltipPosition="left"
             target="_blank"
             rel="noopener"
             [attr.href]="


### PR DESCRIPTION
**Description**
The PR changes the "Launch with" button tooltips so they appear to the left of the button, rather than below.  This avoids the tooltip obscuring the next button in the list, which is frustrating and makes the buttons hard to use.

It would be great to be able to style this, but I suspect [but am not sure] that's not possible.

**Review Instructions**
Fire up the UI and make sure the "Launch with" tooltips all appear correctly, to the left of the corresponding buttons.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5511

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
