### PR TITLE
SEAB-5992: Remove Twitter from smoke tests

### DIFF
--- a/cypress/e2e/group1/dashboard.ts
+++ b/cypress/e2e/group1/dashboard.ts
@@ -20,7 +20,7 @@ import {
   verifyGithubLinkDashboard,
   checkFeaturedContent,
   checkNewsAndUpdates,
-  checkMastodonFeedOrTwitterFeed,
+  checkMastodonFeed,
 } from '../../support/commands';
 
 describe('Dockstore dashboard', () => {
@@ -71,7 +71,7 @@ describe('Dockstore dashboard', () => {
 
   it('mastodon feed should be visible', () => {
     cy.visit('/dashboard');
-    checkMastodonFeedOrTwitterFeed();
+    checkMastodonFeed();
   });
 });
 

--- a/cypress/e2e/immutableDatabaseTests/app-spec.ts
+++ b/cypress/e2e/immutableDatabaseTests/app-spec.ts
@@ -27,9 +27,9 @@ describe('Logged in Dockstore Home', () => {
     // expect(browser.getLocationAbsUrl()).toMatch("/");
   });
 
-  it('should have the mastodon or twitter timeline', () => {
+  it('should have the mastodon timeline', () => {
     cy.scrollTo('bottom');
-    cy.get('[data-cy=mt-toot],.twitter-timeline').should('be.visible');
+    cy.get('[data-cy=mt-toot]').should('be.visible');
   });
 
   function starColumn(url: string, type: string) {

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -1,6 +1,6 @@
 import { ga4ghPath } from '../../../../src/app/shared/constants';
 import { ToolDescriptor } from '../../../../src/app/shared/openapi';
-import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeedOrTwitterFeed } from '../../../support/commands';
+import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeed } from '../../../support/commands';
 
 // Test an entry, these should be ambiguous between tools, workflows, and notebooks.
 describe('run stochastic smoke test', () => {
@@ -374,7 +374,7 @@ describe('Check extra content', () => {
 
   it('mastodon feed should be visible', () => {
     cy.visit('/');
-    checkMastodonFeedOrTwitterFeed();
+    checkMastodonFeed();
   });
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -276,6 +276,6 @@ export function checkNewsAndUpdates() {
   });
 }
 
-export function checkMastodonFeedOrTwitterFeed() {
-  cy.get('[data-cy=mt-toot],.twitter-timeline').should('exist');
+export function checkMastodonFeed() {
+  cy.get('[data-cy=mt-toot]').should('exist');
 }


### PR DESCRIPTION
**Description**
Previously, due to conflicting contents in staging/prod (i.e. Mastodon widget) versus qa (i.e. Twitter widget), smoke tests had to include Twitter in order to pass (https://github.com/dockstore/dockstore-ui2/pull/1861). Now that 1.15 has been deployed, we can remove the Twitter checks.

**Review Instructions**
All additions of Twitter from https://github.com/dockstore/dockstore-ui2/pull/1861 should be removed, and smoke tests should succeed.

**Issue**
SEAB-5992

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 