### PR TITLE
Display engine version for Nextflow workflows

### DIFF
--- a/src/app/shared/entry/descriptor-language-versions.pipe.ts
+++ b/src/app/shared/entry/descriptor-language-versions.pipe.ts
@@ -6,15 +6,26 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class DescriptorLanguageVersionsPipe implements PipeTransform {
   /**
-   * Creates a string containing the descriptor language and descriptor language versions
+   * Creates a string containing the descriptor language or engine versions, and the descriptor language if specified by showDescriptorLanguage
    * @param descriptorLanguage
-   * @param descriptorLanguageVersions
+   * @param descriptorLanguageOrEngineVersions
+   * @param showDescriptorLanguage whether or not the descriptor language should be included in the resulting string
    * @returns
    */
-  transform(descriptorLanguage: string, descriptorLanguageVersions: Array<string>): string {
-    if (descriptorLanguageVersions && descriptorLanguageVersions.length > 0) {
-      const languageVersions = [...descriptorLanguageVersions];
-      return descriptorLanguage + ' ' + languageVersions.sort().join(', ');
+  transform(descriptorLanguage: string, descriptorLanguageOrEngineVersions: Array<string>, showDescriptorLanguage: boolean = true): string {
+    if (descriptorLanguageOrEngineVersions && descriptorLanguageOrEngineVersions.length > 0) {
+      const versions = [...descriptorLanguageOrEngineVersions];
+      if (showDescriptorLanguage) {
+        return descriptorLanguage + ' ' + versions.sort().join(', ');
+      } else {
+        // Remove the descriptor language from the version if it exists. Ex: 'Nextflow !>=23.04.0' -> '!>=23.04.0'
+        return versions
+          .map((version) => {
+            return version.replace(descriptorLanguage + ' ', '');
+          })
+          .sort()
+          .join(', ');
+      }
     }
     return '';
   }

--- a/src/app/shared/entry/descriptor-language-versions.spec.ts
+++ b/src/app/shared/entry/descriptor-language-versions.spec.ts
@@ -7,5 +7,7 @@ describe('Pipe: DescriptorLanguageVersionsPipe', () => {
     expect(pipe.transform('WDL', ['1.0, 1.1'])).toBe('WDL 1.0, 1.1');
     expect(pipe.transform('CWL', ['v1.0'])).toBe('CWL v1.0');
     expect(pipe.transform('WDL', [])).toBe('');
+    expect(pipe.transform('Nextflow', ['Nextflow >=0.32.0', 'Nextflow !>=23.04.0'], false)).toBe('!>=23.04.0, >=0.32.0');
+    expect(pipe.transform('Nextflow', ['Nextflow >=0.32.0'], false)).toBe('>=0.32.0');
   });
 });

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -118,6 +118,24 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="engineVersions">
+      <th
+        scope="col"
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        matTooltip="The engine version used by the version's descriptor file(s)."
+        matTooltipPosition="above"
+      >
+        Engine Versions
+      </th>
+      <td mat-cell *matCellDef="let version">
+        <div *ngFor="let engineVersion of version.versionMetadata?.engineVersions">
+          <div class="no-wrap">{{ version.versionMetadata?.engineVersions }}</div>
+        </div>
+      </td>
+    </ng-container>
+
     <ng-container matColumnDef="valid">
       <th
         scope="col"

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -130,9 +130,9 @@
         Engine Versions
       </th>
       <td mat-cell *matCellDef="let version">
-        <div *ngFor="let engineVersion of version.versionMetadata?.engineVersions">
-          <div class="no-wrap">{{ engineVersion }}</div>
-        </div>
+        <span>{{
+          workflow.descriptorType | descriptorLanguage | descriptorLanguageVersions: version.versionMetadata?.engineVersions:false
+        }}</span>
       </td>
     </ng-container>
 

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -131,7 +131,7 @@
       </th>
       <td mat-cell *matCellDef="let version">
         <div *ngFor="let engineVersion of version.versionMetadata?.engineVersions">
-          <div class="no-wrap">{{ version.versionMetadata?.engineVersions }}</div>
+          <div class="no-wrap">{{ engineVersion }}</div>
         </div>
       </td>
     </ng-container>

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -124,7 +124,7 @@
         mat-header-cell
         *matHeaderCellDef
         mat-sort-header
-        matTooltip="The engine version used by the version's descriptor file(s)."
+        matTooltip="The minimum required {{ workflow.descriptorType | descriptorLanguage }} engine version."
         matTooltipPosition="above"
       >
         Engine Versions

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -89,6 +89,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
   workflow: ExtendedWorkflow;
   entryType = EntryType;
   DoiInitiatorEnum = Doi.InitiatorEnum;
+  engineVersionsList: string[] = ['Nextflow !>=22.10.1', 'Nextflow !>=23.04.0'];
   setNoOrderCols(): Array<number> {
     return [4, 5];
   }
@@ -116,7 +117,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
     const allColumns = [
       'name',
       'last_modified',
-      'descriptorTypeVersions',
+      this.workflow?.descriptorType === Workflow.DescriptorTypeEnum.NFL ? 'engineVersions' : 'descriptorTypeVersions',
       'valid',
       hiddenColumn,
       verifiedColumn,
@@ -143,7 +144,6 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
   }
 
   ngOnInit() {
-    this.publicPageSubscription();
     this.extendedWorkflowQuery.extendedWorkflow$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((workflow) => {
       this.workflow = workflow;
       if (workflow) {
@@ -160,6 +160,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
         ],
       };
     });
+    this.publicPageSubscription();
   }
 
   /**

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -158,8 +158,8 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
           },
         ],
       };
+      this.publicPageSubscription();
     });
-    this.publicPageSubscription();
   }
 
   /**

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -89,7 +89,6 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
   workflow: ExtendedWorkflow;
   entryType = EntryType;
   DoiInitiatorEnum = Doi.InitiatorEnum;
-  engineVersionsList: string[] = ['Nextflow !>=22.10.1', 'Nextflow !>=23.04.0'];
   setNoOrderCols(): Array<number> {
     return [4, 5];
   }


### PR DESCRIPTION
**Description**
This PR displays the Engine Versions column instead of Language Versions for Nextflow workflows.

![Screenshot 2024-08-07 at 10-53-16 Dockstore Workflow github com_nf-core_rnaseq](https://github.com/user-attachments/assets/4ff794fa-1e66-43b3-ac8d-ae48309a60a3)

**Review Instructions**
On QA, navigate to https://qa.dockstore.org/workflows/github.com/nf-core/rnaseq:dev?tab=versions and verify that there's an Engine Versions column and no Language Versions column for Nextflow workflows. Go to a non-Nextflow workflow, click the Versions tab and verify that it has a Language Versions column.

**Issue**
https://github.com/dockstore/dockstore/issues/5918
https://ucsc-cgl.atlassian.net/browse/DOCK-2536

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
