### PR TITLE
SEAB-6062: Fix topic editing irregularities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
   slack: circleci/slack@4.4.4
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.6
 executors:
   integration_test_exec: # declares a reusable executor
     docker:

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -255,7 +255,7 @@
                     mat-raised-button
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
                     (click)="toggleEditTopic()"
-                    data-cy="topicSaveButton"
+                    [attr.data-cy]="topicEditing ? 'topicSaveButton' : 'topicEditButton'"
                     [matTooltip]="
                       workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML
                         ? 'Edit the manual topic for this ' +

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -243,21 +243,14 @@
                     <img src="../assets/svg/icons-reject-small.svg" alt="Cancel" class="pr-2 pb-1" />Cancel
                   </button>
                   <button
-                    *ngIf="!workflow?.topic && !topicEditing"
                     [disabled]="
-                      forumUrlEditing || workflowPathEditing || defaultTestFilePathEditing || (isRefreshing$ | async) || !canWrite
+                      forumUrlEditing ||
+                      workflowPathEditing ||
+                      defaultTestFilePathEditing ||
+                      (isRefreshing$ | async) ||
+                      !canWrite ||
+                      workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML
                     "
-                    type="button"
-                    mat-raised-button
-                    class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"
-                    (click)="toggleEditTopic()"
-                    data-cy="topicEditButton"
-                  >
-                    <img src="../assets/svg/icons-actions-edit.svg" class="pr-2" alt="Edit Topic Manual" />Edit
-                  </button>
-                  <button
-                    *ngIf="workflow?.topic || topicEditing"
-                    [disabled]="!canWrite || workflow?.mode === WorkflowType.ModeEnum.DOCKSTOREYML"
                     type="button"
                     mat-raised-button
                     class="small-mat-btn-skin accent-1-dark small-btn-structure mat-elevation-z"


### PR DESCRIPTION
**Description**
This PR changes the manual topic editing code to make it work more consistently.

During a planning meeting demo, I noticed that I couldn't edit the manual topic of a notebook.  I could press the "Edit" button, which would bring up the topic editing text box, but the "Save" button was disabled.  So, we wrote this ticket.

We'd forgotten in ???, we disabled manual topic editing for `.dockstore.yml`-based entries.  Now, users are supposed to set the manual topic in `.dockstore.yml`.

However, the UI also wasn't working quite right, and Kathy confirmed that the correct behavior is for the manual topic "Edit" button should be disabled for all `.dockstore.yml`-based entries.  So, to accomplish the above, this PR fixes the relevant button code by consolidating two code paths. 

After this PR, the manual topic "Edit" button will:
* Always be disabled for `.dockstore.yml`-based entries.
* Always display the tooltip advising users of how to change the manual topic for `.dockstore.yml`-based entries. 
* Work as it did before, otherwise, allowing a user to change the manual topic for other types of entries via the UI.

I did some user testing on various types of workflows and notebooks, and it seems to work.  However, please build and test, there's lots of shifting state and special cases in this component, which makes it super easy to mess up...

**Review Instructions**
On qa:
1. Navigate to the info tab of a non-`.dockstore.yml`-based workflow that you own, and confirm you can successfully edit the manual topic.
2. Navigate to the info tab of a `.dockstore.yml`-based workflow that you own, and confirm that the manual topic "Edit" button is disabled and displays a tooltip that discusses how to change the manual topic.
3. Repeat step 2 for a notebook that you own.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6062

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
