### PR TITLE
Update smoke tests for both Twitter and Mastodon

### DIFF
--- a/cypress/e2e/group1/dashboard.ts
+++ b/cypress/e2e/group1/dashboard.ts
@@ -20,7 +20,7 @@ import {
   verifyGithubLinkDashboard,
   checkFeaturedContent,
   checkNewsAndUpdates,
-  checkMastodonFeed,
+  checkMastodonFeedOrTwitterFeed,
 } from '../../support/commands';
 
 describe('Dockstore dashboard', () => {
@@ -71,7 +71,7 @@ describe('Dockstore dashboard', () => {
 
   it('mastodon feed should be visible', () => {
     cy.visit('/dashboard');
-    checkMastodonFeed();
+    checkMastodonFeedOrTwitterFeed();
   });
 });
 

--- a/cypress/e2e/immutableDatabaseTests/app-spec.ts
+++ b/cypress/e2e/immutableDatabaseTests/app-spec.ts
@@ -27,9 +27,9 @@ describe('Logged in Dockstore Home', () => {
     // expect(browser.getLocationAbsUrl()).toMatch("/");
   });
 
-  it('should have the mastodon timeline', () => {
+  it('should have the mastodon or twitter timeline', () => {
     cy.scrollTo('bottom');
-    cy.get('[data-cy=mt-toot]').should('be.visible');
+    cy.get('[data-cy=mt-toot],.twitter-timeline').should('be.visible');
   });
 
   function starColumn(url: string, type: string) {

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -1,6 +1,6 @@
 import { ga4ghPath } from '../../../../src/app/shared/constants';
 import { ToolDescriptor } from '../../../../src/app/shared/openapi';
-import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeed } from '../../../support/commands';
+import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeedOrTwitterFeed } from '../../../support/commands';
 
 // Test an entry, these should be ambiguous between tools, workflows, and notebooks.
 describe('run stochastic smoke test', () => {
@@ -375,7 +375,7 @@ describe('Check extra content', () => {
 
   it('mastodon feed should be visible', () => {
     cy.visit('/');
-    checkMastodonFeed();
+    checkMastodonFeedOrTwitterFeed();
   });
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -278,6 +278,6 @@ export function checkNewsAndUpdates() {
   });
 }
 
-export function checkMastodonFeed() {
-  cy.get('[data-cy=mt-toot]').should('exist');
+export function checkMastodonFeedOrTwitterFeed() {
+  cy.get('[data-cy=mt-toot],.twitter-timeline').should('exist');
 }


### PR DESCRIPTION
**Description**
Currently, Twitter widget is in staging/prod, Mastodon is in qa. Add an "or" selector to handle both cases.

Created a follow-up ticket, SEAB-5992, to undo after 1.15 is released.

**Review Instructions**
Nightly smoke tests should pass in all environments.

**Issue**
No issue created.

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
