### PR TITLE
SEAB-5808: Upgrade sonarscanner to 5.0.1 (#1835)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           command: |
             if [[ -n "${CIRCLE_BRANCH}" ]] && [[ -n "${CIRCLE_PULL_REQUEST}" || "${CIRCLE_BRANCH}" == "develop" ]]
             then
-              export SONAR_SCANNER_VERSION=4.7.0.2747
+              export SONAR_SCANNER_VERSION=5.0.1.3006
               export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
               curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
               unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   integration_test_exec: # declares a reusable executor
     docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-browsers
+      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -40,7 +40,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-browsers
+      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -74,7 +74,7 @@ jobs:
         type: string
     working_directory: ~/repo
     docker:
-        - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-browsers
+        - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
           auth:
             username: dockstoretestuser
             password: $DOCKERHUB_PASSWORD
@@ -102,7 +102,7 @@ jobs:
   lint_license_unit_test_coverage:
     working_directory: ~/repo
     docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-browsers
+      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -207,7 +207,7 @@ jobs:
   upload_to_s3:
     working_directory: ~/repo
     docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-node
+      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -252,7 +252,7 @@ jobs:
   check_build_develop:
     working_directory: ~/repo
     docker:
-      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>-node
+      - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -277,7 +277,7 @@ parameters:
     default: false
   java-tag:
     type: string
-    default: "17.0.4"
+    default: "17.0.4-browsers"
 
 workflows:
   version: 2


### PR DESCRIPTION
Have not had a hotfix, but probably need https://github.com/dockstore/dockstore-ui2/pull/1835 in develop to avoid sonarcloud warning about Java 11 (and old sonarscanner version)