### PR TITLE
Fix TRS ID when getting metrics for notebooks, apptools, and services

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/metrics.ts
+++ b/cypress/e2e/immutableDatabaseTests/metrics.ts
@@ -10,7 +10,6 @@ describe('Dockstore Metrics', () => {
     cy.get('[data-cy=no-metrics-banner]').should('be.visible');
 
     cy.visit('/notebooks/github.com/dockstore-testing/simple-notebook?metrics');
-    cy.get('.mat-tab-header-pagination-after').click();
     goToTab('Metrics');
     cy.get('[data-cy=no-metrics-banner]').should('be.visible');
   });

--- a/cypress/e2e/immutableDatabaseTests/metrics.ts
+++ b/cypress/e2e/immutableDatabaseTests/metrics.ts
@@ -1,9 +1,15 @@
-import { goToTab, setTokenUserViewPort } from '../../support/commands';
+import { goToTab, insertNotebooks, setTokenUserViewPort } from '../../support/commands';
 
 describe('Dockstore Metrics', () => {
+  insertNotebooks();
   setTokenUserViewPort();
   it('Should see no metrics banner', () => {
     cy.visit('/workflows/github.com/A/l:master?metrics');
+    cy.get('.mat-tab-header-pagination-after').click();
+    goToTab('Metrics');
+    cy.get('[data-cy=no-metrics-banner]').should('be.visible');
+
+    cy.visit('/notebooks/github.com/dockstore-testing/simple-notebook?metrics');
     cy.get('.mat-tab-header-pagination-after').click();
     goToTab('Metrics');
     cy.get('[data-cy=no-metrics-banner]').should('be.visible');

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.13.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/9814/workflows/42b0d392-6004-4277-b284-8462335534cb/jobs/32860/artifacts",
-    "circle_build_id": "32860",
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10092/workflows/8d9c7d01-9b33-4126-99c1-875a890063bf/jobs/34936/artifacts",
+    "circle_build_id": "34936",
     "base_branch": "develop"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10092/workflows/8d9c7d01-9b33-4126-99c1-875a890063bf/jobs/34936/artifacts",
     "circle_build_id": "34936",
-    "base_branch": "develop"
+    "base_branch": "hotfix/2.11.1"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -202,9 +202,4 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
       this.validationsTable = [];
     }
   }
-
-  ngOnDestroy() {
-    this.ngUnsubscribe.next();
-    this.ngUnsubscribe.complete();
-  }
 }

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -19,7 +19,6 @@ import { CloudInstance, ExtendedGA4GHService, Metrics, ValidatorInfo, ValidatorV
 import { SessionQuery } from '../../shared/session/session.query';
 import { takeUntil } from 'rxjs/operators';
 import { BioWorkflow, Notebook, Service } from '../../shared/swagger';
-import { CheckerWorkflowQuery } from '../../shared/state/checker-workflow.query';
 import PartnerEnum = CloudInstance.PartnerEnum;
 import { MatSelectChange } from '@angular/material/select';
 import { AlertService } from '../../shared/alert/state/alert.service';
@@ -71,15 +70,14 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
   constructor(
     private extendedGA4GHService: ExtendedGA4GHService,
     private alertService: AlertService,
-    protected sessionQuery: SessionQuery,
-    private checkerWorkflowQuery: CheckerWorkflowQuery
+    protected sessionQuery: SessionQuery
   ) {
     super();
   }
 
   ngOnChanges() {
     this.alertService.start('Retrieving metrics data');
-    this.trsID = this.checkerWorkflowQuery.getTRSId(this.entry);
+    this.trsID = this.entry.entryTypeMetadata.trsPrefix + this.entry.full_workflow_path;
     this.extendedGA4GHService
       .aggregatedMetricsGet(this.trsID, this.version.name)
       .pipe(takeUntil(this.ngUnsubscribe))


### PR DESCRIPTION
**Description**
This PR fixes the `Tool Not Found` error when viewing metrics for notebooks, apptools, and services by fixing the TRS ID used when called the `aggregatedMetricsGet` endpoint. The bug was happening for notebooks, apptools, and services because the TRS ID was using the `#workflow` prefix instead of the correct one for notebooks, apptools, and services so the endpoint returned a 404 because it couldn't find the entry.

**Review Instructions**
Follow the instructions in the ticket and verify that there is no Tool Not Found error. Verify for notebooks, apptools, and services.

**Issue**
dockstore/dockstore#5561
https://ucsc-cgl.atlassian.net/browse/DOCK-2421

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
