### PR TITLE
Clean up smoke test code after 1.14 release

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -140,7 +140,7 @@ describe('Test search page functionality', () => {
     cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
-      expect($el.text()).to.be('Nextflow');
+      cy.wrap($el).contains('Nextflow');
     });
     cy.url().should('contain', 'descriptorType=NFL');
     cy.url().should('contain', 'searchMode=files');

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -140,9 +140,7 @@ describe('Test search page functionality', () => {
     cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
-      // In 1.13, the Nextflow badge displays as 'NFL'
-      // In 1.14, the Nextflow badge displays as 'Nextflow'
-      expect($el.text()).to.be.oneOf(['Nextflow', 'NFL']);
+      expect($el.text()).to.be('Nextflow');
     });
     cy.url().should('contain', 'descriptorType=NFL');
     cy.url().should('contain', 'searchMode=files');
@@ -286,9 +284,7 @@ function testWorkflow(url: string, version1: string, version2: string, trsUrl: s
     if (type === 'WDL') {
       const launchSelectors = ['dnanexusLaunchWith', 'terraLaunchWith', 'anvilLaunchWith'];
       launchSelectors
-        // In 1.13, launch button images are <svg>
-        // In 1.14, launch button images are <img>
-        .map((launchSelector) => `[data-cy=${launchSelector}] svg, [data-cy=${launchSelector}] img`)
+        .map((launchSelector) => `[data-cy=${launchSelector}] img`)
         .forEach((launchSelector) => cy.get(launchSelector).should('exist'));
     }
     if (type === 'CWL') {


### PR DESCRIPTION
**Description**
This PR removes 1.13 specific code in the smoke tests.

**Review Instructions**
Check in the various slack channels to verify that the nightly smoke tests pass for all environments.

**Issue**
dockstore/dockstore#5372
https://ucsc-cgl.atlassian.net/browse/DOCK-2328

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
