### PR TITLE
SEAB-5655: allow admins and curators to see user's other linked accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,7 +490,8 @@ commands:
               fi
   install_browser_tools:
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chromedriver
   build_ui:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,8 +490,7 @@ commands:
               fi
   install_browser_tools:
     steps:
-      - browser-tools/install-chrome:
-          chrome-version: "114.0.5735.90"
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
   build_ui:
     steps:

--- a/cypress/e2e/immutableDatabaseTests/admin.ts
+++ b/cypress/e2e/immutableDatabaseTests/admin.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { setTokenUserViewPort } from '../../support/commands';
+import { goToTab, setTokenUserViewPort } from '../../support/commands';
 describe('Admin UI', () => {
   setTokenUserViewPort();
   beforeEach(() => {
@@ -27,6 +27,13 @@ describe('Admin UI', () => {
     it('Admin status indicated on profile page', () => {
       cy.get('#dropdown-accounts').click();
       cy.get('[data-cy=account-is-admin]').should('exist');
+    });
+  });
+  describe('Userpage', () => {
+    it('Admin can view other linked accounts of a user', () => {
+      cy.visit('/users/user_A');
+      goToTab('Other Linked Accounts');
+      cy.get('[data-cy=other-linked-accounts-quay]').should('be.visible');
     });
   });
 });

--- a/cypress/e2e/immutableDatabaseTests/admin.ts
+++ b/cypress/e2e/immutableDatabaseTests/admin.ts
@@ -34,6 +34,7 @@ describe('Admin UI', () => {
       cy.visit('/users/user_A');
       goToTab('Other Linked Accounts');
       cy.get('[data-cy=other-linked-accounts-Quay]').should('be.visible');
+      cy.get('[data-cy=Quay-username]').contains('user_A').should('be.visible');
 
       //log out and confirm the tab does not exist
       cy.get('[data-cy=dropdown-main]:visible').click();

--- a/cypress/e2e/immutableDatabaseTests/admin.ts
+++ b/cypress/e2e/immutableDatabaseTests/admin.ts
@@ -33,7 +33,13 @@ describe('Admin UI', () => {
     it('Admin can view other linked accounts of a user', () => {
       cy.visit('/users/user_A');
       goToTab('Other Linked Accounts');
-      cy.get('[data-cy=other-linked-accounts-quay]').should('be.visible');
+      cy.get('[data-cy=other-linked-accounts-Quay]').should('be.visible');
+
+      //log out and confirm the tab does not exist
+      cy.get('[data-cy=dropdown-main]:visible').click();
+      cy.get('[data-cy=dropdown-logout-button]').click();
+      cy.visit('/users/user_A');
+      cy.get('.mat-tab-label').contains('Other Linked Accounts').should('not.exist');
     });
   });
 });

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -46,6 +46,7 @@ export interface AccountInfo {
   show: boolean;
   logo: string;
   isLinked?: boolean;
+  username?: string;
 }
 
 @Component({
@@ -187,10 +188,6 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
         );
       }
     });
-  }
-
-  getAccountsInfo(): AccountInfo[] {
-    return this.accountsInfo;
   }
 
   /**

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -31,7 +31,7 @@ import { AccountsService } from './accounts.service';
 import { LogoutService } from '../../../shared/logout.service';
 import { RevokeTokenDialogComponent } from './revoke-token-dialog/revoke-token-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
-import { bootstrap4largeModalSize } from '../../../shared/constants';
+import { accountInfo, bootstrap4largeModalSize } from '../../../shared/constants';
 import { AlertService } from '../../../shared/alert/state/alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
@@ -59,86 +59,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   public TokenSource = TokenSource;
   public username$: Observable<string>;
   Dockstore = Dockstore;
-  accountsInfo: Array<AccountInfo> = [
-    {
-      name: 'GitHub',
-      source: TokenSource.GITHUB,
-      bold: 'One of GitHub or Google is required.',
-      control: true,
-      docker: false,
-      research: false,
-      message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub.',
-      show: false,
-      logo: 'github.svg',
-    },
-    {
-      name: 'Google',
-      source: TokenSource.GOOGLE,
-      bold: 'One of GitHub or Google is required.',
-      control: false,
-      docker: false,
-      research: false,
-      message: 'Google credentials are used for login purposes and integration with Terra.',
-      show: false,
-      logo: 'google.svg',
-    },
-    {
-      name: 'Quay',
-      source: TokenSource.QUAY,
-      bold: '',
-      control: false,
-      docker: true,
-      research: false,
-      message: 'Quay.io credentials are used for pulling information about Docker images and automated builds.',
-      show: false,
-      logo: 'quay.svg',
-    },
-    {
-      name: 'Bitbucket',
-      source: TokenSource.BITBUCKET,
-      bold: '',
-      control: true,
-      docker: false,
-      research: false,
-      message: 'Bitbucket credentials are used for pulling source code from Bitbucket.',
-      show: false,
-      logo: 'bitbucket.svg',
-    },
-    {
-      name: 'GitLab',
-      source: TokenSource.GITLAB,
-      bold: '',
-      control: true,
-      docker: false,
-      research: false,
-      message: 'GitLab credentials are used for pulling source code from GitLab.',
-      show: false,
-      logo: 'gitlab.svg',
-    },
-    {
-      name: 'Zenodo',
-      source: TokenSource.ZENODO,
-      bold: '',
-      control: false,
-      docker: false,
-      research: true,
-      message: 'Zenodo credentials are used for creating Digital Object Identifiers (DOIs) on Zenodo.',
-      show: false,
-      logo: 'zenodo.jpg',
-    },
-    {
-      name: 'ORCID',
-      source: TokenSource.ORCID,
-      bold: '',
-      control: false,
-      docker: false,
-      research: true,
-      message:
-        'ORCID credentials are used for creating ORCID works by exporting snapshotted entries and versions from Dockstore and to link to your ORCID record when your Dockstore account is displayed on the site.',
-      show: false,
-      logo: 'orcid.svg',
-    },
-  ];
+  accountsInfo: Array<AccountInfo> = accountInfo;
 
   public tokens: TokenUser[];
   private ngUnsubscribe: Subject<{}> = new Subject();
@@ -266,6 +187,10 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
         );
       }
     });
+  }
+
+  getAccountsInfo(): AccountInfo[] {
+    return this.accountsInfo;
   }
 
   /**

--- a/src/app/loginComponents/requests/requests.component.html
+++ b/src/app/loginComponents/requests/requests.component.html
@@ -21,8 +21,8 @@
             <p>
               Requested by user(s)
               <span *ngFor="let user of org?.users; let last = last">
-                <strong *ngIf="user?.status === OrganizationUser.StatusEnum.ACCEPTED"
-                  >{{ user.user.username }}<span *ngIf="!last">, </span></strong
+                <a *ngIf="user?.status === OrganizationUser.StatusEnum.ACCEPTED" [routerLink]="'/users/' + user.user.username"
+                  >{{ user.user.username }}<span *ngIf="!last">, </span></a
                 >
               </span>
               on {{ org.dbCreateDate | date }}

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -15,6 +15,7 @@
  */
 
 import { User } from './openapi/model/user';
+import { TokenSource } from './enum/token-source.enum';
 
 export const ga4ghPath = '/ga4gh/trs/v2';
 export const ga4ghExtendedPath = '/api/ga4gh/v2/extended';
@@ -82,4 +83,84 @@ export const tagCloudCommonTerms: string[] = [
   'in',
   'is',
   'on',
+];
+export const accountInfo = [
+  {
+    name: 'GitHub',
+    source: TokenSource.GITHUB,
+    bold: 'One of GitHub or Google is required.',
+    control: true,
+    docker: false,
+    research: false,
+    message: 'GitHub credentials are used for login purposes as well as for pulling source code from GitHub.',
+    show: false,
+    logo: 'github.svg',
+  },
+  {
+    name: 'Google',
+    source: TokenSource.GOOGLE,
+    bold: 'One of GitHub or Google is required.',
+    control: false,
+    docker: false,
+    research: false,
+    message: 'Google credentials are used for login purposes and integration with Terra.',
+    show: false,
+    logo: 'google.svg',
+  },
+  {
+    name: 'Quay',
+    source: TokenSource.QUAY,
+    bold: '',
+    control: false,
+    docker: true,
+    research: false,
+    message: 'Quay.io credentials are used for pulling information about Docker images and automated builds.',
+    show: false,
+    logo: 'quay.svg',
+  },
+  {
+    name: 'Bitbucket',
+    source: TokenSource.BITBUCKET,
+    bold: '',
+    control: true,
+    docker: false,
+    research: false,
+    message: 'Bitbucket credentials are used for pulling source code from Bitbucket.',
+    show: false,
+    logo: 'bitbucket.svg',
+  },
+  {
+    name: 'GitLab',
+    source: TokenSource.GITLAB,
+    bold: '',
+    control: true,
+    docker: false,
+    research: false,
+    message: 'GitLab credentials are used for pulling source code from GitLab.',
+    show: false,
+    logo: 'gitlab.svg',
+  },
+  {
+    name: 'Zenodo',
+    source: TokenSource.ZENODO,
+    bold: '',
+    control: false,
+    docker: false,
+    research: true,
+    message: 'Zenodo credentials are used for creating Digital Object Identifiers (DOIs) on Zenodo.',
+    show: false,
+    logo: 'zenodo.jpg',
+  },
+  {
+    name: 'ORCID',
+    source: TokenSource.ORCID,
+    bold: '',
+    control: false,
+    docker: false,
+    research: true,
+    message:
+      'ORCID credentials are used for creating ORCID works by exporting snapshotted entries and versions from Dockstore and to link to your ORCID record when your Dockstore account is displayed on the site.',
+    show: false,
+    logo: 'orcid.svg',
+  },
 ];

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -127,38 +127,19 @@
           <span>Other Linked Accounts</span>
         </div>
       </ng-template>
-      <div class="p-2">
-        <div *ngFor="let token of tokens">
-          <mat-card *ngIf="token.tokenSource === 'quay.io'" data-cy="other-linked-accounts-quay">
-            <mat-card-header>
-              <div mat-card-avatar matBadge="✓" class="mr-4">
-                <img src="../../assets/images/account-logos/quay.svg" alt="Quay.io logo" class="w-100" />
-              </div>
-              <mat-card-title class="normal-line-height">Quay.io Account</mat-card-title>
-            </mat-card-header>
+      <div class="w-100">
+        <div *ngIf="otherLinkedAccountsInfo.length === 0">
+          <mat-card class="alert alert-info mat-elevation-z starred-header" role="alert" data-cy="no-other-linked-accounts-banner">
+            This user has no other linked accounts.
           </mat-card>
-          <mat-card *ngIf="token.tokenSource === 'zenodo.org'" data-cy="other-linked-accounts-zenodo">
+        </div>
+        <div *ngFor="let row of otherLinkedAccountsInfo" class="p-3" fxFlex.lt-md="100">
+          <mat-card [attr.data-cy]="'other-linked-accounts-' + row.name">
             <mat-card-header>
               <div mat-card-avatar matBadge="✓" class="mr-4">
-                <img src="../../assets/images/account-logos/zenodo.svg" alt="Zenodo logo" class="w-100" />
+                <img src="../../assets/images/account-logos/{{ row.logo }}" alt="{{ row.name }} logo" class="w-100" />
               </div>
-              <mat-card-title class="normal-line-height">Zenodo Account</mat-card-title>
-            </mat-card-header>
-          </mat-card>
-          <mat-card *ngIf="token.tokenSource === 'bitbucket.org'" data-cy="other-linked-accounts-bitbucket">
-            <mat-card-header>
-              <div mat-card-avatar matBadge="✓" class="mr-4">
-                <img src="../../assets/images/account-logos/bitbucket.svg" alt="BitBucket logo" class="w-100" />
-              </div>
-              <mat-card-title class="normal-line-height">BitBucket Account</mat-card-title>
-            </mat-card-header>
-          </mat-card>
-          <mat-card *ngIf="token.tokenSource === 'gitlab.com'" data-cy="other-linked-accounts-gitlab">
-            <mat-card-header>
-              <div mat-card-avatar matBadge="✓" class="mr-4">
-                <img src="../../assets/images/account-logos/gitlab.svg" alt="GitLab logo" class="w-100" />
-              </div>
-              <mat-card-title class="normal-line-height">GitLab Account</mat-card-title>
+              <mat-card-title class="normal-line-height">{{ row.name }} Account</mat-card-title>
             </mat-card-header>
           </mat-card>
         </div>

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -140,10 +140,10 @@
                 <img src="../../assets/images/account-logos/{{ row.logo }}" alt="{{ row.name }} logo" class="w-100" />
               </div>
               <mat-card-title class="normal-line-height">{{ row.name }} Account</mat-card-title>
+              <mat-card-subtitle class="accent-1-dark normal-line-height weight-bold mt-2 mb-0" [attr.data-cy]="row.name + '-username'">
+                <span>Username: {{ row.username }}</span>
+              </mat-card-subtitle>
             </mat-card-header>
-            <mat-card-subtitle class="accent-1-dark normal-line-height weight-bold mt-2 mb-0" [attr.data-cy]="row.name + '-username'">
-              <span>Username: {{ row.username }}</span>
-            </mat-card-subtitle>
           </mat-card>
         </div>
       </div>

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -141,6 +141,9 @@
               </div>
               <mat-card-title class="normal-line-height">{{ row.name }} Account</mat-card-title>
             </mat-card-header>
+            <mat-card-subtitle class="accent-1-dark normal-line-height weight-bold mt-2 mb-0" [attr.data-cy]="row.name + '-username'">
+              <span>Username: {{ row.username }}</span>
+            </mat-card-subtitle>
           </mat-card>
         </div>
       </div>

--- a/src/app/user-page/user-page.component.html
+++ b/src/app/user-page/user-page.component.html
@@ -111,6 +111,49 @@
         <app-recent-events></app-recent-events>
       </div>
     </mat-tab>
+    <mat-tab *ngIf="loggedInUserIsAdminOrCurator">
+      <ng-template mat-tab-label>
+        <div fxLayoutGap="0.5rem">
+          <span>Other Linked Accounts</span>
+        </div>
+      </ng-template>
+      <div class="p-2">
+        <div *ngFor="let token of tokens">
+          <mat-card *ngIf="token.tokenSource === 'quay.io'" data-cy="other-linked-accounts-quay">
+            <mat-card-header>
+              <div mat-card-avatar matBadge="✓" class="mr-4">
+                <img src="../../assets/images/account-logos/quay.svg" alt="Quay.io logo" class="w-100" />
+              </div>
+              <mat-card-title class="normal-line-height">Quay.io Account</mat-card-title>
+            </mat-card-header>
+          </mat-card>
+          <mat-card *ngIf="token.tokenSource === 'zenodo.org'" data-cy="other-linked-accounts-zenodo">
+            <mat-card-header>
+              <div mat-card-avatar matBadge="✓" class="mr-4">
+                <img src="../../assets/images/account-logos/zenodo.svg" alt="Zenodo logo" class="w-100" />
+              </div>
+              <mat-card-title class="normal-line-height">Zenodo Account</mat-card-title>
+            </mat-card-header>
+          </mat-card>
+          <mat-card *ngIf="token.tokenSource === 'bitbucket.org'" data-cy="other-linked-accounts-bitbucket">
+            <mat-card-header>
+              <div mat-card-avatar matBadge="✓" class="mr-4">
+                <img src="../../assets/images/account-logos/bitbucket.svg" alt="BitBucket logo" class="w-100" />
+              </div>
+              <mat-card-title class="normal-line-height">BitBucket Account</mat-card-title>
+            </mat-card-header>
+          </mat-card>
+          <mat-card *ngIf="token.tokenSource === 'gitlab.com'" data-cy="other-linked-accounts-gitlab">
+            <mat-card-header>
+              <div mat-card-avatar matBadge="✓" class="mr-4">
+                <img src="../../assets/images/account-logos/gitlab.svg" alt="GitLab logo" class="w-100" />
+              </div>
+              <mat-card-title class="normal-line-height">GitLab Account</mat-card-title>
+            </mat-card-header>
+          </mat-card>
+        </div>
+      </div>
+    </mat-tab>
     <!-- TODO: Comment back in once we have the required resources to display user specific tools, workflows etc. -->
     <!-- When commented back in, also add mat-stretch-tabs to the tab-group -->
     <!-- <mat-tab>

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -30,7 +30,7 @@ export class UserPageComponent extends Base implements OnInit {
   protected otherLinkedAccountsInfo: AccountInfo[] = [];
   accountsInfo: Array<AccountInfo> = Object.assign([], accountInfo);
   //these type of accounts are visible to everyone on their userpage
-  private publicAccountsSource = [TokenSource.GITHUB, TokenSource.GOOGLE, TokenSource.ORCID];
+  private publicAccountsSource: TokenSource[] = [TokenSource.GITHUB, TokenSource.GOOGLE, TokenSource.ORCID];
 
   constructor(
     public dialog: MatDialog,

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -11,11 +11,6 @@ import { AlertService } from '../shared/alert/state/alert.service';
 import { UserQuery } from '../shared/user/user.query';
 import { TokenQuery } from '../shared/state/token.query';
 
-export interface OtherAccountInfo {
-  name: string;
-  source: TokenSource;
-  logo: string;
-}
 @Component({
   selector: 'app-user-page',
   templateUrl: './user-page.component.html',

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -28,6 +28,7 @@ export class UserPageComponent extends Base implements OnInit {
   public gitHubProfile: Profile;
   public loggedInUserIsAdminOrCurator: boolean;
   protected otherLinkedAccountsInfo: AccountInfo[] = [];
+  accountsInfo: Array<AccountInfo> = accountInfo;
 
   constructor(
     public dialog: MatDialog,
@@ -82,9 +83,10 @@ export class UserPageComponent extends Base implements OnInit {
   ngOnInit(): void {
     this.getUserInfo(this.username);
     this.tokenQuery.tokens$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((tokens: TokenUser[]) => {
-      for (const account of accountInfo) {
+      for (const account of this.accountsInfo) {
         const found = tokens.find((token) => token.tokenSource === account.source);
-        if (found && !['GitHub', 'Google'].includes(account.name)) {
+        if (found && !['GitHub', 'Google', 'ORCID'].includes(account.name)) {
+          account.username = found?.username;
           this.otherLinkedAccountsInfo.push(account);
         }
       }

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -28,7 +28,9 @@ export class UserPageComponent extends Base implements OnInit {
   public gitHubProfile: Profile;
   public loggedInUserIsAdminOrCurator: boolean;
   protected otherLinkedAccountsInfo: AccountInfo[] = [];
-  accountsInfo: Array<AccountInfo> = accountInfo;
+  accountsInfo: Array<AccountInfo> = Object.assign([], accountInfo);
+  //these type of accounts are visible to everyone on their userpage
+  private publicAccountsSource = [TokenSource.GITHUB, TokenSource.GOOGLE, TokenSource.ORCID];
 
   constructor(
     public dialog: MatDialog,
@@ -85,7 +87,7 @@ export class UserPageComponent extends Base implements OnInit {
     this.tokenQuery.tokens$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((tokens: TokenUser[]) => {
       for (const account of this.accountsInfo) {
         const found = tokens.find((token) => token.tokenSource === account.source);
-        if (found && !['GitHub', 'Google', 'ORCID'].includes(account.name)) {
+        if (found && !this.publicAccountsSource.includes(account.source)) {
           account.username = found?.username;
           this.otherLinkedAccountsInfo.push(account);
         }

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -8,11 +8,12 @@ import { takeUntil } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AlertService } from '../shared/alert/state/alert.service';
 import { GithubAppsLogsComponent } from '../myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component';
-import { bootstrap4largeModalSize } from '../shared/constants';
+import { accountInfo, bootstrap4largeModalSize } from '../shared/constants';
 import { MatDialog } from '@angular/material/dialog';
 import { UserQuery } from '../shared/user/user.query';
 import { Base } from '../shared/base';
 import { TokenQuery } from '../shared/state/token.query';
+import { AccountInfo } from '../loginComponents/accounts/external/accounts.component';
 
 @Component({
   selector: 'app-user-page',
@@ -26,7 +27,8 @@ export class UserPageComponent extends Base implements OnInit {
   public googleProfile: Profile;
   public gitHubProfile: Profile;
   public loggedInUserIsAdminOrCurator: boolean;
-  protected tokens: TokenUser[];
+  protected otherLinkedAccountsInfo: AccountInfo[] = [];
+
   constructor(
     public dialog: MatDialog,
     private userService: UserService,
@@ -79,8 +81,13 @@ export class UserPageComponent extends Base implements OnInit {
 
   ngOnInit(): void {
     this.getUserInfo(this.username);
-    this.tokenQuery.tokens$.subscribe((tokens: TokenUser[]) => {
-      this.tokens = tokens;
+    this.tokenQuery.tokens$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((tokens: TokenUser[]) => {
+      for (const account of accountInfo) {
+        const found = tokens.find((token) => token.tokenSource === account.source);
+        if (found && !['GitHub', 'Google'].includes(account.name)) {
+          this.otherLinkedAccountsInfo.push(account);
+        }
+      }
     });
   }
 }

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -28,7 +28,7 @@ export class UserPageComponent extends Base implements OnInit {
   public gitHubProfile: Profile;
   public loggedInUserIsAdminOrCurator: boolean;
   protected otherLinkedAccountsInfo: AccountInfo[] = [];
-  accountsInfo: Array<AccountInfo> = Object.assign([], accountInfo);
+  accountsInfo: Array<AccountInfo> = accountInfo;
   //these type of accounts are visible to everyone on their userpage
   private publicAccountsSource: TokenSource[] = [TokenSource.GITHUB, TokenSource.GOOGLE, TokenSource.ORCID];
 
@@ -88,8 +88,7 @@ export class UserPageComponent extends Base implements OnInit {
       for (const account of this.accountsInfo) {
         const found = tokens.find((token) => token.tokenSource === account.source);
         if (found && !this.publicAccountsSource.includes(account.source)) {
-          account.username = found?.username;
-          this.otherLinkedAccountsInfo.push(account);
+          this.otherLinkedAccountsInfo.push(Object.assign({ username: found?.username }, account));
         }
       }
     });


### PR DESCRIPTION
**Description**
This PR adds a new tab "Other linked accounts" on a user's profile page that only admins and curators can see. This allows community leads to view what other types of accounts a user has linked.

![Screenshot from 2023-07-21 14-47-09](https://github.com/dockstore/dockstore-ui2/assets/61166764/1bd1794f-954d-4aa0-8492-3c30fae07ed4)


When there are no other linked accounts
![Screenshot from 2023-07-21 13-56-01](https://github.com/dockstore/dockstore-ui2/assets/61166764/bbcde3b1-6cd0-474f-88d5-785a4092c8a9)

Tab is not visible when logged out or not an admin/curator
![Screenshot from 2023-07-21 15-13-40](https://github.com/dockstore/dockstore-ui2/assets/61166764/c5f70641-ca30-48fb-ac39-aa639b4fd7db)


In requests page, the username is linked to their page
![Screenshot from 2023-07-21 13-48-35](https://github.com/dockstore/dockstore-ui2/assets/61166764/c728cccd-cc22-4998-af56-cc4bb2e830cb)


**Review Instructions**
1. Log into an admin or curator account. 
2. Go to https://qa.dockstore.org/users/denis-yuen and confirm that a zenodo account is linked.
3. Log out and verify that the tab is not visible.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5655

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
