### PR TITLE
SEAB-5570: Fix "non-sticky" search facets

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -265,6 +265,12 @@ export class SearchComponent implements OnInit, OnDestroy {
       this.searchService.setSearchText('');
       this.unsubmittedSearchText = '';
     }
+    if (paramMap.has('entryType')) {
+      const value = paramMap.getAll('entryType');
+      const tabIndex = SearchService.convertEntryTypeToTabIndex(value[0]);
+      this.searchService.saveCurrentTab(tabIndex);
+      this.initializeMappings(tabIndex);
+    }
     paramMap.keys.forEach((key) => {
       const value = paramMap.getAll(key);
       if (this.friendlyNames.get(key)) {
@@ -272,8 +278,6 @@ export class SearchComponent implements OnInit, OnDestroy {
           categoryValue = decodeURIComponent(categoryValue);
           newFilters = this.searchService.updateFiltersFromParameter(key, categoryValue, newFilters);
         });
-      } else if (key === 'entryType') {
-        this.searchService.saveCurrentTab(SearchService.convertEntryTypeToTabIndex(value[0]));
       } else if (key === 'search') {
         this.searchTerm = true;
         this.searchService.setSearchText(value[0]);
@@ -443,7 +447,6 @@ export class SearchComponent implements OnInit, OnDestroy {
   updateQuery() {
     const tabIndex = this.searchQuery.getValue().currentTabIndex;
     const entryType = SearchService.convertTabIndexToEntryType(tabIndex);
-    this.initializeMappings(tabIndex);
     // Separating into 2 queries otherwise the queries interfere with each other (filter applied before aggregation)
     // The first query handles the aggregation and is used to update the sidebar buckets
     // The second query updates the result table


### PR DESCRIPTION
**Description**
In some cases, on the Search page, when you clicked on a facet radiobox, its state would not toggle, and the URL would not update properly.  This behavior could be reproduced by visiting the "Notebooks" tab in search, clicking on a notebook link, using the browser's "Back" button to return to the Search page, and then clicking on the "Python" radiobox in the "Language" facet.  For a split second, the UI appears to be doing the right thing, but then fails.

This PR fixes the problem, by moving the code that initializes the mappings for a given tab index, so that it runs before the facet settings are extracted from the search URL and processed. 

**Review Instructions**
Try the procedure mentioned in the above description, and confirm that the "Language" facet radiobox toggles when clicked, and that the search URL is updated properly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5570

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
