### PR TITLE
SEAB-4703: Parameterize version numbers in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ parameters:
     default: "17.0.4-browsers"
   postgres-tag:
     type: string
-    default: "13.3"
+    default: "13.13"
   python-tag:
     type: string
     default: "3.11"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ parameters:
     default: "17.0.4-browsers"
   postgres-tag:
     type: string
-    default: "13.13"
+    default: "13.3"
   python-tag:
     type: string
     default: "3.11"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
         environment:
           JAVA_TOOL_OPTIONS: -Xmx2g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
-      - image: cimg/postgres:13.3
+      - image: cimg/postgres:<< pipeline.parameters.postgres-tag >>
         command: postgres -c max_connections=200 -c jit=off
         auth:
           username: dockstoretestuser
@@ -211,7 +211,7 @@ jobs:
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
-      - image: cimg/python:3.11
+      - image: cimg/python:<< pipeline.parameters.python-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -256,7 +256,7 @@ jobs:
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
-      - image: cimg/python:3.11
+      - image: cimg/python:<< pipeline.parameters.python-tag >>
         auth:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
@@ -278,6 +278,12 @@ parameters:
   java-tag:
     type: string
     default: "17.0.4-browsers"
+  postgres-tag:
+    type: string
+    default: "13.3"
+  python-tag:
+    type: string
+    default: "3.11"
 
 workflows:
   version: 2


### PR DESCRIPTION
**Description**
This PR defines parameters for the version numbers of `cimg/postgres` and `cimg/python`. This should help to keep Docker images in sync, thus preventing inconsistent versions within a configuration (see [previously conflicting `cimg/base` versions](https://github.com/dockstore/dockstore-ui2/blob/91f821ec5be06a877a97a3f5a859657856ed476f/.circleci/config.yml)) and making them easier to access/update.

**Review Instructions**
All relevant version numbers in config.yml should be parameterized, and all CircleCI tests should pass.

**Issue**
SEAB-4703

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
