### PR TITLE
DOCK-2464: Display ignored lambdaevents appropriately

### DIFF
--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -47,6 +47,7 @@ describe('GitHub App Tools', () => {
           eventDate: 1582165220000,
           githubUsername: 'testUser',
           id: 1,
+          ignored: false,
           message: 'HTTP 400 ',
           organization: 'C',
           reference: 'refs/head/main',
@@ -98,6 +99,7 @@ describe('GitHub App Tools', () => {
           eventDate: 1582165220000,
           githubUsername: 'testUser',
           id: 1,
+          ignored: false,
           message: 'HTTP 418 ',
           organization: 'C',
           reference: 'refs/head/main',
@@ -211,6 +213,15 @@ describe('GitHub App Tools', () => {
       cy.get('#starCountButton').should('contain', '1');
       goToTab('Info');
       cy.get('[data-cy=trs-link]').contains('TRS: github.com/C/test-github-app-tools/md5sum');
+
+      // Make sure an ignored event is displayed correctly.
+      realResponse.ignored = true;
+      cy.intercept('GET', '/api/lambdaEvents/**', {
+        body: realResponse,
+      }).as('lambdaEvents');
+      cy.contains('Close').click();
+      cy.contains('Apps Logs').click();
+      cy.contains('Ignored');
     });
 
     it('Table view', () => {

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -214,12 +214,12 @@ describe('GitHub App Tools', () => {
       goToTab('Info');
       cy.get('[data-cy=trs-link]').contains('TRS: github.com/C/test-github-app-tools/md5sum');
 
-      // Make sure an ignored event is displayed correctly.
-      realResponse.ignored = true;
+      // Confirm that an ignored event is displayed correctly.
+      realResponse[0].ignored = true;
       cy.intercept('GET', '/api/lambdaEvents/**', {
         body: realResponse,
       }).as('lambdaEvents');
-      cy.contains('Close').click();
+      cy.visit('/my-tools');
       cy.contains('Apps Logs').click();
       cy.contains('Ignored');
     });

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -55,6 +55,10 @@
               </div>
             </td>
           </div>
+          <div *ngSwitchCase="'success'">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Success</th>
+            <td mat-cell *matCellDef="let element">{{ element.ignored ? 'Ignored' : (column | mapFriendlyValue: element[column]) }}</td>
+          </div>
           <div *ngSwitchDefault>
             <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column | titlecase }}</th>
             <td mat-cell *matCellDef="let element">{{ column | mapFriendlyValue: element[column] }}</td>


### PR DESCRIPTION
**Description**
This PR changes the GitHub Apps lambda event table so it displayed "Ignored" in the "Success" column when the `LambdaEvent`'s `ignored` property is true.

**Review Instructions**
Install the github app on a repo, do two pushes to it in rapid succession (within 20 seconds of each other), wait five minutes, view the Apps Logs, and confirm that two new events have appeared, one of which should be marked "Ignored". 

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
