### PR TITLE
Change pip3 to pipx

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -177,10 +177,14 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 \`\`\`
 curl -o requirements.txt "${this.dsServerURI}/metadata/runner_dependencies?client_version=${this.dockstoreVersion}&python_version=3"
 pipx install cwltool==${this.cwltoolVersion}
-pipx inject cwltool -r requirements.txt --force
+pipx runpip cwltool install -r requirements.txt
 \`\`\`
-2. Confirm cwltool installation by checking the version.
+
+**Note:** If you receive a warning saying \`'/YOUR_HOME_DIR/.local/bin' is not on your PATH environment variable.\`, use \`pipx ensurepath\` to add it to your shell's config. Then open a new shell or run \`source ~/.bashrc\`.
+
+2. Verify using that the installed python packages match the ones specified in the downloaded requirements.txt. Confirm cwltool installation by checking the version.
 \`\`\`
+$ pipx runpip cwltool list
 $ cwltool --version
 /usr/local/bin/cwltool ${this.cwltoolVersion}
 \`\`\`

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -176,7 +176,8 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 1. Install cwltool
 \`\`\`
 curl -o requirements.txt "${this.dsServerURI}/metadata/runner_dependencies?client_version=${this.dockstoreVersion}&python_version=3"
-pipx install -r requirements.txt
+pipx install cwltool==${this.cwltoolVersion}
+pipx inject cwltool -r requirements.txt --force
 \`\`\`
 2. Verify using \`pipx list\` that the installed pip packages match the ones specified in the downloaded requirements.txt. Confirm cwltool installation by checking the version.
 \`\`\`

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -179,7 +179,7 @@ curl -o requirements.txt "${this.dsServerURI}/metadata/runner_dependencies?clien
 pipx install cwltool==${this.cwltoolVersion}
 pipx inject cwltool -r requirements.txt --force
 \`\`\`
-2. Verify using \`pipx list\` that the installed pip packages match the ones specified in the downloaded requirements.txt. Confirm cwltool installation by checking the version.
+2. Confirm cwltool installation by checking the version.
 \`\`\`
 $ cwltool --version
 /usr/local/bin/cwltool ${this.cwltoolVersion}

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -177,7 +177,7 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 \`\`\`
 curl -o requirements.txt "${this.dsServerURI}/metadata/runner_dependencies?client_version=${this.dockstoreVersion}&python_version=3"
 pipx install cwltool==${this.cwltoolVersion}
-pipx runpip cwltool install -r requirements.txt
+pipx runpip cwltool install -r requirements.txt # this ensures that your version of cwltool and its dependencies matches what we test with
 \`\`\`
 
 **Note:** If you receive a warning saying \`'/YOUR_HOME_DIR/.local/bin' is not on your PATH environment variable.\`, use \`pipx ensurepath\` to add it to your shell's config. Then open a new shell or run \`source ~/.bashrc\`.

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -86,7 +86,7 @@ run scripts or interact programmatically against Dockstore APIs, and [run workfl
 #### Requirements
 1. Linux/Ubuntu (Recommended - Tested on 22.04 LTS) or Mac OS X machine
 2. Java 17 (Tested with OpenJDK 17 and Eclipse Temurin JDK 17; Oracle JDK may work but is untested)
-3. Python3 and pip3 (Required if working with CWL, optional otherwise)
+3. Python3 and pipx (Required if working with CWL, optional otherwise)
     `;
 
     this.textDataUbuntuLinux = `
@@ -168,7 +168,7 @@ At this point, you now have the Dockstore CLI set up for interacting with the Do
 
 #### Part 6 - Install cwltool (Optional)
 Dockstore relies on [cwltool](https://github.com/common-workflow-language/cwltool) - a reference implementation of CWL - for local execution of tools and workflows described with CWL.
-You'll need to have Python 3 and [pip3](https://pip.pypa.io/en/latest/installing/) to be installed on your machine.
+You'll need to have Python 3 and [pipx](https://pipx.pypa.io/latest/installation/) to be installed on your machine.
 
 **Note:** cwltool must be available on your PATH for the Dockstore CLI to find it.
 
@@ -176,15 +176,15 @@ You can install the version of cwltool that we've tested for use with Dockstore 
 1. Install cwltool
 \`\`\`
 curl -o requirements.txt "${this.dsServerURI}/metadata/runner_dependencies?client_version=${this.dockstoreVersion}&python_version=3"
-pip3 install -r requirements.txt
+pipx install -r requirements.txt
 \`\`\`
-2. Verify using \`pip3 list\` that the installed pip packages match the ones specified in the downloaded requirements.txt. Confirm cwltool installation by checking the version.
+2. Verify using \`pipx list\` that the installed pip packages match the ones specified in the downloaded requirements.txt. Confirm cwltool installation by checking the version.
 \`\`\`
 $ cwltool --version
 /usr/local/bin/cwltool ${this.cwltoolVersion}
 \`\`\`
 
-Although Dockstore has only been tested with the above cwltool version, if you have issues installing cwltool please try running \`pip3 install cwltool\`. This will install the latest released version from PyPi that is compatible with your Python version.
+Although Dockstore has only been tested with the above cwltool version, if you have issues installing cwltool please try running \`pipx install cwltool\`. This will install the latest released version from PyPi that is compatible with your Python version.
 
 #### Part 7 - Install Nextflow (Optional)
 The Dockstore CLI does not run Nextflow workflows. Users can run them directly by using the Nextflow command line tool. For installation instructions, follow [Nextflow's documentation](https://github.com/nextflow-io/nextflow#download-the-package)


### PR DESCRIPTION
**Description**

Following on discussion in https://github.com/dockstore/dockstore/pull/5958 and at the suggestion of @mr-c we now suggest using pipx over pip3 (it manages virtual environments for the user).

**Review Instructions**

Successfully install cwltool using the instructions described in the onboarding.

**Issue**

https://ucsc-cgl.atlassian.net/browse/DOCK-2539

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [ ] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [ ] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [ ] Do not use cookies, although this may change in the future
- [ ] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [ ] Do due diligence on new 3rd party libraries, checking for CVEs
- [ ] Don't allow user-uploaded images to be served from the Dockstore domain
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
