### PR TITLE
DOCK-2523: fix concept DOI link

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.html
+++ b/src/app/workflow/info-tab/info-tab.component.html
@@ -418,14 +418,14 @@
           <div>
             <strong matTooltip="Digital Object Identifier for all workflow versions">DOI</strong>:
             <a
-              [href]="'https://doi.org/' + workflow.conceptDoi"
+              [href]="'https://doi.org/' + formattedConceptDOI"
               *ngIf="workflow.conceptDoi"
               matTooltip="Click to view the DOI entry information for all versions."
               target="_blank"
               rel="noopener noreferrer"
-              ><img src="{{ zenodoUrl }}/badge/DOI/{{ workflow.conceptDoi }}.svg" alt="{{ workflow.conceptDoi }}"
+              ><img src="{{ zenodoUrl }}/badge/DOI/{{ formattedConceptDOI }}.svg" alt="{{ formattedConceptDOI }}"
             /></a>
-            {{ workflow?.conceptDoi ? '' : 'n/a' }}
+            {{ formattedConceptDOI ? '' : 'n/a' }}
           </div>
         </div>
       </ul>

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -54,6 +54,8 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   publicAccessibleTestParameterFile: boolean | null;
   isValidVersion = false;
   zenodoUrl: string;
+  formattedConceptDOI: string;
+
   @Input() selectedVersion: WorkflowVersion;
 
   public validationPatterns = validationDescriptorPatterns;
@@ -166,6 +168,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       .subscribe((entryType) => (this.displayTextForButton = this.infoTabService.getTRSId(this.workflow, entryType)));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
     this.infoTabService.topicEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((topicEditing) => (this.topicEditing = topicEditing));
+    this.formatConceptDOI();
   }
   /**
    * Handle restubbing a workflow
@@ -188,6 +191,13 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
         const url = window.URL.createObjectURL(blob);
         window.open(url);
       });
+  }
+
+  formatConceptDOI() {
+    if (this.workflow.conceptDoi.startsWith('doi')) {
+      this.formattedConceptDOI = this.workflow.conceptDoi.split('doi/')[1];
+      console.log(this.formattedConceptDOI);
+    }
   }
 
   toggleEditWorkflowPath() {

--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -196,7 +196,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
   formatConceptDOI() {
     if (this.workflow.conceptDoi.startsWith('doi')) {
       this.formattedConceptDOI = this.workflow.conceptDoi.split('doi/')[1];
-      console.log(this.formattedConceptDOI);
     }
   }
 


### PR DESCRIPTION
**Description**
This PR fixes the DOI link on the workflow page. 

Before fix (notice the `doi/` prefix: 
![image](https://github.com/dockstore/dockstore-ui2/assets/61166764/234f42b7-2f70-4f6e-924f-18ee963ad32a)

After fix:
![image](https://github.com/dockstore/dockstore-ui2/assets/61166764/52505fd9-12f2-4e36-a952-4ccd8c7a36dc)


**Review Instructions**
Go to https://qa.dockstore.org/workflows/github.com/kathy-t/ghapps-single-workflow:master?tab=info and verify that the link works correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2523

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
