### PR TITLE
Fix media content for mastodon post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,4 @@
-{
+{ 
   "name": "dockstore-ui2",
   "version": "2.10.0",
   "lockfileVersion": 2,

--- a/src/app/shared/mastodon/mastodon.component.html
+++ b/src/app/shared/mastodon/mastodon.component.html
@@ -68,11 +68,7 @@
             <div [innerHTML]="data.postContent"></div>
           </div>
           <div class="toot-media" *ngIf="data.mediaContent.length > 0">
-            <img
-              *ngFor="let picid of data.mediaContent"
-              src="{{ data.mediaContent[picid].preview_url }}"
-              alt="{{ data.mediaContent[picid].description }}"
-            />
+            <img *ngFor="let picid of data.mediaContent" src="{{ picid.preview_url }}" alt="{{ picid.description }}" />
           </div>
           <a *ngIf="data.previewLink" [href]="data.previewLink['url']" class="toot-preview-link" target="_blank" rel="noopener noreferrer">
             <div *ngIf="!data.previewLink['image']" class="toot-preview-noImage">📄</div>

--- a/src/app/shared/mastodon/mastodon.component.html
+++ b/src/app/shared/mastodon/mastodon.component.html
@@ -68,7 +68,7 @@
             <div [innerHTML]="data.postContent"></div>
           </div>
           <div class="toot-media" *ngIf="data.mediaContent.length > 0">
-            <img *ngFor="let picid of data.mediaContent" src="{{ picid.preview_url }}" alt="{{ picid.description }}" />
+            <img *ngFor="let media of data.mediaContent" src="{{ media.preview_url }}" alt="{{ media.description }}" />
           </div>
           <a *ngIf="data.previewLink" [href]="data.previewLink['url']" class="toot-preview-link" target="_blank" rel="noopener noreferrer">
             <div *ngIf="!data.previewLink['image']" class="toot-preview-noImage">📄</div>


### PR DESCRIPTION
**Description**
This hotfix PR fixes the `undefined` errors that were a result of pictures in the Mastodon feed. We added our first post yesterday that contained pictures which resulted in the errors. That post with pictures no longer has pictures, so the error is not there anymore, but can happen again if we add pictures. See https://oicr.slack.com/archives/C05EZH3RVNY/p1720052421982209 for more discussion.

**Review Instructions**
- Create a Mastodon post with pictures
- Go to the home page and verify that the Mastodon feed displays the picture
- Click on the account dropdown in the upper right and verify that it expands and you can navigate to one of the pages

**Issue**
https://github.com/dockstore/dockstore/issues/5930
https://ucsc-cgl.atlassian.net/browse/DOCK-2546

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
