### PR TITLE
SEAB-6185: Do not display "Refresh Organization" button in my-notebooks accordion

### DIFF
--- a/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.html
+++ b/src/app/myworkflows/sidebar-accordion/sidebar-accordion.component.html
@@ -100,7 +100,11 @@
             fxFlex
             fxLayout
             fxLayoutAlign="end"
-            *ngIf="!orgObj?.sourceControl.startsWith('dockstore.org') && (entryType$ | async) !== EntryType.Tool"
+            *ngIf="
+              !orgObj?.sourceControl.startsWith('dockstore.org') &&
+              (entryType$ | async) !== EntryType.Tool &&
+              (entryType$ | async) !== EntryType.Notebook
+            "
           >
             <app-refresh-workflow-organization [orgWorkflowObject]="orgObj"></app-refresh-workflow-organization>
           </span>


### PR DESCRIPTION
**Description**
This PR removes the "Refresh Organization" button from the sidebar accordion on the my-notebooks page.  Notebooks are registered via `.dockstore.yml` only, so there's never anything to refresh. 

**Review Instructions**
Navigate to your my-notebooks page, and confirm that the "Refresh Organization" no longer appears at the bottom of the sidebar accordion.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6185

**Security**
No concerns.

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
