### PR TITLE
DOCK-2470: make organizations sort by name case-insensitive

### DIFF
--- a/src/app/organizations/state/organizations.query.ts
+++ b/src/app/organizations/state/organizations.query.ts
@@ -75,7 +75,7 @@ export class OrganizationsQuery extends Query<OrganizationsState> {
       let newOrganizations = this.filterOrganizations(organizations, searchName);
       const arrayForSort = [...newOrganizations];
       if (sortBy === 'name') {
-        arrayForSort.sort((a, b) => (a.displayName < b.displayName ? -1 : 1));
+        arrayForSort.sort((a, b) => (a.displayName.toLowerCase() < b.displayName.toLowerCase() ? -1 : 1));
         newOrganizations = arrayForSort;
       } else if (sortBy === 'starred') {
         arrayForSort.sort((a, b) => (a.starredUsers.length < b.starredUsers.length ? 1 : -1));


### PR DESCRIPTION
**Description**
At [https://dockstore.org/organizations](https://dockstore.org/organizations), sorting organizations by name is case-insensitive. For example, eLWazi and nf-core should be sorted in the middle and not on the last page.

**Review Instructions**
In the commit, appending `.toLowerCase()` to the organizations' display names ignores whether organizations are uppercase or lowercase.

**Issue**
[DOCK-2470](https://ucsc-cgl.atlassian.net/browse/DOCK-2470)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 