### PR TITLE
SEAB-6014: UI link checks

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -12,12 +12,15 @@ function formatPaths(paths: string[]): string {
 describe('Find broken anchor links', () => {
   setTokenUserViewPort();
 
-  let visitedUrls: string[] = [
-    'https://twitter.com/DockstoreOrg', // Skip, test only fails because it redirects to login page if not logged in
+  // These links should be intentionally skipped
+  const skippedUrls: string[] = [
+    'https://twitter.com/DockstoreOrg', // Test only fails because it redirects to login page if not logged in
   ];
 
+  let visitedUrls: string[] = [];
+
   function isDynamicUrl(url: string): boolean {
-    return url.includes('/my-workflows/') || url.includes('/my-tools/');
+    return url.includes('/my-workflows/') || url.includes('/my-tools/') || url.includes('/my-notebooks/');
   }
 
   function checkUrls(path: string) {
@@ -27,8 +30,8 @@ describe('Find broken anchor links', () => {
       .each((anchor) => {
         cy.get(anchor).then((anchor) => {
           const href = anchor.prop('href');
-          // Send requests to non-dynamic URLs that haven't yet been visited
-          if (href && !visitedUrls.includes(href) && !isDynamicUrl(href)) {
+          // Send requests to non-dynamic URLs that haven't yet been visited and shouldn't be skipped
+          if (href && !skippedUrls.includes(href) && !visitedUrls.includes(href) && !isDynamicUrl(href)) {
             cy.request({
               url: href,
               failOnStatusCode: false,
@@ -50,7 +53,7 @@ describe('Find broken anchor links', () => {
       });
   }
 
-  const urlPages: string = ['/', '/sitemap', '/about', '/funding', '/docs', '/dashboard'];
+  const urlPages: string = ['/', '/sitemap', '/about', '/funding', '/docs', '/dashboard', '/quick-start'];
 
   urlPages.forEach((urlPage) => {
     it(`anchor links at "${urlPage}" should work`, () => {
@@ -62,9 +65,11 @@ describe('Find broken anchor links', () => {
 describe('Find broken image links', () => {
   setTokenUserViewPort();
 
-  let visitedImages: string = [
-    'http://localhost:4200/', // Quick fix to skip the failing stock avatar image in navbar
+  const skippedImages: string = [
+    'http://localhost:4200/', // Failing stock avatar image in navbar
   ];
+
+  let visitedImages: string = [];
 
   function checkImages(path: string, selector: string) {
     let brokenImages = [];
@@ -74,7 +79,7 @@ describe('Find broken image links', () => {
       .each((image) => {
         cy.get(image).then((image) => {
           const src = image.prop('src');
-          if (!visitedImages.includes(src)) {
+          if (!skippedImages.includes(src) && !visitedImages.includes(src)) {
             if (image.prop('naturalWidth') === 0) {
               brokenImages.push(src);
               cy.log(`image not visible: ${src}`);

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -60,7 +60,7 @@ describe('Find broken image links', () => {
 
   function checkImages(path: string, selector: string) {
     let brokenImages = [];
-    cy.visit(path).wait(300);
+    cy.visit(path).wait(500);
     cy.get(selector)
       .find('img')
       .each((image) => {

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -1,11 +1,18 @@
 import { setTokenUserViewPort } from '../../support/commands';
 
+// Formats paths to be displayed in an error log
 function formatPaths(paths: string[]) {
   let formattedPaths = '';
   paths.forEach((path) => {
     formattedPaths += '\n- ' + path;
   });
   return formattedPaths;
+}
+
+// Represents a page to visit on the site - organizes urlPages, imagePages
+interface Page {
+  path: string;
+  selector: string;
 }
 
 describe('Find broken anchor links', () => {
@@ -16,9 +23,9 @@ describe('Find broken anchor links', () => {
     cy.visit(path);
     cy.get(selector)
       .find('a')
-      .each((url) => {
-        cy.get(url).then((url) => {
-          const href = url.prop('href');
+      .each((anchor) => {
+        cy.get(anchor).then((anchor) => {
+          const href = anchor.prop('href');
           if (href) {
             cy.request({
               url: href,
@@ -39,18 +46,18 @@ describe('Find broken anchor links', () => {
       });
   }
 
-  const urlPages = [
-    ['/', 'app-root'],
-    ['/sitemap', 'app-sitemap'],
-    ['/about', 'app-about'],
-    ['/funding', 'app-funding'],
-    ['/docs', 'app-docs'],
-    ['/dashboard', 'app-my-sidebar'],
+  const urlPages: Page[] = [
+    { path: '/', selector: 'app-root' },
+    { path: '/sitemap', selector: 'app-sitemap' },
+    { path: '/about', selector: 'app-about' },
+    { path: '/funding', selector: 'app-funding' },
+    { path: '/docs', selector: 'app-docs' },
+    { path: '/dashboard', selector: 'app-my-sidebar' },
   ];
 
   urlPages.forEach((urlPage) => {
-    it(`anchor links at "${urlPage[0]}" should work`, () => {
-      checkUrls(urlPage[0], urlPage[1]);
+    it(`anchor links at "${urlPage.path}" should work`, () => {
+      checkUrls(urlPage.path, urlPage.selector);
     });
   });
 });
@@ -78,27 +85,27 @@ describe('Find broken image links', () => {
       });
   }
 
-  const imagePages = [
-    ['/', 'app-root'],
-    ['/about', 'app-about'],
-    ['/funding', 'app-funding'],
-    ['/docs', 'app-docs'],
-    ['/dashboard', 'app-dashboard'],
-    ['/workflows', 'app-workflows'],
-    ['/notebooks', 'app-workflows'],
-    ['/services', 'app-workflows'],
-    ['/apptools', 'app-workflows'],
-    ['/search-workflows', 'app-workflows'],
-    ['/tools', 'app-containers'],
-    ['/containers', 'app-containers'],
-    ['/search-containers', 'app-containers'],
-    ['/accounts', 'app-account-sidebar'],
-    ['/accounts', 'app-accounts-external'],
+  const imagePages: Page[] = [
+    { path: '/', selector: 'app-root' },
+    { path: '/about', selector: 'app-about' },
+    { path: '/funding', selector: 'app-funding' },
+    { path: '/docs', selector: 'app-docs' },
+    { path: '/dashboard', selector: 'app-dashboard' },
+    { path: '/workflows', selector: 'app-workflows' },
+    { path: '/notebooks', selector: 'app-workflows' },
+    { path: '/services', selector: 'app-workflows' },
+    { path: '/apptools', selector: 'app-workflows' },
+    { path: '/search-workflows', selector: 'app-workflows' },
+    { path: '/tools', selector: 'app-containers' },
+    { path: '/containers', selector: 'app-containers' },
+    { path: '/search-containers', selector: 'app-containers' },
+    { path: '/accounts', selector: 'app-account-sidebar' },
+    { path: '/accounts', selector: 'app-accounts-external' },
   ];
 
   imagePages.forEach((imagePage) => {
-    it(`images at "${imagePage[0]}" should work`, () => {
-      checkImages(imagePage[0], imagePage[1]);
+    it(`images at "${imagePage.path}" should work`, () => {
+      checkImages(imagePage.path, imagePage.selector);
     });
   });
 });

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -1,0 +1,76 @@
+import { setTokenUserViewPort } from '../../support/commands';
+
+describe('Find broken links', () => {
+  setTokenUserViewPort();
+
+  function checkUrls(path: string, selector: string) {
+    cy.visit(path);
+    cy.get(selector).within(() => {
+      cy.get('a').each((url) => {
+        cy.get(url);
+        const href = url.prop('href');
+        if (href) {
+          cy.request({
+            url: url.prop('href'),
+            failOnStatusCode: false,
+          }).then((result) => {
+            if (result.status != 200) {
+              cy.log(result.status + ': ' + href);
+            }
+          });
+        }
+      });
+    });
+  }
+
+  function checkImages(path: string, selector: string) {
+    cy.visit(path).wait(500);
+    cy.get(selector).within(() => {
+      cy.get('img').each((image) => {
+        cy.get(image);
+        if (image.prop('naturalWidth') === 0 && image.prop('naturalHeight') === 0) {
+          cy.log('image not visible: ' + image.prop('src'));
+        }
+      });
+    });
+  }
+
+  const urlPages = [
+    ['/', 'app-root'],
+    ['/sitemap', 'app-sitemap'],
+    ['/about', 'app-about'],
+    ['/funding', 'app-funding'],
+    ['/docs', 'app-docs'],
+    ['/dashboard', 'app-my-sidebar'],
+  ];
+
+  const imagePages = [
+    ['/', 'app-root'],
+    ['/about', 'app-about'],
+    ['/funding', 'app-funding'],
+    ['/docs', 'app-docs'],
+    ['/dashboard', 'app-dashboard'],
+    ['/workflows', 'app-workflows'],
+    ['/notebooks', 'app-workflows'],
+    ['/services', 'app-workflows'],
+    ['/apptools', 'app-workflows'],
+    ['/search-workflows', 'app-workflows'],
+    ['/tools', 'app-containers'],
+    ['/containers', 'app-containers'],
+    ['/search-containers', 'app-containers'],
+    ['/accounts', 'app-account-sidebar'],
+    ['/accounts', 'app-accounts-external'],
+  ];
+
+  it('should detect broken anchor links', () => {
+    urlPages.forEach((page) => {
+      checkUrls(page[0], page[1]);
+    });
+  });
+
+  it('should detect broken images', () => {
+    imagePages.forEach((page) => {
+      checkImages(page[0], page[1]);
+    });
+  });
+});

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -12,7 +12,9 @@ function formatPaths(paths: string[]): string {
 describe('Find broken anchor links', () => {
   setTokenUserViewPort();
 
-  let visitedUrls: string[] = [];
+  let visitedUrls: string[] = [
+    'https://twitter.com/DockstoreOrg', // Skip, test only fails because it redirects to login page if not logged in
+  ];
 
   function isDynamicUrl(url: string): boolean {
     return url.includes('/my-workflows/') || url.includes('/my-tools/');
@@ -60,7 +62,9 @@ describe('Find broken anchor links', () => {
 describe('Find broken image links', () => {
   setTokenUserViewPort();
 
-  let visitedImages: string = [];
+  let visitedImages: string = [
+    'http://localhost:4200/', // Quick fix to skip the failing stock avatar image in navbar
+  ];
 
   function checkImages(path: string, selector: string) {
     let brokenImages = [];

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -17,19 +17,20 @@ describe('Find broken anchor links', () => {
     cy.get(selector)
       .find('a')
       .each((url) => {
-        cy.get(url);
-        const href = url.prop('href');
-        if (href) {
-          cy.request({
-            url: href,
-            failOnStatusCode: false,
-          }).then((result) => {
-            if (result.status != 200) {
-              brokenUrls.push(href);
-              cy.log(result.status + ': ' + href);
-            }
-          });
-        }
+        cy.get(url).then((url) => {
+          const href = url.prop('href');
+          if (href) {
+            cy.request({
+              url: href,
+              failOnStatusCode: false,
+            }).then((result) => {
+              if (result.status != 200) {
+                brokenUrls.push(href);
+                cy.log(result.status + ': ' + href);
+              }
+            });
+          }
+        });
       })
       .then(() => {
         if (brokenUrls.length) {
@@ -59,15 +60,16 @@ describe('Find broken image links', () => {
 
   function checkImages(path: string, selector: string) {
     let brokenImages = [];
-    cy.visit(path);
+    cy.visit(path).wait(300);
     cy.get(selector)
       .find('img')
       .each((image) => {
-        cy.get(image);
-        if (image.prop('naturalWidth') === 0) {
-          brokenImages.push(image.prop('src'));
-          cy.log('image not visible: ' + image.prop('src'));
-        }
+        cy.get(image).then((image) => {
+          if (image.prop('naturalWidth') === 0) {
+            brokenImages.push(image.prop('src'));
+            cy.log('image not visible: ' + image.prop('src'));
+          }
+        });
       })
       .then(() => {
         if (brokenImages.length) {

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -69,6 +69,7 @@ describe('Find broken image links', () => {
   function checkImages(path: string, selector: string) {
     let brokenImages = [];
     cy.visit(path).wait(500);
+    cy.get('app-root').should('be.visible');
     cy.get('img')
       .each((image) => {
         cy.get(image).then((image) => {

--- a/src/app/sitemap/sitemap.component.html
+++ b/src/app/sitemap/sitemap.component.html
@@ -43,7 +43,7 @@
           <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/news.html'" rel="noopener noreferrer"> News and Events </a>
         </li>
         <li>
-          <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/advanced-features.html'" rel="noopener noreferrer">
+          <a target="_blank" [href]="Dockstore.DOCUMENTATION_URL + '/index.html#advanced-developer-topics'" rel="noopener noreferrer">
             Advanced Features
           </a>
         </li>

--- a/test/web.yml
+++ b/test/web.yml
@@ -113,3 +113,5 @@ uiConfig:
 
   featuredContentUrl: https://content.dockstore.org/develop/feat-content.html
   featuredNewsUrl: https://content.dockstore.org/develop/news.html
+
+  documentationUrl: https://docs.dockstore.org/en/latest


### PR DESCRIPTION
**Description**
The goal of this PR is to experiment with integration testing for broken links, which aims to detect instances of broken URLs and images (currently falls under integration_test_4 as linkCheck.ts).

As of now, the test should iterate through relevant pages/selectors on the site (via `urlPages` and `imagePages`) and, for each, perform link checks. It targets anchor links by sending requests to their `href` property ([example](https://www.linkedin.com/pulse/finding-broken-links-using-cypress-brahma-rao-kothapalli)), and targets images by asserting their `naturalWidth` property is greater than zero ([example](https://stackoverflow.com/questions/51246606/test-loading-of-image-in-cypress/58641462#58641462)).

**Review Instructions**
Look over [linkCheck.ts](https://github.com/dockstore/dockstore-ui2/blob/feature/seab-6014/cypress/e2e/immutableDatabaseTests/linkCheck.ts) and the results/outputs of the [Cypress runs](https://cloud.cypress.io/projects/1ya4vj/runs/33225/overview?roarHideRunsWithDiffGroupsAndTags=1); ponder the effectiveness/relevance of a test like this and/or how it could be modified/improved. Would also appreciate any feedback relating to the thoughts included below!

Thoughts:

- Is it inefficient (edit: is it useful/meaningful) to run this test on every push? For example, it's probably unlikely that anchor links to /workflows, /dashboard, etc will ever break, and the same follows for internal images (other than newly added ones) that stay in the repo. In other words, a lot of links are relatively stable.
- ^ A possible solution is only testing external URLs (particularly for anchor links). On the other hand, are there instances of internal links that might break, and thus should be tested?

- For this test to stay up to date (at least with this version), we have to maintain `urlPages` and `imagePages` whenever new pages/components with links are added to the UI. Are the results of this test worth the effort?
- ^ If we keep this method, are there paths/selectors that could be added to/removed from `urlPages` and/or `imagePages`?
- False positives (finds broken links that aren't broken): in previous commits, some [image checks fail on first run](https://cloud.cypress.io/projects/1ya4vj/runs/33196/overview?roarHideRunsWithDiffGroupsAndTags=1), I think this is temporarily fixed by adding `cy.wait(500)` (and looks to be part of a larger flakiness issue, SEAB-6207).
- False negatives (fails to find links that are broken): the link to "[Advanced Features](https://docs.dockstore.org/en/stable/advanced-topics/advanced-features.html)" at /sitemap fails locally, but succeeds in the web run. Seems like the `href` for documentation links isn't formed correctly and takes on the form null/*. (EDIT: fixed by updating test/web.yml, link fails properly)
- There are some links that "fail" but aren't necessarily erroneous (ex. the Twitter link in the footer redirects to login, the token user avatar image in the navbar isn't "visible"). We could filter out such links while checking, but the more we filter out the less useful this test becomes.
- Should a test like this be required for merging PRs?

**Issue**
SEAB-6014

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 