### PR TITLE
Fix width of register tool dialog

### DIFF
--- a/src/app/mytools/my-tool/my-tool.component.ts
+++ b/src/app/mytools/my-tool/my-tool.component.ts
@@ -32,6 +32,7 @@ import { AccountsService } from '../../loginComponents/accounts/external/account
 import { OrgWorkflowObject } from '../../myworkflows/my-workflow/my-workflow.component';
 import { MyWorkflowsService } from '../../myworkflows/myworkflows.service';
 import { AlertQuery } from '../../shared/alert/state/alert.query';
+import { bootstrap4largeModalSize } from '../../shared/constants';
 import { ContainerService } from '../../shared/container.service';
 import { MyEntry, OrgEntryObject } from '../../shared/my-entry';
 import { TokenQuery } from '../../shared/state/token.query';
@@ -123,7 +124,7 @@ export class MyToolComponent extends MyEntry implements OnInit {
 
     this.registerToolService.isModalShown.pipe(takeUntil(this.ngUnsubscribe)).subscribe((isModalShown: boolean) => {
       if (isModalShown) {
-        const dialogRef = this.dialog.open(RegisterToolComponent, { width: '600px' });
+        const dialogRef = this.dialog.open(RegisterToolComponent, { width: bootstrap4largeModalSize });
         dialogRef
           .afterClosed()
           .pipe(takeUntil(this.ngUnsubscribe))


### PR DESCRIPTION
**Description**
One invocation of the register tool was missed when we went to a wider dialog; it was missed on the My Tools page (worked from the Dashboard page).

**Review Instructions**
1. Go to the Dashboard, e.g., https://staging.dockstore.org
2. Click the `Register a tool` button, note the width of the dialog that pops up, dismiss it.
3. Click the `Tools` tile on the left side of the dashboard, so you are in My Tools
4. Click the `Register a tool` button. Ensure that its width is the same as in step 2.

**Issue**
SEAB-5999

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
