### PR TITLE
DOCK-984: Remove "Format" column from Services table

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/services.ts
+++ b/cypress/e2e/immutableDatabaseTests/services.ts
@@ -50,6 +50,7 @@ describe('Dockstore Home', () => {
       cy.visit('/services');
       cy.url().should('contain', 'services');
       cy.get('[data-cy=header]').contains('h3', 'Services');
+      cy.get('mat-header-cell').contains('Format').should('not.exist');
       cy.contains('Search services');
       cy.contains('garyluu/another-test-service');
     });

--- a/src/app/workflows/list/list.component.ts
+++ b/src/app/workflows/list/list.component.ts
@@ -37,9 +37,10 @@ export class ListWorkflowsComponent extends ToolLister<PublishedWorkflowsDataSou
 
   public workflowColumns = ['repository', 'verified', 'author', 'descriptorType', 'projectLinks', 'stars'];
   public notebookColumns = ['repository', 'author', 'descriptorType', 'descriptorTypeSubclass', 'projectLinks', 'stars'];
+  public serviceColumns = ['repository', 'verified', 'author', 'projectLinks', 'stars'];
   public typeToDisplayedColumns = {
     workflow: this.workflowColumns,
-    service: this.workflowColumns,
+    service: this.serviceColumns,
     appTool: this.workflowColumns,
     notebook: this.notebookColumns,
   };


### PR DESCRIPTION
**Description**
This PR drops the "Format" column from the Services table. The value is not important when it comes to services (always equals "Service"), and it saves some space.

_(Services before removing "Format" column)_
![Services before](https://github.com/dockstore/dockstore-ui2/assets/122565245/edd93d12-5558-487a-b638-4536fcaaaf58)

**Review Instructions**
The `serviceColumns` field excludes `'descriptorType'`, which removes "Format" for Services. Can visit the /services path to verify that the table and spacing look good.

_(Services after removing "Format" column)_
![Services after](https://github.com/dockstore/dockstore-ui2/assets/122565245/723f6ef1-cb22-4788-a367-0c9cf0fa1772)

**Issue**
https://github.com/dockstore/dockstore/issues/2867
DOCK-984

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 