### PR TITLE
SEAB-6207: Fix flaky platform partner test

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/platform-partner.ts
+++ b/cypress/e2e/immutableDatabaseTests/platform-partner.ts
@@ -19,15 +19,14 @@ import { setTokenUserViewPortPlatformPartner, setPlatformPartnerRole } from '../
 describe('Platform Partner UI', () => {
   setTokenUserViewPortPlatformPartner();
   beforeEach(() => {
+    setPlatformPartnerRole();
     cy.visit('');
-
     // Select dropdown
     cy.get('[data-cy=dropdown-main]:visible').click();
   });
 
   describe('Profile', () => {
     it('Platform Partner status indicated on profile page', () => {
-      setPlatformPartnerRole();
       cy.get('#dropdown-accounts').click();
       cy.get('[data-cy=account-is-platform-partner]').should('exist');
     });


### PR DESCRIPTION
**Description**
The integration test platform-partner.ts has been flaking on almost every run; it tends to fail on the first attempt, then succeed on the second. The most common error seems to be: `Timed out retrying after 30000ms: Expected to find element: [data-cy=account-is-platform-partner], but never found it.` See this [video of a flaky run](https://cloud.cypress.io/projects/1ya4vj/runs/33450/overview/053a0c61-5b6d-4845-a1bc-ff916ff1d833/video?roarHideRunsWithDiffGroupsAndTags=1).

The issue should be resolved by calling `setPlatformPartnerRole()` before beginning the test.

_Flakiness on all branches in the past 30 days: ([source](https://cloud.cypress.io/projects/1ya4vj/analytics/flaky-tests?branches=%5B%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222024-02-21%22%2C%22endDate%22%3A%222024-03-22%22%7D&viewBy=TEST_CASE))_
![Screenshot from 2024-03-22 10-57-28](https://github.com/dockstore/dockstore-ui2/assets/122565245/72a16ac1-9068-40d4-b19a-2b1b9d09b8c3)

_Flakiness on develop in the past year: ([source](https://cloud.cypress.io/projects/1ya4vj/analytics/flaky-tests?branches=%5B%7B%22label%22%3A%22develop%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22develop%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222023-03-23%22%2C%22endDate%22%3A%222024-03-22%22%7D&viewBy=TEST_CASE))_
![Screenshot from 2024-03-22 10-59-27](https://github.com/dockstore/dockstore-ui2/assets/122565245/03112876-8a9f-4772-9c63-391f78587941)

**Review Instructions**
platform-partner.ts should not flake on the [run for this PR](https://cloud.cypress.io/projects/1ya4vj/runs/33454/overview/5a522976-e71c-420c-8a61-4182215626ec?roarHideRunsWithDiffGroupsAndTags=1). For more evidence, the branch [feature/seab-6207](https://github.com/dockstore/dockstore-ui2/tree/feature/seab-6207) also incorporates this change and appears to eliminate the platform partner flakiness on all runs.

**Issue**
SEAB-6207

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
