### PR TITLE
DOCK-2438: Fix mystery person avatar

### DIFF
--- a/src/app/gravatar/gravatar.service.spec.ts
+++ b/src/app/gravatar/gravatar.service.spec.ts
@@ -20,6 +20,11 @@ describe('GravatarService', () => {
     const gravatarUrlForImageUrl = service.gravatarUrlForImageUrl('https://foo.com');
     expect(gravatarUrlForImageUrl.endsWith(encodeURIComponent('https://foo.com'))).toBeTrue();
     expect(gravatarUrlForImageUrl.startsWith(service.gravatarBaseUrl)).toBeTrue();
+
+    const mysteryPersonAvatar = service.gravatarUrlForMysteryPerson();
+    expect(mysteryPersonAvatar).toContain('d=mp');
+    expect(mysteryPersonAvatar.startsWith(service.gravatarBaseUrl)).toBeTrue();
+
     const emailAvatar = service.gravatarUrlForEmail('foo@goo.com', 'https://foo.com');
     // email hashified
     expect(emailAvatar.indexOf('foo@goo.com')).toBe(-1);

--- a/src/app/gravatar/gravatar.service.ts
+++ b/src/app/gravatar/gravatar.service.ts
@@ -14,7 +14,7 @@ export class GravatarService {
 
   public gravatarUrlForMysteryPerson() {
     // use "mp" (mystery-person) from https://en.gravatar.com/site/implement/images/
-    return `${this.gravatarBaseUrl}?d=mp&s=500`;
+    return `${this.gravatarBaseUrl}000?s=500&d=mp`;
   }
 
   public gravatarUrlForImageUrl(imageUrl: string | null) {


### PR DESCRIPTION
**Description**
This PR fixes the issue where the mystery person avatar is not showing up for starred events belonging to unknown users.

Before:
![Screenshot from 2023-08-09 11-56-12](https://github.com/dockstore/dockstore-ui2/assets/68610185/e7c88024-4255-4e38-ac57-f959488984a2)

After:
![Screenshot from 2023-08-09 11-56-36](https://github.com/dockstore/dockstore-ui2/assets/68610185/e658427e-e14b-403f-a72c-d850243320d3)

NOTES: I tried to find a change log for gravatar but I wasn't able to, so I ended up changing the request url to include a fake hash similar to the examples in their [documentation](https://en.gravatar.com/site/implement/images/) (also we're doing something similar with `gravatarUrlForImageUrl` anyways). Typically, gravatar would try to return an image associated with the hashed email address and return the default when there's no image associated with the email. Before we would exclude the hash from the url so the default is returned, but I guess something changed with the gravatar api so that's no longer working. 

Also, I found out while playing around with the urls that https://www.gravatar.com/avatar/?d=mp&s=500 fails but apparently all the following return a valid image:
- https://www.gravatar.com/avatar/000?s=500&d=mp
- https://www.gravatar.com/avatar/000?d=mp&s=500
- https://www.gravatar.com/avatar?s=500&d=mp
- https://www.gravatar.com/avatar?d=mp&s=500
- https://www.gravatar.com/avatar/?s=500&d=mp (I couldn't find why switching the order of the parameters worked)
- https://www.gravatar.com/avatar/?d=mp&s=200 (also not sure why the smaller image size works but not the larger one)

I'm thinking it might be safer to use a fake hash than some of the other options since gravatar seems to use that as an example to retrieve default images in their documentation.

**Review Instructions**
Go to the "Starred" section in "My Dashboard" and check that the mystery person avatar is displayed for events belonging to unknown users (you can star the workflow mentioned in the linked ticket).

**Issue**
[DOCK-2438](https://ucsc-cgl.atlassian.net/browse/DOCK-2438)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2438]: https://ucsc-cgl.atlassian.net/browse/DOCK-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ