### PR TITLE
DOCK-1946: Adjust for openapi change

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "config": {
     "webservice_version": "1.15.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10613/workflows/f1f34097-8382-43b1-9421-c2a4cba0c582/jobs/38798/artifacts",
-    "circle_build_id": "38798"
+    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/10658/workflows/275ec189-a808-4936-8eb3-597925fc85a0/jobs/39171/artifacts",
+    "circle_build_id": "39171"
   },
   "scripts": {
     "ng": "npx ng",

--- a/src/app/shared/state/entry-wizard.service.ts
+++ b/src/app/shared/state/entry-wizard.service.ts
@@ -117,7 +117,7 @@ export class EntryWizardService {
     this.entryWizardStore.setLoading(true);
     const registryEnum = this.convertSourceControlStringToEnum(repository.gitRegistry);
     this.workflowsService
-      .deleteWorkflow(registryEnum as '...', repository.organization, repository.repositoryName)
+      .deleteWorkflow(registryEnum as 'github.com' | 'bitbucket.org' | 'gitlab.com', repository.organization, repository.repositoryName)
       .pipe(finalize(() => this.entryWizardStore.setLoading(false)))
       .subscribe(
         (workflow: BioWorkflow) => {

--- a/src/app/shared/state/entry-wizard.service.ts
+++ b/src/app/shared/state/entry-wizard.service.ts
@@ -117,7 +117,7 @@ export class EntryWizardService {
     this.entryWizardStore.setLoading(true);
     const registryEnum = this.convertSourceControlStringToEnum(repository.gitRegistry);
     this.workflowsService
-      .deleteWorkflow(registryEnum, repository.organization, repository.repositoryName)
+      .deleteWorkflow(registryEnum as '...', repository.organization, repository.repositoryName)
       .pipe(finalize(() => this.entryWizardStore.setLoading(false)))
       .subscribe(
         (workflow: BioWorkflow) => {


### PR DESCRIPTION
**Description**
A previous webservice PR https://github.com/dockstore/dockstore/pull/5747 narrowed the type of an endpoint argument, which propagated to the UI via openapi.yaml and caused the build to fail.  This PR makes the requisite adjustment to the UI code.  It feels a bit grimy but is probably fine.

**Review Instructions**
Confirm UI builds successfully.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1946
https://github.com/dockstore/dockstore/issues/4513

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
