### PR TITLE
DOCK-2442: Handle null version in Event

### DIFF
--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -42,8 +42,12 @@
               unpublished the {{ event | recentEvents: 'entryType' }} <strong>{{ event | recentEvents: 'displayName' }}</strong>
             </span>
             <span *ngSwitchCase="EventType.ADDVERSIONTOENTRY">
-              created the {{ event.version?.referenceType | lowercase }} <strong>{{ event.version?.name }}</strong> in
-              {{ event | recentEvents: 'entryType' }}
+              created
+              <span *ngIf="event.version"
+                >the {{ event.version?.referenceType | lowercase }} <strong>{{ event.version?.name }}</strong></span
+              >
+              <span *ngIf="!event.version">a tag</span>
+              in {{ event | recentEvents: 'entryType' }}
               <a [routerLink]="event | recentEvents: 'entryLink'">{{ event | recentEvents: 'displayName' }}</a>
             </span>
             <!-- Organizations -->

--- a/src/app/home-page/recent-events/recent-events.component.html
+++ b/src/app/home-page/recent-events/recent-events.component.html
@@ -44,7 +44,7 @@
             <span *ngSwitchCase="EventType.ADDVERSIONTOENTRY">
               created
               <span *ngIf="event.version"
-                >the {{ event.version?.referenceType | lowercase }} <strong>{{ event.version?.name }}</strong></span
+                >the {{ event.version.referenceType | lowercase }} <strong>{{ event.version.name }}</strong></span
               >
               <span *ngIf="!event.version">a tag</span>
               in {{ event | recentEvents: 'entryType' }}


### PR DESCRIPTION
**Description**
In https://github.com/dockstore/dockstore/pull/5697, in the webservice, we added a Hibernate `NotFound` annotation to make dangling `Event` versions gracefully resolve to null.  This PR modifies the UI to gracefully handle said nulls by substituting some generic text where the detailed description of the version would have gone.

We don't know what kind of reference the null represented, so the most future-proof generic text would be "a version".  However, all of the `Events` with existing versions point to tags, so for now, it's probably relatively safe, and definitely less generic, to instead say "a tag".  This PR implements the latter.

```
webservice_test=# select distinct v.referenceType from event join workflowversion as v on event.versionid = v.id;
 referencetype 
---------------
 TAG
(1 row)

webservice_test=# select distinct v.referenceType from event join tag as v on event.versionid = v.id;
 referencetype 
---------------
 TAG
(1 row)
```

**Review Instructions**
Find a user with a recent ADD_VERSION_TO_ENTRY event and view their profile.  In the database `event` table, set the `versionid` of the corresponding row to 0.  Reload the profile, and confirm that the event now contains the generic text description of the version.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2442
https://github.com/dockstore/dockstore/issues/5623

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
