### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/accessibility_test.yml
+++ b/.github/workflows/accessibility_test.yml
@@ -120,7 +120,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Download accessibility results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: accessibility-results
           # Download to this directory because this is the directory that the accessibility script looks at for the results


### PR DESCRIPTION
Reverts dockstore/dockstore-ui2#1899

Actually, probably blocked by  https://github.com/actions/upload-artifact/releases/tag/v4.0.0 
and https://ucsc-cgl.atlassian.net/browse/SEAB-6108
