### PR TITLE
SEAB-5951: "Launch with" to a GitHub Codespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.15.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10525/workflows/55f4ae2f-36a9-40c6-8c99-22b95a16605e/jobs/38179/artifacts",
-    "circle_build_id": "38179"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10592/workflows/21ae0e7a-89fc-4b6e-994e-829fe9e6d4c9/jobs/38638/artifacts",
+    "circle_build_id": "38638"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.15.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10592/workflows/21ae0e7a-89fc-4b6e-994e-829fe9e6d4c9/jobs/38638/artifacts",
-    "circle_build_id": "38638"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10596/workflows/9cdc4129-e82d-4829-bea9-083c4963efa1/jobs/38667/artifacts",
+    "circle_build_id": "38667"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -117,6 +117,7 @@ import { ViewService } from './workflow/view/view.service';
 import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { PreviewWarningModule } from './shared/modules/preview-warning.module';
 import { MyOrganizationsDialogComponent } from './home-page/widget/organization-box/my-organizations-dialog.component/my-organizations-dialog.component';
+import { LaunchToCodespaceDialogComponent } from './workflow/launch-third-party/dialog/launch-to-codespace-dialog.component';
 
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   showDelay: 500,
@@ -176,6 +177,7 @@ export function initializerFactory(
     ChangeUsernameBannerComponent,
     RevokeTokenDialogComponent,
     MyOrganizationsDialogComponent,
+    LaunchToCodespaceDialogComponent,
   ],
   imports: [
     environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -47,6 +47,7 @@ export class ConfigurationService {
     Dockstore.ELWAZI_IMPORT_URL = config.elwaziImportUrl;
     Dockstore.COLAB_IMPORT_URL = config.colabImportUrl;
     Dockstore.MYBINDER_IMPORT_URL = config.mybinderImportUrl;
+    Dockstore.GITHUB_CODESPACES_IMPORT_URL = config.gitHubCodespacesImportUrl;
 
     Dockstore.GITHUB_CLIENT_ID = config.githubClientId;
     Dockstore.GITHUB_AUTH_URL = config.gitHubAuthUrl;

--- a/src/app/shared/dockstore.model.ts
+++ b/src/app/shared/dockstore.model.ts
@@ -45,6 +45,7 @@ export class Dockstore {
   static ELWAZI_IMPORT_URL = 'https://elwazi.terra.bio/#import-tool/dockstore';
   static COLAB_IMPORT_URL = 'https://colab.research.google.com/github/';
   static MYBINDER_IMPORT_URL = 'https://mybinder.org/v2/gh/';
+  static GITHUB_CODESPACES_IMPORT_URL = 'https://github.com/codespaces/new';
 
   static GITHUB_CLIENT_ID = 'will be filled in by configuration.service';
   static GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -7,11 +7,11 @@
     repository, which specifies the files to use and software to run.
   </p>
   <p *ngIf="!hasDevcontainer">
-    <b>No dev container files were detected in this repository.</b> When GitHub can't find a dev container file, it creates a default
-    Codespace environment that may not automatically run the {{ term }} or the software required to support it.
+    <b>No dev container files were detected in this version.</b> When GitHub can't find a dev container file, it creates a default Codespace
+    environment that may not automatically run the {{ term }} or the software required to support it.
   </p>
   <p *ngIf="hasDevcontainer">
-    This repository contains dev container files, but Dockstore could not confirm that they will automatically run the {{ term }} when the
+    This version contains dev container files, but Dockstore could not confirm that they will automatically run the {{ term }} when the
     Codespace starts.
   </p>
   <p>

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -7,11 +7,11 @@
     repository, which specifies the files to use and software to run.
   </p>
   <p *ngIf="!hasDevcontainer">
-    <b>No dev container files were detected in this version.</b> When GitHub can't find a dev container file, it creates a default Codespace
-    environment that may not automatically run the {{ term }} or the software required to support it.
+    <b>No dev container files were detected in this repository.</b> When GitHub can't find a dev container file, it creates a default
+    Codespace environment that may not automatically run the {{ term }} or the software required to support it.
   </p>
   <p *ngIf="hasDevcontainer">
-    This version contains dev container files, but Dockstore could not confirm that they will automatically run the {{ term }} when the
+    This repository contains dev container files, but Dockstore could not confirm that they will automatically run the {{ term }} when the
     Codespace starts.
   </p>
   <p>
@@ -31,7 +31,7 @@
   <p>Launch this {{ term }} to a GitHub Codespace?</p>
   <div class="btn-group" fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="1rem">
     <button mat-flat-button (click)="no()" data-cy="archive-no" [disabled]="clicked" mat-dialog-close class="secondary-1">Cancel</button>
-    <button mat-flat-button (click)="yes()" data-cy="archive-yes" [disabled]="clicked" color="warn">
+    <button mat-flat-button (click)="yes()" data-cy="archive-yes" [disabled]="clicked" class="accent-1-dark-btn mat-elevation-z">
       Launch This {{ term | titlecase }}
     </button>
   </div>

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -19,7 +19,7 @@
     <b>you may need to click on the {{ term }} file and select the appropriate menu options to enable the required extensions.</b>
   </p>
   <p>
-    If you own the repository, you can create a dev container file that will automatically and run this {{ term }}. See
+    If you own the repository, you can create a dev container file that will automatically run this {{ term }}. See
     <a href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html#launch-with-github-codespaces"
       >our documentation</a
     >

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -1,0 +1,30 @@
+<h1 mat-dialog-title>Launch this {{ term }} to a GitHub Codespace?</h1>
+<div mat-dialog-content>
+  <app-alert></app-alert>
+  <p>
+    You are about to launch the {{ term }} <b>{{ path }}</b> in a GitHub Codespace. To configure the Codespace, GitHub reads a dev container
+    file from the repository, which specifies the files to use and software to run.
+  </p>
+  <p *ngIf="!hasDevcontainer">
+    <b>No dev container files were detected in this repository.</b> When GitHub can't find a dev container file, it creates a default
+    Codespace environment that may not automatically run the {{ term }} or the software required to support it.
+  </p>
+  <p *ngIf="hasDevcontainer">
+    This repository contains dev container files, but Dockstore could not confirm that they will automatically run the {{ term }} when the
+    Codespace starts.
+  </p>
+  <p>
+    After the Codespace UI loads, to run the {{ term }},
+    <b>you may need to click on the {{ term }} file and select the appropriate menu options to enable the required extensions.</b>
+  </p>
+  <p>
+    If you own the repository, you can create a dev container file that will automatically and run this {{ term }}. Link to documentation.
+  </p>
+  <p>Launch this {{ term }} to a GitHub Codespace?</p>
+  <div class="btn-group" fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="1rem">
+    <button mat-flat-button (click)="no()" data-cy="archive-no" [disabled]="clicked" mat-dialog-close class="secondary-1">Cancel</button>
+    <button mat-flat-button (click)="yes()" data-cy="archive-yes" [disabled]="clicked" color="warn">
+      Launch This {{ term | titlecase }}
+    </button>
+  </div>
+</div>

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -3,8 +3,8 @@
   <app-alert></app-alert>
   <p>
     You are about to launch the {{ term }} <b>{{ path }}</b> in a GitHub Codespace. To configure the Codespace, GitHub reads a
-    <a href="https://containers.dev/">development container</a> ("dev container") file from the repository, which specifies the files to use
-    and software to run.
+    <a href="https://containers.dev" target="_blank" rel="noopener noreferrer">development container</a> ("dev container") file from the
+    repository, which specifies the files to use and software to run.
   </p>
   <p *ngIf="!hasDevcontainer">
     <b>No dev container files were detected in this repository.</b> When GitHub can't find a dev container file, it creates a default
@@ -20,7 +20,10 @@
   </p>
   <p>
     If you own the repository, you can create a dev container file that will automatically run this {{ term }}. See
-    <a href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html#launch-with-github-codespaces"
+    <a
+      href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/getting-started-with-notebooks.html#launch-with-github-codespaces"
+      target="_blank"
+      rel="noopener noreferrer"
       >our documentation</a
     >
     for more information.

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.html
@@ -2,8 +2,9 @@
 <div mat-dialog-content>
   <app-alert></app-alert>
   <p>
-    You are about to launch the {{ term }} <b>{{ path }}</b> in a GitHub Codespace. To configure the Codespace, GitHub reads a dev container
-    file from the repository, which specifies the files to use and software to run.
+    You are about to launch the {{ term }} <b>{{ path }}</b> in a GitHub Codespace. To configure the Codespace, GitHub reads a
+    <a href="https://containers.dev/">development container</a> ("dev container") file from the repository, which specifies the files to use
+    and software to run.
   </p>
   <p *ngIf="!hasDevcontainer">
     <b>No dev container files were detected in this repository.</b> When GitHub can't find a dev container file, it creates a default
@@ -18,7 +19,11 @@
     <b>you may need to click on the {{ term }} file and select the appropriate menu options to enable the required extensions.</b>
   </p>
   <p>
-    If you own the repository, you can create a dev container file that will automatically and run this {{ term }}. Link to documentation.
+    If you own the repository, you can create a dev container file that will automatically and run this {{ term }}. See
+    <a href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html#launch-with-github-codespaces"
+      >our documentation</a
+    >
+    for more information.
   </p>
   <p>Launch this {{ term }} to a GitHub Codespace?</p>
   <div class="btn-group" fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="1rem">

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.ts
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.ts
@@ -17,6 +17,7 @@ import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { Dockstore } from '../../../shared/dockstore.model';
 import { DockstoreTool, Entry, Workflow } from '../../../shared/openapi';
 
 @Component({
@@ -29,6 +30,7 @@ export class LaunchToCodespaceDialogComponent {
   term: string;
   path: string;
   hasDevcontainer: boolean;
+  Dockstore = Dockstore;
 
   constructor(
     public dialogRef: MatDialogRef<LaunchToCodespaceDialogComponent>,

--- a/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.ts
+++ b/src/app/workflow/launch-third-party/dialog/launch-to-codespace-dialog.component.ts
@@ -1,0 +1,66 @@
+/*
+ *     Copyright 2023 OICR, UCSC
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { DockstoreTool, Entry, Workflow } from '../../../shared/openapi';
+
+@Component({
+  selector: 'app-launch-to-codespace-dialog',
+  templateUrl: './launch-to-codespace-dialog.component.html',
+  styleUrls: ['./launch-to-codespace-dialog.component.scss'],
+})
+export class LaunchToCodespaceDialogComponent {
+  clicked: boolean;
+  term: string;
+  path: string;
+  hasDevcontainer: boolean;
+
+  constructor(
+    public dialogRef: MatDialogRef<LaunchToCodespaceDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { entry: Entry; hasDevcontainer: boolean },
+    public matSnackBar: MatSnackBar,
+    public router: Router
+  ) {
+    this.clicked = false;
+    this.term = data.entry.entryTypeMetadata.term;
+    this.path = (data.entry as Workflow).full_workflow_path ?? (data.entry as DockstoreTool).tool_path ?? data.entry.gitUrl;
+    this.hasDevcontainer = data.hasDevcontainer;
+  }
+
+  no(): void {
+    this.click();
+    this.close(false);
+  }
+
+  yes(): void {
+    this.click();
+    this.close(true);
+  }
+
+  click(): void {
+    this.clicked = true;
+  }
+
+  reset(): void {
+    this.clicked = false;
+  }
+
+  close(action: boolean): void {
+    this.dialogRef.close(action);
+  }
+}

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -283,7 +283,28 @@
             "
             [disabled]="(hasContent$ | async) === false"
             data-cy="colabLaunchWith"
-            ><img class="partner-icon mr-2" src="../assets/images/thirdparty/colab.svg" alt="Google Colab icon" />Google Colab</a
+            ><img class="partner-icon mr-3" src="../assets/images/thirdparty/colab.svg" alt="Google Colab icon" />Google Colab</a
+          >
+          <a
+            mat-button
+            class="launch-with-button private-btn"
+            [matTooltip]="codespaceTooltip$ | async"
+            matTooltipPosition="left"
+            target="_blank"
+            rel="noopener"
+            [attr.href]="
+              'https://github.com/codespaces/new' +
+              '?hide_repo_select=true' +
+              '&ref=' +
+              selectedVersionNameAsQueryValue +
+              '&repo=' +
+              workflowOrganizationAsQueryValue +
+              '/' +
+              workflowRepositoryAsQueryValue
+            "
+            [disabled]="(hasContent$ | async) === false"
+            data-cy="codespaceLaunchWith"
+            ><img class="partner-icon mr-3" src="../assets/images/thirdparty/github.svg" alt="GitHub Codespace icon" />GitHub Codespace</a
           >
           <a
             mat-button
@@ -305,7 +326,7 @@
             "
             [disabled]="(hasContent$ | async) === false"
             data-cy="mybinderLaunchWith"
-            ><img class="partner-icon mr-2" src="../assets/images/thirdparty/binder.svg" alt="Binder icon" />mybinder.org</a
+            ><img class="partner-icon mr-3" src="../assets/images/thirdparty/binder.svg" alt="Binder icon" />mybinder.org</a
           >
         </div>
       </div>

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -290,18 +290,7 @@
             class="launch-with-button private-btn"
             [matTooltip]="codespaceTooltip$ | async"
             matTooltipPosition="left"
-            target="_blank"
-            rel="noopener"
-            [attr.href]="
-              'https://github.com/codespaces/new' +
-              '?hide_repo_select=true' +
-              '&ref=' +
-              selectedVersionNameAsQueryValue +
-              '&repo=' +
-              workflowOrganizationAsQueryValue +
-              '/' +
-              workflowRepositoryAsQueryValue
-            "
+            (click)="launchToCodespace()"
             [disabled]="(hasContent$ | async) === false"
             data-cy="codespaceLaunchWith"
             ><img class="partner-icon mr-3" src="../assets/images/thirdparty/github.svg" alt="GitHub Codespace icon" />GitHub Codespace</a

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -293,7 +293,7 @@
             (click)="launchToCodespace()"
             [disabled]="(hasContent$ | async) === false || !devcontainers"
             data-cy="codespaceLaunchWith"
-            ><img class="partner-icon mr-3" src="../assets/images/thirdparty/github.svg" alt="GitHub Codespace icon" />GitHub Codespace</a
+            ><img class="partner-icon mr-3" src="../assets/images/thirdparty/github.svg" alt="GitHub icon" />GitHub Codespaces</a
           >
           <a
             mat-button

--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -291,7 +291,7 @@
             [matTooltip]="codespaceTooltip$ | async"
             matTooltipPosition="left"
             (click)="launchToCodespace()"
-            [disabled]="(hasContent$ | async) === false"
+            [disabled]="(hasContent$ | async) === false || !devcontainers"
             data-cy="codespaceLaunchWith"
             ><img class="partner-icon mr-3" src="../assets/images/thirdparty/github.svg" alt="GitHub Codespace icon" />GitHub Codespace</a
           >

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -130,7 +130,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
 
   /**
    * The selected version's devcontainer files, currently retrieved only for notebooks.
-   * Set to "undefined" during retrieval or if not retrieved.
+   * Set to "undefined" during retrieval or if never retrieved.
    */
   devcontainers: SourceFile[] | undefined;
 

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -367,8 +367,9 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     });
   }
 
-  // TODO document
   private computeCorrectDevcontainerPath(devcontainers: SourceFile[]): string | undefined {
+    // Return the path, relative to root, of the devcontainer with a body that contains the absolute notebook path as a substring,
+    // or undefined if there is no such devcontainer
     return devcontainers.find((file) => file.content.includes(this.selectedVersion.workflow_path))?.absolutePath?.substring(1);
   }
 

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -305,13 +305,10 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
       if (this.workflow.descriptorType === Workflow.DescriptorTypeEnum.Jupyter) {
         const workflowId = this.workflow.id;
         const versionId = this.selectedVersion.id;
-        this.workflowsService
-          .getWorkflowVersionsSourcefiles(workflowId, versionId, ['DOCKSTORE_NOTEBOOK_DEVCONTAINER'])
-          // TODO add pipe to disable button
-          .subscribe(
-            (devcontainers: SourceFile[]) => (this.devcontainers = devcontainers),
-            (error) => (this.devcontainers = [])
-          );
+        this.workflowsService.getWorkflowVersionsSourcefiles(workflowId, versionId, ['DOCKSTORE_NOTEBOOK_DEVCONTAINER']).subscribe(
+          (devcontainers: SourceFile[]) => (this.devcontainers = devcontainers),
+          (error) => (this.devcontainers = [])
+        );
       }
     }
   }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -218,6 +218,10 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     map(([hasContent]) => (hasContent ? 'Run this notebook in Google Colaboratory' : 'The notebook has no content.'))
   );
 
+  codespaceTooltip$: Observable<string> = combineLatest([this.hasContent$]).pipe(
+    map(([hasContent]) => (hasContent ? 'Run this notebook in a GitHub Codespace' : 'The notebook has no content.'))
+  );
+
   mybinderTooltip$: Observable<string> = combineLatest([this.hasContent$]).pipe(
     map(([hasContent]) => (hasContent ? 'Run this notebook at mybinder.org' : 'The notebook has no content.'))
   );

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -1,5 +1,6 @@
 import { HttpUrlEncodingCodec } from '@angular/common/http';
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { combineLatest, Observable } from 'rxjs';
 import { map, shareReplay, takeUntil } from 'rxjs/operators';
@@ -14,6 +15,8 @@ import { UserQuery } from '../../shared/user/user.query';
 import { DescriptorsQuery } from './state/descriptors-query';
 import { DescriptorsStore } from './state/descriptors-store';
 import { DescriptorsService } from './state/descriptors.service';
+import { LaunchToCodespaceDialogComponent } from './dialog/launch-to-codespace-dialog.component';
+import { bootstrap4largeModalSize } from '../../shared/constants';
 import FileTypeEnum = ToolFile.FileTypeEnum;
 
 /* eslint-disable max-len */
@@ -241,7 +244,8 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     private cloudInstanceService: CloudInstancesService,
     private usersService: UsersService,
     private userQuery: UserQuery,
-    private descriptorLanguageService: DescriptorLanguageService
+    private descriptorLanguageService: DescriptorLanguageService,
+    private dialog: MatDialog
   ) {
     super();
   }
@@ -350,15 +354,21 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     if (correctDevcontainerPath) {
       this.openNewCodespaceWindow(correctDevcontainerPath);
     } else {
-      // const observable = displayLaunchToCodespaceDialog(this.workflow, devcontainers.length);
-      // if (yes) {
-      this.openNewCodespaceWindow(null);
-      // }
+      this.displayLaunchToCodespaceDialog(this.devcontainers.length > 0)
+        .afterClosed()
+        .subscribe((shouldLaunch: boolean) => {
+          if (shouldLaunch) {
+            this.openNewCodespaceWindow(undefined);
+          }
+        });
     }
   }
 
-  private displayLaunchToCodespaceDialog(hasDevcontainers: boolean) {
-    // TODO
+  private displayLaunchToCodespaceDialog(hasDevcontainer: boolean) {
+    return this.dialog.open(LaunchToCodespaceDialogComponent, {
+      width: bootstrap4largeModalSize,
+      data: { entry: this.workflow, hasDevcontainer: hasDevcontainer },
+    });
   }
 
   // TODO document

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -325,4 +325,76 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     }
     return `Export this workflow version to ${platform}.`;
   }
+
+  /*
+  launchToCodespace() {
+    // retrieve list of devcontainer sourcefiles
+    //
+    // if no sourcefiles, pop up dialog
+    const launchUrl = // compute url
+    if (!devcontainers) {
+      const observable = displayGitHubCodespaceDialog(launchUrl, false);
+      if (no) return;
+    } else {
+      if (!devcontainerThatReferencesNotebook) {
+      const observable = displayGitHubCodespaceDialog(launchUrl, true);
+      if (no) return;
+    }
+    openWindow(launchUrl);
+  }
+  */
+
+  launchToCodespace() {
+    const workflowId = this.workflow.id;
+    const versionId = this.selectedVersion.id;
+    this.workflowsService
+      .getWorkflowVersionsSourcefiles(workflowId, versionId, ['DOCKSTORE_NOTEBOOK_DEVCONTAINER'])
+      // TODO add pipe to disable button
+      .subscribe(
+        (devcontainers: SourceFile[]) => {
+          this.launchToCodespaceWithDevcontainers(devcontainers);
+        },
+        (error) => {
+          this.launchToCodespaceWithDevcontainers([]);
+        }
+      );
+  }
+
+  private launchToCodespaceWithDevcontainers(devcontainers: SourceFile[]) {
+    const correctDevcontainerPath = this.computeCorrectDevcontainerPath(devcontainers);
+    if (correctDevcontainerPath) {
+      this.openNewCodespaceWindow(correctDevcontainerPath);
+    } else {
+      // const observable = displayLaunchToCodespaceDialog(this.workflow, devcontainers.length);
+      // if (yes) {
+      this.openNewCodespaceWindow(null);
+      // }
+    }
+  }
+
+  private displayLaunchToCodespaceDialog(hasDevcontainers: boolean) {
+    // TODO
+  }
+
+  private computeCorrectDevcontainerPath(devcontainers: SourceFile[]): string | undefined {
+    // TODO scan for sourcefile with body that contains workflow_path
+    return devcontainers.find((file) => file.content.includes(this.selectedVersion.workflow_path))?.absolutePath?.substring(1);
+  }
+
+  private openNewCodespaceWindow(devcontainerPath: string | undefined) {
+    let url: string =
+      'https://github.com/codespaces/new' +
+      '?hide_repo_select=true' +
+      '&ref=' +
+      this.selectedVersionNameAsQueryValue +
+      '&repo=' +
+      this.workflowOrganizationAsQueryValue +
+      '/' +
+      this.workflowRepositoryAsQueryValue;
+    if (devcontainerPath) {
+      url += '&devcontainer=' + devcontainerPath;
+    }
+    console.log('OPEN NCSW ' + url);
+    window.open(url, '_blank');
+  }
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -386,6 +386,6 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
     if (devcontainerPath) {
       url += '&devcontainer_path=' + this.encode(devcontainerPath);
     }
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
   }
 }

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -305,7 +305,6 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
       if (this.workflow.descriptorType === Workflow.DescriptorTypeEnum.Jupyter) {
         const workflowId = this.workflow.id;
         const versionId = this.selectedVersion.id;
-        console.log('retrieving devcontainers ' + workflowId + ' ' + versionId);
         this.workflowsService
           .getWorkflowVersionsSourcefiles(workflowId, versionId, ['DOCKSTORE_NOTEBOOK_DEVCONTAINER'])
           // TODO add pipe to disable button
@@ -378,7 +377,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
 
   private openNewCodespaceWindow(devcontainerPath: string | undefined) {
     let url: string =
-      'https://github.com/codespaces/new' +
+      this.config.GITHUB_CODESPACES_IMPORT_URL +
       '?hide_repo_select=true' +
       '&ref=' +
       this.selectedVersionNameAsQueryValue +
@@ -387,9 +386,8 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
       '/' +
       this.workflowRepositoryAsQueryValue;
     if (devcontainerPath) {
-      url += '&devcontainer=' + devcontainerPath;
+      url += '&devcontainer_path=' + this.encode(devcontainerPath);
     }
-    console.log('OPEN NCSW ' + url);
     window.open(url, '_blank');
   }
 }


### PR DESCRIPTION
**Description**
This PR adds a "Launch with" button to the public notebook entry page that runs the notebook in a GitHub Codespace.  See the webservice PR for GitHub Codespace background: https://github.com/dockstore/dockstore/pull/5721

The new Codespace "launch with" button works a bit differently than the other "launch with" buttons.  When it is clicked, it checks the notebook's devcontainer files (which the enclosing component fetches during initialization), and attempts to find a devcontainer file that contains a reference to the notebook file.  Currently, "reference" is defined as the devcontainer file contents containing the notebook file absolute path as a substring.  This is a rough heuristic, but probably works pretty good in practice, and is probably fine for now...

If we find a devcontainer that references the notebook file, the GitHub "Create codespace" interface is loaded into a new window.  We pass the path of the referencing devcontainer, so that it is selected in the corresponding dropdown by default.  This mechanism allows users to more easily launch a notebook from a multi-notebook repo that contains a devcontainer for each notebook.

If we don't find a devcontainer that references the notebook file, we pop up a dialog that explains that either: a) no devcontainer was found, or b) there were devcontainers, but we couldn't find one that referenced the notebook file.  The dialog also suggests some actions.  If the user clicks the "Launch" button, the GitHub "Create codespace" interface is loaded into a new window.

The github logo is from:
https://github.com/logos
The associated guidelines appear to allow our use.

Similar to the existing launch-with functionality, it's currently user-tested.  This particular launch-with functionality is more difficult to test because it requires devcontainers to have been ingested into the webservice as sourcefiles, and there are a number of different subcases.  After pondering how to best automate, I concluded that in the UI integration tests, it might be much easier to push test notebooks into the webservice via the github app path, and use the resulting entries as test subjects, rather than trying to mock them or recreate them via database dumps.  However, implementing that approach might take a decent bit of R&D, so in the interest of forward progress, I suggest we make due with user testing for this release, and write a 1.16 ticket to develop better testing mechanisms for the "launch with" functionality, which might also involve improving the GitHub Apps testing.

I will create a documentation ticket for this feature once it merges.

**Screenshots**
<img width="455" alt="image" src="https://github.com/dockstore/dockstore-ui2/assets/88108675/cff2f415-8bf7-4700-877a-f925877dc94b">
<img width="940" alt="image" src="https://github.com/dockstore/dockstore-ui2/assets/88108675/897ecacf-d099-40d1-b8d8-24fb2b90a0a5">
<img width="1080" alt="image" src="https://github.com/dockstore/dockstore-ui2/assets/88108675/27dd49b8-9928-42b4-bc92-ef1e5a964e25">


**Review Instructions**
Register a notebook that doesn't have a devcontainer.  Navigate to the public entry page, click the Codespace "launch with" button, and confirm that the dialog pops up, and the buttons do the right things.  Launch the notebook into a Codespace, and confirm that after loading, you see the generic VSCode interface.

Register a notebook that has a devcontainer that references the notebook, similar to this devcontainer: https://github.com/dockstore-testing/simple-notebook/blob/root-devcontainer/.devcontainer.json
Navigate to the public entry page, click the Codespace "launch with" button, and confirm that the GitHub Codespace creation page pops up in a window, with no intervening dialog.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5951

**Security**
We are opening a window to another site, and passing some information to it, this could have security implications.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
