### PR TITLE
SEAB-6021: Fix stuck profile page

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/dropdown.ts
+++ b/cypress/e2e/immutableDatabaseTests/dropdown.ts
@@ -58,6 +58,22 @@ describe('Dropdown test', () => {
     });
   });
 
+  describe('Go to profile page from another profile page', () => {
+    it('Should show user correct profile', () => {
+      const fromUser = 'potato';
+      const currentUser = 'user_curator';
+      cy.visit(`/users/${fromUser}`);
+      cy.contains('Activity');
+      cy.get('app-user-page').contains(fromUser);
+      cy.get('app-user-page').contains(currentUser).should('not.exist');
+      cy.get('[data-cy=dropdown-main]:visible').click();
+      cy.get('[data-cy=dropdown-profile-button]').should('be.visible').click();
+      cy.contains('Activity');
+      cy.get('app-user-page').contains(currentUser);
+      cy.get('app-user-page').contains(fromUser).should('not.exist');
+    });
+  });
+
   describe('Go to accounts page', () => {
     beforeEach(() => {
       // Select dropdown accounts

--- a/src/app/home-page/recent-events/recent-events.component.ts
+++ b/src/app/home-page/recent-events/recent-events.component.ts
@@ -39,7 +39,6 @@ export class RecentEventsComponent extends Base implements OnInit {
   public displayLimit: number;
   private userPageDisplayLimit = 10;
   private dashboardDisplayLimit = 4;
-  private username: string;
   private supportedEventTypes: Event.TypeEnum[];
   private readonly supportedUserEventTypes = [
     Event.TypeEnum.ADDVERSIONTOENTRY,
@@ -93,7 +92,6 @@ export class RecentEventsComponent extends Base implements OnInit {
   }
 
   handleNewUser(username: string): void {
-    this.username = username;
     this.getUserInfo(username);
   }
 

--- a/src/app/home-page/recent-events/recent-events.component.ts
+++ b/src/app/home-page/recent-events/recent-events.component.ts
@@ -91,10 +91,6 @@ export class RecentEventsComponent extends Base implements OnInit {
     super();
   }
 
-  handleNewUser(username: string): void {
-    this.getUserInfo(username);
-  }
-
   getUserInfo(username: string): void {
     if (!this.eventType && username) {
       // On user page, get user, then get user's events
@@ -173,6 +169,6 @@ export class RecentEventsComponent extends Base implements OnInit {
   }
 
   ngOnInit(): void {
-    this.activatedRoute.params.pipe(takeUntil(this.ngUnsubscribe)).subscribe((params) => this.handleNewUser(params['username']));
+    this.activatedRoute.params.pipe(takeUntil(this.ngUnsubscribe)).subscribe((params) => this.getUserInfo(params['username']));
   }
 }

--- a/src/app/home-page/recent-events/recent-events.component.ts
+++ b/src/app/home-page/recent-events/recent-events.component.ts
@@ -90,13 +90,17 @@ export class RecentEventsComponent extends Base implements OnInit {
     public gravatarService: GravatarService
   ) {
     super();
-    this.username = this.activatedRoute.snapshot.paramMap.get('username');
   }
 
-  ngOnInit() {
-    if (!this.eventType && this.username) {
+  handleNewUser(username: string): void {
+    this.username = username;
+    this.getUserInfo(username);
+  }
+
+  getUserInfo(username: string): void {
+    if (!this.eventType && username) {
       // On user page, get user, then get user's events
-      this.usersService.listUser(this.username).subscribe(
+      this.usersService.listUser(username).subscribe(
         (currentUser: User) => {
           this.recentEventsService.get(currentUser);
         },
@@ -168,5 +172,9 @@ export class RecentEventsComponent extends Base implements OnInit {
 
   remove(id: ID) {
     this.recentEventsService.remove(id);
+  }
+
+  ngOnInit(): void {
+    this.activatedRoute.params.pipe(takeUntil(this.ngUnsubscribe)).subscribe((params) => this.handleNewUser(params['username']));
   }
 }

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -4,7 +4,6 @@ import { Profile, TokenUser, User } from '../shared/openapi';
 import { UsersService } from '../shared/openapi/api/users.service';
 import { UserService } from '../shared/user/user.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AlertService } from '../shared/alert/state/alert.service';

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -45,14 +45,11 @@ export class UserPageComponent extends Base implements OnInit, OnDestroy {
   }
 
   handleNewUser(username: string): void {
-    if (username) {
-      this.username = username;
-      this.getUserInfo(username);
-    }
+    this.username = username;
+    this.getUserInfo(username);
   }
 
   getUserInfo(username: string): void {
-    console.log('NEW USER ' + username);
     this.usersService.listUser(username, 'userProfiles').subscribe(
       (user) => {
         this.user = user;

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { TokenSource } from '../shared/enum/token-source.enum';
 import { Profile, TokenUser, User } from '../shared/openapi';
 import { UsersService } from '../shared/openapi/api/users.service';
@@ -19,7 +19,7 @@ import { AccountInfo } from '../loginComponents/accounts/external/accounts.compo
   templateUrl: './user-page.component.html',
   styleUrls: ['./user-page.component.scss'],
 })
-export class UserPageComponent extends Base implements OnInit, OnDestroy {
+export class UserPageComponent extends Base implements OnInit {
   public user: User;
   public TokenSource = TokenSource;
   public googleProfile: Profile;

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -42,10 +42,6 @@ export class UserPageComponent extends Base implements OnInit {
     super();
   }
 
-  handleNewUser(username: string): void {
-    this.getUserInfo(username);
-  }
-
   getUserInfo(username: string): void {
     this.usersService.listUser(username, 'userProfiles').subscribe(
       (user) => {
@@ -94,8 +90,9 @@ export class UserPageComponent extends Base implements OnInit {
         }
       });
   }
+
   ngOnInit(): void {
-    this.activatedRoute.params.pipe(takeUntil(this.ngUnsubscribe)).subscribe((params) => this.handleNewUser(params['username']));
+    this.activatedRoute.params.pipe(takeUntil(this.ngUnsubscribe)).subscribe((params) => this.getUserInfo(params['username']));
     this.userQuery.isAdminOrCurator$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isAdminOrCurator) => {
       this.loggedInUserIsAdminOrCurator = isAdminOrCurator;
     });

--- a/src/app/user-page/user-page.component.ts
+++ b/src/app/user-page/user-page.component.ts
@@ -21,7 +21,6 @@ import { AccountInfo } from '../loginComponents/accounts/external/accounts.compo
 })
 export class UserPageComponent extends Base implements OnInit, OnDestroy {
   public user: User;
-  public username: string;
   public TokenSource = TokenSource;
   public googleProfile: Profile;
   public gitHubProfile: Profile;
@@ -44,7 +43,6 @@ export class UserPageComponent extends Base implements OnInit, OnDestroy {
   }
 
   handleNewUser(username: string): void {
-    this.username = username;
     this.getUserInfo(username);
   }
 


### PR DESCRIPTION
**Description**
This PR fixes the UI so that when the profile page switches from user X's to user Y's profile page, user Y's information is displayed.  Previously, the UI was broken, and would get "stuck" on user X's page.  The URL would change, but the information on the profile page did not.

The fix was to the `UserPageComponent` and `RecentEventsComponent` components, which comprise most of the profile page, and previously both read the username from the route upon construction.  Now, they observe the route parameters and update the user when they change.  

Both components were lightly refactored to make their internals more similar to each other.  Also, I deleted the unused property `username`, please inspect and confirm that it is unused. 

I kinda feel like both components should be embedded in a "profile page" component, which passes the username to them as an Input.  But that's a substantial [philosophical] difference and a big change for "right before the release" so I left it the way it is.

**Review Instructions**
Log into qa, navigate to `qa.dockstore.org/users/svonworl`, and use the dropdown menu at upper right to see your profile.  Confirm that all information on the profile page changes from svonworl's to yours.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6021

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
