### PR TITLE
Update ini version

### DIFF
--- a/THIRD-PARTY-LICENSES.csv
+++ b/THIRD-PARTY-LICENSES.csv
@@ -129,7 +129,7 @@
 "infer-owner@1.0.4","ISC","https://github.com/npm/infer-owner"
 "inflight@1.0.6","ISC","https://github.com/npm/inflight"
 "inherits@2.0.4","ISC","https://github.com/isaacs/inherits"
-"ini@1.3.5","ISC","https://github.com/isaacs/ini"
+"ini@1.3.8","ISC","https://github.com/isaacs/ini"
 "ini@4.1.1","ISC","https://github.com/npm/ini"
 "internmap@2.0.3","ISC","https://github.com/mbostock/internmap"
 "ip@1.1.5","MIT","https://github.com/indutny/node-ip"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4560,13 +4560,9 @@
       }
     },
     "node_modules/@schematics/update/node_modules/ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
-      "engines": {
-        "node": "*"
-      }
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/@schematics/update/node_modules/lru-cache": {
       "version": "5.1.1",
@@ -24703,7 +24699,7 @@
         "@angular-devkit/core": "8.3.29",
         "@angular-devkit/schematics": "8.3.29",
         "@yarnpkg/lockfile": "1.1.0",
-        "ini": "1.3.5",
+        "ini": "^1.3.8",
         "pacote": "9.5.5",
         "rxjs": "6.4.0",
         "semver": "6.3.0",
@@ -24856,9 +24852,9 @@
           }
         },
         "ini": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "lru-cache": {
           "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,9 @@
     "ng2-ui-auth": {
       "@angular/common": "~14.2.7",
       "@angular/core": "~14.2.7"
+    },
+    "@schematics/update": {
+      "ini": "^1.3.8"
     }
   }
 }


### PR DESCRIPTION
**Description**
Overrides the `ini` package, that is a transitive dependency, with a newer version.

Tried first upgrading `@dataroma/akita`, the package that uses the older `ini`, but that was a major upgrade with breaking changes.

**Review Instructions**
See ticket for review instructions.

**Issue**
SEAB-3091

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
