### PR TITLE
Fix ChromeDriver install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
   slack: circleci/slack@4.4.4
-  browser-tools: circleci/browser-tools@1.4.2
+  browser-tools: circleci/browser-tools@1.4.5
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
@@ -491,7 +491,7 @@ commands:
   install_browser_tools:
     steps:
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver@1.4.5
+      - browser-tools/install-chromedriver
   build_ui:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ commands:
   install_browser_tools:
     steps:
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-chromedriver@1.4.5
   build_ui:
     steps:
       - run:


### PR DESCRIPTION
**Description**
Upgrading to a version of the orb that better deals with a missing chomedriver. 
Details in linked thread (basically, Google is not guaranteeing a synced ChromeDriver release with new Chrome versions)

**Review Instructions**
See if nightly builds and develop builds pass the install chromedriver step

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
