### PR TITLE
DOCK-2551: change automatic topic badge

### DIFF
--- a/src/app/shared/entry/info-tab-topic/display-topic/display-topic.component.html
+++ b/src/app/shared/entry/info-tab-topic/display-topic/display-topic.component.html
@@ -2,7 +2,7 @@
   <div>
     <strong matTooltip="Short description of the {{ entryTypeMetadata.term }}">Topic: </strong>
     <span data-cy="selected-topic">{{ selectedTopic || 'n/a' }}</span>
-    <!-- Display a bubble indicating the topic selection. AI bubble is always displayed privately. Publicly, AI bubble is only displayed if the topic is not user-approved. 
+    <!-- Display a bubble indicating the topic selection. AI bubble is always displayed privately. Publicly, AI bubble is only displayed if the topic is not user-approved.
      Bubbles for other topic types are only displayed for the non-public view -->
     <app-ai-bubble
       *ngIf="entry.topicSelection === TopicSelectionEnum.AI && (!entry.approvedAITopic || (isPublic$ | async) === false)"
@@ -21,8 +21,14 @@
       }}"
       data-cy="topic-selection-bubble"
     >
-      <mat-icon class="mat-icon-sm">{{ entry.topicSelection === TopicSelectionEnum.MANUAL ? 'edit' : 'sync' }}</mat-icon>
-      <span>{{ entry.topicSelection | titlecase }}</span>
+      <mat-icon *ngIf="entry.topicSelection === TopicSelectionEnum.MANUAL" class="mat-icon-sm">edit</mat-icon>
+      <img
+        *ngIf="entry.topicSelection === TopicSelectionEnum.AUTOMATIC"
+        class="site-icons-small mr-2"
+        src="../assets/images/thirdparty/github.svg"
+        alt="GitHub icon"
+      />
+      <span>{{ entry.topicSelection === TopicSelectionEnum.MANUAL ? 'Manual' : 'GitHub' }}</span>
     </span>
   </div>
   <button

--- a/src/app/shared/entry/info-tab-topic/display-topic/display-topic.component.html
+++ b/src/app/shared/entry/info-tab-topic/display-topic/display-topic.component.html
@@ -2,7 +2,7 @@
   <div>
     <strong matTooltip="Short description of the {{ entryTypeMetadata.term }}">Topic: </strong>
     <span data-cy="selected-topic">{{ selectedTopic || 'n/a' }}</span>
-    <!-- Display a bubble indicating the topic selection. AI bubble is always displayed privately. Publicly, AI bubble is only displayed if the topic is not user-approved.
+    <!-- Display a bubble indicating the topic selection. AI bubble is always displayed privately. Publicly, AI bubble is only displayed if the topic is not user-approved. 
      Bubbles for other topic types are only displayed for the non-public view -->
     <app-ai-bubble
       *ngIf="entry.topicSelection === TopicSelectionEnum.AI && (!entry.approvedAITopic || (isPublic$ | async) === false)"

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -28,7 +28,7 @@
                 />
                 <img
                   *ngIf="topicOption.type === TopicSelectionEnum.AI"
-                  class="site-icons-small mr-1"
+                  class="site-icons-small"
                   src="../../../assets/svg/ai-icon.svg"
                   alt="AI generation icon"
                 />

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -33,7 +33,7 @@
                   alt="AI generation icon"
                 />
               </span>
-              <strong>{{ topicOption.type === TopicSelectionEnum.AUTOMATIC ? 'GitHub' : topicOption.label }}</strong>
+              <strong>{{ topicOption.label }}</strong>
             </div>
             <span
               *ngIf="topicOption.type === TopicSelectionEnum.AI && entry.approvedAITopic"

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -20,15 +20,20 @@
             <div>
               <span class="bubble mr-2">
                 <mat-icon *ngIf="topicOption.type === TopicSelectionEnum.MANUAL" class="mat-icon-sm">edit</mat-icon>
-                <mat-icon *ngIf="topicOption.type === TopicSelectionEnum.AUTOMATIC" class="mat-icon-sm">sync</mat-icon>
+                <img
+                  *ngIf="topicOption.type === TopicSelectionEnum.AUTOMATIC"
+                  class="site-icons-small"
+                  src="../assets/images/thirdparty/github.svg"
+                  alt="GitHub icon"
+                />
                 <img
                   *ngIf="topicOption.type === TopicSelectionEnum.AI"
-                  class="site-icons-small"
+                  class="site-icons-small mr-1"
                   src="../../../assets/svg/ai-icon.svg"
                   alt="AI generation icon"
                 />
               </span>
-              <strong>{{ topicOption.label }}</strong>
+              <strong>{{ topicOption.type === TopicSelectionEnum.AUTOMATIC ? 'GitHub' : topicOption.label }}</strong>
             </div>
             <span
               *ngIf="topicOption.type === TopicSelectionEnum.AI && entry.approvedAITopic"

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -102,7 +102,7 @@ export class EditTopicDialogComponent {
     };
     const automaticTopicOption: TopicOption = {
       type: this.TopicSelectionEnum.AUTOMATIC,
-      label: 'Automatic',
+      label: 'GitHub',
       description: 'Retrieved automatically from the GitHub repository description.',
       value: this.entry.topicAutomatic,
     };


### PR DESCRIPTION
**Description**
This PR changes the badge from Automatic to GitHub.

![image](https://github.com/user-attachments/assets/af06f9b1-284e-4d5d-8ced-f897b3529db6)

![image](https://github.com/user-attachments/assets/026f0eb1-e51d-49cd-a626-5b092728ddd5)


**Review Instructions**
Verify that the topic badge in My Workflows is changed to GitHub and also in the edit topic dialog component.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2551

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
