### PR TITLE
ui2 - run against webservice develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
               command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
           - run:
               name: set use_circle to false (openapi.yaml from github)
-              command: bash -i -c 'npm config set dockstore-ui2:use_circle true'              
+              command: bash -i -c 'npm config set dockstore-ui2:use_circle false'              
       - build_ui
       - run:
           name: Install codecov
@@ -287,7 +287,7 @@ jobs:
                 command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
             - run:
                 name: set use_circle to false (openapi.yaml from github)
-                command: bash -i -c 'npm config set dockstore-ui2:use_circle true'                 
+                command: bash -i -c 'npm config set dockstore-ui2:use_circle false'                 
             - build_ui
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,11 @@ jobs:
           username: dockstoretestuser
           password: $DOCKERHUB_PASSWORD
     steps:
+      - run: # should not need this, but circle ci does not like it when a condition wipes out a whole job https://discuss.circleci.com/t/pipeline-parameters-in-steps-when-conditions-seems-to-have-no-value-using-dynamic-configuration/50524/2
+          name: Java/Maven/Python versions
+          command: |
+            java -version
+            npm --version
       - when:
           condition:
             not: << pipeline.parameters.sanity-check-against-develop >>      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       # Override the webservice version in package.json to instead build against develop webservice
       - run:
           when:
-            condition: <<parameters.sanity_check_against_develop>>
+            condition: << parameters.sanity_check_against_develop >>
           name: set webservice to develop
           command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
       - build_ui
@@ -374,7 +374,7 @@ workflows:
       - check_build_develop:
           when:
             condition:
-              not: <<parameters.sanity_check_against_develop>>
+              not: << parameters.sanity_check_against_develop >>
           requires:
             - upload_to_s3
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,12 @@ jobs:
           command: |
             bash -i -c 'npm run circle-ci-license-test-file'
             bash scripts/detect-package-json-changes.sh
+      # Override the webservice version in package.json to instead build against develop webservice
+      - run:
+          when:
+            condition: <<parameters.sanity_check_against_develop>>
+          name: set webservice to develop
+          command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
       - build_ui
       - run:
           name: Install codecov
@@ -284,6 +290,9 @@ parameters:
   python-tag:
     type: string
     default: "3.11"
+  sanity_check_against_develop:
+    type: boolean
+    default: false
 
 workflows:
   version: 2
@@ -363,6 +372,9 @@ workflows:
             - dockerhub
             - aws-ui2
       - check_build_develop:
+          when:
+            condition:
+              not: <<parameters.sanity_check_against_develop>>
           requires:
             - upload_to_s3
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,9 @@ jobs:
           - run:
               name: set webservice to develop
               command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
+          - run:
+              name: set use_circle to false (openapi.yaml from github)
+              command: bash -i -c 'npm config set dockstore-ui2:use_circle true'              
       - build_ui
       - run:
           name: Install codecov
@@ -282,6 +285,9 @@ jobs:
             - run:
                 name: set webservice to develop
                 command: bash -i -c 'npm config set dockstore-ui2:webservice_version develop'
+            - run:
+                name: set use_circle to false (openapi.yaml from github)
+                command: bash -i -c 'npm config set dockstore-ui2:use_circle true'                 
             - build_ui
 
 parameters:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "webservice_version": "1.16.0",
     "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/11135/workflows/fa998d0e-13c1-4ba2-8f6c-c535d4731e7d/jobs/42660/artifacts",
-    "circle_build_id": "42660"
+    "circle_build_id": "43087"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version": "1.16.0-alpha.10",
-    "use_circle": false,
+    "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/gh/dockstore/dockstore/11187/workflows/06dcae07-dc91-4fc3-ae1f-2007a49f7535/jobs/43090/artifacts",
     "circle_build_id": "43090"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.13.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.16.0-alpha.9",
+    "webservice_version": "1.16.0-alpha.10",
     "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/gh/dockstore/dockstore/11187/workflows/06dcae07-dc91-4fc3-ae1f-2007a49f7535/jobs/43090/artifacts",
     "circle_build_id": "43090"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "config": {
     "webservice_version": "1.16.0",
     "use_circle": true,
-    "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/11135/workflows/fa998d0e-13c1-4ba2-8f6c-c535d4731e7d/jobs/42660/artifacts",
+    "circle_ci_source": "https://app.circleci.com/pipelines/gh/dockstore/dockstore/11187/workflows/06dcae07-dc91-4fc3-ae1f-2007a49f7535/jobs/43090/artifacts",
     "circle_build_id": "43090"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "webservice_version": "1.16.0",
     "use_circle": true,
     "circle_ci_source": "https://app.circleci.com/pipelines/github/dockstore/dockstore/11135/workflows/fa998d0e-13c1-4ba2-8f6c-c535d4731e7d/jobs/42660/artifacts",
-    "circle_build_id": "43087"
+    "circle_build_id": "43090"
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.13.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version": "1.16.0",
-    "use_circle": true,
+    "webservice_version": "1.16.0-alpha.9",
+    "use_circle": false,
     "circle_ci_source": "https://app.circleci.com/pipelines/gh/dockstore/dockstore/11187/workflows/06dcae07-dc91-4fc3-ae1f-2007a49f7535/jobs/43090/artifacts",
     "circle_build_id": "43090"
   },

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" -H "Circle-Token: ''" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
 
 echo "${ARTIFACT_URL}"

--- a/scripts/get-circleci-artifact-url.sh
+++ b/scripts/get-circleci-artifact-url.sh
@@ -14,6 +14,6 @@ fi
 
 CIRCLECI_BUILD_ID=${1}
 ARTIFACT_NAME=${2}
-ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
+ARTIFACT_URL=$(curl "https://circleci.com/api/v2/project/gh/dockstore/dockstore/${CIRCLECI_BUILD_ID}/artifacts" -H "Accept: application/json" -H "Circle-Token: ''" | jq -r --arg ARTIFACT_NAME "${ARTIFACT_NAME}" '[.items[] | select( .path | contains($ARTIFACT_NAME) ) | .url] | first ')
 
 echo "${ARTIFACT_URL}"


### PR DESCRIPTION
**Description**
Moves the check_build_develop step earlier (conditionally) and controls it with a new parameter. 
This allows us to run a build nightly, checking for new issues caused by a changing webservice. 

Example of build as usual: 
https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/11796/workflows/0959c4f8-e5d1-42d4-8d0b-2f428b23a2cc

Example  of build with moved check develop step:
https://app.circleci.com/pipelines/github/dockstore/dockstore-ui2/11797/workflows/9f04c924-c765-43aa-9f68-8dcc7d5225f5/jobs/53146

On merge, will create a cron trigger, similar to what we have for the CLI. 

**Review Instructions**
Check for nightly builds, ideally should see a build fail due to an incompatible change to the webservice. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6380

**Security**
None

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
