### PR TITLE
SEAB-5913: Improve search relevance

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -228,13 +228,15 @@ export class QueryBuilderService {
    * @param searchString The string entered into the basic search bar by the user
    */
   private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
-    body.orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } });
-    body.orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } });
-    body.orQuery('match_phrase', 'workflowVersions.sourceFiles.content', searchString);
-    body.orQuery('match_phrase', 'tags.sourceFiles.content', searchString);
-    body.orQuery('match_phrase', 'description', searchString);
-    body.orQuery('match_phrase', 'labels', searchString);
-    body.orQuery('match_phrase', 'author', searchString);
+    body
+      .orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
+      .orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
+      .orQuery('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
+      .orQuery('match_phrase', 'tags.sourceFiles.content', searchString)
+      .orQuery('match_phrase', 'description', searchString)
+      .orQuery('match_phrase', 'labels', searchString)
+      .orQuery('match_phrase', 'author', searchString)
+      .queryMinimumShouldMatch(1);
     // TODO add topic and categories
     return body;
   }

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -229,20 +229,18 @@ export class QueryBuilderService {
    * @param searchString The string entered into the basic search bar by the user
    */
   private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
-    body
-      .orQuery('match', 'full_workflow_path', { query: searchString, boost: 3 })
-      .orQuery('match', 'tool_path', { query: searchString, boost: 3 })
+    return body
+      .orQuery('match', 'full_workflow_path', { query: searchString, boost: 4 })
+      .orQuery('match', 'tool_path', { query: searchString, boost: 4 })
       .orQuery('match', 'workflowVersions.sourceFiles.content', searchString)
       .orQuery('match', 'tags.sourceFiles.content', searchString)
-      .orQuery('match', 'description', { query: searchString, boost: 1.5 })
+      .orQuery('match', 'description', { query: searchString, boost: 2 })
       .orQuery('match', 'labels', { query: searchString, boost: 2 })
       .orQuery('match', 'author', { query: searchString, boost: 3 })
-      .orQuery('match', 'topicAutomatic', { query: searchString, boost: 2 })
+      .orQuery('match', 'topicAutomatic', { query: searchString, boost: 3 })
       .orQuery('match', 'categories.topic', { query: searchString, boost: 1.5 })
       .orQuery('match', 'categories.displayName', { query: searchString, boost: 2 })
       .queryMinimumShouldMatch(1);
-    // TODO add topic and categories
-    return body;
   }
 
   /**===============================================

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -115,8 +115,9 @@ export class QueryBuilderService {
     tableBody = tableBody.query('match', '_index', index);
     tableBody = this.appendQuery(tableBody, values, advancedSearchObject, searchTerm);
     tableBody = this.appendFilter(tableBody, null, filters, exclusiveFilters);
-    // the default sort order is by ES score
-    // only sort by stars if there's no search term
+    // if there's no search term, tell ES to sort hits by stars
+    // otherwise, use the default ES hit ordering, which should be by
+    // ES-calcalated score if we craft our query correctly
     if (this.isEmpty(values)) {
       tableBody = tableBody.sort('stars_count', 'desc');
     }
@@ -236,6 +237,9 @@ export class QueryBuilderService {
       .orQuery('match_phrase', 'description', searchString)
       .orQuery('match_phrase', 'labels', searchString)
       .orQuery('match_phrase', 'author', searchString)
+      .orQuery('match_phrase', 'topicAutomatic', searchString)
+      .orQuery('match_phrase', 'categories.topic', searchString)
+      .orQuery('match_phrase', 'categories.displayName', searchString)
       .queryMinimumShouldMatch(1);
     // TODO add topic and categories
     return body;

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -59,7 +59,7 @@ export class QueryBuilderService {
     let sidebarBody = bodybuilder().size(0);
     sidebarBody = this.excludeContent(sidebarBody);
     sidebarBody = sidebarBody.query('match', '_index', index);
-    sidebarBody = this.appendQuery(sidebarBody, values, advancedSearchObject, searchTerm, index);
+    sidebarBody = this.appendQuery(sidebarBody, values, advancedSearchObject, searchTerm);
     sidebarBody = this.appendAggregations(count, sidebarBody, bucketStubs, filters, exclusiveFilters, sortModeMap);
     const builtSideBarBody = sidebarBody.build();
     const sideBarQuery = JSON.stringify(builtSideBarBody);
@@ -113,7 +113,7 @@ export class QueryBuilderService {
     let tableBody = bodybuilder().size(query_size);
     tableBody = this.sourceOptions(tableBody);
     tableBody = tableBody.query('match', '_index', index);
-    tableBody = this.appendQuery(tableBody, values, advancedSearchObject, searchTerm, index);
+    tableBody = this.appendQuery(tableBody, values, advancedSearchObject, searchTerm);
     tableBody = this.appendFilter(tableBody, null, filters, exclusiveFilters);
     // if there's no inclusive search term, tell ES to sort hits by stars
     // otherwise, use the default ES hit ordering, which should be by
@@ -193,7 +193,7 @@ export class QueryBuilderService {
    * @returns {*} the new body builder object
    * @memberof SearchComponent
    */
-  appendQuery(body: any, values: string, oldAdvancedSearchObject: AdvancedSearchObject, searchTerm: boolean, index: string): any {
+  appendQuery(body: any, values: string, oldAdvancedSearchObject: AdvancedSearchObject, searchTerm: boolean): any {
     const advancedSearchObject = { ...oldAdvancedSearchObject };
     if (this.hasSettings(advancedSearchObject)) {
       if (advancedSearchObject.searchMode === 'description') {

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -230,16 +230,16 @@ export class QueryBuilderService {
    */
   private searchEverything(body: bodybuilder.Bodybuilder, searchString: string): bodybuilder.Bodybuilder {
     body
-      .orQuery('wildcard', { 'full_workflow_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('wildcard', { 'tool_path.keyword': { value: '*' + searchString + '*', case_insensitive: true } })
-      .orQuery('match_phrase', 'workflowVersions.sourceFiles.content', searchString)
-      .orQuery('match_phrase', 'tags.sourceFiles.content', searchString)
-      .orQuery('match_phrase', 'description', searchString)
-      .orQuery('match_phrase', 'labels', searchString)
-      .orQuery('match_phrase', 'author', searchString)
-      .orQuery('match_phrase', 'topicAutomatic', searchString)
-      .orQuery('match_phrase', 'categories.topic', searchString)
-      .orQuery('match_phrase', 'categories.displayName', searchString)
+      .orQuery('match', 'full_workflow_path', { query: searchString, boost: 3 })
+      .orQuery('match', 'tool_path', { query: searchString, boost: 3 })
+      .orQuery('match', 'workflowVersions.sourceFiles.content', searchString)
+      .orQuery('match', 'tags.sourceFiles.content', searchString)
+      .orQuery('match', 'description', { query: searchString, boost: 1.5 })
+      .orQuery('match', 'labels', { query: searchString, boost: 2 })
+      .orQuery('match', 'author', { query: searchString, boost: 3 })
+      .orQuery('match', 'topicAutomatic', { query: searchString, boost: 2 })
+      .orQuery('match', 'categories.topic', { query: searchString, boost: 1.5 })
+      .orQuery('match', 'categories.displayName', { query: searchString, boost: 2 })
       .queryMinimumShouldMatch(1);
     // TODO add topic and categories
     return body;

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -56,9 +56,14 @@ export abstract class SearchEntryTable extends Base implements OnInit {
         this.dataSource.data = entries || [];
       });
     this.dataSource.sortData = (data: DockstoreTool[] | AppTool[] | Workflow[] | Notebook[], sort: MatSort) => {
-      return data.slice().sort((a: Workflow | AppTool | DockstoreTool | Notebook, b: Workflow | AppTool | DockstoreTool | Notebook) => {
-        return this.searchService.compareAttributes(a, b, sort.active, sort.direction, this.entryType);
-      });
+      if (sort.active && sort.direction) {
+        return data.slice().sort((a: Workflow | AppTool | DockstoreTool | Notebook, b: Workflow | AppTool | DockstoreTool | Notebook) => {
+          return this.searchService.compareAttributes(a, b, sort.active, sort.direction, this.entryType);
+        });
+      } else {
+        // Either the active field or direction is unset, so return the data in the original order, unsorted.
+        return data;
+      }
     };
   }
 

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -2,15 +2,7 @@
   <div *ngIf="!dataSource">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
-  <mat-table
-    [hidden]="!dataSource"
-    [dataSource]="dataSource"
-    matSort
-    matSortActive="starredUsers"
-    matSortDirection="desc"
-    matSortDisableClear
-    data-cy="search-notebook-results-table"
-  >
+  <mat-table [hidden]="!dataSource" [dataSource]="dataSource" matSort data-cy="search-notebook-results-table">
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
       <mat-cell data-cy="notebookColumn" *matCellDef="let notebook">
@@ -62,7 +54,7 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="starredUsers">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let notebook"
         >{{ !notebook?.starredUsers || notebook?.starredUsers.length === 0 ? '' : notebook?.starredUsers?.length }}
         <mat-icon class="star-icon" *ngIf="notebook?.starredUsers?.length > 0">star_rate</mat-icon>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -17,14 +17,7 @@
   <div *ngIf="!dataSource">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
-  <mat-table
-    [hidden]="!dataSource"
-    [dataSource]="dataSource"
-    matSort
-    matSortActive="starredUsers"
-    matSortDirection="desc"
-    matSortDisableClear
-  >
+  <mat-table [hidden]="!dataSource" [dataSource]="dataSource" matSort>
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <!-- the wrap causes slightly odd behavior with the mat-icon but is needed for the topic -->
@@ -98,7 +91,7 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="starredUsers">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let tool"
         ><mat-icon class="star-icon" *ngIf="tool?.starredUsers?.length > 0">star_rate</mat-icon>
         {{ !tool?.starredUsers || tool?.starredUsers.length === 0 ? '' : tool?.starredUsers.length }}

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -2,15 +2,7 @@
   <div *ngIf="!dataSource">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
-  <mat-table
-    [hidden]="!dataSource"
-    [dataSource]="dataSource"
-    matSort
-    matSortActive="starredUsers"
-    matSortDirection="desc"
-    matSortDisableClear
-    data-cy="search-workflow-results-table"
-  >
+  <mat-table [hidden]="!dataSource" [dataSource]="dataSource" matSort data-cy="search-workflow-results-table">
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
@@ -60,7 +52,7 @@
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="starredUsers">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Stars</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="starred-cell weight-bold" *matCellDef="let workflow"
         ><mat-icon class="star-icon" *ngIf="workflow?.starredUsers?.length > 0">star_rate</mat-icon>
         {{ !workflow?.starredUsers || workflow?.starredUsers.length === 0 ? '' : workflow?.starredUsers?.length }}


### PR DESCRIPTION
**Description**
This PR improves the relevance of Dockstore search results.

To run a search, the UI synthesizes a search query using the bodybuilder library and submits it to ES.  Before continuing, please read the following, which explains the structure of typical ES search queries:

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html

In the previous implementation:
* Keyword subqueries were run in a `filter` context, preventing ES from scoring the results.
* The UI always sorted the results, per the header control settings, so even if ES returned results sorted by relevance, the UI would reorder them (in descending star order by default).
* Essentially, when we ran a search, ES was determining all of the hits that matched the search criteria, sorting them by stars, and returning an arbitrary 200 of them.  There was no ordering by relevance, so for searches with many hits, it was entirely possible that the most relevant entry could be omitted from the results.

In this implementation:
* Keyword subqueries run in a `should` context, which allows ES to calculate a relevance score for each hit by combining the scores of the subqueries and order the returned hits by score.  Each hit's score is returned in the query response.
* We change the UI so sorting is initially disabled, and the results are displayed in the order that ES returns them.  Each header sort control now has a "none" setting, in addition to "ascending" and "descending".
* When we run a keyword search,  ES now orders the hits by score.  Otherwise, it orders the results by stars as it did before.
* The query synthesizer now splits the search string into terms, and creates individual subqueries for each term.   The net effect is that entries which contain both terms are marked as more relevant than before.
* To improve relevance, weights have been introduced, via the `boost` setting in each subquery.
* The topic and categories are now included in keyword subqueries.

When reviewing the code, keep in mind that bodybuilder's `orQuery` adds a subquery to the `should` context, and that we force a minimum number of "shoulds" to match via the `minimum_should_match` field.

There is a companion PR that tweaks the webservice to further improve search relevance:
https://github.com/dockstore/dockstore/pull/5686

In combination, these two PRs greatly improve the quality of Dockstore keyword search results.  On prod, Ash's "samtools index" keyword search test ranks his and Milan's workflows, which are probably the most relevant hits, somewhere between the middle and bottom of all results.

After the improvements, his and Milan's workflows appear as results 1 and 3, with Julian's, which is also quite relevant, as result 2:

<img width="1162" alt="image" src="https://github.com/dockstore/dockstore-ui2/assets/88108675/0b427147-b009-46a7-b136-c968912bbe3f">


Yay!


**Review Instructions**
Go to Search, and run some keyword, facet, and advanced searches, looking for inconsistencies in the behavior or results, or regressions in search quality.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5913

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
