### PR TITLE
Display correct message for no stargazers

### DIFF
--- a/src/app/stargazers/stargazers.component.html
+++ b/src/app/stargazers/stargazers.component.html
@@ -20,7 +20,7 @@
   </mat-card-header>
   <mat-card-content>
     <mat-icon>warning</mat-icon>
-    There are no stargazers for this <span>{{ organization !== null ? 'organization' : 'entry' }}.</span>
+    There are no stargazers for this entry.
   </mat-card-content>
 </mat-card>
 <div *ngIf="starGazers?.length > 0" class="mb-3 p-4">

--- a/src/app/stargazers/stargazers.component.ts
+++ b/src/app/stargazers/stargazers.component.ts
@@ -19,6 +19,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Base } from '../shared/base';
 import { altAvatarImg } from '../shared/constants';
 import { StarentryService } from '../shared/starentry.service';
+import { User } from '../shared/swagger';
 import { UserService } from '../shared/user/user.service';
 import { StarringService } from '../starring/starring.service';
 
@@ -28,7 +29,7 @@ import { StarringService } from '../starring/starring.service';
   styleUrls: ['./stargazers.component.css'],
 })
 export class StargazersComponent extends Base implements OnInit {
-  starGazers: any;
+  starGazers: User[];
   public altAvatarImg = altAvatarImg;
 
   constructor(private starringService: StarringService, private userService: UserService, private starentryService: StarentryService) {


### PR DESCRIPTION
**Description**
For an entry, display "There are no stargazers for this entry" instead of "There are no stargazers for this organization".

The "organization" property doesn't exist, so it's undefined, not null, which caused it to display the text "organization".

Also got rid of an `any`.

**Review Instructions**
1. Navigate to a workflow or tool with no stargazers
2. Click on the star to view stargazers
3. Message should say "There are no stargazers for this entry".

**Issue**
dockstore/dockstore#5535

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
