### PR TITLE
SEAB-5413: create pipe for partner display names

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/metrics.ts
+++ b/cypress/e2e/immutableDatabaseTests/metrics.ts
@@ -34,7 +34,7 @@ describe('Dockstore Metrics', () => {
     // Change partner to Galaxy, which only has validator tool metrics
     cy.get('[data-cy=metrics-partner-dropdown]').click();
     cy.get('[data-cy=metrics-partner-options]').contains('Galaxy').click();
-    cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'GALAXY');
+    cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'Galaxy');
     cy.get('[data-cy=execution-metrics-table]').should('not.exist');
     cy.get('[data-cy=execution-metrics-total-executions-div]').should('not.exist');
     cy.get('[data-cy=validations-table]').should('be.visible');

--- a/cypress/e2e/immutableDatabaseTests/metrics.ts
+++ b/cypress/e2e/immutableDatabaseTests/metrics.ts
@@ -22,7 +22,7 @@ describe('Dockstore Metrics', () => {
     goToTab('Metrics');
 
     cy.get('[data-cy=no-metrics-banner]').should('not.exist');
-    cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'ALL');
+    cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'All Platforms');
     cy.get('[data-cy=execution-metrics-table]').should('be.visible');
     cy.get('[data-cy=execution-metrics-total-executions-div]').should('contain', 9);
     cy.get('[data-cy=validations-table]').should('be.visible');

--- a/cypress/e2e/immutableDatabaseTests/metrics.ts
+++ b/cypress/e2e/immutableDatabaseTests/metrics.ts
@@ -31,9 +31,9 @@ describe('Dockstore Metrics', () => {
     cy.get('[data-cy=metrics-validator-tool-options]').should('contain', 'WOMTOOL');
     cy.get('[data-cy=metrics-validator-tool-options]').contains('WOMTOOL').click();
     cy.get('[data-cy=validations-table]').should('be.visible');
-    // Change partner to DNAstack, which only has validator tool metrics
+    // Change partner to Galaxy, which only has validator tool metrics
     cy.get('[data-cy=metrics-partner-dropdown]').click();
-    cy.get('[data-cy=metrics-partner-options]').contains('GALAXY').click();
+    cy.get('[data-cy=metrics-partner-options]').contains('Galaxy').click();
     cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'GALAXY');
     cy.get('[data-cy=execution-metrics-table]').should('not.exist');
     cy.get('[data-cy=execution-metrics-total-executions-div]').should('not.exist');

--- a/src/app/shared/entry/platform-partner.pipe.spec.ts
+++ b/src/app/shared/entry/platform-partner.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { PlatformPartnerPipe } from './platform-partner.pipe';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('Pipe: PlatformPartner', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PlatformPartnerPipe],
+    });
+  });
+
+  it('create an instance', () => {
+    const pipe = new PlatformPartnerPipe();
+    expect(pipe).toBeTruthy();
+    expect(pipe.transform('DNA_STACK')).toBe('DNAstack');
+    expect(pipe.transform('AGC')).toBe('AGC');
+    expect(pipe.transform('ANVIL')).toBe('AnVIL');
+  });
+});

--- a/src/app/shared/entry/platform-partner.pipe.ts
+++ b/src/app/shared/entry/platform-partner.pipe.ts
@@ -1,0 +1,39 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CloudInstance } from '../../shared/openapi';
+import PartnerEnum = CloudInstance.PartnerEnum;
+
+@Pipe({
+  name: 'platformPartner',
+})
+export class PlatformPartnerPipe implements PipeTransform {
+  /**
+   * Transforms PartnerEnum into their display name
+   * @param partner
+   * @returns {string}
+   */
+  transform(partner: PartnerEnum): string {
+    switch (partner) {
+      case PartnerEnum.GALAXY:
+        return 'Galaxy';
+      case PartnerEnum.TERRA:
+        return 'Terra';
+      case PartnerEnum.DNASTACK:
+        return 'DNAstack';
+      case PartnerEnum.DNANEXUS:
+        return 'DNAnexus';
+      case PartnerEnum.NHLBIBIODATACATALYST:
+        return 'NHLBI BioData Catalyst';
+      case PartnerEnum.ANVIL:
+        return 'AnVIL';
+      case PartnerEnum.CAVATICA:
+        return 'Cavatica';
+      case PartnerEnum.NEXTFLOWTOWER:
+        return 'Nextflow Tower';
+      case PartnerEnum.ELWAZI:
+        return 'eLwazi';
+      default:
+        //includes CGC, AGC, OTHER, ALL
+        return partner;
+    }
+  }
+}

--- a/src/app/shared/entry/platform-partner.pipe.ts
+++ b/src/app/shared/entry/platform-partner.pipe.ts
@@ -31,8 +31,12 @@ export class PlatformPartnerPipe implements PipeTransform {
         return 'Nextflow Tower';
       case PartnerEnum.ELWAZI:
         return 'eLwazi';
+      case PartnerEnum.OTHER:
+        return 'Other';
+      case PartnerEnum.ALL:
+        return 'All Platforms';
       default:
-        //includes CGC, AGC, OTHER, ALL
+        //includes CGC, AGC
         return partner;
     }
   }

--- a/src/app/shared/pipe/pipe.module.ts
+++ b/src/app/shared/pipe/pipe.module.ts
@@ -15,6 +15,7 @@ import { DescriptorLanguagePipe } from '../entry/descriptor-language.pipe';
 import { RecentEventsPipe } from '../entry/recent-events.pipe';
 import { EntryToDisplayNamePipe } from '../entry-to-display-name.pipe';
 import { SearchAuthorsHtmlPipe } from 'app/search/search-authors-html.pipe';
+import { PlatformPartnerPipe } from '../entry/platform-partner.pipe';
 
 const DECLARATIONS: any[] = [
   FilePathPipe,
@@ -31,11 +32,12 @@ const DECLARATIONS: any[] = [
   DescriptorLanguagePipe,
   RecentEventsPipe,
   SearchAuthorsHtmlPipe,
+  PlatformPartnerPipe,
 ];
 @NgModule({
   imports: [CommonModule],
   declarations: DECLARATIONS,
   exports: DECLARATIONS,
-  providers: [EntryToDisplayNamePipe],
+  providers: [EntryToDisplayNamePipe, PlatformPartnerPipe],
 })
 export class PipeModule {}

--- a/src/app/workflow/executions/executions-tab.component.html
+++ b/src/app/workflow/executions/executions-tab.component.html
@@ -13,7 +13,7 @@
       <mat-label>Select a Platform</mat-label>
       <mat-select data-cy="metrics-partner-dropdown" [value]="currentPartner" (selectionChange)="matSelectChange($event)">
         <mat-option data-cy="metrics-partner-options" [value]="partner" *ngFor="let partner of partners">
-          {{ getPartnerDisplayName(partner) }}
+          {{ partner | platformPartner }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/src/app/workflow/executions/executions-tab.component.html
+++ b/src/app/workflow/executions/executions-tab.component.html
@@ -13,7 +13,7 @@
       <mat-label>Select a Platform</mat-label>
       <mat-select data-cy="metrics-partner-dropdown" [value]="currentPartner" (selectionChange)="matSelectChange($event)">
         <mat-option data-cy="metrics-partner-options" [value]="partner" *ngFor="let partner of partners">
-          {{ partner }}
+          {{ getPartnerDisplayName(partner) }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/src/app/workflow/executions/executions-tab.component.spec.ts
+++ b/src/app/workflow/executions/executions-tab.component.spec.ts
@@ -22,6 +22,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AlertService } from '../../shared/alert/state/alert.service';
 import { DescriptorLanguageService } from '../../shared/entry/descriptor-language.service';
 import { CustomMaterialModule } from '../../shared/modules/material.module';
+import { PipeModule } from '../../shared/pipe/pipe.module';
 
 describe('ExecutionsTabComponent', () => {
   let component: ExecutionsTabComponent;
@@ -32,7 +33,7 @@ describe('ExecutionsTabComponent', () => {
       TestBed.configureTestingModule({
         declarations: [ExecutionsTabComponent],
         schemas: [NO_ERRORS_SCHEMA],
-        imports: [HttpClientTestingModule, CustomMaterialModule],
+        imports: [HttpClientTestingModule, CustomMaterialModule, PipeModule],
         providers: [{ provide: DescriptorLanguageService, useClass: DescriptorLanguageStubService }, AlertService],
       }).compileComponents();
     })

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -23,7 +23,6 @@ import { CheckerWorkflowQuery } from '../../shared/state/checker-workflow.query'
 import PartnerEnum = CloudInstance.PartnerEnum;
 import { MatSelectChange } from '@angular/material/select';
 import { AlertService } from '../../shared/alert/state/alert.service';
-import { PlatformPartnerPipe } from '../../shared/entry/platform-partner.pipe';
 
 interface ExecutionMetricsTableObject {
   metric: string; // Name of the execution metric
@@ -70,7 +69,6 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
   @Input() version: WorkflowVersion;
 
   constructor(
-    private partnerPipe: PlatformPartnerPipe,
     private extendedGA4GHService: ExtendedGA4GHService,
     private alertService: AlertService,
     protected sessionQuery: SessionQuery,
@@ -176,9 +174,6 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
     }
   }
 
-  getPartnerDisplayName(partner: PartnerEnum) {
-    return this.partnerPipe.transform(partner);
-  }
   matSelectChange(event: MatSelectChange) {
     this.selectPartner(event.value);
   }

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -23,6 +23,7 @@ import { CheckerWorkflowQuery } from '../../shared/state/checker-workflow.query'
 import PartnerEnum = CloudInstance.PartnerEnum;
 import { MatSelectChange } from '@angular/material/select';
 import { AlertService } from '../../shared/alert/state/alert.service';
+import { PlatformPartnerPipe } from '../../shared/entry/platform-partner.pipe';
 
 interface ExecutionMetricsTableObject {
   metric: string; // Name of the execution metric
@@ -69,6 +70,7 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
   @Input() version: WorkflowVersion;
 
   constructor(
+    private partnerPipe: PlatformPartnerPipe,
     private extendedGA4GHService: ExtendedGA4GHService,
     private alertService: AlertService,
     protected sessionQuery: SessionQuery,
@@ -174,6 +176,9 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
     }
   }
 
+  getPartnerDisplayName(partner: PartnerEnum) {
+    return this.partnerPipe.transform(partner);
+  }
   matSelectChange(event: MatSelectChange) {
     this.selectPartner(event.value);
   }

--- a/src/app/workflows/workflows.module.ts
+++ b/src/app/workflows/workflows.module.ts
@@ -16,9 +16,11 @@
 import { NgModule } from '@angular/core';
 import { WorkflowsPageModule } from 'app/shared/modules/workflowsPage.module';
 import { workflowsRouting } from './workflows.routing';
+import { PlatformPartnerPipe } from '../shared/entry/platform-partner.pipe';
 
 @NgModule({
   declarations: [],
   imports: [workflowsRouting, WorkflowsPageModule],
+  providers: [PlatformPartnerPipe],
 })
 export class WorkflowsModule {}


### PR DESCRIPTION
**Description**
This PR creates a pipe to change the `PartnerEnum` values to its display names (ex. `DNA_STACK` -> `DNAstack`) in the metrics dropdown.

Before fix: 
![Screenshot from 2023-06-19 11-53-51](https://github.com/dockstore/dockstore-ui2/assets/61166764/345aa730-77e8-43d5-a6d6-4cf5754b7d3e)

After fix:
![Screenshot from 2023-06-19 11-49-08](https://github.com/dockstore/dockstore-ui2/assets/61166764/949f0b76-0b98-4299-ae73-98ffc683dda0)


**Review Instructions**
1. Go to https://qa.dockstore.org/workflows/github.com/broadinstitute/gatk-sv/merge-cohort-vcfs:v0.13-beta?tab=info&metrics
2. click the Metrics tab and confirm the dropdown shows 'DNAstack' instead of DNA_STACK.
3. Also the new unit tests should pass

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5413

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
