### PR TITLE
Disable manual topic editing in the UI for GitHub App entries

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -261,8 +261,12 @@
                     [disabled]="workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML"
                     [matTooltip]="
                       workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML
-                        ? 'Edit the manual topic for this ' + (entryType$ | async) + ' in the .dockstore.yml file on GitHub'
-                        : ''
+                        ? 'Edit the manual topic for this ' +
+                          (entryType$ | async) +
+                          ' in the .dockstore.yml file on GitHub. Editing the topic in the UI is deprecated for GitHub App ' +
+                          (entryType$ | async) +
+                          's.'
+                        : 'Edit the manual topic for this ' + (entryType$ | async)
                     "
                   >
                     <mat-icon *ngIf="topicEditing" class="mat-icon-sm">save</mat-icon>

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -198,11 +198,25 @@
                 }}</span>
               </div>
               <div *ngIf="!isPublic">
-                <span><strong matTooltip="Short description of the workflow">Topic Automatic</strong>:&nbsp;</span>
+                <span
+                  ><strong
+                    matTooltip="Short description of the {{
+                      entryType$ | async
+                    }}, retrieved automatically from the GitHub repository description"
+                    >Topic Automatic</strong
+                  >:&nbsp;</span
+                >
                 <span>{{ workflow?.topicAutomatic }}</span>
               </div>
               <form *ngIf="!isPublic" #editTopic="ngForm" fxLayout="row" fxLayoutAlign="start center" class="w-100">
-                <span><strong matTooltip="Short description of the workflow">Topic Manual</strong>:&nbsp;</span>
+                <span
+                  ><strong
+                    matTooltip="Short description of the {{ entryType$ | async }}, entered manually in the {{
+                      workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML ? '.dockstore.yml' : 'UI'
+                    }}"
+                    >Topic Manual</strong
+                  >:&nbsp;</span
+                >
                 <span *ngIf="!topicEditing"> {{ workflow?.topicManual }} </span>
                 <span fxFlex>
                   <input
@@ -244,6 +258,12 @@
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
                     (click)="toggleEditTopic()"
                     data-cy="topicSaveButton"
+                    [disabled]="workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML"
+                    [matTooltip]="
+                      workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML
+                        ? 'Edit the manual topic for this ' + (entryType$ | async) + ' in the .dockstore.yml file on GitHub'
+                        : ''
+                    "
                   >
                     <mat-icon *ngIf="topicEditing" class="mat-icon-sm">save</mat-icon>
                     <img *ngIf="!topicEditing" src="../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit Topic Manual" />


### PR DESCRIPTION
**Description**
This PR goes with https://github.com/dockstore/dockstore/pull/5713 and disables manual topic editing in the UI for GitHub app entries since they should be updating it in the .dockstore.yml instead. Topic selection is left as is, so the user can still change the selection for a GitHub app entry.

Also updated some tooltips for the topics.

**Review Instructions**
In addition to the instructions in https://github.com/dockstore/dockstore/pull/5713, verify that the `Edit` button for editing manual topics is disabled for GitHub App entries.

**Issue**
dockstore/dockstore#5625
[DOCK-2444](https://ucsc-cgl.atlassian.net/browse/DOCK-2444)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2444]: https://ucsc-cgl.atlassian.net/browse/DOCK-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ