### PR TITLE
SEAB-5982: fix news box on homepage

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -272,8 +272,8 @@
     <div fxLayout="row" fxLayout.lt-md="column" class="container mt-5" fxLayoutGap="2rem">
       <div fxLayout="column" fxLayoutAlign="start stretch" fxFlex="33" fxFlex.lt-md="100" id="news" class="p-3">
         <h3>News & Updates</h3>
+        <app-news-and-updates></app-news-and-updates>
       </div>
-      <app-news-and-updates></app-news-and-updates>
       <div fxLayout="column" fxLayoutAlign="start stretch" fxFlex="33" fxFlex.lt-md="100" id="resources" class="p-3">
         <h3>Helpful Resources</h3>
         <div>


### PR DESCRIPTION
**Description**
Fixes the news box on the homepage by putting the tag back into its parent div.

It looks like it got messed up in https://github.com/dockstore/dockstore-ui2/pull/1837

**Review Instructions**
Review that the homepage news and updates box looks normal.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5982

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
