### PR TITLE
DOCK-2471: Reenable skipped test

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -58,7 +58,7 @@ describe('Dockstore my workflows', () => {
 
   describe('Should contain extended Workflow properties', () => {
     // Flaky test, see https://github.com/dockstore/dockstore/issues/5696
-    it.skip('visit another page then come back', () => {
+    it('visit another page then come back', () => {
       cy.visit('/my-workflows');
       cy.contains('github.com/A/l');
 


### PR DESCRIPTION
**Description**
This PR unskips a UI2 integration test that was skipped as part of a previous PR.  Per the description in https://ucsc-cgl.atlassian.net/browse/DOCK-2471, a flaky test was disabled.  Most of the description refers to a test in `mytools.ts`, however, the skipped test is in `myworkflows.ts`.  Possibly, this test was inadvertently disabled because the string argument to `it()` is the same as the test that was failing in mytools? https://github.com/dockstore/dockstore-ui2/blob/3fd09ee103c67c95f44774c1f63280d74c3637e4/cypress/e2e/group3/mytools.ts#L66
The mytools test was fixed in another previous PR.

**Review Instructions**
Confirm that the reenabled test is passing when CircleCI runs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2471
dockstore/dockstore#5696

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
