### PR TITLE
DOCK-2137: fix checker workflow field refresh issue

### DIFF
--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -15,7 +15,7 @@
       >
         <mat-icon class="mat-icon-sm">visibility</mat-icon> View
       </a>
-      <span *ngIf="(isPublic$ | async) === false">
+      <span *ngIf="(isPublic$ | async) === false && (isRefreshing$ | async) === false">
         <button
           id="addCheckerWorkflowButton"
           #addCheckerWorkflowButton

--- a/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
+++ b/src/app/shared/entry/info-tab-checker-workflow-path/info-tab-checker-workflow-path.component.html
@@ -1,4 +1,4 @@
-<li *ngIf="((checkerId$ | async) || (canAdd$ | async)) && (isRefreshing$ | async) === false">
+<li *ngIf="(checkerId$ | async) || (canAdd$ | async)">
   <form #editCheckerWorkflowPathForm="ngForm" class="form-inline">
     <div class="form-group" fxFlex="noshrink" fxLayout fxLayoutAlign=" center">
       <strong matTooltip="Checker workflow of this tool/workflow that tests it">Checker Workflow</strong>:


### PR DESCRIPTION
**Description**
This PR fixes the issue where the checker workflow field briefly disappears when toggling between the different topic sentences.

**Review Instructions**
Go to one of your workflows and change the topic sentence from Automatic to Manual. The checker workflow field should not disappear.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2137

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
