### PR TITLE
DOCK-2428: Display markdown tables correctly

### DIFF
--- a/src/app/shared/markdown-wrapper/markdown-wrapper.component.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.component.spec.ts
@@ -52,6 +52,22 @@ describe('MarkdownWrapperComponent', () => {
   );
 
   it(
+    'should contain table',
+    waitForAsync(() => {
+      wrapperComponent.data = '|this|is|a|test|\n|---|---|---|---|\n|1|2|3|4|';
+      wrapperComponent.ngOnChanges(); // has to be called manually in unit tests (TestBed doesn't by default)
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toContain('table');
+
+      // tab characters should be removed
+      wrapperComponent.data = '|this|is|a|test|\n|---|---|---   \t|---\t|\n|1|2|3|4|';
+      wrapperComponent.ngOnChanges(); // has to be called manually in unit tests (TestBed doesn't by default)
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toContain('table');
+    })
+  );
+
+  it(
     'should have correctly sanitized spans',
     waitForAsync(() => {
       // first <span> should contain just a link and no class

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -25,8 +25,8 @@ describe('MarkdownWrapperService', () => {
     );
 
     // tab characters should not removed for strings that do not follow table syntax
-    expect(service.removeTabsFromTableHeaders('| this | is | not | a\t | table |')).toEqual('| this | is | not | a\t | table |');
-    expect(service.removeTabsFromTableHeaders('not |\n|| | a |----||--\t  ---|table')).toEqual('not |\n|| | a |----||--\t  ---|table');
-    expect(service.removeTabsFromTableHeaders('|---\t-|----\t\t:|-\t---\t-::\t|\n')).toEqual('|---\t-|----\t\t:|-\t---\t-::\t|\n');
+    expect(service.removeTabsFromTableHeaders('someString\t')).toEqual('someString\t');
+    expect(service.removeTabsFromTableHeaders('this | is | not | a\t | table')).toEqual('this | is | not | a\t | table');
+    expect(service.removeTabsFromTableHeaders('---\t-|----\t\t:|-\t---\t-::\t|\n')).toEqual('---\t-|----\t\t:|-\t---\t-::\t|\n');
   }));
 });

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -19,9 +19,11 @@ describe('MarkdownWrapperService', () => {
     expect(service.removeTabsFromTableHeaders('|table|with|tabs|\n|\t---|---:|---\t|\n|1|2|3|')).toEqual(
       '|table|with|tabs|\n|    ---|---:|---    |\n|1|2|3|'
     );
-    expect(service.removeTabsFromTableHeaders('|test||table|\n| --- \t|| --- \t\t|')).toEqual('|test||table|\n| ---     || ---         |');
-    expect(service.removeTabsFromTableHeaders('| :---: \t   \t| ------: \t | \t---------- |')).toEqual(
-      '| :---:            | ------:      |     ---------- |'
+    expect(service.removeTabsFromTableHeaders('|test||table|\n | --- \t|| --- \t\t|')).toEqual(
+      '|test||table|\n | ---     || ---         |'
+    );
+    expect(service.removeTabsFromTableHeaders('   | :---: \t   \t| ------: \t | \t---------- |')).toEqual(
+      '   | :---:            | ------:      |     ---------- |'
     );
 
     // tab characters should not removed for strings that do not follow table syntax

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -20,8 +20,8 @@ describe('MarkdownWrapperService', () => {
       '|table|with|tabs|\n|    ---|---:|---    |\n|1|2|3|'
     );
     expect(service.removeTabsFromTableHeaders('|test||table|\n| --- \t|| --- \t\t|')).toEqual('|test||table|\n| ---     || ---         |');
-    expect(service.removeTabsFromTableHeaders('| :--: \t   \t| ------: \t | \t---------- |')).toEqual(
-      '| :--:            | ------:      |     ---------- |'
+    expect(service.removeTabsFromTableHeaders('| :---: \t   \t| ------: \t | \t---------- |')).toEqual(
+      '| :---:            | ------:      |     ---------- |'
     );
 
     // tab characters should not removed for strings that do not follow table syntax

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -1,0 +1,32 @@
+import { inject, TestBed } from '@angular/core/testing';
+import { SecurityContext } from '@angular/core';
+import { MarkdownWrapperService } from './markdown-wrapper.service';
+import { MarkdownService, SECURITY_CONTEXT } from 'ngx-markdown';
+
+describe('MarkdownWrapperService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MarkdownWrapperService, MarkdownService, { provide: SECURITY_CONTEXT, useValue: SecurityContext.HTML }],
+    });
+  });
+
+  it('should be created', inject([MarkdownWrapperService], (service: MarkdownWrapperService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should remove tabs from table headers', inject([MarkdownWrapperService], (service: MarkdownWrapperService) => {
+    // tab characters should be removed from the header for strings with table syntax
+    expect(service.removeTabsFromTableHeaders('|table|with|tabs|\n|\t---|---:|---\t|\n|1|2|3|')).toEqual(
+      '|table|with|tabs|\n|    ---|---:|---    |\n|1|2|3|'
+    );
+    expect(service.removeTabsFromTableHeaders('|test||table|\n| --- \t|| --- \t\t|')).toEqual('|test||table|\n| ---     || ---         |');
+    expect(service.removeTabsFromTableHeaders('| :--: \t   \t| ------: \t | \t---------- |')).toEqual(
+      '| :--:            | ------:      |     ---------- |'
+    );
+
+    // tab characters should not removed for strings that do not follow table syntax
+    expect(service.removeTabsFromTableHeaders('| this | is | not | a\t | table |')).toEqual('| this | is | not | a\t | table |');
+    expect(service.removeTabsFromTableHeaders('not |\n|| | a |----||--\t  ---|table')).toEqual('not |\n|| | a |----||--\t  ---|table');
+    expect(service.removeTabsFromTableHeaders('|---\t-|----\t\t:|-\t---\t-::\t|\n')).toEqual('|---\t-|----\t\t:|-\t---\t-::\t|\n');
+  }));
+});

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -107,6 +107,6 @@ export class MarkdownWrapperService {
    * @returns {string} The modified string where all tabs in lines beginning with '|' are replaced with four spaces
    */
   removeTabsFromTableHeaders(data: string): string {
-    return data.replace(/(^\|.*)/gm, (match) => match.replace(/\t/g, '    '));
+    return data.replace(/(^ {0,3}\|.*)/gm, (match) => match.replace(/\t/g, '    '));
   }
 }

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -87,7 +87,9 @@ export class MarkdownWrapperService {
    */
   customCompile(data, baseUrl): string {
     const parseOptions = { markedOptions: { baseUrl: baseUrl } };
-    return this.markdownService.parse(data, parseOptions);
+    // Remove tab characters from markdown table headers or they won't display properly
+    const markdownData = data.replace(/(?<=\|[-:\t ]*)\t(?=[-:\t ]*\|)/g, '');
+    return this.markdownService.parse(markdownData, parseOptions);
   }
 
   customSanitize(html): string {

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -87,8 +87,7 @@ export class MarkdownWrapperService {
    */
   customCompile(data, baseUrl): string {
     const parseOptions = { markedOptions: { baseUrl: baseUrl } };
-    // Remove tab characters from markdown table headers or they won't display properly
-    const markdownData = data.replace(/(?<=\|[-:\t ]*)\t(?=[-:\t ]*\|)/g, '');
+    const markdownData = this.removeTabsFromTableHeaders(data);
     return this.markdownService.parse(markdownData, parseOptions);
   }
 
@@ -98,5 +97,18 @@ export class MarkdownWrapperService {
       FORBID_TAGS: this.forbidTags,
       FORBID_ATTR: this.forbidAttr,
     });
+  }
+
+  /**
+   * Removes tab characters from markdown table headers or they won't display properly
+   * Markdown uses pipes with three or more hyphens in between to create columns and headers, and colons to align text
+   * E.g., |---|---|---| or | :--- | ---: | where there can be spaces between pipes and hypens but not tabs
+   * @param {string} data A string containing the markdown data
+   * @returns {string}
+   */
+  removeTabsFromTableHeaders(data: string): string {
+    return data
+      .replace(/(?<=\|[\t ]*)\t(?=[\t ]*:?-+:?[\t ]*\|)/g, '    ') // remove tabs after the starting pipe before the hyphens
+      .replace(/(?<=\|[\t ]*:?-+:?[\t ]*)\t(?=[\t ]*\|)/g, '    '); // remove tabs after the hyphens before the ending pipe
   }
 }

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -104,11 +104,9 @@ export class MarkdownWrapperService {
    * Markdown uses pipes with three or more hyphens in between to create columns and headers, and colons to align text
    * E.g., |---|---|---| or | :--- | ---: | where there can be spaces between pipes and hyphens but not tabs
    * @param {string} data A string containing the markdown data
-   * @returns {string}
+   * @returns {string} The modified string where all tabs in lines beginning with '|' are replaced with four spaces
    */
   removeTabsFromTableHeaders(data: string): string {
-    return data
-      .replace(/(?<=\|[\t ]*)\t(?=[\t ]*:?-{3,}:?[\t ]*\|)/g, '    ') // remove tabs after the starting pipe before the hyphens
-      .replace(/(?<=\|[\t ]*:?-{3,}:?[\t ]*)\t(?=[\t ]*\|)/g, '    '); // remove tabs after the hyphens before the ending pipe
+    return data.replace(/(^\|.*)/gm, (match) => match.replace(/\t/g, '    '));
   }
 }

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -102,13 +102,13 @@ export class MarkdownWrapperService {
   /**
    * Removes tab characters from markdown table headers or they won't display properly
    * Markdown uses pipes with three or more hyphens in between to create columns and headers, and colons to align text
-   * E.g., |---|---|---| or | :--- | ---: | where there can be spaces between pipes and hypens but not tabs
+   * E.g., |---|---|---| or | :--- | ---: | where there can be spaces between pipes and hyphens but not tabs
    * @param {string} data A string containing the markdown data
    * @returns {string}
    */
   removeTabsFromTableHeaders(data: string): string {
     return data
-      .replace(/(?<=\|[\t ]*)\t(?=[\t ]*:?-+:?[\t ]*\|)/g, '    ') // remove tabs after the starting pipe before the hyphens
-      .replace(/(?<=\|[\t ]*:?-+:?[\t ]*)\t(?=[\t ]*\|)/g, '    '); // remove tabs after the hyphens before the ending pipe
+      .replace(/(?<=\|[\t ]*)\t(?=[\t ]*:?-{3,}:?[\t ]*\|)/g, '    ') // remove tabs after the starting pipe before the hyphens
+      .replace(/(?<=\|[\t ]*:?-{3,}:?[\t ]*)\t(?=[\t ]*\|)/g, '    '); // remove tabs after the hyphens before the ending pipe
   }
 }


### PR DESCRIPTION
**Description**
Some markdown tables do not render properly due to the presence of tab characters in the table. This PR removes tabs from table headers before parsing so that the html is generated correctly for the table.

Before:
![Screenshot from 2023-08-01 16-48-48](https://github.com/dockstore/dockstore-ui2/assets/68610185/dda7f6a0-65d6-4ad1-90bc-57d5fbbea885)

After:
![Screenshot from 2023-08-01 16-47-06](https://github.com/dockstore/dockstore-ui2/assets/68610185/090c945f-4015-4678-8f87-05e502ba378b)

**Review Instructions**
Go to the info tab for a workflow with a table in the description (e.g., the workflow mentioned in the related ticket /workflows/github.com/aofarrel/tree_nine/tree_nine:main?tab=info) and make sure the table is displayed properly.

**Issue**
[DOCK-2428](https://ucsc-cgl.atlassian.net/browse/DOCK-2428)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2428]: https://ucsc-cgl.atlassian.net/browse/DOCK-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ