### PR TITLE
DOCK-2403: Link to individual source files

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -414,12 +414,12 @@ describe('Dockstore my workflows part 2', () => {
   });
 
   it('Should be able to reference a specific source file in a Dockstore URL', () => {
-    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2Fnonexistent.txt');
+    cy.visit('/workflows/github.com/B/z?tab=files&file=%2Fnonexistent.txt');
     cy.contains('Could not find the specified file');
-    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2FDockstore.cwl');
+    cy.visit('/workflows/github.com/B/z?tab=files&file=%2FDockstore.cwl');
     cy.contains('/Dockstore.cwl');
     cy.contains('cwlVersion:');
-    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2Fdockstore.yml');
+    cy.visit('/workflows/github.com/B/z?tab=files&file=%2Fdockstore.yml');
     cy.contains('/.dockstore.yml');
     cy.contains('workflows:');
   });

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -398,7 +398,7 @@ describe('Dockstore my workflows part 2', () => {
 
     cy.contains('/Dockstore.cwl');
     cy.contains('class: Workflow');
-    cy.url().should('contain', 'file=/Dockstore.cwl');
+    cy.url().should('contain', 'file=%2FDockstore.cwl');
 
     cy.get('app-source-file-tabs').within((tabBody) => {
       cy.get('mat-select').click();
@@ -410,7 +410,7 @@ describe('Dockstore my workflows part 2', () => {
     goToTab('Configuration');
     cy.contains('Configuration');
     cy.contains('/.dockstore.yml');
-    cy.url().should('contain', 'file=/.dockstore.yml');
+    cy.url().should('contain', 'file=%2Fdockstore.yml');
   });
 
   it('Should be able to reference a specific source file in a Dockstore URL', () => {

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -398,6 +398,7 @@ describe('Dockstore my workflows part 2', () => {
 
     cy.contains('/Dockstore.cwl');
     cy.contains('class: Workflow');
+    cy.url().should('contain', 'file=/Dockstore.cwl');
 
     cy.get('app-source-file-tabs').within((tabBody) => {
       cy.get('mat-select').click();
@@ -409,6 +410,18 @@ describe('Dockstore my workflows part 2', () => {
     goToTab('Configuration');
     cy.contains('Configuration');
     cy.contains('/.dockstore.yml');
+    cy.url().should('contain', 'file=/.dockstore.yml');
+  });
+
+  it('Should be able to reference a specific source file in a Dockstore URL', () => {
+    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2Fnonexistent.txt');
+    cy.contains('Could not find the specified file');
+    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2FDockstore.cwl');
+    cy.contains('/Dockstore.cwl');
+    cy.contains('cwlVersion:');
+    cy.visit('/my-workflows/github.com/B/z?tab=files&file=%2Fdockstore.yml');
+    cy.contains('/.dockstore.yml');
+    cy.contains('workflows:');
   });
 
   it('Should be able to refresh a workflow version', () => {

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -398,7 +398,6 @@ describe('Dockstore my workflows part 2', () => {
 
     cy.contains('/Dockstore.cwl');
     cy.contains('class: Workflow');
-    cy.url().should('contain', 'file=%2FDockstore.cwl');
 
     cy.get('app-source-file-tabs').within((tabBody) => {
       cy.get('mat-select').click();
@@ -410,18 +409,6 @@ describe('Dockstore my workflows part 2', () => {
     goToTab('Configuration');
     cy.contains('Configuration');
     cy.contains('/.dockstore.yml');
-    cy.url().should('contain', 'file=%2Fdockstore.yml');
-  });
-
-  it('Should be able to reference a specific source file in a Dockstore URL', () => {
-    cy.visit('/workflows/github.com/B/z?tab=files&file=%2Fnonexistent.txt');
-    cy.contains('Could not find the specified file');
-    cy.visit('/workflows/github.com/B/z?tab=files&file=%2FDockstore.cwl');
-    cy.contains('/Dockstore.cwl');
-    cy.contains('cwlVersion:');
-    cy.visit('/workflows/github.com/B/z?tab=files&file=%2Fdockstore.yml');
-    cy.contains('/.dockstore.yml');
-    cy.contains('workflows:');
   });
 
   it('Should be able to refresh a workflow version', () => {

--- a/cypress/e2e/immutableDatabaseTests/toolDetails.ts
+++ b/cypress/e2e/immutableDatabaseTests/toolDetails.ts
@@ -35,15 +35,15 @@ describe('Variations of URL', () => {
   });
   it('Should redirect to canonical url (tab)', () => {
     cy.visit('/containers/quay.io/A2/a?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
   });
   it('Should redirect to canonical url (tab + version)', () => {
     cy.visit('/containers/quay.io/A2/a:latest?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
   });
   it('Should redirect to canonical url (tools + encoding + tab + version)', () => {
     cy.visit('/tools/quay.io%2FA2%2Fa:latest?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
   });
 });
 
@@ -74,7 +74,7 @@ describe('Dockstore Tool Details of quay.io/A2/a', () => {
   describe('Change tab to files', () => {
     beforeEach(() => {
       goToTab('Files');
-      cy.url().should('eq', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
+      cy.url().should('contain', Cypress.config().baseUrl + '/containers/quay.io/A2/a:latest?tab=files');
     });
 
     it('Should have Dockerfile tab selected', () => {

--- a/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
@@ -27,15 +27,15 @@ describe('Variations of URL', () => {
   });
   it('Should redirect to canonical url (tab)', () => {
     cy.visit('/workflows/github.com/A/l?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
   });
   it('Should redirect to canonical url (version + tab)', () => {
     cy.visit('/workflows/github.com/A/l:master?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
   });
   it('Should redirect to canonical url (encoding + version + tab)', () => {
     cy.visit('/workflows/github.com%2FA%2Fl:master?tab=files');
-    cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
+    cy.url().should('contain', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
   });
 });
 
@@ -74,7 +74,7 @@ describe('Dockstore Workflow Details', () => {
   describe('Change tab to files', () => {
     beforeEach(() => {
       goToTab('Files');
-      cy.url().should('eq', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
+      cy.url().should('contain', Cypress.config().baseUrl + '/workflows/github.com/A/l:master?tab=files');
     });
 
     it('Should have Descriptor files tab selected', () => {

--- a/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
+++ b/cypress/e2e/immutableDatabaseTests/workflowDetails.ts
@@ -168,3 +168,26 @@ describe('Test engine versions', () => {
     cy.get('[data-cy=engine-versions]').should('be.visible');
   });
 });
+
+describe('Test sourcefile links', () => {
+  it('Should change the Dockstore URL to include the source file path', () => {
+    cy.visit('/workflows/github.com/A/l?tab=files');
+    cy.url().should('contain', 'file=%2F1st-workflow.cwl');
+    goToTab('Configuration');
+    cy.url().should('not.contain', 'file=');
+  });
+
+  it('Should be able to reference a specific source file in a Dockstore URL', () => {
+    cy.visit('/workflows/github.com/A/l?tab=files&file=%2Fnonexistent.txt');
+    cy.contains('Could not find the specified file');
+    cy.url().should('contain', 'file=%2F1st-workflow.cwl');
+    cy.visit('/workflows/github.com/A/l?tab=files&file=%2F1st-workflow.cwl');
+    cy.contains('1st-workflow.cwl');
+    cy.contains('Workflow');
+    cy.url().should('contain', 'file=%2F1st-workflow.cwl');
+    cy.visit('/workflows/github.com/A/l?tab=files&file=%2Farguments.cwl');
+    cy.contains('arguments.cwl');
+    cy.contains('CommandLineTool');
+    cy.url().should('contain', 'file=%2Farguments.cwl');
+  });
+});

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -21,7 +21,7 @@
       page.</mat-card
     >
   </div>
-  <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)">
+  <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)" [(selectedIndex)]="selectedTabIndex">
     <mat-tab *ngFor="let fileTab of fileTabs | keyvalue: originalOrder" [label]="fileTab.key">
       <ng-template matTabContent>
         <div class="p-3" *ngIf="fileTab.value.length === 0">

--- a/src/app/source-file-tabs/source-file-tabs.component.html
+++ b/src/app/source-file-tabs/source-file-tabs.component.html
@@ -21,6 +21,11 @@
       page.</mat-card
     >
   </div>
+  <div *ngIf="notFoundError" class="p-3">
+    <mat-card class="alert alert-warning mat-elevation-z">
+      <mat-icon class="alert-warning-icon">warning</mat-icon>Could not find the specified file.<br />Other files are displayed below.
+    </mat-card>
+  </div>
   <mat-tab-group mat-stretch-tabs (selectedTabChange)="matTabChange($event)" [(selectedIndex)]="selectedTabIndex">
     <mat-tab *ngFor="let fileTab of fileTabs | keyvalue: originalOrder" [label]="fileTab.key">
       <ng-template matTabContent>

--- a/src/app/source-file-tabs/source-file-tabs.component.spec.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MapFriendlyValuesPipe } from 'app/search/map-friendly-values.pipe';
 import { FileService } from 'app/shared/file.service';
@@ -18,7 +19,7 @@ describe('SourceFileTabsComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [SourceFileTabsComponent, MapFriendlyValuesPipe],
-        imports: [HttpClientTestingModule, MatDialogModule, HttpClientTestingModule],
+        imports: [HttpClientTestingModule, MatDialogModule, RouterTestingModule],
         providers: [
           { provide: SourceFileTabsService, useClass: SourceFileTabsStubService },
           { provide: FileService, useClass: FileStubService },

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -112,7 +112,8 @@ export class SourceFileTabsComponent implements OnChanges {
             if (sourceFile.absolutePath === queryFileName) {
               this.changeTab(tabIndex);
               console.log('INDEXOF ' + sourceFiles.indexOf(sourceFile));
-              this.changeFileType(sourceFiles.indexOf(sourceFile), sourceFiles);
+              this.selectFile(sourceFile);
+              this.changeTab(tabIndex);
               return;
             }
           }
@@ -121,8 +122,9 @@ export class SourceFileTabsComponent implements OnChanges {
 
       // Otherwise, select the first file in the first tab.
       console.log('DEFAULT');
+      const files = this.fileTabs.values().next().value;
+      this.selectFile(files[0]);
       this.changeTab(0);
-      this.changeFileType(0, this.fileTabs.values().next().value);
     }
   }
 
@@ -135,10 +137,12 @@ export class SourceFileTabsComponent implements OnChanges {
    * Sets the validation message and new default selected file
    * @param fileType
    */
-  changeFileType(index: number, files: SourceFile[]) {
+  changeFileType(files: SourceFile[]) {
     console.log('CHANGEFILETYPE');
-    this.selectFile(files[index]);
     this.validationMessage = this.sourceFileTabsService.getValidationMessage(files, this.version);
+    if (files.indexOf(this.currentFile) < 0) {
+      this.selectFile(files[0]);
+    }
   }
 
   selectFile(file: SourceFile) {
@@ -177,7 +181,7 @@ export class SourceFileTabsComponent implements OnChanges {
 
   matTabChange(event: MatTabChangeEvent) {
     console.log('MAT TAB CHANGE');
-    this.changeFileType(0, this.fileTabs.get(event.tab.textLabel));
+    this.changeFileType(this.fileTabs.get(event.tab.textLabel));
   }
 
   matSelectChange(event: MatSelectChange) {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,5 +1,4 @@
 import { KeyValue, Location } from '@angular/common';
-import { HttpUrlEncodingCodec } from '@angular/common/http';
 import { Component, Input, OnChanges } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
@@ -170,7 +169,7 @@ export class SourceFileTabsComponent implements OnChanges {
     }
     // Add the sourcefile's absolute path as the 'file' query parameter.
     if (file) {
-      params.set('file', new HttpUrlEncodingCodec().encodeValue(file.absolutePath));
+      params.set('file', file.absolutePath);
     } else {
       params.delete('file');
     }

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -164,6 +164,11 @@ export class SourceFileTabsComponent implements OnChanges {
     const url = this.location.path();
     const root = url.split('?')[0];
     const params = new URLSearchParams(url.split('?')[1] ?? '');
+    // Don't modify the URL if it's not tracking the current tab.
+    if (!params.has('tab')) {
+      return;
+    }
+    // Add the sourcefile's absolute path as the 'file' query parameter.
     if (file) {
       params.set('file', new HttpUrlEncodingCodec().encodeValue(file.absolutePath));
     } else {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -140,9 +140,6 @@ export class SourceFileTabsComponent implements OnChanges {
   changeFileType(files: SourceFile[]) {
     console.log('CHANGEFILETYPE');
     this.validationMessage = this.sourceFileTabsService.getValidationMessage(files, this.version);
-    if (files.indexOf(this.currentFile) < 0) {
-      this.selectFile(files[0]);
-    }
   }
 
   selectFile(file: SourceFile) {
@@ -181,7 +178,11 @@ export class SourceFileTabsComponent implements OnChanges {
 
   matTabChange(event: MatTabChangeEvent) {
     console.log('MAT TAB CHANGE');
-    this.changeFileType(this.fileTabs.get(event.tab.textLabel));
+    const files = this.fileTabs.get(event.tab.textLabel);
+    if (files.indexOf(this.currentFile) < 0) {
+      this.selectFile(files[0]);
+    }
+    this.changeFileType(files);
   }
 
   matSelectChange(event: MatSelectChange) {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -62,9 +62,7 @@ export class SourceFileTabsComponent implements OnChanges {
 
   ngOnInit() {
     this.route.queryParams.subscribe((params) => {
-      if (this.fileTabs) {
-        this.selectTabAndFile();
-      }
+      this.selectTabAndFile();
     });
   }
 
@@ -100,22 +98,14 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   selectTabAndFile() {
-    console.log(this.fileTabs.size);
-    if (this.fileTabs.size > 0) {
+    if (this.fileTabs?.size > 0) {
       // Attempt to set the file as indicated by the 'file' query parameter.
       const queryFileName = this.route.snapshot.queryParams['file'];
-      console.log('PARAM ' + queryFileName);
       if (queryFileName) {
-        // console.log("VALUES " + JSON.stringify(this.fileTabs.values()));
         for (let tabIndex = 0; tabIndex < this.fileTabs.size; tabIndex++) {
           const sourceFiles = Array.from(this.fileTabs.values())[tabIndex];
-          // console.log("SOURCEFILES " + JSON.stringify(sourceFiles));
           for (let sourceFile of sourceFiles) {
-            console.log('CMP ' + sourceFile.absolutePath + ' ' + queryFileName);
-            // console.log("SOURCEFILE " + JSON.stringify(sourceFile));
             if (sourceFile.absolutePath === queryFileName) {
-              this.changeTab(tabIndex);
-              console.log('INDEXOF ' + sourceFiles.indexOf(sourceFile));
               this.selectFile(sourceFile);
               this.changeTab(tabIndex);
               return;
@@ -125,7 +115,6 @@ export class SourceFileTabsComponent implements OnChanges {
       }
 
       // Otherwise, select the first file in the first tab.
-      console.log('DEFAULT');
       const files = this.fileTabs.values().next().value;
       this.selectFile(files[0]);
       this.changeTab(0);
@@ -133,7 +122,6 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   changeTab(tabIndex: number) {
-    console.log('CHANGETAB ' + this.selectedTabIndex + ' ' + tabIndex);
     this.selectedTabIndex = tabIndex;
   }
 
@@ -142,7 +130,6 @@ export class SourceFileTabsComponent implements OnChanges {
    * @param fileType
    */
   changeFileType(files: SourceFile[]) {
-    console.log('CHANGEFILETYPE');
     this.validationMessage = this.sourceFileTabsService.getValidationMessage(files, this.version);
   }
 
@@ -161,6 +148,7 @@ export class SourceFileTabsComponent implements OnChanges {
       this.fileName = null;
       this.relativePath = null;
       this.downloadFilePath = null;
+      this.isCurrentFilePrimary = false;
     }
     this.currentFile = file;
     this.setUrl(file);
@@ -171,12 +159,11 @@ export class SourceFileTabsComponent implements OnChanges {
     if (file) {
       query += `&file=${file.absolutePath}`;
     }
-    const root = this.router.url.split('?')[0];
-    this.location.replaceState(root, query);
+    const url = this.router.url.split('?')[0];
+    this.location.replaceState(url, query);
   }
 
   matTabChange(event: MatTabChangeEvent) {
-    console.log('MAT TAB CHANGE');
     const files = this.fileTabs.get(event.tab.textLabel);
     if (files.indexOf(this.currentFile) < 0) {
       this.selectFile(files[0]);
@@ -185,7 +172,6 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   matSelectChange(event: MatSelectChange) {
-    console.log('MAT SELECT CHANGE ' + event.value);
     this.selectFile(event.value);
   }
 

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -157,18 +157,20 @@ export class SourceFileTabsComponent implements OnChanges {
       this.isCurrentFilePrimary = false;
     }
     this.currentFile = file;
-    this.addFilePathToUrl(file);
+    this.setFilePathInLocation(file);
     this.notFoundError = false;
   }
 
-  addFilePathToUrl(file: SourceFile) {
-    let query = 'tab=files';
+  setFilePathInLocation(file: SourceFile) {
+    const url = this.location.path();
+    const root = url.split('?')[0];
+    const params = new URLSearchParams(url.split('?')[1] ?? '');
     if (file) {
-      const encodedPath = new HttpUrlEncodingCodec().encodeValue(file.absolutePath);
-      query += `&file=${encodedPath}`;
+      params.set('file', new HttpUrlEncodingCodec().encodeValue(file.absolutePath));
+    } else {
+      params.delete('file');
     }
-    const url = this.router.url.split('?')[0];
-    this.location.replaceState(url, query);
+    this.location.replaceState(root, params.toString());
   }
 
   matTabChange(event: MatTabChangeEvent) {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -38,6 +38,7 @@ export class SourceFileTabsComponent implements OnChanges {
   @Input() version: WorkflowVersion;
   loading = true;
   displayError = false;
+  notFoundError = false;
   currentFile: SourceFile | null;
   validationMessage: Map<string, string>;
   fileName: string;
@@ -118,6 +119,10 @@ export class SourceFileTabsComponent implements OnChanges {
       const files = this.fileTabs.values().next().value;
       this.selectFile(files[0]);
       this.changeTab(0);
+
+      if (queryFileName) {
+        this.notFoundError = true;
+      }
     }
   }
 
@@ -152,6 +157,7 @@ export class SourceFileTabsComponent implements OnChanges {
     }
     this.currentFile = file;
     this.setUrl(file);
+    this.notFoundError = false;
   }
 
   setUrl(file: SourceFile) {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -61,7 +61,11 @@ export class SourceFileTabsComponent implements OnChanges {
   }
 
   ngOnInit() {
-    // TODO field url changes
+    this.route.queryParams.subscribe((params) => {
+      if (this.fileTabs) {
+        this.selectTabAndFile();
+      }
+    });
   }
 
   setupVersionFileTabs() {
@@ -152,28 +156,23 @@ export class SourceFileTabsComponent implements OnChanges {
         this.version.name,
         this.relativePath
       );
+      this.isCurrentFilePrimary = this.isPrimaryDescriptor(file.path);
     } else {
       this.fileName = null;
       this.relativePath = null;
       this.downloadFilePath = null;
     }
     this.currentFile = file;
-    // TODO fix npe
-    this.isCurrentFilePrimary = this.isPrimaryDescriptor(this.currentFile.path);
-    // Set "file" query parameter
-    /*
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { tab: 'files', file: file.absolutePath },
-      queryParamsHandling: 'merge',
-      skipLocationChange: true
-    });
-    */
-    console.log('PATH ' + file.absolutePath);
+    this.setUrl(file);
+  }
+
+  setUrl(file: SourceFile) {
+    let query = 'tab=files';
+    if (file) {
+      query += `&file=${file.absolutePath}`;
+    }
     const root = this.router.url.split('?')[0];
-    console.log('ROOT ' + root);
-    this.location.replaceState(root, 'tab=files&file=' + file.absolutePath);
-    console.log('URL ' + JSON.stringify(this.router.url));
+    this.location.replaceState(root, query);
   }
 
   matTabChange(event: MatTabChangeEvent) {

--- a/src/app/source-file-tabs/source-file-tabs.component.ts
+++ b/src/app/source-file-tabs/source-file-tabs.component.ts
@@ -1,7 +1,7 @@
 import { KeyValue, Location } from '@angular/common';
 import { HttpUrlEncodingCodec } from '@angular/common/http';
 import { Component, Input, OnChanges } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MatLegacySelectChange as MatSelectChange } from '@angular/material/legacy-select';
 import { MatLegacyTabChangeEvent as MatTabChangeEvent } from '@angular/material/legacy-tabs';
@@ -26,7 +26,6 @@ export class SourceFileTabsComponent implements OnChanges {
     private matDialog: MatDialog,
     private workflowQuery: WorkflowQuery,
     private activatedRoute: ActivatedRoute,
-    private router: Router,
     private location: Location
   ) {
     this.isPublished$ = this.workflowQuery.workflowIsPublished$;


### PR DESCRIPTION
**Description**
This PR changes the UI so that when the user views a source file, its absolute path is added to the URL as the `file` query parameter.  The resulting URL directly references the source file and can be copied/pasted/saved for future use.

Please view this PR locally and try to make it malfunction.

Believe it or not, the private entry page does not track the selected tab in the URL or allow linking to a particular tab, like the public entry page does.  I poked around and it looks like harmonizing the behavior would be hazardous and quite a chore, so I left it as is.  Thus, the new functionality is only available on the public entry page.

When a version changes, source files can potentially disappear.  When a URL references a now non-existent file, the UI displays a message to that effect, and displays a different file.

As the team informally decided, this PR doesn't implement the "line number" part of DOCK-2403.  However, whilst coding this PR, I realized that it might be relatively easy to do.  If we add a hash of the source file's content to the URL, we can detect that the source file has changed and take appropriate action (for example, no longer highlight the specified line, because the source file content could no longer match up).  If we decide to include the "line number" functionality, I suggest we add it in a follow-up PR.

**Review Instructions**
View an entry's public page.  Click on the "Files" tab.  Confirm that the absolute path of the displayed source file has been added to the URL as the `file` query parameter.  Copy the URL.  Select a different file.  Visit the URL.  Confirm that the original file is displayed.  Paste the URL, corrupt the `file` query parameter, visit the resulting URL, and confirm that an appropriate message is displayed.  Play around with the interface in similar fashion and try to find bugs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2403
https://github.com/dockstore/dockstore/issues/5523

**Security**
This PR changes the browser URL to include the absolute path of a source file as a query parameter.  The code appears to encode characters correctly, and source files are limited to a small subset of "safe" characters, so I don't believe there is an issue.  However, please scrutinize.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
