### PR TITLE
Make all tabs visible for a workflow

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -537,10 +537,6 @@ describe('Dockstore my workflows part 3', () => {
       cy.visit('/my-workflows/github.com/A/l');
       isActiveTab('Info');
       tabs.forEach((tab) => {
-        if (tab === 'Tools') {
-          // Ugh, got to scroll to click this.
-          cy.get('#workflow_tabs').find('.mat-tab-header-pagination-after').first().click();
-        }
         goToTab(tab);
         isActiveTab(tab);
         if (tab === 'Versions') {

--- a/cypress/e2e/group3/metrics.ts
+++ b/cypress/e2e/group3/metrics.ts
@@ -6,7 +6,6 @@ describe('Dockstore Metrics', () => {
   setTokenUserViewPort();
   it('Should see no metrics banner', () => {
     cy.visit('/workflows/github.com/A/l:master');
-    cy.get('.mat-tab-header-pagination-after').click();
     goToTab('Metrics');
     cy.get('[data-cy=no-metrics-banner]').should('be.visible');
 
@@ -23,7 +22,6 @@ describe('Dockstore Metrics', () => {
       }).as('getMetrics');
     });
     cy.visit('/workflows/github.com/A/l:master');
-    cy.get('.mat-tab-header-pagination-after').click();
     cy.wait('@getMetrics');
     goToTab('Metrics');
 

--- a/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
@@ -108,7 +108,6 @@ describe('Dockstore Workflow Details', () => {
   });
 
   it('Change tab to tools', () => {
-    cy.get('.mat-tab-header-pagination-after').click();
     goToTab('Tools');
     cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=tools');
   });

--- a/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
@@ -100,7 +100,6 @@ describe('Dockstore Workflow Details', () => {
     it('Should see No Metrics banner', () => {
       cy.visit('/workflows/github.com/A/l');
       cy.get('.mat-tab-label').should('have.length', 7);
-      cy.get('.mat-tab-header-pagination-after').click();
       goToTab('Metrics');
       cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=metrics');
       cy.get('[data-cy=no-metrics-banner]').should('be.visible');

--- a/src/app/shared/styles/workflow-container.component.scss
+++ b/src/app/shared/styles/workflow-container.component.scss
@@ -23,3 +23,9 @@ a.underline-none {
   width: 14rem;
   text-align: start;
 }
+
+:host ::ng-deep .mat-tab-label {
+  padding-left: 0.5em !important;
+  padding-right: 0.5em !important;
+  min-width: 0 !important;
+}

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -374,10 +374,18 @@
               </ng-template>
             </ng-template>
           </mat-tab>
-          <mat-tab id="metricsTab" label="Metrics">
-            <app-executions-tab [entry]="workflow" [version]="selectedVersion"></app-executions-tab>
-          </mat-tab>
           <div *ngIf="entryType === EntryType.BioWorkflow">
+            <mat-tab id="toolsTab" label="Tools">
+              <div *ngIf="!isStub()">
+                <app-tool-tab [selectedVersion]="selectedVersion" [canRead]="canRead" [canWrite]="canWrite" [isOwner]="isOwner">
+                </app-tool-tab>
+              </div>
+              <div *ngIf="isStub()" class="p-3">
+                <mat-card class="alert alert-warning mat-elevation-z" role="alert">
+                  <mat-icon class="alert-warning-icon">warning</mat-icon> To see tools, please refresh the workflow.
+                </mat-card>
+              </div>
+            </mat-tab>
             <mat-tab id="dagTab" label="DAG">
               <ng-template matTabContent>
                 <app-dag
@@ -401,18 +409,10 @@
                 </div>
               </ng-template>
             </mat-tab>
-            <mat-tab id="toolsTab" label="Tools">
-              <div *ngIf="!isStub()">
-                <app-tool-tab [selectedVersion]="selectedVersion" [canRead]="canRead" [canWrite]="canWrite" [isOwner]="isOwner">
-                </app-tool-tab>
-              </div>
-              <div *ngIf="isStub()" class="p-3">
-                <mat-card class="alert alert-warning mat-elevation-z" role="alert">
-                  <mat-icon class="alert-warning-icon">warning</mat-icon> To see tools, please refresh the workflow.
-                </mat-card>
-              </div>
-            </mat-tab>
           </div>
+          <mat-tab id="metricsTab" label="Metrics">
+            <app-executions-tab [entry]="workflow" [version]="selectedVersion"></app-executions-tab>
+          </mat-tab>
           <mat-tab *ngIf="!isPublic() && isHosted() && isOwner" id="permissionsTab" label="Permissions">
             <app-permissions [workflow]="workflow"></app-permissions>
           </mat-tab>


### PR DESCRIPTION
**Description**
Rolls back #1926, which reordered the tabs to make the Metrics tab visible without scrolling.

Instead make the tabs narrower, so they all fit, and no scrolling is required, per Steve's [comment](https://github.com/dockstore/dockstore-ui2/pull/1926#pullrequestreview-1857164742).

TLDR; restore original order of tabs on workflow component, tabs are now narrower to avoid scrolling.

**Review Instructions**
1. Go to a workflow version with metrics
2. Ensure all tabs are visible and the "scroll arrows" are not present.
3. To make sure there's not a regression, do a browser refresh of the page when positioned on the metrics tab, and ensure the metrics tab is still the active tab.

What it looks like with the fix, full screen and minimum width screen:

<img width="434" alt="Screen Shot 2024-02-01 at 2 57 46 PM" src="https://github.com/dockstore/dockstore-ui2/assets/1049340/87c97386-ef7b-47b0-81c7-2cb393c01f32">
<img width="966" alt="Screen Shot 2024-02-01 at 2 56 44 PM" src="https://github.com/dockstore/dockstore-ui2/assets/1049340/231243cd-34b7-45b9-bf19-4236a5fbf57f">


**Issue**
SEAB-6231

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
