### PR TITLE
DOCK-2335: Suppress CommonJS module warnings during build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -51,6 +51,16 @@
               "node_modules/ace-builds/src-min-noconflict/theme-idle_fingers.js",
               "node_modules/ace-builds/src-min-noconflict/ext-searchbox.js",
               "node_modules/bootstrap/dist/js/bootstrap.js"
+            ],
+            "allowedCommonJsDependencies": [
+              "ts-md5/dist/md5",
+              "bodybuilder",
+              "rxjs/internal/observable/of",
+              "file-saver",
+              "dompurify",
+              "cytoscape",
+              "cytoscape-dagre",
+              "cytoscape-popper"
             ]
           },
           "configurations": {

--- a/angular.json
+++ b/angular.json
@@ -53,9 +53,8 @@
               "node_modules/bootstrap/dist/js/bootstrap.js"
             ],
             "allowedCommonJsDependencies": [
-              "ts-md5/dist/md5",
+              "ts-md5",
               "bodybuilder",
-              "rxjs/internal/observable/of",
               "file-saver",
               "dompurify",
               "cytoscape",

--- a/src/app/gravatar/gravatar.service.ts
+++ b/src/app/gravatar/gravatar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Md5 } from 'ts-md5/dist/md5';
+import { Md5 } from 'ts-md5';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/auth.guard.ts
+++ b/src/app/shared/auth.guard.ts
@@ -16,7 +16,7 @@
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
-import { of } from 'rxjs/internal/observable/of';
+import { of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AuthService } from '../ng2-ui-auth/public_api';
 import { LogoutService } from './logout.service';


### PR DESCRIPTION
**Description**
This PR suppresses the module warnings shown on build. Example is below.
```
Warning: /home/nhyun/Documents/dockstore-ui2/src/app/gravatar/gravatar.service.ts depends on 'ts-md5/dist/md5'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies

Warning: /home/nhyun/Documents/dockstore-ui2/src/app/search/query-builder.service.ts depends on 'bodybuilder'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```

**Review Instructions**
Build the UI and you shouldn't see these warnings on the bottom.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2335

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
