### PR TITLE
Refactor and change text for GitHub app registration

### DIFF
--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -77,6 +77,7 @@ describe('GitHub App Tools', () => {
 
       cy.contains('Install our GitHub App in');
       cy.get('.modal-footer').contains('Next').first().click();
+      cy.get('[data-cy=install-dockstore-app]');
       cy.contains('Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.');
       cy.contains('Tool storage type').click();
       cy.contains('Close').click();

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -78,7 +78,6 @@ describe('GitHub App Tools', () => {
       cy.contains('Install our GitHub App in');
       cy.get('.modal-footer').contains('Next').first().click();
       cy.get('[data-cy=install-dockstore-app]');
-      cy.contains('Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.');
       cy.contains('Tool storage type').click();
       cy.contains('Close').click();
 

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -77,7 +77,7 @@ describe('GitHub App Tools', () => {
 
       cy.contains('Install our GitHub App in');
       cy.get('.modal-footer').contains('Next').first().click();
-      cy.contains('Navigate to GitHub to install our GitHub app');
+      cy.contains('Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.');
       cy.contains('Tool storage type').click();
       cy.contains('Close').click();
 

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -56,27 +56,7 @@
         <app-refresh-wizard></app-refresh-wizard>
       </div>
       <div *ngIf="selectedOption?.value === OptionChoice.GitHubApps">
-        <p>
-          Navigate to GitHub to install our GitHub app in an organization or your personal account. See our
-          <a
-            href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            documentation <mat-icon>open_in_new</mat-icon>
-          </a>
-          for how to use GitHub Apps to automatically sync your tools with GitHub. A .dockstore.yml file is required.
-        </p>
-        <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
-          <a
-            mat-raised-button
-            class="accent-1-dark-btn mat-elevation-z no-underline"
-            type="button"
-            [href]="gitHubAppInstallationLink$ | async"
-            matTooltip="Manage Dockstore installations on GitHub"
-            ><mat-icon>add</mat-icon> Manage Dockstore installations on GitHub</a
-          >
-        </div>
+        <app-register-github-app entryType="tool"></app-register-github-app>
       </div>
       <form
         *ngIf="selectedOption?.value === OptionChoice.Remote"

--- a/src/app/container/register-tool/register-tool.component.html
+++ b/src/app/container/register-tool/register-tool.component.html
@@ -29,20 +29,21 @@
       <p>Tools are a combination of Docker images describing the tool environment and descriptor files describing how the tool is run.</p>
       <div class="modal-body">
         <mat-radio-group class="radio-group" [(ngModel)]="selectedOption">
-          <mat-radio-button
-            class="radio-button"
-            *ngFor="let option of options"
-            [value]="option"
-            [id]="OptionChoice[option.value] + '-register-workflow-option'"
-            data-cy="storage-type-choice"
-          >
-            <span class="text-wrap">
-              {{ option.label }}
-              <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">
-                {{ selectedOption.extendedLabel }}
-              </div>
-            </span>
-          </mat-radio-button>
+          <div *ngFor="let option of options">
+            <mat-radio-button
+              class="radio-button"
+              [value]="option"
+              [id]="OptionChoice[option.value] + '-register-workflow-option'"
+              data-cy="storage-type-choice"
+            >
+              <span class="text-wrap">
+                {{ option.label }}
+                <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">
+                  {{ selectedOption.extendedLabel }}
+                </div>
+              </span>
+            </mat-radio-button>
+          </div>
         </mat-radio-group>
       </div>
       <div class="modal-footer">

--- a/src/app/home-page/dashboard/dashboard.component.ts
+++ b/src/app/home-page/dashboard/dashboard.component.ts
@@ -6,7 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { RegisterToolComponent } from 'app/container/register-tool/register-tool.component';
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { Dockstore } from 'app/shared/dockstore.model';
-import { bootstrap4largeModalSize, bootstrap4mediumModalSize } from '../../shared/constants';
+import { bootstrap4largeModalSize } from '../../shared/constants';
 import { EntryType } from '../../shared/openapi';
 
 @Component({

--- a/src/app/home-page/dashboard/dashboard.component.ts
+++ b/src/app/home-page/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { RegisterToolComponent } from 'app/container/register-tool/register-tool.component';
 import { AlertService } from 'app/shared/alert/state/alert.service';
 import { Dockstore } from 'app/shared/dockstore.model';
+import { bootstrap4largeModalSize, bootstrap4mediumModalSize } from '../../shared/constants';
 import { EntryType } from '../../shared/openapi';
 
 @Component({
@@ -23,7 +24,7 @@ export class DashboardComponent extends Base implements OnInit {
   ngOnInit() {
     this.registerToolService.isModalShown.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isModalShown: boolean) => {
       if (isModalShown) {
-        const dialogRef = this.dialog.open(RegisterToolComponent, { width: '500px' });
+        const dialogRef = this.dialog.open(RegisterToolComponent, { width: bootstrap4largeModalSize });
         dialogRef
           .afterClosed()
           .pipe(takeUntil(this.ngUnsubscribe))

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -13,6 +13,7 @@ import { RefreshWizardModule } from '../container/refresh-wizard.module';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { CategoryButtonModule } from '../categories/button/category-button.module';
 import { JsonLdModule } from '../shared/modules/json-ld.module';
+import { RegisterGithubAppModule } from '../shared/modules/register-github-app.module';
 import { RecentEventsModule } from './recent-events/recent-events.module';
 import { FeaturedContentComponent } from './widget/featured-content/featured-content.component';
 import { NewsAndUpdatesComponent } from './widget/featured-content/news-and-updates.component';
@@ -57,6 +58,7 @@ import { MastodonComponent } from '../shared/mastodon/mastodon.component';
     HeaderModule,
     MarkdownWrapperModule,
     PreviewWarningModule,
+    RegisterGithubAppModule,
   ],
   declarations: [
     HomeComponent,

--- a/src/app/myworkflows/myworkflows.service.ts
+++ b/src/app/myworkflows/myworkflows.service.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { transaction } from '@datorama/akita';
 import { AlertService } from 'app/shared/alert/state/alert.service';
-import { includesAuthors, includesValidation, bootstrap4mediumModalSize, bootstrap4largeModalSize } from 'app/shared/constants';
+import { includesAuthors, includesValidation, bootstrap4largeModalSize } from 'app/shared/constants';
 import { EntryType } from 'app/shared/enum/entry-type';
 import { MyEntriesService } from 'app/shared/myentries.service';
 import { SessionQuery } from 'app/shared/session/session.query';

--- a/src/app/myworkflows/myworkflows.service.ts
+++ b/src/app/myworkflows/myworkflows.service.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { transaction } from '@datorama/akita';
 import { AlertService } from 'app/shared/alert/state/alert.service';
-import { includesAuthors, includesValidation, bootstrap4mediumModalSize } from 'app/shared/constants';
+import { includesAuthors, includesValidation, bootstrap4mediumModalSize, bootstrap4largeModalSize } from 'app/shared/constants';
 import { EntryType } from 'app/shared/enum/entry-type';
 import { MyEntriesService } from 'app/shared/myentries.service';
 import { SessionQuery } from 'app/shared/session/session.query';
@@ -234,7 +234,7 @@ export class MyWorkflowsService extends MyEntriesService<Workflow, OrgWorkflowOb
   registerEntry(entryType: EntryType | null) {
     if (entryType === EntryType.BioWorkflow) {
       // Open modal with various workflow registration options
-      const dialogRef = this.matDialog.open(RegisterWorkflowModalComponent, { width: bootstrap4mediumModalSize });
+      const dialogRef = this.matDialog.open(RegisterWorkflowModalComponent, { width: bootstrap4largeModalSize });
       dialogRef.afterClosed().subscribe((reloadEntries) => {
         if (reloadEntries) {
           const user = this.userQuery.getValue().user;
@@ -257,7 +257,7 @@ export class MyWorkflowsService extends MyEntriesService<Workflow, OrgWorkflowOb
    * @param entryType
    */
   openRegisterGithubAppModal(entryType: EntryType) {
-    const dialogRef = this.matDialog.open(RegisterGithubAppModalComponent, { width: bootstrap4mediumModalSize, data: entryType });
+    const dialogRef = this.matDialog.open(RegisterGithubAppModalComponent, { width: bootstrap4largeModalSize, data: entryType });
     dialogRef.afterClosed().subscribe((reloadEntries) => {
       if (reloadEntries) {
         const user = this.userQuery.getValue().user;

--- a/src/app/shared-workflow-services-notebooks/shared-workflow-services-notebooks.module.ts
+++ b/src/app/shared-workflow-services-notebooks/shared-workflow-services-notebooks.module.ts
@@ -21,17 +21,18 @@ import { RouterModule } from '@angular/router';
 import { MyWorkflowsService } from 'app/myworkflows/myworkflows.service';
 import { EntryWizardModule } from 'app/shared/entry-wizard.module';
 import { MyEntriesModule } from 'app/shared/modules/my-entries.module';
+import { PreviewWarningModule } from 'app/shared/modules/preview-warning.module';
+import { RegisterGithubAppModalComponent } from 'app/workflow/register-workflow-modal/register-github-app-modal/register-github-app-modal.component';
 import { MyWorkflowComponent } from '../myworkflows/my-workflow/my-workflow.component';
 import { SidebarAccordionComponent } from '../myworkflows/sidebar-accordion/sidebar-accordion.component';
 import { RefreshAlertModule } from '../shared/alert/alert.module';
 import { HeaderModule } from '../shared/modules/header.module';
 import { CustomMaterialModule } from '../shared/modules/material.module';
+import { RegisterGithubAppModule } from '../shared/modules/register-github-app.module';
 import { WorkflowModule } from '../shared/modules/workflow.module';
 import { PipeModule } from '../shared/pipe/pipe.module';
 import { RefreshWorkflowOrganizationComponent } from '../workflow/refresh-workflow-organization/refresh-workflow-organization.component';
 import { RegisterWorkflowModalComponent } from '../workflow/register-workflow-modal/register-workflow-modal.component';
-import { RegisterGithubAppModalComponent } from 'app/workflow/register-workflow-modal/register-github-app-modal/register-github-app-modal.component';
-import { PreviewWarningModule } from 'app/shared/modules/preview-warning.module';
 
 const DECLARATIONS: any[] = [
   MyWorkflowComponent,
@@ -52,6 +53,7 @@ const IMPORTS = [
   MyEntriesModule,
   EntryWizardModule,
   PreviewWarningModule,
+  RegisterGithubAppModule,
 ];
 
 /**

--- a/src/app/shared/modules/register-github-app.module.ts
+++ b/src/app/shared/modules/register-github-app.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FlexModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterLinkWithHref } from '@angular/router';
+import { RegisterGithubAppComponent } from '../register-github-app/register-github-app.component';
+
+@NgModule({
+  declarations: [RegisterGithubAppComponent],
+  exports: [RegisterGithubAppComponent],
+  imports: [CommonModule, FlexModule, MatButtonModule, MatIconModule, MatTooltipModule, RouterLinkWithHref],
+})
+export class RegisterGithubAppModule {}

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -1,29 +1,31 @@
 <div>
-  <p>
-    Install the Dockstore GitHub app on your repositories. This gives GitHub permission to notify Dockstore when pushes are made to GitHub.
-    For more details, see our
-    <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
-      documentation <mat-icon>open_in_new</mat-icon> </a
-    >.
-  </p>
-  <p>Perform the following steps in order:</p>
   <ol>
-    <li>Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.</li>
     <li>
-      Push a valid .dockstore.yml to the root of a GitHub repo that has the Dockstore GitHub app installed. The .dockstore.yml tells
-      Dockstore where the {{ entryType }}'s files are located.
+      Click the "Manage..." button below to install Dockstore's App on your GitHub repositories that contain {{ entryType }}s. The App
+      notifies Dockstore whenever the repositories change.
     </li>
     <li>
-      It takes about 2 minutes after a push to GitHub for Dockstore to get notified and process the update. After those 2 minutes, refresh
-      your dashboard, and you should see the {{ entryType }}.
+      Describe your {{ entryType }}s by adding a
+      <a href="{{ Dockstore.DOCUMENTATION_URL }}/assets/templates/template.html" target="_blank" rel="noopener noreferrer"
+        >.dockstore.yml</a
+      >
+      to the root directory of the repositories where you installed the App.
     </li>
+    <li>Push your changes and wait two minutes for Dockstore to read your {{ entryType }}s.</li>
     <li>
-      If you don't see the {{ entryType }}, navigate to the {{ entryType }}s section of My Dashboard, and click the Apps Logs link for the
-      GitHub organization for more details. It displays the notifications received from GitHub and will indicate if there were any errors
-      processing the GitHub notifications.
+      Refresh your Dockstore dashboard to see your {{ entryType }}s. If they don't appear, click the dashboard's "{{
+        entryType | titlecase
+      }}s" tile and click on the organization's "Apps Logs" button to see what went wrong.
     </li>
   </ol>
 
+  <p class="pb-1">
+    For more details, see our
+    <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
+      documentation
+      <mat-icon>open_in_new</mat-icon> </a
+    >.
+  </p>
   <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
     <a
       mat-raised-button

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -1,0 +1,27 @@
+<div>
+  <p>Perform the following in order:</p>
+  <ol>
+    <li>Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.</li>
+    <li>Push a valid .dockstore.yml to the root of a GitHub repo that has the Dockstore GitHub app installed.</li>
+    <li>After 2 minutes, refresh your dashboard, and you should see the {{ entryType }}.</li>
+    <li>
+      If you don't see the {{ entryType }}, navigate to <a routerLink="/my-{{ entryType }}s">my-{{ entryType }}s</a>, and click the Apps
+      Logs link for the GitHub organization for more details.
+    </li>
+  </ol>
+  For more details, see our
+  <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
+    documentation <mat-icon>open_in_new</mat-icon> </a
+  >.
+  <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
+    <a
+      mat-raised-button
+      type="button"
+      class="accent-1-dark-btn mat-elevation-z no-underline"
+      [href]="gitHubAppInstallationLink$ | async"
+      [disabled]="isUsernameChangeRequired$ | async"
+      matTooltip="Manage Dockstore installations on GitHub"
+      ><mat-icon>add</mat-icon> Manage Dockstore installations on GitHub</a
+    >
+  </div>
+</div>

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -28,7 +28,7 @@
       <mat-icon>open_in_new</mat-icon> </a
     >.
   </p>
-  <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
+  <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-4">
     <a
       mat-raised-button
       type="button"

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -3,7 +3,7 @@
   <ol>
     <li>Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.</li>
     <li>Push a valid .dockstore.yml to the root of a GitHub repo that has the Dockstore GitHub app installed.</li>
-    <li>After 2 minutes, refresh your dashboard, and you should see the {{ entryType }}.</li>
+    <li>After about 2 minutes, refresh your dashboard, and you should see the {{ entryType }}.</li>
     <li>
       If you don't see the {{ entryType }}, navigate to <a routerLink="/my-{{ entryType }}s">my-{{ entryType }}s</a>, and click the Apps
       Logs link for the GitHub organization for more details.

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -1,8 +1,10 @@
 <div>
   <ol>
     <li>
-      Click the "Manage..." button below to install Dockstore's App on your GitHub repositories that contain {{ entryType }}s. The App
-      notifies Dockstore whenever the repositories change.
+      <span data-cy="install-dockstore-app"
+        >Click the "Manage..." button below to install Dockstore's App on your GitHub repositories that contain {{ entryType }}s. The App
+        notifies Dockstore whenever the repositories change.</span
+      >
     </li>
     <li>
       Describe your {{ entryType }}s by adding a

--- a/src/app/shared/register-github-app/register-github-app.component.html
+++ b/src/app/shared/register-github-app/register-github-app.component.html
@@ -1,18 +1,29 @@
 <div>
-  <p>Perform the following in order:</p>
+  <p>
+    Install the Dockstore GitHub app on your repositories. This gives GitHub permission to notify Dockstore when pushes are made to GitHub.
+    For more details, see our
+    <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
+      documentation <mat-icon>open_in_new</mat-icon> </a
+    >.
+  </p>
+  <p>Perform the following steps in order:</p>
   <ol>
     <li>Click the button below to install the Dockstore GitHub app on your GitHub organizations or specific repositories.</li>
-    <li>Push a valid .dockstore.yml to the root of a GitHub repo that has the Dockstore GitHub app installed.</li>
-    <li>After about 2 minutes, refresh your dashboard, and you should see the {{ entryType }}.</li>
     <li>
-      If you don't see the {{ entryType }}, navigate to <a routerLink="/my-{{ entryType }}s">my-{{ entryType }}s</a>, and click the Apps
-      Logs link for the GitHub organization for more details.
+      Push a valid .dockstore.yml to the root of a GitHub repo that has the Dockstore GitHub app installed. The .dockstore.yml tells
+      Dockstore where the {{ entryType }}'s files are located.
+    </li>
+    <li>
+      It takes about 2 minutes after a push to GitHub for Dockstore to get notified and process the update. After those 2 minutes, refresh
+      your dashboard, and you should see the {{ entryType }}.
+    </li>
+    <li>
+      If you don't see the {{ entryType }}, navigate to the {{ entryType }}s section of My Dashboard, and click the Apps Logs link for the
+      GitHub organization for more details. It displays the notifications received from GitHub and will indicate if there were any errors
+      processing the GitHub notifications.
     </li>
   </ol>
-  For more details, see our
-  <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
-    documentation <mat-icon>open_in_new</mat-icon> </a
-  >.
+
   <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
     <a
       mat-raised-button

--- a/src/app/shared/register-github-app/register-github-app.component.spec.ts
+++ b/src/app/shared/register-github-app/register-github-app.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegisterGithubAppComponent } from './register-github-app.component';
+
+describe('RegisterGithubAppComponent', () => {
+  let component: RegisterGithubAppComponent;
+  let fixture: ComponentFixture<RegisterGithubAppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RegisterGithubAppComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegisterGithubAppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/register-github-app/register-github-app.component.spec.ts
+++ b/src/app/shared/register-github-app/register-github-app.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RegisterGithubAppComponent } from './register-github-app.component';
@@ -9,6 +10,7 @@ describe('RegisterGithubAppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RegisterGithubAppComponent],
+      imports: [HttpClientTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RegisterGithubAppComponent);

--- a/src/app/shared/register-github-app/register-github-app.component.ts
+++ b/src/app/shared/register-github-app/register-github-app.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Dockstore } from '../dockstore.model';
+import { SessionQuery } from '../session/session.query';
+import { UserQuery } from '../user/user.query';
+
+@Component({
+  selector: 'app-register-github-app',
+  templateUrl: './register-github-app.component.html',
+})
+export class RegisterGithubAppComponent implements OnInit {
+  public Dockstore = Dockstore;
+  public gitHubAppInstallationLink$ = this.sessionQuery.gitHubAppInstallationLink$;
+  public isUsernameChangeRequired$ = this.userQuery.isUsernameChangeRequired$;
+  @Input() public entryType: string;
+
+  constructor(private sessionQuery: SessionQuery, private userQuery: UserQuery) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/register-github-app/register-github-app.component.ts
+++ b/src/app/shared/register-github-app/register-github-app.component.ts
@@ -7,13 +7,11 @@ import { UserQuery } from '../user/user.query';
   selector: 'app-register-github-app',
   templateUrl: './register-github-app.component.html',
 })
-export class RegisterGithubAppComponent implements OnInit {
+export class RegisterGithubAppComponent {
   public Dockstore = Dockstore;
   public gitHubAppInstallationLink$ = this.sessionQuery.gitHubAppInstallationLink$;
   public isUsernameChangeRequired$ = this.userQuery.isUsernameChangeRequired$;
   @Input() public entryType: string;
 
   constructor(private sessionQuery: SessionQuery, private userQuery: UserQuery) {}
-
-  ngOnInit(): void {}
 }

--- a/src/app/shared/register-github-app/register-github-app.component.ts
+++ b/src/app/shared/register-github-app/register-github-app.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Dockstore } from '../dockstore.model';
 import { SessionQuery } from '../session/session.query';
 import { UserQuery } from '../user/user.query';

--- a/src/app/workflow/register-workflow-modal/register-github-app-modal/register-github-app-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-github-app-modal/register-github-app-modal.component.html
@@ -1,22 +1,5 @@
 <h4 mat-dialog-title>Register {{ entryType | titlecase }}</h4>
-<p>
-  Navigate to GitHub to install our GitHub app on your repositories/organizations. See our
-  <a href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html" target="_blank" rel="noopener noreferrer">
-    documentation <mat-icon>open_in_new</mat-icon>
-  </a>
-  for how to use GitHub Apps to automatically sync your {{ entryType }} with GitHub. A .dockstore.yml file is required.
-</p>
-<div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
-  <a
-    mat-raised-button
-    type="button"
-    class="accent-1-dark-btn mat-elevation-z no-underline"
-    [href]="gitHubAppInstallationLink$ | async"
-    [disabled]="isUsernameChangeRequired$ | async"
-    matTooltip="Manage Dockstore installations on GitHub"
-    ><mat-icon>add</mat-icon> Manage Dockstore installations on GitHub</a
-  >
-</div>
+<app-register-github-app entryType="{{ entryType }}"></app-register-github-app>
 <div class="modal-footer p-0 mt-4">
   <button
     type="button"

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -51,28 +51,7 @@
     <mat-step>
       <ng-template matStepLabel>Create a workflow</ng-template>
       <div *ngIf="selectedOption?.value === 0">
-        <p>
-          Navigate to GitHub to install our GitHub app in an organization or your personal account. See our
-          <a
-            href="{{ Dockstore.DOCUMENTATION_URL }}/getting-started/github-apps/github-apps.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            documentation <mat-icon>open_in_new</mat-icon>
-          </a>
-          for how to use GitHub Apps to automatically sync your workflows with GitHub. A .dockstore.yml file is required.
-        </p>
-        <div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="2rem" class="mb-2">
-          <a
-            mat-raised-button
-            type="button"
-            class="accent-1-dark-btn mat-elevation-z no-underline"
-            [href]="gitHubAppInstallationLink$ | async"
-            [disabled]="isUsernameChangeRequired$ | async"
-            matTooltip="Manage Dockstore installations on GitHub"
-            ><mat-icon>add</mat-icon> Manage Dockstore installations on GitHub</a
-          >
-        </div>
+        <app-register-github-app entryType="workflow"></app-register-github-app>
         <div class="modal-footer">
           <button mat-flat-button class="secondary-1" matStepperPrevious>Back</button>
           <button

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.html
@@ -28,19 +28,16 @@
       </p>
       <div class="modal-body">
         <mat-radio-group [(ngModel)]="selectedOption">
-          <mat-radio-button
-            *ngFor="let option of options"
-            [value]="option"
-            [id]="option.value + '-register-workflow-option'"
-            data-cy="storage-type-choice"
-          >
-            <span class="text-wrap">
-              {{ option.label }}
-              <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">
-                {{ selectedOption.extendedLabel }}
-              </div>
-            </span>
-          </mat-radio-button>
+          <div *ngFor="let option of options">
+            <mat-radio-button [value]="option" [id]="option.value + '-register-workflow-option'" data-cy="storage-type-choice">
+              <span class="text-wrap">
+                {{ option.label }}
+                <div *ngIf="selectedOption.value === option.value" class="extended-label mat-small">
+                  {{ selectedOption.extendedLabel }}
+                </div>
+              </span>
+            </mat-radio-button>
+          </div>
         </mat-radio-group>
       </div>
       <div class="modal-footer">

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.service.ts
@@ -36,7 +36,6 @@ export class RegisterWorkflowModalService {
   workflows: Array<any>;
   isModalShown$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public descriptorLanguages$: Observable<Array<DescriptorTypeEnum>>;
-  public filteredDescriptorLanguages$: Observable<Array<DescriptorTypeEnum>>;
   workflow: BehaviorSubject<Workflow> = new BehaviorSubject<Workflow>(this.sampleWorkflow);
   constructor(
     private workflowsService: WorkflowsService,


### PR DESCRIPTION
**Description**
Adds more explicit steps for the GitHub App flow. This is hard to word, and I expect a lot of feedback. :)

Here's what it looks like now:

![Screen Shot 2023-11-14 at 4 34 24 PM](https://github.com/dockstore/dockstore-ui2/assets/1049340/b5f10d03-b422-44e3-9e05-b0e6586af923)

I know the steps are not comprehensive, e.g., it doesn't talk about optionally installing to the .github directory instead, nor does it cover the case where we now do discover a .dockstore.yml in certain branches after installation. I'm trying to balance it between being short enough that it will be read, but long enough to be informative and/or spark enough curiosity to click the documentation link.

Another option is to break up the list into "wizard pages", e.g., "Click here to install the Dockstore GitHub App. When you have completed, click Next"; then "Push a valid .dockstore.yml to your repo. When you have completed, click Next. Etc." Which could be a good idea, but I think is beyond the scope of a "quick fix" for 1.15.

**Accompanying Refactoring**
We had the same text 3 times for the GitHub apps registration; once for tools, once for workflows, and a shared component for services and notebooks.

I created a shared component so we only have to change text once now.


**Review Instructions**
Try registering a tool, workflow, service, and notebook (do try all 4, to make sure the shared component works in all cases). The page for GitHub apps should have the new list or whatever is decided upon in this PR.

**Issue**
SEAB-5999

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
