### PR TITLE
Metrics column value in my-workflows was wrong

### DIFF
--- a/cypress/e2e/group3/metrics.ts
+++ b/cypress/e2e/group3/metrics.ts
@@ -1,6 +1,7 @@
-import { goToTab, insertNotebooks, setTokenUserViewPort } from '../../support/commands';
+import { goToTab, insertNotebooks, resetDB, setTokenUserViewPort } from '../../support/commands';
 
 describe('Dockstore Metrics', () => {
+  resetDB();
   insertNotebooks();
   setTokenUserViewPort();
   it('Should see no metrics banner', () => {
@@ -55,5 +56,11 @@ describe('Dockstore Metrics', () => {
     cy.get('[data-cy=metrics-partner-dropdown]').should('contain', 'AGC');
     cy.get('[data-cy=execution-metrics-total-executions-div]').should('contain', 4);
     cy.get('[data-cy=validations-table]').should('not.exist');
+  });
+
+  it('Should not see metrics checked on versions table if no metrics', () => {
+    cy.visit('/my-workflows/github.com/A/l:master');
+    goToTab('Versions');
+    cy.get('[data-cy=metrics]').should('not.exist');
   });
 });

--- a/src/app/myworkflows/myworkflows.service.ts
+++ b/src/app/myworkflows/myworkflows.service.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { transaction } from '@datorama/akita';
 import { AlertService } from 'app/shared/alert/state/alert.service';
-import { includesAuthors, includesValidation, bootstrap4largeModalSize } from 'app/shared/constants';
+import { includesAuthors, includesValidation, bootstrap4largeModalSize, includesMetrics } from 'app/shared/constants';
 import { EntryType } from 'app/shared/enum/entry-type';
 import { MyEntriesService } from 'app/shared/myentries.service';
 import { SessionQuery } from 'app/shared/session/session.query';
@@ -198,13 +198,16 @@ export class MyWorkflowsService extends MyEntriesService<Workflow, OrgWorkflowOb
   /**
    * Grabs the workflow/service/notebook from the webservice and loads it
    * @param workflow Selected workflow
+   * @param entryType
    */
   selectEntry(workflow: DockstoreTool | Workflow | null, entryType: EntryType | null): void {
     if (workflow && entryType && workflow.id) {
-      this.workflowsService.getWorkflow(workflow.id, includesValidation + ',' + includesAuthors).subscribe((result: Workflow) => {
-        this.location.go('/my-' + entryType + 's/' + result.full_workflow_path);
-        this.workflowService.setWorkflow(result);
-      });
+      this.workflowsService
+        .getWorkflow(workflow.id, [includesValidation, includesAuthors, includesMetrics].join(','))
+        .subscribe((result: Workflow) => {
+          this.location.go('/my-' + entryType + 's/' + result.full_workflow_path);
+          this.workflowService.setWorkflow(result);
+        });
     }
   }
 

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -184,7 +184,7 @@
         >
       </th>
       <td mat-cell *matCellDef="let version">
-        <mat-icon data-cy="metrics" *ngIf="(version.metricsByPlatform | json) !== '{}'">check</mat-icon>
+        <mat-icon data-cy="metrics" *ngIf="version.metricsByPlatform && (version.metricsByPlatform | json) !== '{}'">check</mat-icon>
       </td>
     </ng-container>
 


### PR DESCRIPTION
**Description**
It was showing all versions have metrics, regardless of whether they did have metrics or not.

This worked on the public facing page, because the public facing page calls a different [endpoint](https://staging.dockstore.org/api/static/swagger-ui/index.html#/workflows/getPublishedWorkflowByPath) than [my-workflows](https://staging.dockstore.org/api/static/swagger-ui/index.html#/workflows/getWorkflow). The public facing page was already passing the `metrics` query parameter value, my-workflows wasn't. 

**Review Instructions**
1. Go to My Workflows
2. Select a workflow that has no metrics, or some metrics
3. Navigate to the versions tab
4. Verify that the Metrics column does not have a checkmark visible.

**Issue**
DOCK-2501
dockstore/dockstore#5790

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
