### PR TITLE
SEAB-6189: Add notebooks count to dashboard "Starred" box

### DIFF
--- a/src/app/home-page/widget/starred-box/starred-box.component.html
+++ b/src/app/home-page/widget/starred-box/starred-box.component.html
@@ -17,6 +17,12 @@
             {{ totalStarredTools }} Tool<span *ngIf="totalStarredTools !== 1">s</span>
           </a>
         </div>
+        <div fxLayout fxLayoutAlign="center center">
+          <mat-icon class="mat-icon-sm">{{ totalStarredNotebooks ? 'star' : 'star_border' }}</mat-icon>
+          <a [routerLink]="['/starred']" [queryParams]="{ tab: 'notebooks' }">
+            {{ totalStarredNotebooks }} Notebook<span *ngIf="totalStarredNotebooks !== 1">s</span>
+          </a>
+        </div>
         <!-- TODO: remove *ngIf when services implemented-->
         <div *ngIf="serviceImplemented" fxLayout fxLayoutAlign="center center">
           <mat-icon class="mat-icon-sm">{{ totalStarredServices ? 'star' : 'star_border' }}</mat-icon>

--- a/src/app/home-page/widget/starred-box/starred-box.component.ts
+++ b/src/app/home-page/widget/starred-box/starred-box.component.ts
@@ -12,6 +12,7 @@ export class StarredBoxComponent extends Base implements OnInit {
   public Dockstore = Dockstore;
   public totalStarredWorkflows: number = 0;
   public totalStarredTools: number = 0;
+  public totalStarredNotebooks: number = 0;
   public totalStarredServices: number = 0;
   public totalStarredOrganizations: number = 0;
 
@@ -23,14 +24,17 @@ export class StarredBoxComponent extends Base implements OnInit {
   }
 
   ngOnInit(): void {
-    this.usersService.getStarredServices().subscribe((starredServices) => {
-      this.totalStarredServices = starredServices.length;
+    this.usersService.getStarredWorkflows().subscribe((starredWorkflows) => {
+      this.totalStarredWorkflows = starredWorkflows.length;
     });
     this.usersService.getStarredTools().subscribe((starredTools) => {
       this.totalStarredTools = starredTools.length;
     });
-    this.usersService.getStarredWorkflows().subscribe((starredWorkflows) => {
-      this.totalStarredWorkflows = starredWorkflows.length;
+    this.usersService.getStarredNotebooks().subscribe((starredNotebooks) => {
+      this.totalStarredNotebooks = starredNotebooks.length;
+    });
+    this.usersService.getStarredServices().subscribe((starredServices) => {
+      this.totalStarredServices = starredServices.length;
     });
     this.usersService.getStarredOrganizations().subscribe((starredOrganizations) => {
       this.totalStarredOrganizations = starredOrganizations.length;


### PR DESCRIPTION
**Description**
This PR adds a count of starred notebooks to the "Starred" box that appears in lower right corner of the dashboard.  It also reorders the "get starred entry" requests so the results for the entry types that our userbase is most interested in will probably show up first.

**Review Instructions**
Navigate to your dashboard and confirm that a correct count of starred notebooks in the "Starred" box.  Star a notebook.  Confirm that the count of starred notebooks has increased by one.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6189

**Security**
No concerns.
Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
