### PR TITLE
Use the descriptorLanguage pipe to handle Galaxy on the versions tab

### DIFF
--- a/cypress/e2e/group3/deletion.ts
+++ b/cypress/e2e/group3/deletion.ts
@@ -23,12 +23,6 @@ type Entry = {
   myPrefix: string;
 };
 
-const entries: Entry[] = [
-  { table: 'workflow', id: 11, versionId: 14, myPrefix: 'my-workflows', path: 'github.com/A/l' },
-  { table: 'apptool', id: 50, versionId: 1000, myPrefix: 'my-tools', path: 'github.com/C/test-github-app-tools/testing' },
-  { table: 'notebook', id: 1000, versionId: 1000, myPrefix: 'my-notebooks', path: 'github.com/dockstore-testing/simple-notebook' },
-];
-
 function unpublicize(entry: Entry): void {
   invokeSql(`update ${entry.table} set ispublished = false, waseverpublic = false where id = ${entry.id}`);
   invokeSql(`update ${entry.table} set actualdefaultversion = ${entry.versionId} where id = ${entry.id}`);
@@ -95,17 +89,26 @@ function deletionTests(entry: Entry) {
   });
 }
 
-describe('Entry Deletion 0', () => {
+describe('Workflow Deletion', () => {
   init();
-  deletionTests(entries[0]);
+  const workflow = { table: 'workflow', id: 11, versionId: 14, myPrefix: 'my-workflows', path: 'github.com/A/l' };
+  deletionTests(workflow);
 });
 
-describe('Entry Deletion 1', () => {
+describe('AppTool Deletion', () => {
   init();
-  deletionTests(entries[1]);
+  const appTool = { table: 'apptool', id: 50, versionId: 1000, myPrefix: 'my-tools', path: 'github.com/C/test-github-app-tools/testing' };
+  deletionTests(appTool);
 });
 
-describe('Entry Deletion 2', () => {
+describe('Notebook Deletion', () => {
   init();
-  deletionTests(entries[2]);
+  const notebook = {
+    table: 'notebook',
+    id: 1000,
+    versionId: 1000,
+    myPrefix: 'my-notebooks',
+    path: 'github.com/dockstore-testing/simple-notebook',
+  };
+  deletionTests(notebook);
 });

--- a/cypress/e2e/group3/deletion.ts
+++ b/cypress/e2e/group3/deletion.ts
@@ -13,75 +13,99 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
-import { resetDB, setTokenUserViewPort, insertNotebooks, insertAppTools, invokeSql, goToTab } from '../../support/commands';
+import { insertAppTools, insertNotebooks, invokeSql, resetDB, setTokenUserViewPort } from '../../support/commands';
 
-describe('Entry Deletion', () => {
+type Entry = {
+  path: string;
+  id: number;
+  versionId: number;
+  table: string;
+  myPrefix: string;
+};
+
+const entries: Entry[] = [
+  { table: 'workflow', id: 11, versionId: 14, myPrefix: 'my-workflows', path: 'github.com/A/l' },
+  { table: 'apptool', id: 50, versionId: 1000, myPrefix: 'my-tools', path: 'github.com/C/test-github-app-tools/testing' },
+  { table: 'notebook', id: 1000, versionId: 1000, myPrefix: 'my-notebooks', path: 'github.com/dockstore-testing/simple-notebook' },
+];
+
+function unpublicize(entry: Entry): void {
+  invokeSql(`update ${entry.table} set ispublished = false, waseverpublic = false where id = ${entry.id}`);
+  invokeSql(`update ${entry.table} set actualdefaultversion = ${entry.versionId} where id = ${entry.id}`);
+  invokeSql(`delete from event where ${entry.table}id = ${entry.id}`);
+}
+
+function goToPrivatePage(entry: Entry): void {
+  cy.visit('/');
+  cy.visit(`${entry.myPrefix}/${entry.path}`);
+  cy.contains(entry.path);
+}
+
+function init() {
   resetDB();
   setTokenUserViewPort();
   insertAppTools();
   insertNotebooks();
+}
 
-  type Entry = {
-    path: string;
-    id: number;
-    table: string;
-    myPrefix: string;
-  };
+function checkCantDeleteIsPublished(entry: Entry) {
+  unpublicize(entry);
+  goToPrivatePage(entry);
+  cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled');
+  cy.contains('button', 'Publish').should('be.visible').should('not.be.disabled').click();
+  goToPrivatePage(entry);
+  cy.contains('button', 'Delete').should('not.exist');
+}
 
-  const entries: Entry[] = [
-    { table: 'workflow', id: 11, versionId: 14, myPrefix: 'my-workflows', path: 'github.com/A/l' },
-    { table: 'apptool', id: 50, versionId: 1000, myPrefix: 'my-tools', path: 'github.com/C/test-github-app-tools/testing' },
-    { table: 'notebook', id: 1000, versionId: 1000, myPrefix: 'my-notebooks', path: 'github.com/dockstore-testing/simple-notebook' },
-  ];
+function checkCantDeletePreviouslyPublished(entry: Entry) {
+  unpublicize(entry);
+  goToPrivatePage(entry);
+  cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled');
+  cy.contains('button', 'Publish').should('be.visible').should('not.be.disabled').click();
+  goToPrivatePage(entry);
+  cy.contains('button', 'Unpublish').should('be.visible').should('not.be.disabled').click();
+  goToPrivatePage(entry);
+  cy.contains('button', 'Delete').should('not.exist');
+}
 
-  function unpublicize(entry: Entry): void {
-    invokeSql(`update ${entry.table} set ispublished = false, waseverpublic = false where id = ${entry.id}`);
-    invokeSql(`update ${entry.table} set actualdefaultversion = ${entry.versionId} where id = ${entry.id}`);
-    invokeSql(`delete from event where ${entry.table}id = ${entry.id}`);
-  }
+function checkCanDeleteNeverPublished(entry: Entry) {
+  unpublicize(entry);
+  goToPrivatePage(entry);
+  cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled').click();
+  cy.get('[data-cy=delete-no]').should('be.visible').should('not.be.disabled').click();
+  goToPrivatePage(entry);
+  cy.contains(entry.path).should('exist');
+  cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled').click();
+  cy.get('[data-cy=delete-yes]').should('be.visible').should('not.be.disabled').click();
+  cy.wait(1000);
+  cy.contains(entry.path).should('not.exist');
+}
 
-  function goToPrivatePage(entry: Entry): void {
-    cy.visit('/');
-    cy.visit(`${entry.myPrefix}/${entry.path}`);
-    cy.contains(entry.path);
-  }
-
+function deletionTests(entry: Entry) {
   it('Should not be able to delete an entry that is published', () => {
-    entries.forEach((entry) => {
-      unpublicize(entry);
-      goToPrivatePage(entry);
-      cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled');
-      cy.contains('button', 'Publish').should('be.visible').should('not.be.disabled').click();
-      goToPrivatePage(entry);
-      cy.contains('button', 'Delete').should('not.exist');
-    });
+    checkCantDeleteIsPublished(entry);
   });
 
   it('Should not be able to delete an entry that was previously published', () => {
-    entries.forEach((entry) => {
-      unpublicize(entry);
-      goToPrivatePage(entry);
-      cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled');
-      cy.contains('button', 'Publish').should('be.visible').should('not.be.disabled').click();
-      goToPrivatePage(entry);
-      cy.contains('button', 'Unpublish').should('be.visible').should('not.be.disabled').click();
-      goToPrivatePage(entry);
-      cy.contains('button', 'Delete').should('not.exist');
-    });
+    checkCantDeletePreviouslyPublished(entry);
   });
 
   it('Should be able to delete an entry that was never published', () => {
-    entries.forEach((entry) => {
-      unpublicize(entry);
-      goToPrivatePage(entry);
-      cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled').click();
-      cy.get('[data-cy=delete-no]').should('be.visible').should('not.be.disabled').click();
-      goToPrivatePage(entry);
-      cy.contains(entry.path).should('exist');
-      cy.contains('button', 'Delete').should('be.visible').should('not.be.disabled').click();
-      cy.get('[data-cy=delete-yes]').should('be.visible').should('not.be.disabled').click();
-      cy.wait(1000);
-      cy.contains(entry.path).should('not.exist');
-    });
+    checkCanDeleteNeverPublished(entry);
   });
+}
+
+describe('Entry Deletion 0', () => {
+  init();
+  deletionTests(entries[0]);
+});
+
+describe('Entry Deletion 1', () => {
+  init();
+  deletionTests(entries[1]);
+});
+
+describe('Entry Deletion 2', () => {
+  init();
+  deletionTests(entries[2]);
 });

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -102,7 +102,9 @@
         {{ workflow.entryType === entryType.NOTEBOOK ? 'Format' : 'Language Versions' }}
       </th>
       <td mat-cell *matCellDef="let version">
-        <span>{{ this.workflow.descriptorType | descriptorLanguageVersions: version.versionMetadata?.descriptorTypeVersions }}</span>
+        <span>{{
+          this.workflow.descriptorType | descriptorLanguage | descriptorLanguageVersions: version.versionMetadata?.descriptorTypeVersions
+        }}</span>
       </td>
     </ng-container>
 


### PR DESCRIPTION
**Description**
For Galaxy workflows, display `Galaxy` instead of `gxformat2` in the Versions tab.

TLDR; Use the pipe built just for this.

Longer explanation -- we weren't actually displaying the language version twice; we were displaying the language followed by the language version. For example, for WDL versions it displays something like `WDL draft-2`, where `WDL` is the language and  `draft-2` is the language version.

For Galaxy we made a mistake in having the language be `gxformat2` (not to be confused with the language version); the language is Galaxy. But it got baked in, so we use the pipe to display it as Galaxy, but missed this place.

**Review Instructions**
1. Go to a Galaxy workflow
2. Select the Versions table
3. Ensure that it the language versions say `Galaxy gxformat1` instead of `gxformat2 gxformat1`. Unless you pick the one Galaxy workflow currently in our system that is gxformat2, in which case it should say `Galaxy gxformat2`.

**Issue**
dockstore/dockstore#5701

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
