### PR TITLE
SEAB-6108: Update upload/download artifacts from v3 to v4

### DIFF
--- a/.github/workflows/accessibility_test.yml
+++ b/.github/workflows/accessibility_test.yml
@@ -12,7 +12,7 @@ jobs:
     # Uses if/else expression evaluation workaround from https://github.com/actions/runner/issues/409#issuecomment-752775072
     # 'matrix.branch == github.base_ref' is the condition, 'base' is the true value and 'current' is the false value
     name: Accessibility test (${{ matrix.branch == github.base_ref && 'base' || 'current' }} branch)
-  
+
     runs-on: ubuntu-20.04
     services:
       postgres:
@@ -97,17 +97,17 @@ jobs:
           if [[ "${{ matrix.branch }}" == "$GITHUB_BASE_REF" ]]; then
             echo "Running accessibility test for base branch"
             npm run accessibility-test -- -RB
-          else 
+          else
             echo "Running accessibility test for current branch"
             npm run accessibility-test -- -R
           fi
-          
+
       - name: Save accessibility results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: accessibility-results
+          name: accessibility-results-${{ matrix.branch == github.base_ref && 'base' || 'current' }}
           path: accessibility-results/
-  
+
   compare_accessibility_results:
     needs: run-accessibility-test
     runs-on: ubuntu-20.04
@@ -120,12 +120,12 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Download accessibility results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: accessibility-results
           # Download to this directory because this is the directory that the accessibility script looks at for the results
-          path: accessibility-results 
-          
+          path: accessibility-results
+          pattern: accessibility-results-*
+          merge-multiple: true
+
       - name: Compare accessibility results
         run: npm run accessibility-test -- -A
-        

--- a/scripts/run-pa11y-ci.sh
+++ b/scripts/run-pa11y-ci.sh
@@ -21,7 +21,7 @@ usage() {
   echo "-H, Display help command"
   echo "-B, Do all commands on base branch (if this option is not given all commands are done on current branch)"
   echo "-R, Runs pa11y-ci on branch (requires webservice to be running) and outputs results in a form that can be analysed"
-  echo "-A, Determines if current branch has more accessibility issues then base branch, requires the results from option -R to be available"
+  echo "-A, Determines if current branch has more accessibility issues than base branch, requires the results from option -R to be available"
 }
 
 # Variables for determining which command to run
@@ -104,7 +104,7 @@ then
 
   # If the number of accessibility errors is equal, then check that if they are the same set of errors.
   if [ "$ACCESSIBILITY_ERRORS_CURRENT_BRANCH" -eq "$ACCESSIBILITY_ERRORS_BASE_BRANCH" ]; then
-    echo "The number of accessibility erorrs in this PR and the base branch are the same"
+    echo "The number of accessibility errors in this PR and the base branch are the same"
     exit 0
   fi
 


### PR DESCRIPTION
**Description**
Actions Artifacts v4 no longer allows multiple jobs to upload to the same artifact. This caused the accessibility check to fail during builds ([example](https://github.com/dockstore/dockstore-ui2/actions/runs/7401876576/job/20139880557?pr=1882)). To fix this, the accessibility test should save each test result to its own unique artifact instead of a shared one.

**Review Instructions**
To adhere to v4, the accessibility test results are saved to separately named artifacts, one for the current branch and one for the base branch. Both artifacts are then downloaded to the same directory to be compared as normal.

The accessibility test (using v4) should succeed upon creating this PR.

**Issue**
[SEAB-6108](https://ucsc-cgl.atlassian.net/browse/SEAB-6108?atlOrigin=eyJpIjoiODMyMmNlYTE3MGQxNDUzOGExNjE0MjRiMGI0ZThmYzUiLCJwIjoiaiJ9)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 

[SEAB-6108]: https://ucsc-cgl.atlassian.net/browse/SEAB-6108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ