### PR TITLE
SEAB-4303: Improve error message when github app log retrieval fails

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -61,7 +61,7 @@ describe('Dockstore my workflows', () => {
       cy.contains('github.com/A/l');
 
       cy.contains('Apps Logs').click();
-      cy.contains('There were problems retrieving GitHub App logs for this organization.');
+      cy.contains('There were problems retrieving the GitHub App logs for this organization.');
       cy.contains('Close').click();
       cy.intercept('GET', '/api/lambdaEvents/**', {
         body: [],

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -53,7 +53,7 @@ describe('GitHub App Tools', () => {
 
       // GitHub App Logs
       cy.contains('Apps Logs').click();
-      cy.contains('There were problems retrieving GitHub App logs for this organization.');
+      cy.contains('There were problems retrieving the GitHub App logs for this organization.');
       cy.contains('Close').click();
       cy.intercept('GET', '/api/lambdaEvents/**', {
         body: [],

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -3,7 +3,7 @@
   <app-loading [loading]="loading">
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
       <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving the GitHub App logs for this organization.<br />
-      Typically, if you cannot view the logs for your GitHub user account, you must unlink and relink it via<br />
+      Typically, if you cannot view the logs for your GitHub user account, you must unlink and relink it in<br />
       your Dockstore profile.<br />
       Otherwise, your GitHub user or the Dockstore app may not have access to the GitHub organization.<br />
       <a href="https://github.com/settings/connections/applications/7ad54aa857c6503013ea" target="_blank" rel="noopener noreferrer"

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -2,7 +2,14 @@
 <div mat-dialog-content>
   <app-loading [loading]="loading">
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
-      <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving GitHub App logs for this organization.
+      <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving the GitHub App logs for this organization.<br />
+      Typically, if you cannot view the logs for your user account,<br />
+      you must unlink and relink your GitHub account via your Dockstore profile.<br />
+      Otherwise, your GitHub user or the Dockstore app may not have access to the GitHub organization.<br />
+      Github admins should
+      <a href="https://github.com/settings/connections/applications/7ad54aa857c6503013ea" target="_blank" rel="noopener noreferrer"
+        >confirm that the Dockstore app is authorized (via OAuth)</a
+      >.
     </mat-card>
     <mat-card *ngIf="showContent === 'empty'" class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> There are no GitHub App logs for this organization.

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -4,11 +4,11 @@
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
       <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving the GitHub App logs for this organization.<br />
       Typically, if you cannot view the logs for your GitHub user account, you must unlink and relink it in<br />
-      your Dockstore profile.<br />
+      your <a mat-dialog-close routerLink="/accounts">Dockstore profile</a>.<br />
       Otherwise, your GitHub user or the Dockstore app may not have access to the GitHub organization.<br />
       <a href="https://github.com/settings/connections/applications/7ad54aa857c6503013ea" target="_blank" rel="noopener noreferrer"
-        >Click here to confirm that the Dockstore app is authorized.</a
-      >
+        >Click here to confirm that the Dockstore app is authorized</a
+      >.
     </mat-card>
     <mat-card *ngIf="showContent === 'empty'" class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> There are no GitHub App logs for this organization.

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -3,13 +3,12 @@
   <app-loading [loading]="loading">
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
       <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving the GitHub App logs for this organization.<br />
-      Typically, if you cannot view the logs for your user account,<br />
-      you must unlink and relink your GitHub account via your Dockstore profile.<br />
+      Typically, if you cannot view the logs for your GitHub user account, you must unlink and relink it via<br />
+      your Dockstore profile.<br />
       Otherwise, your GitHub user or the Dockstore app may not have access to the GitHub organization.<br />
-      Github admins should
       <a href="https://github.com/settings/connections/applications/7ad54aa857c6503013ea" target="_blank" rel="noopener noreferrer"
-        >confirm that the Dockstore app is authorized (via OAuth)</a
-      >.
+        >Click here to confirm that the Dockstore app is authorized.</a
+      >
     </mat-card>
     <mat-card *ngIf="showContent === 'empty'" class="alert alert-info mat-elevation-z" role="alert">
       <mat-icon>warning</mat-icon> There are no GitHub App logs for this organization.

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -3,7 +3,7 @@
   <app-loading [loading]="loading">
     <mat-card *ngIf="showContent === 'error'" class="alert alert-warning mat-elevation-z" role="alert">
       <mat-icon class="alert-warning-icon">warning</mat-icon> There were problems retrieving the GitHub App logs for this organization.<br />
-      Typically, if you cannot view the logs for your GitHub user account, you must unlink and relink it in<br />
+      Often, if you cannot view the logs for your GitHub user account, you must unlink and relink it in<br />
       your <a mat-dialog-close routerLink="/accounts">Dockstore profile</a>.<br />
       Otherwise, your GitHub user or the Dockstore app may not have access to the GitHub organization.<br />
       <a href="https://github.com/settings/connections/applications/7ad54aa857c6503013ea" target="_blank" rel="noopener noreferrer"

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.module.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.module.ts
@@ -16,6 +16,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RefreshAlertModule } from 'app/shared/alert/alert.module';
 import { CustomMaterialModule } from 'app/shared/modules/material.module';
@@ -23,7 +24,7 @@ import { PipeModule } from '../../../shared/pipe/pipe.module';
 import { GithubAppsLogsComponent } from './github-apps-logs.component';
 
 @NgModule({
-  imports: [CustomMaterialModule, CommonModule, RefreshAlertModule, FlexLayoutModule, PipeModule],
+  imports: [CustomMaterialModule, CommonModule, RefreshAlertModule, FlexLayoutModule, PipeModule, RouterModule],
   declarations: [GithubAppsLogsComponent],
 })
 export class GitHubAppsLogsModule {}


### PR DESCRIPTION
**Description**
This PR adds information to the error box that's displayed when the GitHub apps logs cannot be retrieved for a particular organization, informing the user of the typical problems and ways to fix them.

After surveying the UI and webservice codebases, I decided to go with a "low code" approach.  This error doesn't happen often and IMHO, the new informational text provides actionable solutions.  A different approach would be to detect the specific failure mode and display instructions tailored to it, but that would require significantly more modification, some to the webservice, and felt like overkill.

<img width="817" alt="Screen Shot 2023-06-29 at 1 13 15 PM" src="https://github.com/dockstore/dockstore-ui2/assets/88108675/15118b71-c0e0-49ed-af8c-0e0733dba60f">

The error box links to the GitHib page that displays the prod Dockstore app's orgs/access.  We could try to display the correct link for qa/staging/etc, but there's probably bigger fish to fry.  The same link (to prod app's page, irregardless of actual env) appears in one other place in the UI.  If we duplicate the link again, it's probably worth putting it in `constants.ts`.

**Review Instructions**
Register an entry from a repo in a test GitHub account/org that you control access to, via the .dockstore.yml method.  Wait five minutes, then confirm that you can view the corresponding GitHub apps logs entries.  Then, revoke access for the Dockstore app [for the correct env] to the account.  Reload the UI.  Try to view the GitHub apps logs again and confirm that the new error message appears.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4303

**Security**

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
