### PR TITLE
SEAB-6000: Adjust for UNINSTALL LambdaEvent

### DIFF
--- a/src/app/search/map-friendly-values.pipe.ts
+++ b/src/app/search/map-friendly-values.pipe.ts
@@ -118,6 +118,7 @@ export class MapFriendlyValuesPipe implements PipeTransform {
         ['PUSH', 'Push'],
         ['DELETE', 'Delete'],
         ['INSTALL', 'Install'],
+        ['UNINSTALL', 'Uninstall'],
         ['PUBLISH', 'Publish'],
       ]),
     ],


### PR DESCRIPTION
**Description**
This PR adds a mapping of "UNINSTALL" to "Uninstall" in `MapFriendlyValuesPipe`, to properly handle the new lambda event type added in https://github.com/dockstore/dockstore/pull/5852

**Review Instructions**
See https://github.com/dockstore/dockstore/pull/5852

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6000

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
