### PR TITLE
SEAB-5676: allow admins and curators to see a users GitHub app logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,7 +490,8 @@ commands:
               fi
   install_browser_tools:
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
   build_ui:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,8 +490,7 @@ commands:
               fi
   install_browser_tools:
     steps:
-      - browser-tools/install-chrome:
-          chrome-version: "114.0.5735.90"
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
   build_ui:
     steps:

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -37,6 +37,32 @@ describe('GitHub App Tools', () => {
     cy.get('#workflow-path').contains(tool);
   }
 
+  describe('User Page', () => {
+    it('Admins should see user GitHub app logs', () => {
+      cy.visit('/users/user_A');
+      const mockEvent: LambdaEvent[] = [
+        {
+          eventDate: 1582165220000,
+          githubUsername: 'testUser',
+          id: 1,
+          message: 'HTTP 400 ',
+          organization: 'C',
+          reference: 'refs/head/main',
+          repository: 'test-github-app-tools',
+          success: false,
+          type: 'PUSH',
+        },
+      ];
+      cy.intercept('GET', '/api/lambdaEvents/user/**', {
+        body: mockEvent,
+      }).as('lambdaEvents');
+      cy.get('[data-cy=user-app-logs-button]').should('be.visible').click();
+      cy.contains('refs/head/main');
+      cy.contains('1 – 1 of 1');
+      cy.contains('Close').click();
+    });
+  });
+
   describe('My Tools', () => {
     it('Side Bar', () => {
       cy.visit('/my-tools');
@@ -45,6 +71,7 @@ describe('GitHub App Tools', () => {
       cy.get('#register_tool_button').click();
       cy.contains('Register using GitHub Apps');
       cy.get('#GitHubApps-register-workflow-option').click();
+
       cy.contains('Install our GitHub App in');
       cy.get('.modal-footer').contains('Next').first().click();
       cy.contains('Navigate to GitHub to install our GitHub app');

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -48,7 +48,7 @@ export class GithubAppsLogsComponent implements OnInit {
   isExpansionDetailRow = (i: number, row: Object) => row.hasOwnProperty('detailRow');
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public matDialogData: { userId: number; organization: string },
+    @Inject(MAT_DIALOG_DATA) public matDialogData: { userId: number, organization: string },
     private lambdaEventsService: LambdaEventsService,
     private matSnackBar: MatSnackBar,
     private descriptorLanguageService: DescriptorLanguageService

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -48,7 +48,7 @@ export class GithubAppsLogsComponent implements OnInit {
   isExpansionDetailRow = (i: number, row: Object) => row.hasOwnProperty('detailRow');
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public matDialogData: { userId: number, organization: string },
+    @Inject(MAT_DIALOG_DATA) public matDialogData: { userId?: number; organization?: string },
     private lambdaEventsService: LambdaEventsService,
     private matSnackBar: MatSnackBar,
     private descriptorLanguageService: DescriptorLanguageService
@@ -73,7 +73,7 @@ export class GithubAppsLogsComponent implements OnInit {
     this.dataSource.paginator = this.paginator;
     const lambdaEvents = this.matDialogData.userId
       ? this.lambdaEventsService.getUserLambdaEvents(this.matDialogData.userId)
-      : this.lambdaEventsService.getLambdaEventsByOrganization(this.matDialogData.organization); // Or have this logic in a method
+      : this.lambdaEventsService.getLambdaEventsByOrganization(this.matDialogData.organization);
     lambdaEvents
       .pipe(
         finalize(() => {

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.ts
@@ -48,7 +48,7 @@ export class GithubAppsLogsComponent implements OnInit {
   isExpansionDetailRow = (i: number, row: Object) => row.hasOwnProperty('detailRow');
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public matDialogData: string,
+    @Inject(MAT_DIALOG_DATA) public matDialogData: any,
     private lambdaEventsService: LambdaEventsService,
     private matSnackBar: MatSnackBar,
     private descriptorLanguageService: DescriptorLanguageService
@@ -67,22 +67,41 @@ export class GithubAppsLogsComponent implements OnInit {
     this.loading = true;
     this.dataSource.sort = this.sort;
     this.dataSource.paginator = this.paginator;
-    this.lambdaEventsService
-      .getLambdaEventsByOrganization(this.matDialogData)
-      .pipe(
-        finalize(() => {
-          this.loading = false;
-          this.updateContentToShow(this.lambdaEvents);
-        })
-      )
-      .subscribe(
-        (lambdaEvents) => (this.lambdaEvents = lambdaEvents),
-        (error) => {
-          this.lambdaEvents = null;
-          const detailedErrorMessage = AlertService.getDetailedErrorMessage(error);
-          this.matSnackBar.open(detailedErrorMessage);
-        }
-      );
+    if (this.matDialogData.getUserEvents) {
+      this.lambdaEventsService
+        .getUserLambdaEvents(this.matDialogData.value)
+        .pipe(
+          finalize(() => {
+            this.loading = false;
+            this.updateContentToShow(this.lambdaEvents);
+          })
+        )
+        .subscribe(
+          (lambdaEvents) => (this.lambdaEvents = lambdaEvents),
+          (error) => {
+            this.lambdaEvents = null;
+            const detailedErrorMessage = AlertService.getDetailedErrorMessage(error);
+            this.matSnackBar.open(detailedErrorMessage);
+          }
+        );
+    } else {
+      this.lambdaEventsService
+        .getLambdaEventsByOrganization(this.matDialogData.value)
+        .pipe(
+          finalize(() => {
+            this.loading = false;
+            this.updateContentToShow(this.lambdaEvents);
+          })
+        )
+        .subscribe(
+          (lambdaEvents) => (this.lambdaEvents = lambdaEvents),
+          (error) => {
+            this.lambdaEvents = null;
+            const detailedErrorMessage = AlertService.getDetailedErrorMessage(error);
+            this.matSnackBar.open(detailedErrorMessage);
+          }
+        );
+    }
   }
 
   updateContentToShow(lambdaEvents: LambdaEvent[] | null) {

--- a/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.ts
@@ -113,6 +113,6 @@ export class SidebarAccordionComponent implements OnInit, OnChanges {
   }
 
   openGitHubAppsLogs(organization: string) {
-    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: { value: organization } });
+    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: { organization: organization } });
   }
 }

--- a/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.ts
@@ -113,6 +113,6 @@ export class SidebarAccordionComponent implements OnInit, OnChanges {
   }
 
   openGitHubAppsLogs(organization: string) {
-    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: organization });
+    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: { value: organization } });
   }
 }

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -45,6 +45,7 @@
               </span>
               <span *ngIf="loggedInUserIsAdminOrCurator">
                 <button
+                  matTooltip="View the user's GitHub App Logs"
                   mat-button
                   class="small-mat-btn private-btn small-btn-structure mat-elevation-z"
                   (click)="openGitHubAppsLogs(user.id)"

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -46,11 +46,10 @@
               <span *ngIf="loggedInUserIsAdminOrCurator">
                 <button
                   mat-button
-                  class="small-mat-btn accent-1-dark small-btn-structure mat-elevation-z"
+                  class="small-mat-btn private-btn small-btn-structure mat-elevation-z"
                   (click)="openGitHubAppsLogs(user.id)"
                   data-cy="user-app-logs-button"
                 >
-                  <img src="../../../assets/svg/git-hub.svg" alt="GitHub app logs" class="pr-2" />
                   Apps Logs
                 </button>
               </span>

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -43,6 +43,17 @@
                   <span>{{ gitHubProfile.username }}</span>
                 </a>
               </span>
+              <span *ngIf="loggedInUserIsAdminOrCurator">
+                <button
+                  mat-button
+                  class="small-mat-btn accent-1-dark small-btn-structure mat-elevation-z"
+                  (click)="openGitHubAppsLogs(user.id)"
+                  data-cy="user-app-logs-button"
+                >
+                  <img src="../../../assets/svg/git-hub.svg" alt="GitHub app logs" class="pr-2" />
+                  Apps Logs
+                </button>
+              </span>
             </mat-card-subtitle>
           </mat-card-header>
           <span>
@@ -97,7 +108,6 @@
       </mat-card>
     </div>
   </div>
-
   <mat-tab-group class="pb-5 purple-tab-group">
     <mat-tab>
       <ng-template mat-tab-label>

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { TokenSource } from '../shared/enum/token-source.enum';
 import { Profile } from '../shared/openapi';
 import { UsersService } from '../shared/openapi/api/users.service';
@@ -10,8 +10,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { AlertService } from '../shared/alert/state/alert.service';
 import { GithubAppsLogsComponent } from '../myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component';
 import { bootstrap4largeModalSize } from '../shared/constants';
-import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
-import { AuthService } from 'ng2-ui-auth';
+import { MatDialog } from '@angular/material/dialog';
 import { UserQuery } from '../shared/user/user.query';
 
 @Component({

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -5,7 +5,6 @@ import { UsersService } from '../shared/openapi/api/users.service';
 import { UserService } from '../shared/user/user.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AlertService } from '../shared/alert/state/alert.service';
 import { GithubAppsLogsComponent } from '../myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component';

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -12,20 +12,19 @@ import { GithubAppsLogsComponent } from '../myworkflows/sidebar-accordion/github
 import { bootstrap4largeModalSize } from '../shared/constants';
 import { MatDialog } from '@angular/material/dialog';
 import { UserQuery } from '../shared/user/user.query';
+import { Base } from '../shared/base';
 
 @Component({
   selector: 'app-user-page',
   templateUrl: './user-page.component.html',
   styleUrls: ['./user-page.component.scss'],
 })
-export class UserPageComponent implements OnInit {
+export class UserPageComponent extends Base implements OnInit {
   public user: any;
   public username: string;
-  protected lambdaEvents: string[];
   public TokenSource = TokenSource;
   public googleProfile: Profile;
   public gitHubProfile: Profile;
-  protected ngUnsubscribe: Subject<{}> = new Subject();
   public loggedInUserIsAdminOrCurator: boolean;
   constructor(
     public dialog: MatDialog,
@@ -36,6 +35,7 @@ export class UserPageComponent implements OnInit {
     private router: Router,
     private alertService: AlertService
   ) {
+    super();
     this.username = this.activatedRoute.snapshot.paramMap.get('username');
     this.userQuery.isAdminOrCurator$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isAdminOrCurator) => {
       this.loggedInUserIsAdminOrCurator = isAdminOrCurator;
@@ -71,8 +71,8 @@ export class UserPageComponent implements OnInit {
     );
   }
 
-  openGitHubAppsLogs(user: any) {
-    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: { value: user, getUserEvents: true } });
+  openGitHubAppsLogs(userId: number) {
+    this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4largeModalSize, data: { userId: userId } });
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
**Description**
This PR allows admins and curators to see users' GitHub app logs through their userpage. This new button is only visible for admins and curators.

Viewing user page as an admin (App logs button) 
![Screenshot from 2023-07-14 13-30-43](https://github.com/dockstore/dockstore-ui2/assets/61166764/498f39e8-a182-4553-b48c-a7e7f98c0b4d)

When button clicked
![Screenshot from 2023-07-19 12-03-53](https://github.com/dockstore/dockstore-ui2/assets/61166764/164602e5-6c55-4159-96c2-c43a925d4ac4)

Viewing user page as nonadmin nor curator (App Logs button should be hidden)
![Screenshot from 2023-07-14 12-57-57](https://github.com/dockstore/dockstore-ui2/assets/61166764/f658619d-aea9-4c16-9157-2052a8d9d328)


**Review Instructions**
As an admin or curator, go to  https://qa.dockstore.org/users/hyunnaye and confirm that the button works properly.
Then log out and verify that the button is hidden.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5676

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
