### PR TITLE
DOCK-2496: Fix TRS link for Galaxy workflows

### DIFF
--- a/src/app/descriptor-languages/Jupyter.ts
+++ b/src/app/descriptor-languages/Jupyter.ts
@@ -15,8 +15,8 @@ export const extendedJupyter: ExtendedDescriptorLanguageBean = {
   toolDescriptorEnum: ToolDescriptor.TypeEnum.JUPYTER,
   workflowDescriptorEnum: Workflow.DescriptorTypeEnum.Jupyter,
   languageDocumentationURL: JUPYTER_DOCUMENTATION_URL,
-  plainTRS: null,
-  descriptorFileTypes: [],
+  plainTRS: 'PLAIN_JUPYTER',
+  descriptorFileTypes: [SourceFile.TypeEnum.DOCKSTOREJUPYTER],
   toolTab: {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Notebook',

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -59,4 +59,14 @@ describe('ValueService', () => {
     expect(service.getTRSId(sampleWorkflow3, EntryType.Service)).toBe(`#service/${fullWorkflowPath}`);
     expect(service.getTRSId(null, EntryType.BioWorkflow)).toBe('');
   });
+
+  it(`getTRSPlainType should work for various descriptor types`, () => {
+    service = TestBed.inject(InfoTabService);
+    expect(service.getTRSPlainType('CWL')).toBe('PLAIN_CWL');
+    expect(service.getTRSPlainType('WDL')).toBe('PLAIN_WDL');
+    expect(service.getTRSPlainType('NFL')).toBe('PLAIN_NFL');
+    expect(service.getTRSPlainType('gxformat2')).toBe('PLAIN_GALAXY');
+    expect(service.getTRSPlainType('jupyter')).toBe('PLAIN_JUPYTER');
+    expect(service.getTRSPlainType('bogus')).toBe(null);
+  });
 });

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -67,6 +67,6 @@ describe('ValueService', () => {
     expect(service.getTRSPlainType('NFL')).toBe('PLAIN_NFL');
     expect(service.getTRSPlainType('gxformat2')).toBe('PLAIN_GALAXY');
     expect(service.getTRSPlainType('jupyter')).toBe('PLAIN_JUPYTER');
-    expect(service.getTRSPlainType('bogus')).toBe(null);
+    expect(service.getTRSPlainType('bogus')).toBe('PLAIN_BOGUS');
   });
 });

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -218,11 +218,16 @@ export class InfoTabService {
   getTRSLink(path: string, versionName: string, descriptorType: string, descriptorPath: string, entryType: EntryType): string {
     return (
       `${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(this.getTRSIDFromPath(path, entryType))}` +
-      `/versions/${encodeURIComponent(versionName)}/PLAIN_` +
-      descriptorType.toUpperCase() +
+      `/versions/${encodeURIComponent(versionName)}/` +
+      this.getTRSPlainType(descriptorType) +
       `/descriptor/` +
       descriptorPath
     );
+  }
+
+  getTRSPlainType(dockstoreDescriptorType: string): string {
+    const trsDescriptorType = this.descriptorTypeCompatService.stringToDescriptorType(dockstoreDescriptorType);
+    return this.descriptorTypeCompatService.toolDescriptorTypeEnumToPlainTRS(trsDescriptorType);
   }
 
   getTRSId(workflow: Workflow | undefined, entryType: EntryType): string {

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -227,7 +227,10 @@ export class InfoTabService {
 
   getTRSPlainType(dockstoreDescriptorType: string): string {
     const trsDescriptorType = this.descriptorTypeCompatService.stringToDescriptorType(dockstoreDescriptorType);
-    return this.descriptorTypeCompatService.toolDescriptorTypeEnumToPlainTRS(trsDescriptorType);
+    return (
+      this.descriptorTypeCompatService.toolDescriptorTypeEnumToPlainTRS(trsDescriptorType) ??
+      `PLAIN_${dockstoreDescriptorType.toUpperCase()}`
+    );
   }
 
   getTRSId(workflow: Workflow | undefined, entryType: EntryType): string {


### PR DESCRIPTION
**Description**
This PR changes the UI to generate the correct TRS link for a Galaxy workflow.  Previously, the UI was converting the Dockstore Galaxy descriptor type to the plain TRS type by uppercasing and prepending "PLAIN_", which didn't work for "gxformat2".

This PR also makes a couple of changes to the Jupyter "extended descriptor info" that are necessary for fully-functional TRS notebook support.

**Review Instructions**
On qa, navigate to a info tab of a Galaxy workflow, click on the "TRS:" link, and confirm that the primary descriptor contents are displayed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2496
dockstore/dockstore#5751

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
