### PR TITLE
DOCK-2373: Fix inline markdown images

### DIFF
--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -39,6 +39,10 @@ describe('MarkdownWrapperService', () => {
       expect(service.makeGitHubImagesRaw('<img src="https://github.com/some/repo/foo.png" alt="abc" title="123">')).toEqual(
         '<img src="https://github.com/some/repo/foo.png?raw=true" alt="abc" title="123">'
       );
+      // add "raw=true" to multiple imgs on same line
+      expect(
+        service.makeGitHubImagesRaw('<img src="https://github.com/foo.jpg"> some text <img src="https://github.com/bar.jpg">')
+      ).toEqual('<img src="https://github.com/foo.jpg?raw=true"> some text <img src="https://github.com/bar.jpg?raw=true">');
       // don't change anything else
       expect(service.makeGitHubImagesRaw('<img src="foo.html" width="120" height="120">')).toEqual(
         '<img src="foo.html" width="120" height="120">'

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.spec.ts
@@ -31,4 +31,21 @@ describe('MarkdownWrapperService', () => {
     expect(service.removeTabsFromTableHeaders('this | is | not | a\t | table')).toEqual('this | is | not | a\t | table');
     expect(service.removeTabsFromTableHeaders('---\t-|----\t\t:|-\t---\t-::\t|\n')).toEqual('---\t-|----\t\t:|-\t---\t-::\t|\n');
   }));
+
+  it('should add "raw=true" to img.src attributes generated from inline markdown images and change nothing else', inject(
+    [MarkdownWrapperService],
+    (service: MarkdownWrapperService) => {
+      // add "raw=true" to an img.src that references github
+      expect(service.makeGitHubImagesRaw('<img src="https://github.com/some/repo/foo.png" alt="abc" title="123">')).toEqual(
+        '<img src="https://github.com/some/repo/foo.png?raw=true" alt="abc" title="123">'
+      );
+      // don't change anything else
+      expect(service.makeGitHubImagesRaw('<img src="foo.html" width="120" height="120">')).toEqual(
+        '<img src="foo.html" width="120" height="120">'
+      );
+      expect(service.makeGitHubImagesRaw('<a href="https://github.com/some/repo/foo.html">')).toEqual(
+        '<a href="https://github.com/some/repo/foo.html">'
+      );
+    }
+  ));
 });

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -115,7 +115,7 @@ export class MarkdownWrapperService {
    * Add the query 'raw=true' to all img tag src urls that refer to github, causing github to redirect to the raw image.
    */
   makeGitHubImagesRaw(html: string): string {
-    return html.replace(/(<img.*? src=")(.*?)(".*?>)/gm, (all, before, url, after) => {
+    return html.replace(/(<img[^>]*? src=")([^"]*?)("[^>]*?>)/gm, (all, before, url, after) => {
       if (url.startsWith('https://github.com/')) {
         const separator = url.includes('?') ? '&' : '?';
         return `${before}${url}${separator}raw=true${after}`;

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -88,7 +88,8 @@ export class MarkdownWrapperService {
   customCompile(data, baseUrl): string {
     const parseOptions = { markedOptions: { baseUrl: baseUrl } };
     const markdownData = this.removeTabsFromTableHeaders(data);
-    return this.markdownService.parse(markdownData, parseOptions);
+    const html = this.markdownService.parse(markdownData, parseOptions);
+    return this.makeGitHubImagesRaw(html);
   }
 
   customSanitize(html): string {
@@ -108,5 +109,19 @@ export class MarkdownWrapperService {
    */
   removeTabsFromTableHeaders(data: string): string {
     return data.replace(/(^ {0,3}\|.*)/gm, (match) => match.replace(/\t/g, '    '));
+  }
+
+  /**
+   * Add the query 'raw=true' to all img href urls that refer to github, causing github to redirect to the raw image.
+   */
+  makeGitHubImagesRaw(html: string): string {
+    return html.replace(/(<img.*? src=")(.*?)(".*?>)/gm, (all, before, href, after) => {
+      if (href.startsWith('https://github.com/')) {
+        const separator = href.includes('?') ? '&' : '?';
+        return `${before}${href}${separator}raw=true${after}`;
+      } else {
+        return all;
+      }
+    });
   }
 }

--- a/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
+++ b/src/app/shared/markdown-wrapper/markdown-wrapper.service.ts
@@ -112,13 +112,13 @@ export class MarkdownWrapperService {
   }
 
   /**
-   * Add the query 'raw=true' to all img href urls that refer to github, causing github to redirect to the raw image.
+   * Add the query 'raw=true' to all img tag src urls that refer to github, causing github to redirect to the raw image.
    */
   makeGitHubImagesRaw(html: string): string {
-    return html.replace(/(<img.*? src=")(.*?)(".*?>)/gm, (all, before, href, after) => {
-      if (href.startsWith('https://github.com/')) {
-        const separator = href.includes('?') ? '&' : '?';
-        return `${before}${href}${separator}raw=true${after}`;
+    return html.replace(/(<img.*? src=")(.*?)(".*?>)/gm, (all, before, url, after) => {
+      if (url.startsWith('https://github.com/')) {
+        const separator = url.includes('?') ? '&' : '?';
+        return `${before}${url}${separator}raw=true${after}`;
       } else {
         return all;
       }


### PR DESCRIPTION
**Description**
This PR modifies the UI's markdown service to generate correct HTML for relative inline images when the `baseUrl` references github, thus displaying them properly in an entry's description, and in a notebook's "Preview". 

Previously, Dockstore displayed relative inline markdown images as broken image icons, for example, see the broken flowchart images midway down the description here:
https://dockstore.org/workflows/github.com/aofarrel/myco/myco_sra:main?tab=info

The UI calculated a base URL, which it passed to the markdown converter, which prepended it to the relative generated `img` tag urls.  Alas, our base URL (and the URL constructed from it) referenced the github resource embedded _within a github page_.  So, when browser retrieved the image from the URL, it got back a blob of github HTML, rather than the expected image, causing it to barf.  You can't fix the problem simply by changing the base URL we pass to the markdown converter to reference the raw resource, because then the relative outbound links don't reference the github pages anymore.

As it so happens, if you add the query `raw=true` to the url for a github page that references a resource, it redirects to the raw resource.  For example:
https://github.com/aofarrel/myco/blob/main/doc/doc_making_resources/myco_sra_flowchart_1.png (github page)
https://github.com/aofarrel/myco/blob/main/doc/doc_making_resources/myco_sra_flowchart_1.png?raw=true (raw resource)

So, this PR simply adds `raw=true` to all `img` urls that reference github.

The conversion step could happen either before (on the markdown) or after (on the html) the markdown conversion.  I picked after, so that if we ever rewrite relative `img` tags, which are legal in markdown, those would work, too.

A more sophisticated solution would probably generate the appropriate URL for both the outbound link (`a`) and embedded image (`img`) cases, sans redirects, for all of our supported source code repositories, but...

This is a quick hack that probably works well enough for now.

**Review Instructions**
Create a version of an entry that has a README that contains an inline markdown image (the syntax is `![description](link)`) with a relative link that points to an image in the repo.  Register the version on Dockstore, view the entry's info page, and confirm that the image is displayed in the description. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2373

**Security**
We are manipulating HTML which is then displayed on our site.  Possibly, there could be security implications, but we run the results through multiple sanitizers, so it's probably no more of an issue than HTML that users embed in their markdown.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
