### PR TITLE
SEAB-6186: Remove "More" and "Discover Tools" button/menu from accordion.

### DIFF
--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -49,7 +49,10 @@ describe('Dockstore my tools', () => {
     });
   });
 
-  it('Should have discover existing tools button', () => {
+  // The "discover existing tools" functionality was removed in:
+  // https://github.com/dockstore/dockstore-ui2/pull/1919
+  // TODO Unskip this test when we add it back.
+  it.skip('Should have discover existing tools button', () => {
     cy.fixture('myWorkflows.json').then((json) => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -56,33 +56,6 @@
                   <img src="../../../assets/svg/icons-plus.svg" alt="Register a tool" class="pr-2 pb-1" />
                   Register a Tool
                 </button>
-                <button
-                  mat-button
-                  class="private-btn small-btn-structure ml-3 mb-3"
-                  [matMenuTriggerFor]="myToolsActions"
-                  [disabled]="isRefreshing$ | async"
-                  id="myToolsMoreActionButtons"
-                  data-cy="myToolsMoreActionButtons"
-                >
-                  <img src="../../../assets/svg/gear-icon.svg" alt="Gear icon" />
-                  More
-                  <img src="../../../assets/svg/drop-down-arrow.svg" alt="Drop down menu icon" />
-                </button>
-                <mat-menu #myToolsActions="matMenu">
-                  <button
-                    mat-menu-item
-                    color="primary"
-                    type="button"
-                    (click)="addToExistingTools()"
-                    [disabled]="(isRefreshing$ | async) || (userQuery.user$ | async) === null"
-                    matTooltip="Discover tools added by others using your linked source control accounts"
-                    matTooltipPosition="after"
-                    id="addToExistingTools"
-                    data-cy="addToExistingTools"
-                  >
-                    <span>Discover Existing Dockstore Tools</span>
-                  </button>
-                </mat-menu>
               </div>
               <p *ngIf="(hasGroupEntriesObject$ | async) === false && (hasGroupGitHubAppToolEntriesObjects$ | async) === false">
                 You have not registered any tools


### PR DESCRIPTION
**Description**
This PR removes the "More" button and the associated "Discover Existing Dockstore Tools" menu from the my-tools sidebar accordion.  The motivation was that this functionality was broken: when you clicked "Discover Existing Dockstore Tools", the sidebar would be populated with a list of discovered _workflows_, and if you clicked on one, it would be displayed as a tool.  More details here: https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1706134461646039

The original goal of this ticket was to add the "Discover Existing" functionality for notebooks, but if we simply added the button menu to the my-notebooks accordion, the same type of bug would happen.

After this merges, we will write a new ticket to add the "Discover Existing" functionality, for both tools and notebooks, after the 1.15 release.

**Review Instructions**
Navigate to `my-tools`, and confirm that the "More" button no longer appears next to the "Register a Tool" button at the top of the accordion. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6186

**Security**
No concerns.

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
