### PR TITLE
Increase manual topic max length to 250 & move ai bubble on search page

### DIFF
--- a/src/app/container/info-tab/info-tab.component.html
+++ b/src/app/container/info-tab/info-tab.component.html
@@ -293,7 +293,7 @@
                 <span fxFlex>
                   <input
                     *ngIf="topicEditing"
-                    maxlength="150"
+                    maxlength="250"
                     type="text"
                     name="topic"
                     class="w-100"

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -13,9 +13,11 @@
               notebook?.source.repository +
               (notebook?.source.workflowName ? '/' + notebook?.source.workflowName : '')
           }}</a>
-          <div class="truncate-text-2 size-small" [matTooltip]="notebook?.source.topicAutomatic" matTooltipPosition="left">
-            {{ notebook?.source.topicAutomatic }}
+          <div class="truncate-text-2">
             <app-ai-bubble *ngIf="notebook?.source.topicSelection === TopicSelectionEnum.AI" [isPublic]="true"></app-ai-bubble>
+            <span class="size-small" [matTooltip]="notebook?.source.topicAutomatic" matTooltipPosition="left">{{
+              notebook?.source.topicAutomatic
+            }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -44,9 +44,11 @@
               tool?.source.namespace + '/' + tool?.source.name + (tool?.source.toolname ? '/' + tool?.source.toolname : '')
             }}</a>
           </ng-template>
-          <div class="truncate-text-2 size-small" [matTooltip]="tool?.source.topicAutomatic" matTooltipPosition="left">
-            {{ tool?.source.topicAutomatic }}
+          <div class="truncate-text-2">
             <app-ai-bubble *ngIf="tool?.source.topicSelection === TopicSelectionEnum.AI" [isPublic]="true"></app-ai-bubble>
+            <span class="size-small" [matTooltip]="tool?.source.topicAutomatic" matTooltipPosition="left">{{
+              tool?.source.topicAutomatic
+            }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -18,9 +18,11 @@
                 (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
             }}</a
           >
-          <div class="truncate-text-2 size-small" [matTooltip]="workflow?.source.topicAutomatic" matTooltipPosition="left">
-            {{ workflow?.source.topicAutomatic }}
+          <div class="truncate-text-2">
             <app-ai-bubble *ngIf="workflow?.source.topicSelection === TopicSelectionEnum.AI" [isPublic]="true"></app-ai-bubble>
+            <span class="size-small" [matTooltip]="workflow?.source.topicAutomatic" matTooltipPosition="left">{{
+              workflow?.source.topicAutomatic
+            }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/shared/ai-bubble/ai-bubble.component.html
+++ b/src/app/shared/ai-bubble/ai-bubble.component.html
@@ -10,6 +10,6 @@
       : 'This topic sentence was AI generated. AI topic sentences are only generated for published entries.'
   }}"
 >
-  <img class="site-icons-small" src="/assets/svg/ai-icon.svg" alt="AI generation icon" />
+  <img class="site-icons-small" src="../../../assets/svg/ai-icon.svg" alt="AI generation icon" />
   AI
 </a>

--- a/src/app/shared/styles/entry-table.scss
+++ b/src/app/shared/styles/entry-table.scss
@@ -48,3 +48,8 @@ th {
   white-space: nowrap;
   vertical-align: top;
 }
+
+// Align AI bubble all the way to the left
+app-ai-bubble {
+  margin-left: 0;
+}

--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -234,7 +234,7 @@
                 <span fxFlex>
                   <input
                     *ngIf="topicEditing"
-                    maxlength="150"
+                    maxlength="250"
                     type="text"
                     class="w-100"
                     name="topicEditing"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1421,12 +1421,10 @@ div.mat-menu-panel {
   justify-content: space-between;
 }
 
-.ai-bubble {
-  align-items: center;
-  justify-content: center;
-  margin: 0 1%;
+app-ai-bubble {
+  margin: 0 0.5rem;
 }
 
 .ai-bubble:hover {
-  background-color: mat.get-color-from-palette($dockstore-app-gray, 6);
+  background-color: mat.get-color-from-palette($dockstore-app-gray, 7);
 }


### PR DESCRIPTION
**Description**
This PR increases the max length of the Topic Manual field to 250 to match the max length in the webservice. PR https://github.com/dockstore/dockstore/pull/5847 increases the max length from 150 to 250 characters.

This PR also moves the AI bubble on the search page to the beginning of the topic. When the AI bubble is at the end, it becomes hidden by the `truncate-text-2` class because the topic and AI bubble are considered as one element to truncate.

What it looks like now:
![Screenshot 2024-03-28 at 10-20-06 Dockstore Search](https://github.com/dockstore/dockstore-ui2/assets/25287123/0e5bcc63-df3d-4bdd-8c99-558efbf8b1f6)

Also changed the hover color to be darker than the non-hover color which is the pattern for other hover elements.
**Before**
Non-hover -> hover
![image](https://github.com/dockstore/dockstore-ui2/assets/25287123/b16c995b-9561-4057-878d-37fa355e0cc5) ![image](https://github.com/dockstore/dockstore-ui2/assets/25287123/e43fab08-eb0f-4499-9bc1-498cee03b258)

**After**
Non-hover -> hover
![image](https://github.com/dockstore/dockstore-ui2/assets/25287123/38d1744b-116b-4b9d-85f4-cfe22853fb08) ![image](https://github.com/dockstore/dockstore-ui2/assets/25287123/69281844-cc05-418d-abb6-600f9f9977fb)

**Review Instructions**
Verify that you can save a manual topic with 250 characters in the UI. Verify that you can't save a manual topic with more than 250 characters.

Verify that the AI bubble is at the beginning of the topic on the search page.

**Issue**
[SEAB-6007](https://ucsc-cgl.atlassian.net/browse/SEAB-6007)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[SEAB-6007]: https://ucsc-cgl.atlassian.net/browse/SEAB-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ