### PR TITLE
SEAB-5971: Move search result tooltips to the left of results

### DIFF
--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -40,11 +40,16 @@
             >
           </div>
           <ng-template #docktoreToolName>
-            <a [matTooltip]="tool?.source.tool_path" [routerLink]="'/containers/' + tool.source.tool_path">{{
+            <a [matTooltip]="tool?.source.tool_path" matTooltipPosition="left" [routerLink]="'/containers/' + tool.source.tool_path">{{
               tool?.source.namespace + '/' + tool?.source.name + (tool?.source.toolname ? '/' + tool?.source.toolname : '')
             }}</a>
           </ng-template>
-          <div class="truncate-text-2 size-small" *ngIf="tool.source.topicAutomatic" [matTooltip]="tool.source.topicAutomatic">
+          <div
+            class="truncate-text-2 size-small"
+            *ngIf="tool.source.topicAutomatic"
+            [matTooltip]="tool.source.topicAutomatic"
+            matTooltipPosition="left"
+          >
             {{ tool.source.topicAutomatic }}
           </div>
         </div>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -27,9 +27,17 @@
             <app-private-icon></app-private-icon>
           </span>
           <div *ngIf="tool.source | isAppTool; else docktoreToolName">
-            <a [matTooltip]="tool?.source.full_workflow_path" [routerLink]="'/containers/' + tool.source.full_workflow_path">{{
-              tool?.source.organization + '/' + tool?.source.repository + (tool?.source.workflowName ? '/' + tool?.source.workflowName : '')
-            }}</a>
+            <a
+              [matTooltip]="tool?.source.full_workflow_path"
+              matTooltipPosition="left"
+              [routerLink]="'/containers/' + tool.source.full_workflow_path"
+              >{{
+                tool?.source.organization +
+                  '/' +
+                  tool?.source.repository +
+                  (tool?.source.workflowName ? '/' + tool?.source.workflowName : '')
+              }}</a
+            >
           </div>
           <ng-template #docktoreToolName>
             <a [matTooltip]="tool?.source.tool_path" [routerLink]="'/containers/' + tool.source.tool_path">{{

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -7,12 +7,17 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
         <div>
-          <a [matTooltip]="workflow?.source.full_workflow_path" [routerLink]="'/workflows/' + workflow?.source.full_workflow_path">{{
-            workflow?.source.organization +
-              '/' +
-              workflow?.source.repository +
-              (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
-          }}</a>
+          <a
+            [matTooltip]="workflow?.source.full_workflow_path"
+            matTooltipPosition="left"
+            [routerLink]="'/workflows/' + workflow?.source.full_workflow_path"
+            >{{
+              workflow?.source.organization +
+                '/' +
+                workflow?.source.repository +
+                (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
+            }}</a
+          >
           <div class="truncate-text-2 size-small" *ngIf="workflow.source.topicAutomatic" [matTooltip]="workflow.source.topicAutomatic">
             {{ workflow.source.topicAutomatic }}
           </div>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -18,7 +18,12 @@
                 (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
             }}</a
           >
-          <div class="truncate-text-2 size-small" *ngIf="workflow.source.topicAutomatic" [matTooltip]="workflow.source.topicAutomatic">
+          <div
+            class="truncate-text-2 size-small"
+            *ngIf="workflow.source.topicAutomatic"
+            [matTooltip]="workflow.source.topicAutomatic"
+            matTooltipPosition="left"
+          >
             {{ workflow.source.topicAutomatic }}
           </div>
         </div>


### PR DESCRIPTION
**Description**
This PR moves the tooltip for "Name and Description" portion of the search results to the left of the name/description.  Previously, it appeared below, thus covering some of the result and/or the next result, interfering as the user scanned or tried to interact with the results.  The new position overlaps the facets a little bit, but overall, the effect is much less deleterious to the typical flow...

**Review Instructions**
Go to search on qa, mouse over the name/description of a result, and confirm that the tooltip appears to the left.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5971

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
