### PR TITLE
SEAB-6200: hide blank metrics rows

### DIFF
--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -172,16 +172,16 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
     // Only add the rows if there are data for that type
     if (metrics) {
       if (metrics.cpu) {
-        executionsTable.push({ metric: 'CPU', ...metrics?.cpu });
+        executionsTable.push({ metric: 'CPU', ...metrics.cpu });
       }
       if (metrics.memory) {
-        executionsTable.push({ metric: 'Memory', ...metrics?.memory });
+        executionsTable.push({ metric: 'Memory', ...metrics.memory });
       }
       if (metrics.executionTime) {
-        executionsTable.push({ metric: 'Run Time', ...metrics?.executionTime });
+        executionsTable.push({ metric: 'Run Time', ...metrics.executionTime });
       }
       if (metrics.cost) {
-        executionsTable.push({ metric: 'Cost', ...metrics?.cost });
+        executionsTable.push({ metric: 'Cost', ...metrics.cost });
       }
     }
     return executionsTable;

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -170,17 +170,19 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
   private createExecutionsTable(metrics: Metrics | null): ExecutionMetricsTableObject[] {
     let executionsTable: ExecutionMetricsTableObject[] = [];
     // Only add the rows if there are data for that type
-    if (metrics && metrics.cpu) {
-      executionsTable.push({ metric: 'CPU', ...metrics?.cpu });
-    }
-    if (metrics && metrics.memory) {
-      executionsTable.push({ metric: 'Memory', ...metrics?.memory });
-    }
-    if (metrics && metrics.executionTime) {
-      executionsTable.push({ metric: 'Run Time', ...metrics?.executionTime });
-    }
-    if (metrics && metrics.cost) {
-      executionsTable.push({ metric: 'Cost', ...metrics?.cost });
+    if (metrics) {
+      if (metrics.cpu) {
+        executionsTable.push({ metric: 'CPU', ...metrics?.cpu });
+      }
+      if (metrics.memory) {
+        executionsTable.push({ metric: 'Memory', ...metrics?.memory });
+      }
+      if (metrics.executionTime) {
+        executionsTable.push({ metric: 'Run Time', ...metrics?.executionTime });
+      }
+      if (metrics.cost) {
+        executionsTable.push({ metric: 'Cost', ...metrics?.cost });
+      }
     }
     return executionsTable;
   }

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -169,11 +169,17 @@ export class ExecutionsTabComponent extends EntryTab implements OnChanges {
    */
   private createExecutionsTable(metrics: Metrics | null): ExecutionMetricsTableObject[] {
     let executionsTable: ExecutionMetricsTableObject[] = [];
-    // Only create the table if one of the execution metrics exist
-    if (metrics && (metrics.cpu || metrics.memory || metrics.executionTime || metrics.cost)) {
+    // Only add the rows if there are data for that type
+    if (metrics && metrics.cpu) {
       executionsTable.push({ metric: 'CPU', ...metrics?.cpu });
+    }
+    if (metrics && metrics.memory) {
       executionsTable.push({ metric: 'Memory', ...metrics?.memory });
+    }
+    if (metrics && metrics.executionTime) {
       executionsTable.push({ metric: 'Run Time', ...metrics?.executionTime });
+    }
+    if (metrics && metrics.cost) {
       executionsTable.push({ metric: 'Cost', ...metrics?.cost });
     }
     return executionsTable;


### PR DESCRIPTION
**Description**
This PR only adds rows in the Execution Metrics section if there are data present.

Before Fix: 
![Screenshot from 2024-01-31 14-42-59](https://github.com/dockstore/dockstore-ui2/assets/61166764/71c73d83-40ba-4e80-b943-018aa399a977)

After Fix:
![Screenshot from 2024-01-31 14-42-13](https://github.com/dockstore/dockstore-ui2/assets/61166764/cce64bc9-07ba-49c7-b34e-031d3b605302)


**Review Instructions**
Go to https://staging.dockstore.org/workflows/github.com/gatk-workflows/seq-format-conversion/BAM-to-Unmapped-BAM:3.0.0?tab=metrics and verify that the empty CPU, Memory, Cost rows are not shown.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6200

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
