### PR TITLE
Fix news content tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -262,7 +262,7 @@ export function checkFeaturedContent() {
   cy.get('app-featured-content').should('exist');
   cy.get('.feat-content-container').within(() => {
     cy.get('.feat-content-card').its('length').should('be.gt', 0);
-    cy.get('.feat-content-card').first().contains('a').should('have.attr', 'href');
+    cy.get('.feat-content-card').first().get('a').should('have.attr', 'href');
     cy.get('.small-btn-structure').first().contains('View');
   });
 }
@@ -272,7 +272,7 @@ export function checkNewsAndUpdates() {
   cy.get('app-news-and-updates').should('exist');
   cy.get('.news-and-updates-box').within(() => {
     cy.get('.news-entry').its('length').should('be.gt', 0);
-    cy.get('.news-entry').first().contains('a').should('have.attr', 'href');
+    cy.get('.news-entry').first().get('a').should('have.attr', 'href');
   });
 }
 


### PR DESCRIPTION
**Description**
This PR fixes the failing news content tests. The news content was updated yesterday which triggered these failures due to the tests not being able to find the `<a>` element. These tests were not using the best method to get the anchor element and we were just lucky before that the tests were able to get the anchor element. My guess is that `contains('a')` was working before because the most recent news entry had the letter `a` as the text for the anchor element, i.e. "1.15 releAse". After yesterday's news update, the newest anchor element text does not have the letter `a`, "ISMB/BOSC 2024", resulting in the failure.

**Review Instructions**
Builds should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
