### PR TITLE
SEAB-5491: Retry installing cypress dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,8 +429,8 @@ commands:
       - run:
           name: Install cypress dependencies
           command: |
-            sudo apt update -y
-            sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
+            sudo apt-get update -y
+            sudo apt-get -o Acquire::Retries=3 install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb -yq
   setup_integration_test:
     parameters:
       db_dump:


### PR DESCRIPTION
**Description**
On rare occasions, `apt-get` fails to retrieve some cypress dependencies so this ticket tries to reinstall these if the command fails the first time.

**Review Instructions**
Check that dependencies are installed successfully.

**Issue**
[SEAB-5491](https://ucsc-cgl.atlassian.net/browse/SEAB-5491)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[SEAB-5491]: https://ucsc-cgl.atlassian.net/browse/SEAB-5491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ