### PR TITLE
DOCK-2487: Generalize recentEvents pipe

### DIFF
--- a/src/app/shared/entry/recent-events.pipe.spec.ts
+++ b/src/app/shared/entry/recent-events.pipe.spec.ts
@@ -5,11 +5,20 @@ describe('Pipe: recentEvents', () => {
   const entryFields = ['tool', 'workflow', 'apptool', 'service', 'notebook'];
 
   function instantiate(): RecentEventsPipe {
-    return new RecentEventsPipe(undefined);
+    return new RecentEventsPipe({ transform: (entry) => entry.gitUrl });
   }
 
   it('Should instantiate', () => {
     expect(instantiate()).toBeTruthy();
+  });
+
+  it('Should calculate the correct "displayName"', () => {
+    const pipe = instantiate();
+    entryFields.forEach((field) => {
+      const value = `${field}-value`;
+      const event = { [field]: { gitUrl: value } };
+      expect(pipe.transform(event, 'displayName')).toBe(value);
+    });
   });
 
   it('Should calculate the correct "entryType"', () => {

--- a/src/app/shared/entry/recent-events.pipe.spec.ts
+++ b/src/app/shared/entry/recent-events.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { RecentEventsPipe } from './recent-events.pipe';
+import { Workflow } from 'app/shared/openapi';
+
+describe('Pipe: recentEvents', () => {
+  const entryFields = ['tool', 'workflow', 'apptool', 'service', 'notebook'];
+
+  function instantiate(): RecentEventsPipe {
+    return new RecentEventsPipe(undefined);
+  }
+
+  it('Should instantiate', () => {
+    expect(instantiate()).toBeTruthy();
+  });
+
+  it('Should calculate the correct "entryType"', () => {
+    const pipe = instantiate();
+    entryFields.forEach((field) => {
+      const term = `${field}-term`;
+      const event = { [field]: { entryTypeMetadata: { term: term } } };
+      expect(pipe.transform(event, 'entryType')).toBe(term);
+    });
+  });
+
+  it('Should calculate the correct "entryLink"', () => {
+    const pipe = instantiate();
+    entryFields.forEach((field) => {
+      const sitePath = `${field}-site-path`;
+      const entryPath = `${field}-entry-path`;
+      const event = {
+        [field]: { entryTypeMetadata: { sitePath: sitePath }, [field === 'tool' ? 'tool_path' : 'full_workflow_path']: entryPath },
+      };
+      expect(pipe.transform(event, 'entryLink')).toBe(`/${sitePath}/${entryPath}`);
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This PR modifies the `recentEvents` pipe to use the referenced entry's type metadata so that it works for all entry types.  Previously, it malfunctioned when passed an event that referenced a notebook, service, or apptool. 

The PR adds some opinionated (in that they prescribe the underlying implementation in some cases) unit tests that exercise the new code.  Lots of duck typing, quaaack.

**Review Instructions**
On qa, register and publish a notebook, service, or apptool.  Navigate to your profile, and confirm that the entries in the "Recent Events" section are formatted and linked correctly. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2487
dockstore/dockstore#5735

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
