### PR TITLE
Point pcawg link at legacy page 

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -140,7 +140,7 @@
           <h3>Building a Community</h3>
           <p>
             Several large projects and organizations in the Biosciences, specifically cancer sequencing projects such as
-            <a target="_blank" rel="noopener noreferrer" href="https://dcc.icgc.org/pcawg">PCAWG</a>,
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.icgc-argo.org/docs/data-access/icgc-25k-data">PCAWG</a>,
             <a target="_blank" rel="noopener noreferrer" href="https://precision.fda.gov/">PrecisionFDA</a>,
             <a target="_blank" rel="noopener noreferrer" href="https://www.broadinstitute.org/">the Broad Institute</a>,
             <a target="_blank" rel="noopener noreferrer" href="https://www.ucsc.edu/">the University of California Santa Cruz</a>, and

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -58,7 +58,7 @@ export class AboutComponent implements OnInit {
     new Sponsor('ucsc.png', new URL('https://ucscgenomics.soe.ucsc.edu/')),
     new Sponsor('broad.svg', new URL('https://www.broadinstitute.org/')),
     new Sponsor('ga4gh.svg', new URL('https://genomicsandhealth.org/')),
-    new Sponsor('pcawg.png', new URL('https://dcc.icgc.org/pcawg')),
+    new Sponsor('pcawg.png', new URL('https://docs.icgc-argo.org/docs/data-access/icgc-25k-data')),
     new Sponsor('precision.png', new URL('https://precision.fda.gov/')),
     new Sponsor('nf-core.png', new URL('https://nf-co.re/')),
   ];


### PR DESCRIPTION
**Description**
The PCAWG data portal recently shut down:
https://dcc.icgc.org/

Thus, the PCAWG link on the "about" page no longer works, causing the ui2 "link check" test to fail.

This PR changes the link to point at the "legacy" data page:
https://docs.icgc-argo.org/docs/data-access/icgc-25k-data

**Review Instructions**
Visit about page and confirm that the PCAWG image links to the "legacy" data page.

**Issue**
none

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
