### PR TITLE
SEAB-5553: Remove stopgap notebook smoke test code

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -10,18 +10,6 @@ describe('run stochastic smoke test', () => {
 });
 function testEntry(tab: string) {
   function goToRandomEntry() {
-    // Notebooks search is not functional in staging or prod in 1.14.
-    // TODO after 1.15 release: remove the following code path
-    if (tab === 'Notebooks' && isStagingOrProd()) {
-      cy.visit('/notebooks');
-      cy.get('[data-cy=entry-link]')
-        .eq(0)
-        .then((el) => {
-          cy.log(el.prop('href')); // log the href in case a test fails
-          cy.visit(el.prop('href'));
-        });
-      return;
-    }
     cy.visit('/search');
     cy.get('[data-cy=workflowColumn] a');
     goToTab(tab);


### PR DESCRIPTION
**Description**
In the 1.14 release, which included partial notebooks support, we added some code to the smoke tests which would partially test the notebooks functionality.  Some of the code special-cased "random notebook" selection, and the plan was to revert to the general-purpose code path after the full notebook UI was completed (which happened in the 1.15 release).

Per the above, this PR removes the special-case notebook code. 

**Review Instructions**
Confirm that the `basic-enduser` smoke test is passing.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5553

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
