### PR TITLE
Fix "infinite status" workflow-to-tool bug

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -262,7 +262,7 @@ export function checkFeaturedContent() {
   cy.get('app-featured-content').should('exist');
   cy.get('.feat-content-container').within(() => {
     cy.get('.feat-content-card').its('length').should('be.gt', 0);
-    cy.get('.feat-content-card').first().contains('a').should('have.attr', 'href');
+    cy.get('.feat-content-card').first().get('a').should('have.attr', 'href');
     cy.get('.small-btn-structure').first().contains('View');
   });
 }
@@ -272,7 +272,7 @@ export function checkNewsAndUpdates() {
   cy.get('app-news-and-updates').should('exist');
   cy.get('.news-and-updates-box').within(() => {
     cy.get('.news-entry').its('length').should('be.gt', 0);
-    cy.get('.news-entry').first().contains('a').should('have.attr', 'href');
+    cy.get('.news-entry').first().get('a').should('have.attr', 'href');
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,4 @@
-{
+{ 
   "name": "dockstore-ui2",
   "version": "2.10.0",
   "lockfileVersion": 2,

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -249,6 +249,8 @@ export class ContainerComponent extends Entry<Tag> implements AfterViewInit, OnI
     } else if (url.includes('containers') || url.includes('tools')) {
       // Only get published tool if the URI is for a specific tool (/containers/quay.io%2FA2%2Fb3)
       // as opposed to just /tools or /docs etc.
+      this.containerService.setTool(null);
+      this.displayAppTool = false;
       this.containersService.getPublishedContainerByToolPath(this.title, includesValidation).subscribe(
         (tool) => {
           this.containerService.setTool(tool);


### PR DESCRIPTION
**Description**
After viewing a workflow's page and navigating to an old-style tool's page, the status bar will get stuck in the "updating" animation.  This PR fixes the bug.

Targeted to the hotfix branch, because this bug could appear during normal usage, and the fix is minimally invasive.

Cherry picks https://github.com/dockstore/dockstore-ui2/pull/1990 to pass the tests.

**Review Instructions**
Navigate to a workflow's page, then navigate to an old-style tool's page.  Confirm that the status bar stops "updating" a split-second after the page is loaded.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2544

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
