### PR TITLE
SEAB-6188: Enable notebook versions to be hidden

### DIFF
--- a/cypress/e2e/group2/notebooks.ts
+++ b/cypress/e2e/group2/notebooks.ts
@@ -82,8 +82,8 @@ describe('Dockstore notebooks', () => {
     cy.get('[data-cy=versionRow]').contains(/jupyter/i);
     // Click on Info button and check content.
     cy.get('[data-cy=versionRow] button').click();
-    cy.get('input[name=reference]').should('have.value', 'simple-published-v1');
-    cy.get('input[name=workflow_path]').should('have.value', '/notebook.ipynb');
+    cy.get('.label-value').contains('simple-published-v1');
+    cy.get('.label-value').contains('/notebook.ipynb');
   });
 
   it('should have Files tab', () => {

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -24,14 +24,14 @@
             <label class="col-sm-3 col-md-3 col-lg-3 control-label"> Git Reference: </label>
             <div class="col-sm-9 col-md-9 col-lg-9">
               <input
-                *ngIf="(isService$ | async) === false"
+                *ngIf="(isService$ | async) === false && (isNotebook$ | async) === false"
                 type="text"
                 class="form-control"
                 name="reference"
                 ngModel="{{ version.reference ? version.reference : 'n/a' }}"
                 disabled
               />
-              <div *ngIf="isService$ | async" class="label-value">
+              <div *ngIf="(isService$ | async) || (isNotebook$ | async)" class="label-value">
                 {{ version.reference ? version.reference : 'n/a' }}
               </div>
             </div>
@@ -42,14 +42,14 @@
             </label>
             <div class="col-sm-9 col-md-9 col-lg-9">
               <input
-                *ngIf="(isService$ | async) === false"
+                *ngIf="(isService$ | async) === false && (isNotebook$ | async) === false"
                 type="text"
                 class="form-control"
                 name="workflow_path"
                 [(ngModel)]="version.workflow_path"
                 minlength="3"
                 maxlength="1000"
-                [pattern]="(isNotebook$ | async) === false ? validationPatterns.workflowDescriptorPath : undefined"
+                [pattern]="validationPatterns.workflowDescriptorPath"
                 required
                 [matTooltip]="tooltip.workflowPath"
                 placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"
@@ -63,7 +63,7 @@
                   version.doiURL
                 "
               />
-              <div *ngIf="isService$ | async" class="label-value">
+              <div *ngIf="(isService$ | async) || (isNotebook$ | async)" class="label-value">
                 {{ version.workflow_path }}
               </div>
               <mat-card

--- a/src/app/workflow/version-modal/version-modal.component.html
+++ b/src/app/workflow/version-modal/version-modal.component.html
@@ -49,7 +49,7 @@
                 [(ngModel)]="version.workflow_path"
                 minlength="3"
                 maxlength="1000"
-                [pattern]="validationPatterns.workflowDescriptorPath"
+                [pattern]="(isNotebook$ | async) === false ? validationPatterns.workflowDescriptorPath : undefined"
                 required
                 [matTooltip]="tooltip.workflowPath"
                 placeholder="e.g. CancerCollaboratory/dockstore-tool-liftover"


### PR DESCRIPTION
**Description**
Prior to this PR, in the "Edit Notebook Version" dialog, the Git Reference and Notebook Path were displayed as form inputs, and the form validation was failing, because it was applying the regexp that it uses to check workflow paths, which didn't work on notebook paths ending with `.ipynb`.  Because the validation failed, the "Save Changes" button was disabled, thus preventing the only editable setting ("Hidden") from being submitted.

This PR displays a notebook's Git Reference and Notebook Path in `div`s, rather than `form` inputs, thus bypassing the validation, which is unnecessary because they're read only.  Thus, it enables the "Save Changes" button, allowing the user to hide a notebook. 

**Review Instructions**
On qa, select a version of one of your notebooks, and use the Actions menu to edit it and hide it.  Confirm it's hidden.  Then, unhide it.  Next, repeat the process on one of your workflow versions, to confirm that we didn't break anything.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6188

**Security**
No concerns.

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
