### PR TITLE
DOCK-2411: Fix console errors when viewing dag tab

### DIFF
--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -21,9 +21,12 @@
         <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
       </mat-card>
     </div>
-    <div fxFlex *ngIf="dagType === 'classic' && (isNFL$ | async) === false && (dagResult$ | async) === false">
+    <div
+      fxFlex
+      *ngIf="dagType === 'classic' && (isNFL$ | async) === false && (!(dagResult$ | async) || (dagResult$ | async | json) === '{}')"
+    >
       <!-- This covers CWL, WDL, Service, and other plugin languages (everything except NFL) -->
-      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="(dagResult$ | async) === false && !selectedVersion?.valid">
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!selectedVersion?.valid">
         <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;
         <span *ngIf="(descriptorType$ | async) !== ToolDescriptor.TypeEnum.SERVICE">
           The DAG cannot be displayed because the descriptor is either missing or not valid.

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -23,7 +23,7 @@
     </div>
     <div
       fxFlex
-      *ngIf="dagType === 'classic' && (isNFL$ | async) === false && (!(dagResult$ | async) || (dagResult$ | async | json) === '{}')"
+      *ngIf="dagType === 'classic' && (isNFL$ | async) === false && ((dagResult$ | async) === null || (dagResult$ | async | json) === '{}')"
     >
       <!-- This covers CWL, WDL, Service, and other plugin languages (everything except NFL) -->
       <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!selectedVersion?.valid">

--- a/src/app/workflow/dag/dag.component.html
+++ b/src/app/workflow/dag/dag.component.html
@@ -21,10 +21,7 @@
         <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;DAG display is still experimental for Nextflow.
       </mat-card>
     </div>
-    <div
-      fxFlex
-      *ngIf="dagType === 'classic' && (isNFL$ | async) === false && ((dagResult$ | async) === null || (dagResult$ | async | json) === '{}')"
-    >
+    <div fxFlex *ngIf="dagType === 'classic' && (isNFL$ | async) === false && (missingTool$ | async)">
       <!-- This covers CWL, WDL, Service, and other plugin languages (everything except NFL) -->
       <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="!selectedVersion?.valid">
         <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp;
@@ -37,7 +34,7 @@
           }}
         </span>
       </mat-card>
-      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="(missingTool$ | async) && selectedVersion?.valid">
+      <mat-card class="alert alert-warning mat-elevation-z" role="alert" *ngIf="selectedVersion?.valid">
         <mat-icon class="alert-warning-icon">warning</mat-icon>&nbsp; DAG cannot be created because some required tools are missing from
         GitHub repo.
       </mat-card>

--- a/src/app/workflow/dag/dag.component.spec.ts
+++ b/src/app/workflow/dag/dag.component.spec.ts
@@ -62,6 +62,7 @@ describe('DagComponent', () => {
 
   it('dagQuery should return determine whether the dagResults are missing tools', () => {
     expect(dagQuery.isMissingTool(null)).toBeTruthy();
+    expect(dagQuery.isMissingTool({})).toBeTruthy();
     expect(dagQuery.isMissingTool({ edges: [], nodes: [] })).toBeTruthy();
     expect(dagQuery.isMissingTool({ edges: [1], nodes: [1] })).toBeFalsy();
   });

--- a/src/app/workflow/dag/state/dag.query.ts
+++ b/src/app/workflow/dag/state/dag.query.ts
@@ -21,7 +21,7 @@ export class DagQuery extends Query<DagState> {
    * @memberof DagQuery
    */
   isMissingTool(dagResults: any): boolean {
-    if (!dagResults) {
+    if (!dagResults || !dagResults.edges || !dagResults.nodes) {
       return true;
     } else {
       return dagResults.edges.length < 1 && dagResults.nodes.length < 1;


### PR DESCRIPTION
**Description**
When looking at the workflow DAG tab, sometimes there would be an error related to 'edges' being undefined and the tab would be blank. This is because sometimes `dagResults` would be an empty object so this PR adds a check to see if the results contain `edges` and `nodes`, and then display the missing message in the DAG tab.

**Review Instructions**
Go to the DAG tab inside a workflow (such as the workflow mentioned in the linked issue) and check that there are no errors in the browser console.

**Issue**
[DOCK-2411](https://ucsc-cgl.atlassian.net/browse/DOCK-2411)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2411]: https://ucsc-cgl.atlassian.net/browse/DOCK-2411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ