### PR TITLE
SEAB-5443: Remove "Primary" label from notebook file

### DIFF
--- a/cypress/e2e/group2/notebooks.ts
+++ b/cypress/e2e/group2/notebooks.ts
@@ -90,7 +90,6 @@ describe('Dockstore notebooks', () => {
     cy.visit('/notebooks/' + name);
     goToTab('Files');
     // Check for notebook file name and some notebook-specific json content.
-    cy.get('app-source-file-tabs').contains('Primary');
     cy.get('app-source-file-tabs').contains('/notebook.ipynb');
     cy.get('app-source-file-tabs').contains('"nbformat"');
   });

--- a/src/app/file-tree/file-tree.component.ts
+++ b/src/app/file-tree/file-tree.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject } from '@angular/core';
 import { MatTreeFlatDataSource, MatTreeFlattener } from '@angular/material/tree';
 import { FlatTreeControl } from '@angular/cdk/tree';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SourceFile, ToolDescriptor } from 'app/shared/openapi';
+import { EntryType, SourceFile, ToolDescriptor } from 'app/shared/openapi';
 
 /** File node data with possible child nodes. */
 export interface FileNode {
@@ -55,6 +55,7 @@ export class FileTreeComponent {
       versionName: string;
       descriptorType: ToolDescriptor.TypeEnum;
       versionPath: string;
+      entryType: EntryType;
     }
   ) {
     this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);
@@ -142,6 +143,6 @@ export class FileTreeComponent {
   }
 
   isPrimaryDescriptor(path: string): boolean {
-    return path === this.data.versionPath;
+    return path === this.data.versionPath && this.data.entryType !== EntryType.NOTEBOOK;
   }
 }

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -6,7 +6,7 @@ import { MatTabChangeEvent } from '@angular/material/tabs';
 import { FileTreeComponent } from 'app/file-tree/file-tree.component';
 import { bootstrap4largeModalSize } from 'app/shared/constants';
 import { FileService } from 'app/shared/file.service';
-import { SourceFile, ToolDescriptor, WorkflowVersion, BioWorkflow, Notebook, Service } from 'app/shared/openapi';
+import { EntryType, SourceFile, ToolDescriptor, WorkflowVersion, BioWorkflow, Notebook, Service } from 'app/shared/openapi';
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { WorkflowQuery } from '../shared/state/workflow.query';
@@ -135,6 +135,7 @@ export class SourceFileTabsComponent implements OnChanges {
           versionName: this.version.name,
           descriptorType: this.descriptorType,
           versionPath: this.version.workflow_path,
+          entryType: this.entry.entryType,
         },
       })
       .afterClosed()
@@ -151,6 +152,6 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   isPrimaryDescriptor(path: string): boolean {
-    return path === this.version.workflow_path;
+    return path === this.version.workflow_path && this.entry.entryType !== EntryType.NOTEBOOK;
   }
 }


### PR DESCRIPTION
**Description**
This PR removes the "Primary" label from the notebook file in the Files tab, since it arguably doesn't make sense, because there's no notion of a "primary descriptor" in the notebook world.

**Review Instructions**
Navigate to the "Files" tab of a notebook, view the notebook file, and confirm that it is no longer labelled "Primary".

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5443

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
