### PR TITLE
Don't prompt for ORCID link if not required

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import { LambdaEvent, TokenUser } from '../../../src/app/shared/openapi';
 import { Repository } from '../../../src/app/shared/openapi/model/repository';
 import {
   goToTab,
@@ -23,7 +24,7 @@ import {
   setTokenUserViewPortCurator,
   snapshot,
 } from '../../support/commands';
-import { LambdaEvent } from '../../../src/app/shared/openapi';
+import TokenSourceEnum = TokenUser.TokenSourceEnum;
 
 const cwlDescriptorType = 'CWL';
 const wdlDescriptorType = 'WDL';
@@ -298,6 +299,21 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=export-button').should('be.disabled');
       cy.get('[data-cy=link-orcid]').click();
       cy.url().should('eq', Cypress.config().baseUrl + '/accounts?tab=accounts');
+    });
+
+    it('Request to DOI should not require ORCID linked account', () => {
+      cy.fixture('tokens.json').then((json) => {
+        // Remove the ORCID token
+        const tokens = (json as Array<TokenUser>).filter((token) => token.tokenSource !== TokenSourceEnum.OrcidOrg);
+        cy.intercept('GET', '/api/users/1/tokens', {
+          body: tokens,
+          statusCode: 200,
+        });
+        gotoVersionsAndClickActions();
+        // Request DOI
+        cy.get('[data-cy=dockstore-request-doi-button]').click();
+        cy.get('[data-cy=orcid-not-linked]').should('not.exist'); // dockstore/dockstore#5796
+      });
     });
 
     it('Should be able to request DOI and then export to ORCID', () => {

--- a/src/app/workflow/snapshot-exporter-modal/snaphot-exporter-modal.component.html
+++ b/src/app/workflow/snapshot-exporter-modal/snaphot-exporter-modal.component.html
@@ -49,7 +49,7 @@
       <ng-container *ngIf="action === SnapshotExporterAction.DOI && (hasZenodoToken$ | async) === false && !version.doiURL">
         <ng-template *ngTemplateOutlet="warning; context: { innerTemplate: zenodoNotLinked }"></ng-template>
       </ng-container>
-      <div *ngIf="(hasOrcidToken$ | async) === false">
+      <div *ngIf="action === SnapshotExporterAction.ORCID && (hasOrcidToken$ | async) === false">
         <ng-template *ngTemplateOutlet="warning; context: { innerTemplate: orcidNotLinked }"></ng-template>
       </div>
 


### PR DESCRIPTION
**Description**
If only requesting a DOI, do not display a warning that the user needs to link their ORCID account.

**Review Instructions**
1. On the Dockstore accounts page, ensure your Zenodo account is linked, and that ORCID account is **not** linked.
2. Go to My Workflows, then to the versions table of any of your workflows that has tags
3. Click on Actions, Request DOI
4. There should be no red box prompting you to link your ORCID account.


**Issue**
dockstore/dockstore#5796
DOCK-2506

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
