### PR TITLE
DOCK-2425: Fix notebooks documentation link

### DIFF
--- a/src/app/descriptor-languages/Jupyter.ts
+++ b/src/app/descriptor-languages/Jupyter.ts
@@ -2,7 +2,7 @@ import { ExtendedDescriptorLanguageBean } from 'app/entry/extendedDescriptorLang
 import { SourceFile, ToolDescriptor, Workflow } from 'app/shared/swagger';
 import { Dockstore } from '../shared/dockstore.model';
 
-const JUPYTER_DOCUMENTATION_URL = Dockstore.DOCUMENTATION_URL + '/getting-started/notebooks/notebooks.html';
+const JUPYTER_DOCUMENTATION_URL = Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-notebooks.html';
 
 export const extendedJupyter: ExtendedDescriptorLanguageBean = {
   descriptorLanguageEnum: 'JUPYTER',

--- a/src/app/home-page/widget/entry-box/entry-box.component.ts
+++ b/src/app/home-page/widget/entry-box/entry-box.component.ts
@@ -80,7 +80,7 @@ export class EntryBoxComponent extends Base implements OnInit {
       this.allEntriesLink = '/my-services/';
       this.entryTypeParam = 'SERVICES';
     } else if (this.entryType === NewEntryType.NOTEBOOK) {
-      this.helpLink = Dockstore.DOCUMENTATION_URL + '/getting-started/notebooks/notebooks.html';
+      this.helpLink = Dockstore.DOCUMENTATION_URL + '/getting-started/getting-started-with-notebooks.html';
       this.allEntriesLink = '/my-notebooks/';
       this.entryTypeParam = 'NOTEBOOKS';
       // Not loading entries for Notebooks - remove when supported


### PR DESCRIPTION
**Description**
Clicking on "Learn more about notebooks" in the dashboard would take you to a 404 page so this PR replaces the url with the correct one.

**Review Instructions**
After enabling notebooks and going to the link in the dashboard, should take you to the correct documentation page.

**Issue**
[DOCK-2425](https://ucsc-cgl.atlassian.net/browse/DOCK-2425)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2425]: https://ucsc-cgl.atlassian.net/browse/DOCK-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ