### PR TITLE
SEAB-6024: Modify "Files" tabs, mostly for notebooks

### DIFF
--- a/src/app/descriptor-languages/Jupyter.ts
+++ b/src/app/descriptor-languages/Jupyter.ts
@@ -26,15 +26,23 @@ export const extendedJupyter: ExtendedDescriptorLanguageBean = {
   fileTabs: [
     {
       tabName: 'Notebook Files',
-      fileTypes: [SourceFile.TypeEnum.DOCKSTOREJUPYTER, SourceFile.TypeEnum.DOCKSTORENOTEBOOKOTHER],
+      fileTypes: [SourceFile.TypeEnum.DOCKSTOREJUPYTER],
+    },
+    {
+      tabName: 'Configuration Files',
+      fileTypes: [
+        SourceFile.TypeEnum.DOCKSTOREYML,
+        SourceFile.TypeEnum.DOCKSTORENOTEBOOKREES,
+        SourceFile.TypeEnum.DOCKSTORENOTEBOOKDEVCONTAINER,
+      ],
     },
     {
       tabName: 'Test Files',
       fileTypes: [SourceFile.TypeEnum.DOCKSTORENOTEBOOKTESTFILE],
     },
     {
-      tabName: 'Configuration Files',
-      fileTypes: [SourceFile.TypeEnum.DOCKSTORENOTEBOOKREES],
+      tabName: 'Other Files',
+      fileTypes: [SourceFile.TypeEnum.DOCKSTORENOTEBOOKOTHER],
     },
   ],
 };

--- a/src/app/source-file-tabs/source-file-tabs.service.ts
+++ b/src/app/source-file-tabs/source-file-tabs.service.ts
@@ -43,6 +43,7 @@ export class SourceFileTabsService {
     const fileTabsSchematic =
       this.descriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorLanguage).fileTabs;
 
+    // Display all of the tabs, even if they are empty.
     fileTabsSchematic.forEach((fileTab) => {
       fileTabs.set(fileTab.tabName, []);
     });

--- a/src/app/source-file-tabs/source-file-tabs.service.ts
+++ b/src/app/source-file-tabs/source-file-tabs.service.ts
@@ -43,9 +43,9 @@ export class SourceFileTabsService {
     const fileTabsSchematic =
       this.descriptorLanguageService.toolDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorLanguage).fileTabs;
 
-    // Always have the Descriptor Files Tab and Test Parameter Files tab
-    fileTabs.set(fileTabsSchematic[0].tabName, []);
-    fileTabs.set(fileTabsSchematic[1].tabName, []);
+    fileTabsSchematic.forEach((fileTab) => {
+      fileTabs.set(fileTab.tabName, []);
+    });
     if (!sourcefiles || sourcefiles.length === 0) {
       return fileTabs;
     }


### PR DESCRIPTION
**Description**
The original intention for this PR's backing ticket (https://ucsc-cgl.atlassian.net/browse/SEAB-6024) was to add a "Configuration Files" tab to the notebook entry page, which seemed to be conspicuously missing.   However, it turns out that the code already defined a "Configuration Files" tab (how quickly I forget lol) and it simply wasn't appearing, because the code didn't categorize `.dockstore.yml` or devcontainer files as notebook Configuration files, and the existing tab code was written to always display the first two files tabs and hide the rest if they were empty.  Previously, the notebook "Configuration File" tab was third, and thus did not appear if it had no files.

So, this PR changes the UI to:
* Include `.dockstore.yml` and devcontainer files in the set of notebook configuration files.
* Display all the files tabs, whether they're empty or not.
* Split out the notebooks "Other Files" tab.  These files might be code, but they could also be data, documentation, etc.

These changes are effectively a no-op for GitHub-app-registered workflows, since the `Configuration Files` tab always appears due to the presence of a `.dockstore.yml`.

**Review Instructions**
View a notebook on qa, and confirm that four file tabs appear, and that the `Configuration Files` tab appears and includes `.dockstore.yml`. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6024

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
