### PR TITLE
Bump postgres version to 16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ parameters:
     default: "17.0.4-browsers"
   postgres-tag:
     type: string
-    default: "13.3"
+    default: "16.1"
   python-tag:
     type: string
     default: "3.11"


### PR DESCRIPTION
**Description**
This PR bumps the postgres container version to 16.1 to match the [webservice](https://github.com/dockstore/dockstore/blob/7347da6a1ecb1c7f8d1385c4d17b273bf1244b21/docker-compose.yml#L48)

**Review Instructions**
Builds should pass

**Issue**
[SEAB-6334](https://ucsc-cgl.atlassian.net/browse/SEAB-6334)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://gxthub.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
