### PR TITLE
DOCK-2513: Tweak search relevance

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -274,16 +274,16 @@ export class QueryBuilderService {
     const terms = searchString.trim().split(' ').slice(0, 20);
     terms.forEach((term) => {
       body
-        .orQuery('wildcard', 'full_workflow_path', { value: '*' + term + '*', case_insensitive: true, boost: 7 })
-        .orQuery('wildcard', 'tool_path', { value: '*' + term + '*', case_insensitive: true, boost: 7 })
+        .orQuery('wildcard', 'full_workflow_path', { value: '*' + term + '*', case_insensitive: true, boost: 14 })
+        .orQuery('wildcard', 'tool_path', { value: '*' + term + '*', case_insensitive: true, boost: 14 })
         .orQuery('match', 'workflowVersions.sourceFiles.content', { query: term, boost: 0.2 })
         .orQuery('match', 'tags.sourceFiles.content', { query: term, boost: 0.2 })
         .orQuery('match', 'description', { query: term, boost: 2 })
         .orQuery('match', 'labels', { query: term, boost: 2 })
         .orQuery('match', 'all_authors.name', { query: term, boost: 3 })
         .orQuery('match', 'topicAutomatic', { query: term, boost: 4 })
-        .orQuery('match', 'categories.topic', { query: term, boost: 1.5 })
-        .orQuery('match', 'categories.displayName', { query: term, boost: 2 });
+        .orQuery('match', 'categories.topic', { query: term, boost: 2 })
+        .orQuery('match', 'categories.displayName', { query: term, boost: 3 });
     });
     body.queryMinimumShouldMatch(1);
     return body;


### PR DESCRIPTION
**Description**
This PR increases the search query `boost` setting for path matches, so that a hit with a path match ranks higher than an otherwise similar hit with a description match.  14 was the lowest integer boost that seemed to do the trick.  Q: Why did the boost have to be so much higher on the path subqueries?  A: For the answer, we'd have to dive into the details of exactly how ElasticSearch makes the sausage.  Google "BM25" for an idea of what we're talking about here.

While I was doing some experiments, I noticed that entries in our categories weren't ranking as high as I expected.  So I boosted them just a little bit.

**Review Instructions**
Search workflows for the keyword "TheiaProk" and confirm that the hits containing "TheiaProk" in their paths tend to appear first in the results. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2513
dockstore/dockstore#5817

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
