### PR TITLE
Update tar dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dockstore-ui2",
-  "version": "2.10.0",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dockstore-ui2",
-      "version": "2.10.0",
+      "version": "2.13.0",
       "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {
@@ -21064,9 +21064,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -29807,7 +29807,7 @@
         "p-map": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "ssri": "^10.0.0",
-        "tar": "^6.1.11",
+        "tar": "^6.2.1",
         "unique-filename": "^3.0.0"
       },
       "dependencies": {
@@ -37069,7 +37069,7 @@
         "read-package-json-fast": "^3.0.0",
         "sigstore": "^1.0.0",
         "ssri": "^10.0.0",
-        "tar": "^6.1.11"
+        "tar": "^6.2.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -39646,9 +39646,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,9 @@
     },
     "@schematics/update": {
       "ini": "^1.3.8"
+    },
+    "@angular/cli" : {
+      "tar": "^6.2.1"
     }
   }
 }


### PR DESCRIPTION
**Description**
This is an alternative implementation to #1961, which updates tar by updating Akita. This PR only updates tar, since it's a major version upgrade of Akita, which is risky.

I'm not sure we could get hit by this in the browser, since we don't fetch tar files, but seems safe to do.

**Review Instructions**

```
npm ci
cat node_modules/tar/package.json| jq '.version'
"6.2.1"
# Previous line should be 6.2.1 or greater
```
**Issue**
SEAB-6438

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
