### PR TITLE
SEAB-5655: fixed code regarding community leads seeing user's linked accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.15.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10269/workflows/7c7f1613-0ae8-47a8-b333-b1466cf884ba/jobs/36191/artifacts",
-    "circle_build_id": "36191"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10298/workflows/6d3ce13c-045a-4c13-be33-d2b406130c24/jobs/36411/artifacts",
+    "circle_build_id": "36411"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -12,7 +12,6 @@ import { accountInfo, bootstrap4extraLargeModalSize } from '../shared/constants'
 import { MatDialog } from '@angular/material/dialog';
 import { UserQuery } from '../shared/user/user.query';
 import { Base } from '../shared/base';
-import { TokenQuery } from '../shared/state/token.query';
 import { AccountInfo } from '../loginComponents/accounts/external/accounts.component';
 
 @Component({
@@ -21,9 +20,8 @@ import { AccountInfo } from '../loginComponents/accounts/external/accounts.compo
   styleUrls: ['./user-page.component.scss'],
 })
 export class UserPageComponent extends Base implements OnInit {
-  public user: any;
+  public user: User;
   public username: string;
-  public userId: number;
   public TokenSource = TokenSource;
   public googleProfile: Profile;
   public gitHubProfile: Profile;
@@ -40,8 +38,7 @@ export class UserPageComponent extends Base implements OnInit {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private alertService: AlertService,
-    private userQuery: UserQuery,
-    private tokenQuery: TokenQuery
+    private userQuery: UserQuery
   ) {
     super();
     this.username = this.activatedRoute.snapshot.paramMap.get('username');
@@ -70,7 +67,7 @@ export class UserPageComponent extends Base implements OnInit {
               this.gitHubProfile.avatarURL = this.userService.gravatarUrl(this.gitHubProfile.avatarURL);
             }
           }
-          this.getOtherLinkedAccounts(this.user);
+          this.getOtherLinkedAccounts();
         }
       },
       (error: HttpErrorResponse) => {
@@ -84,7 +81,7 @@ export class UserPageComponent extends Base implements OnInit {
     this.dialog.open(GithubAppsLogsComponent, { width: bootstrap4extraLargeModalSize, data: { userId: userId } });
   }
 
-  getOtherLinkedAccounts(user: User) {
+  getOtherLinkedAccounts() {
     this.usersService
       .getUserTokens(this.user.id)
       .pipe(takeUntil(this.ngUnsubscribe))
@@ -92,7 +89,7 @@ export class UserPageComponent extends Base implements OnInit {
         for (const account of this.accountsInfo) {
           const found = tokens.find((token) => token.tokenSource === account.source);
           if (found && !this.publicAccountsSource.includes(account.source)) {
-            this.otherLinkedAccountsInfo.push(Object.assign({ username: found?.username }, account));
+            this.otherLinkedAccountsInfo.push(Object.assign({ username: found.username }, account));
           }
         }
       });

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -82,6 +82,7 @@ export class UserPageComponent extends Base implements OnInit {
   }
 
   getOtherLinkedAccounts() {
+    this.otherLinkedAccountsInfo = [];
     this.usersService
       .getUserTokens(this.user.id)
       .pipe(takeUntil(this.ngUnsubscribe))


### PR DESCRIPTION
**Description**
This PR allows community leads to see a user's linked accounts properly.

In the previous PR, the code was using `this.tokenQuery.tokens$` but that is wrong since it accesses the logged in user's tokens. This PR now use `this.usersService.getUserTokens(this.user.id)` to get the linked accounts for the desired user.

Fixed Screenshot - Note the logged in user is `user_curator` and the linked accounts show `user_A`'s accounts
![Screenshot from 2023-08-15 15-27-40](https://github.com/dockstore/dockstore-ui2/assets/61166764/eaeaa7c7-4ca5-45d0-ae58-e5c17698fae7)


**Review Instructions**
Log into an admin or curator account.
Go to https://qa.dockstore.org/users/denis-yuen and confirm that a zenodo account is linked.
Log out and verify that the tab is not visible.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5655

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
