### PR TITLE
SEAB-6190: Suppress "Retrieving metrics data succeeded" snackbar

### DIFF
--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -111,7 +111,7 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
                 this.selectPartner(platform);
               }
             }
-            this.alertService.detailedSuccess();
+            this.alertService.simpleSuccess();
           },
           (error) => {
             this.alertService.detailedError(error);


### PR DESCRIPTION
**Description**
Recently, a new snackbar that says "Retrieving metrics data succeeded" has been appearing in the UI.  It pops up whenever an entry page loads or a version is selected or hidden, and possibly at other times.  While it serves as an effective advertisement for our new metrics feature, it's also a bit disruptive, and likely to annoy regular users (especially after it's happened a few dozen times).

So, I changed the code so that, on success, it doesn't pop up anymore.  This seems to make sense, it's kinda like other ancillary data we load in the background, like categories.  The end user only needs to be notified on failure (and even then, maybe not with a snackbar).

Whilst documenting this ticket, I noticed that, very occasionally, the snackbar only contained the words "succeeded" and "Dismiss":

![image](https://github.com/dockstore/dockstore-ui2/assets/88108675/6a2d94b8-74e2-4939-82b5-96e7d091c904)

The underlying cause was probably another request in parallel with the metrics request that finished before it, with a response handler that called `alertService.simpleSuccess()`, thus setting the snackbar message to the empty string and wiping out the metrics message.  Then, when the metrics request succeeded, its handler called `alertService.detailedSuccess()`, which retrieved the empty string message and displayed it in the snackbar.

This highlights a conceptual flaw in the alert service: it is not designed (and possibly not easily modified) to properly handle parallel requests.  A better scheme might be to somehow store the alert message in the local scope of the response handler, so it can use the message upon completion.  This would be a major change, something to implement after a release when we've got lots of time to user test it...

**Review Instructions**
Go to an entry's page, and confirm that the snackbar does not display.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6190

**Security**
No concerns.

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
