### PR TITLE
Fix merge of disable edit button for GitHub app entries PR

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -257,13 +257,12 @@
                   </button>
                   <button
                     *ngIf="workflow?.topic || topicEditing"
-                    [disabled]="!canWrite"
+                    [disabled]="!canWrite || workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML"
                     type="button"
                     mat-raised-button
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
                     (click)="toggleEditTopic()"
                     data-cy="topicSaveButton"
-                    [disabled]="workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML"
                     [matTooltip]="
                       workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML
                         ? 'Edit the manual topic for this ' +


### PR DESCRIPTION
**Description**
Follow-up to https://github.com/dockstore/dockstore-ui2/pull/1859. During the demo, the `Edit` manual topic button wasn't disabled for GitHub app entries when it should've been. Turns out there was a bad automatic merge when I merged my PR, resulting in two `[disabled]` fields for the button. The UI took the first one and ignored the second. This PR combines both `[disabled]` conditions so that the `Edit` manual topic button is disabled for GitHub app entries.

**Review Instructions**
See instructions in https://github.com/dockstore/dockstore-ui2/pull/1859

**Issue**
dockstore/dockstore#5635
https://ucsc-cgl.atlassian.net/browse/DOCK-2444

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
