### PR TITLE
DOCK-2504: Position tooltips above Versions table headings

### DIFF
--- a/src/app/container/versions/versions.component.html
+++ b/src/app/container/versions/versions.component.html
@@ -33,6 +33,7 @@
         mat-sort-header
         matTooltip="Tags from Docker repository: The selected tag will be used
           to populate the Info tab including 'Launch With'"
+        matTooltipPosition="above"
       >
         Version
         <a
@@ -68,7 +69,7 @@
       </td>
     </ng-container>
     <ng-container matColumnDef="reference">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="">Git Reference</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="" matTooltipPosition="above">Git Reference</th>
       <td mat-cell *matCellDef="let version">
         <div *ngIf="tool?.mode === DockstoreToolType.ModeEnum.HOSTED">
           {{ version?.versionEditor?.name }}
@@ -89,7 +90,7 @@
       </td>
     </ng-container>
     <ng-container matColumnDef="last_built">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="">Date Built</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="" matTooltipPosition="above">Date Built</th>
       <td mat-cell *matCellDef="let version">
         {{ version.last_built | date: 'yyyy-MM-dd HH:mm' }}
       </td>
@@ -101,6 +102,7 @@
         *matHeaderCellDef
         mat-sort-header
         matTooltip="The language versions used by the version's descriptor file(s)."
+        matTooltipPosition="above"
       >
         Language Versions
       </th>
@@ -112,19 +114,21 @@
       </td>
     </ng-container>
     <ng-container matColumnDef="valid">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="">Valid</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="" matTooltipPosition="above">Valid</th>
       <td mat-cell *matCellDef="let version">
         <mat-icon *ngIf="version.valid">check</mat-icon>
       </td>
     </ng-container>
     <ng-container matColumnDef="hidden">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="">Hidden</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="" matTooltipPosition="above">Hidden</th>
       <td mat-cell *matCellDef="let version">
         <mat-icon data-cy="hiddenCheck" *ngIf="version.hidden">check</mat-icon>
       </td>
     </ng-container>
     <ng-container matColumnDef="verified">
-      <th scope="col" mat-header-cell *matHeaderCellDef [matTooltip]="verifiedVersionTooltip">Verified Platforms</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef [matTooltip]="verifiedVersionTooltip" matTooltipPosition="above">
+        Verified Platforms
+      </th>
       <td mat-cell *matCellDef="let version">
         <span matTooltip="{{ getVerifiedSource(version.name) }}">{{ version.id | verifiedPlatforms: verifiedVersionPlatforms }}</span>
       </td>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -33,6 +33,7 @@
         mat-sort-header
         matTooltip="Git branches/tags: The selected reference and tag will be used
         to populate the info tab including 'launch with'"
+        matTooltipPosition="above"
       >
         Git Reference&nbsp;
         <a
@@ -78,7 +79,15 @@
     </ng-container>
 
     <ng-container matColumnDef="last_modified">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header disableClear matTooltip="Date of last update to Git reference">
+      <th
+        scope="col"
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        disableClear
+        matTooltip="Date of last update to Git reference"
+        matTooltipPosition="above"
+      >
         Date Modified
       </th>
       <td mat-cell *matCellDef="let version">
@@ -98,6 +107,7 @@
         matTooltip="The {{
           workflow.entryType === entryType.NOTEBOOK ? 'format' : 'language versions'
         }} used by the version's descriptor file(s)."
+        matTooltipPosition="above"
       >
         {{ workflow.entryType === entryType.NOTEBOOK ? 'Format' : 'Language Versions' }}
       </th>
@@ -115,6 +125,7 @@
         *matHeaderCellDef
         mat-sort-header
         matTooltip="A version is valid if the descriptor file(s) have been successfully validated."
+        matTooltipPosition="above"
       >
         Valid
       </th>
@@ -130,6 +141,7 @@
         *matHeaderCellDef
         mat-sort-header
         matTooltip="A hidden version is only visible here and not publicly."
+        matTooltipPosition="above"
       >
         Hidden
       </th>
@@ -145,6 +157,7 @@
         *matHeaderCellDef
         mat-sort-header
         matTooltip="The version has a test parameter file with open data or requires no input files."
+        matTooltipPosition="above"
       >
         Open
         <a
@@ -161,7 +174,7 @@
     </ng-container>
 
     <ng-container matColumnDef="verified">
-      <th scope="col" mat-header-cell *matHeaderCellDef [matTooltip]="verifiedVersionTooltip">
+      <th scope="col" mat-header-cell *matHeaderCellDef [matTooltip]="verifiedVersionTooltip" matTooltipPosition="above">
         Verified
         <a class="ds-green" [href]="verifiedLink" target="_blank" rel="noopener noreferrer"><mat-icon>info</mat-icon></a>
       </th>
@@ -177,6 +190,7 @@
         *matHeaderCellDef
         mat-sort-header
         matTooltip="The version has has execution and/or validation metrics."
+        matTooltipPosition="above"
       >
         Metrics
         <a class="ds-green" [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/metrics.html'" target="_blank" rel="noopener noreferrer"
@@ -194,6 +208,7 @@
         mat-header-cell
         *matHeaderCellDef
         matTooltip="The descriptors for a version that has been snapshotted will not change over time."
+        matTooltipPosition="above"
       >
         Snapshot
       </th>
@@ -223,7 +238,7 @@
     </ng-container>
 
     <ng-container matColumnDef="actions">
-      <th scope="col" mat-header-cell *matHeaderCellDef matTooltip="Actions to apply to the version">Actions</th>
+      <th scope="col" mat-header-cell *matHeaderCellDef matTooltip="Actions to apply to the version" matTooltipPosition="above">Actions</th>
       <td mat-cell *matCellDef="let version">
         <app-view-workflow
           [version]="version"


### PR DESCRIPTION
**Description**
Previously, the tooltips of the Versions table headings were positioned, by default, below the headings.  And, most of the time, when I'd move my cursor to the first "Info/Actions" button, the "Action" heading tooltip would pop up and cover the button, preventing me from clicking it.

This PR repositions the Versions table heading tooltips so that they appear _above_ the headings.  There, they will interfere less with user actions, and obscure less relevant information, assuming that, most commonly, the user is either moving the cursor:
* across the headings to figure out what they mean, whilst possibly looking at the version info below.
* down through the headings to reach the version information/elements below.

**Review Instructions**
Navigate to the Versions table for an entry, mouse over the headings, and confirm that the tooltips appear above the headings.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2504
https://github.com/dockstore/dockstore/issues/5793

**Security**
No concerns.

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
