### PR TITLE
Add Galaxy planemo information to launch-with page

### DIFF
--- a/src/app/descriptor-languages/Galaxy.ts
+++ b/src/app/descriptor-languages/Galaxy.ts
@@ -18,7 +18,7 @@ export const extendedGalaxy: ExtendedDescriptorLanguageBean = {
     rowIdentifier: 'tool\xa0ID',
     workflowStepHeader: 'Tool Excerpt',
   },
-  workflowLaunchSupport: false,
+  workflowLaunchSupport: true,
   testParameterFileType: SourceFile.TypeEnum.GXFORMAT2TESTFILE,
   fileTabs: [
     {

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -77,6 +77,13 @@ export abstract class LaunchService {
     return `nextflow run https://${workflowPath} -r ${versionName}`;
   }
 
+  getSharedZipString(workflowPath: string, versionName: string) {
+    return `wget -O temp.zip ${Dockstore.API_URI}${ga4ghPath}/tools/${encodeURIComponent(
+      '#workflow/' + workflowPath
+    )}/versions/${encodeURIComponent(versionName)}/GALAXY/files?format=zip
+unzip temp.zip`;
+  }
+
   /**
    * This creates the planemo local init command
    * @param path The GA4GH Tool's path
@@ -84,11 +91,7 @@ export abstract class LaunchService {
    */
   getPlanemoLocalInitString(workflowPath: string, versionName: string, primaryDescriptorPath: string, testParameterPath: string) {
     return (
-      `wget -O foo.zip ${Dockstore.API_URI}${ga4ghPath}/tools/` +
-      encodeURIComponent('#workflow/' + workflowPath) +
-      `/versions/${versionName}/GALAXY/files?format=zip` +
-      '\nunzip foo.zip' +
-      `\nplanemo workflow_job_init ${primaryDescriptorPath} -o ${testParameterPath}`
+      this.getSharedZipString(workflowPath, versionName) + `\nplanemo workflow_job_init ${primaryDescriptorPath} -o ${testParameterPath}`
     );
   }
 
@@ -99,10 +102,7 @@ export abstract class LaunchService {
    */
   getPlanemoLocalLaunchString(workflowPath: string, versionName: string, primaryDescriptorPath: string, testParameterPath: string) {
     return (
-      `wget -O foo.zip ${Dockstore.API_URI}${ga4ghPath}/tools/` +
-      encodeURIComponent('#workflow/' + workflowPath) +
-      `/versions/${versionName}/GALAXY/files?format=zip` +
-      '\nunzip foo.zip' +
+      this.getSharedZipString(workflowPath, versionName) +
       `\nplanemo run ${primaryDescriptorPath} ${testParameterPath} --download_outputs --output_directory . --output_json output.json --engine docker_galaxy`
     );
   }

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -78,6 +78,21 @@ export abstract class LaunchService {
   }
 
   /**
+   * This creates the planemo local launch commands
+   * @param path The GA4GH Tool's path
+   * @param versionName The ToolVersion's name
+   */
+  getPlanemoLocalLaunchString(workflowPath: string, versionName: string) {
+    return (
+      `wget -O foo.zip ${Dockstore.API_URI}${ga4ghPath}/tools/` +
+      encodeURIComponent('#workflow/' + workflowPath) +
+      `/versions/${versionName}/GALAXY/files?format=zip` +
+      '\nunzip foo.zip' +
+      '\nplanemo run Dockstore.gxwf.yml Dockstore.gxwf-test.yml --download_outputs --output_directory . --output_json output.json --engine docker_galaxy'
+    );
+  }
+
+  /**
    * Gets local launch command
    */
   getNextflowLocalLaunchString(): string {

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -78,17 +78,32 @@ export abstract class LaunchService {
   }
 
   /**
-   * This creates the planemo local launch commands
+   * This creates the planemo local init command
    * @param path The GA4GH Tool's path
    * @param versionName The ToolVersion's name
    */
-  getPlanemoLocalLaunchString(workflowPath: string, versionName: string) {
+  getPlanemoLocalInitString(workflowPath: string, versionName: string, primaryDescriptorPath: string, testParameterPath: string) {
     return (
       `wget -O foo.zip ${Dockstore.API_URI}${ga4ghPath}/tools/` +
       encodeURIComponent('#workflow/' + workflowPath) +
       `/versions/${versionName}/GALAXY/files?format=zip` +
       '\nunzip foo.zip' +
-      '\nplanemo run Dockstore.gxwf.yml Dockstore.gxwf-test.yml --download_outputs --output_directory . --output_json output.json --engine docker_galaxy'
+      `\nplanemo workflow_job_init ${primaryDescriptorPath} -o ${testParameterPath}`
+    );
+  }
+
+  /**
+   * This creates the planemo local launch commands
+   * @param path The GA4GH Tool's path
+   * @param versionName The ToolVersion's name
+   */
+  getPlanemoLocalLaunchString(workflowPath: string, versionName: string, primaryDescriptorPath: string, testParameterPath: string) {
+    return (
+      `wget -O foo.zip ${Dockstore.API_URI}${ga4ghPath}/tools/` +
+      encodeURIComponent('#workflow/' + workflowPath) +
+      `/versions/${versionName}/GALAXY/files?format=zip` +
+      '\nunzip foo.zip' +
+      `\nplanemo run ${primaryDescriptorPath} ${testParameterPath} --download_outputs --output_directory . --output_json output.json --engine docker_galaxy`
     );
   }
 

--- a/src/app/shared/state/workflow.query.ts
+++ b/src/app/shared/state/workflow.query.ts
@@ -39,6 +39,9 @@ export class WorkflowQuery extends QueryEntity<WorkflowState, Service | BioWorkf
   public isWDL$: Observable<boolean> = this.descriptorType$.pipe(
     map((descriptorType: ToolDescriptor.TypeEnum) => descriptorType === ToolDescriptor.TypeEnum.WDL)
   );
+  public isGalaxy$: Observable<boolean> = this.descriptorType$.pipe(
+    map((descriptorType: ToolDescriptor.TypeEnum) => descriptorType === ToolDescriptor.TypeEnum.GALAXY)
+  );
   constructor(
     protected store: WorkflowStore,
     private descriptorTypeCompatService: DescriptorTypeCompatService,

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -47,6 +47,20 @@
             <pre>{{ wgetTestJsonDescription }}</pre>
           </span>
         </mat-card>
+        <mat-card *ngIf="(isGalaxy$ | async) === true" matTooltip="Commands for creating a runtime JSON template">
+          Make a runtime JSON template with Planemo and fill in desired inputs, outputs, and other parameters
+          <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="planemoLocalInitString" appSnackbar>
+            <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
+          </button>
+          <pre>{{ planemoLocalInitString }}</pre>
+          <span *ngIf="wgetTestJsonDescription">
+            or grab one that the workflow author has provided (if applicable)
+            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="wgetTestJsonDescription" appSnackbar>
+              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
+            </button>
+            <pre>{{ wgetTestJsonDescription }}</pre>
+          </span>
+        </mat-card>
         <mat-card
           *ngIf="(isNFL$ | async) === false && (isGalaxy$ | async) === false"
           matTooltip="Commands for launching tool through Dockstore CLI (Supports file provisioning)"

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -30,7 +30,10 @@
         <mat-card *ngIf="entryType === EntryType.Tool" class="alert alert-info mat-elevation-z" role="alert">
           <mat-icon>info</mat-icon> GitHub App Tools are launched in workflow mode with the Dockstore CLI
         </mat-card>
-        <mat-card *ngIf="(isNFL$ | async) === false" matTooltip="Commands for creating a runtime JSON template">
+        <mat-card
+          *ngIf="(isNFL$ | async) === false && (isGalaxy$ | async) === false"
+          matTooltip="Commands for creating a runtime JSON template"
+        >
           Make a runtime JSON template and fill in desired inputs, outputs, and other parameters
           <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="params" appSnackbar>
             <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
@@ -45,7 +48,7 @@
           </span>
         </mat-card>
         <mat-card
-          *ngIf="(isNFL$ | async) === false"
+          *ngIf="(isNFL$ | async) === false && (isGalaxy$ | async) === false"
           matTooltip="Commands for launching tool through Dockstore CLI (Supports file provisioning)"
         >
           Run locally with the Dockstore CLI
@@ -68,6 +71,16 @@
             </button>
             <pre>{{ nextflowNativeLaunchDescription }}</pre>
             <small>*You can override the default parameters by appending --paramName 'value' to the above command.</small>
+          </div>
+        </mat-card>
+
+        <mat-card *ngIf="(isGalaxy$ | async) && DockstoreToolType.ModeEnum.HOSTED !== mode && WorkflowType.ModeEnum.HOSTED !== mode">
+          <div matTooltip="Planemo can run a workflow locally">
+            Run with Planemo
+            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="planemoLocalLaunchString" appSnackbar>
+              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
+            </button>
+            <pre>{{ planemoLocalLaunchString }}</pre>
           </div>
         </mat-card>
 

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -59,11 +59,13 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   nextflowNativeLaunchDescription: string;
   nextflowLocalLaunchDescription: string;
   nextflowDownloadFileDescription: string;
+  planemoLocalInitString: string;
   planemoLocalLaunchString: string;
   descriptors: Array<any>;
   cwlrunnerDescription = this.launchService.cwlrunnerDescription;
   cwlrunnerTooltip = this.launchService.cwlrunnerTooltip;
   cwltoolTooltip = this.launchService.cwltoolTooltip;
+  primaryDescriptorPath: string;
   testParameterPath: string;
   descriptorType$: Observable<ToolDescriptor.TypeEnum>;
   isNFL$: Observable<boolean>;
@@ -118,7 +120,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     this.nextflowNativeLaunchDescription = this.launchService.getNextflowNativeLaunchString(basePath, versionName);
     this.nextflowLocalLaunchDescription = this.launchService.getNextflowLocalLaunchString();
     this.nextflowDownloadFileDescription = this.launchService.getNextflowDownload(basePath, versionName);
-    this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(basePath, versionName);
+    this.updateWgetDescriptorString(versionName, descriptorType);
     this.updateWgetTestJsonString(workflowPath, versionName, descriptorType);
     this.wesLaunchCommand = this.launchService.getWesLaunch(workflowPath, versionName);
     this.wesWrapperJson = this.launchService.getAgcFileWrapper();
@@ -142,6 +144,47 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
         ga4ghWorkflowIdPrefix + workflowPath,
         versionName,
         descriptorType,
+        this.testParameterPath
+      );
+      this.planemoLocalInitString = this.launchService.getPlanemoLocalInitString(
+        this.basePath,
+        versionName,
+        this.primaryDescriptorPath,
+        this.testParameterPath
+      );
+      this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(
+        this.basePath,
+        versionName,
+        this.primaryDescriptorPath,
+        this.testParameterPath
+      );
+    });
+  }
+
+  /**
+   * Updates the wget test json string with the first available test parameter file
+   * @param workflowPath
+   * @param versionName
+   */
+  updateWgetDescriptorString(versionName: string, descriptorType: ToolDescriptor.TypeEnum): void {
+    let toolFiles$: Observable<Array<ToolFile>>;
+    toolFiles$ = this.gA4GHFilesQuery.getToolFiles(descriptorType, [ToolFile.FileTypeEnum.PRIMARYDESCRIPTOR]);
+    toolFiles$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((toolFiles: Array<ToolFile>) => {
+      if (toolFiles && toolFiles.length > 0) {
+        this.primaryDescriptorPath = toolFiles[0].path;
+      } else {
+        this.primaryDescriptorPath = null;
+      }
+      this.planemoLocalInitString = this.launchService.getPlanemoLocalInitString(
+        this.basePath,
+        versionName,
+        this.primaryDescriptorPath,
+        this.testParameterPath
+      );
+      this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(
+        this.basePath,
+        versionName,
+        this.primaryDescriptorPath,
         this.testParameterPath
       );
     });

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -154,17 +154,17 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
             this.testParameterPath
           );
         }
-        if (descriptorFiles !== undefined && descriptorFiles.length > 0) {
+        if (descriptorFiles?.length > 0) {
           // ... but primary descriptor is mandatory
           this.primaryDescriptorPath = descriptorFiles[0].path;
           this.planemoLocalInitString = this.launchService.getPlanemoLocalInitString(
-            this.basePath,
+            workflowPath,
             versionName,
             this.primaryDescriptorPath,
             this.testParameterPath === undefined ? 'example-parameter-file.yml' : this.testParameterPath
           );
           this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(
-            this.basePath,
+            workflowPath,
             versionName,
             this.primaryDescriptorPath,
             this.testParameterPath === undefined ? 'example-parameter-file.yml' : this.testParameterPath

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -153,6 +153,8 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
             descriptorType,
             this.testParameterPath
           );
+        } else {
+          this.testParameterPath = undefined;
         }
         if (descriptorFiles?.length > 0) {
           // ... but primary descriptor is mandatory
@@ -169,6 +171,10 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
             this.primaryDescriptorPath,
             this.testParameterPath === undefined ? 'example-parameter-file.yml' : this.testParameterPath
           );
+        } else {
+          this.primaryDescriptorPath = undefined;
+          this.planemoLocalInitString = undefined;
+          this.planemoLocalLaunchString = undefined;
         }
       },
       (err) => {

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -59,6 +59,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   nextflowNativeLaunchDescription: string;
   nextflowLocalLaunchDescription: string;
   nextflowDownloadFileDescription: string;
+  planemoLocalLaunchString: string;
   descriptors: Array<any>;
   cwlrunnerDescription = this.launchService.cwlrunnerDescription;
   cwlrunnerTooltip = this.launchService.cwlrunnerTooltip;
@@ -66,6 +67,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   testParameterPath: string;
   descriptorType$: Observable<ToolDescriptor.TypeEnum>;
   isNFL$: Observable<boolean>;
+  isGalaxy$: Observable<boolean>;
   ToolDescriptor = ToolDescriptor;
   EntryType = EntryType;
   protected published$: Observable<boolean>;
@@ -90,6 +92,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((descriptorType: ToolDescriptor.TypeEnum) => (this.currentDescriptor = descriptorType));
     this.isNFL$ = this.workflowQuery.isNFL$;
+    this.isGalaxy$ = this.workflowQuery.isGalaxy$;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -115,6 +118,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     this.nextflowNativeLaunchDescription = this.launchService.getNextflowNativeLaunchString(basePath, versionName);
     this.nextflowLocalLaunchDescription = this.launchService.getNextflowLocalLaunchString();
     this.nextflowDownloadFileDescription = this.launchService.getNextflowDownload(basePath, versionName);
+    this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(basePath, versionName);
     this.updateWgetTestJsonString(workflowPath, versionName, descriptorType);
     this.wesLaunchCommand = this.launchService.getWesLaunch(workflowPath, versionName);
     this.wesWrapperJson = this.launchService.getAgcFileWrapper();

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -145,7 +145,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
           if (toolFiles.length > 0) {
             this.testParameterPath = toolFiles[0].path;
           } else {
-            this.testParameterPath = 'example-parameter-file.yml';
+            this.testParameterPath = undefined;
           }
           this.wgetTestJsonDescription = this.launchService.getTestJsonString(
             ga4ghWorkflowIdPrefix + workflowPath,
@@ -161,13 +161,13 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
             this.basePath,
             versionName,
             this.primaryDescriptorPath,
-            this.testParameterPath
+            this.testParameterPath === undefined ? 'example-parameter-file.yml' : this.testParameterPath
           );
           this.planemoLocalLaunchString = this.launchService.getPlanemoLocalLaunchString(
             this.basePath,
             versionName,
             this.primaryDescriptorPath,
-            this.testParameterPath
+            this.testParameterPath === undefined ? 'example-parameter-file.yml' : this.testParameterPath
           );
         }
       },


### PR DESCRIPTION
**Description**
Adds Planemo `run` and `workflow_job_init` (parameter file creation)  to launch-with tab


**Review Instructions**
View Galaxy workflows with and without test parameter files already registered, 
Galaxy workflows with test parameter files will give the user the command to download the first one, and show init, and run info. 
Galaxy workflows without them will skip the panel for downloading a test parameter file

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6273

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
