### PR TITLE
Edit topic dialog improvements to manual and AI topics

### DIFF
--- a/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.html
+++ b/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.html
@@ -20,6 +20,8 @@
             <app-doi-badge [doi]="doiInfo.value.conceptDoi" [displayDoi]="false" class="mr-2"></app-doi-badge>
             <strong>{{ doiInfo.key | titlecase }}</strong>
           </div>
+        </mat-radio-button>
+        <div class="ml-5">
           <div class="size-small gray-caption">
             <span *ngIf="doiInfo.key === DoiInitiatorEnum.USER"> Manually created by a user in the Dockstore UI. </span>
             <span *ngIf="doiInfo.key === DoiInitiatorEnum.DOCKSTORE">
@@ -36,7 +38,7 @@
             <span>Concept DOI: </span>
             <app-doi-badge *ngIf="doiInfo.value.conceptDoi" [doi]="doiInfo.value.conceptDoi" [displayInitiator]="false"></app-doi-badge>
           </span>
-        </mat-radio-button>
+        </div>
       </mat-card>
     </div>
   </mat-radio-group>

--- a/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.html
+++ b/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.html
@@ -12,35 +12,33 @@
     <mat-icon class="alert-info-icon">info</mat-icon> This {{ entryTypeMetadata.term }} has no DOIs.
   </mat-card>
   <p *ngIf="doiInfoMap.size">Select which DOI to display publicly:</p>
-  <mat-radio-group [(ngModel)]="selectedOption" aria-label="Select an option">
-    <div fxLayout="column" fxLayoutGap="1rem">
-      <mat-card *ngFor="let doiInfo of doiInfoMap | keyvalue: originalOrder">
-        <mat-radio-button [value]="doiInfo.key" class="w-100">
-          <div>
-            <app-doi-badge [doi]="doiInfo.value.conceptDoi" [displayDoi]="false" class="mr-2"></app-doi-badge>
-            <strong>{{ doiInfo.key | titlecase }}</strong>
-          </div>
-        </mat-radio-button>
-        <div class="ml-5">
-          <div class="size-small gray-caption">
-            <span *ngIf="doiInfo.key === DoiInitiatorEnum.USER"> Manually created by a user in the Dockstore UI. </span>
-            <span *ngIf="doiInfo.key === DoiInitiatorEnum.DOCKSTORE">
-              Automatically created by Dockstore for valid tags belonging to published {{ entryTypeMetadata.termPlural }}.
-            </span>
-            <span *ngIf="doiInfo.key === DoiInitiatorEnum.GITHUB"> Created by Zenodo's integration with GitHub. </span>
-          </div>
-          <span class="mr-4">
-            <span>Version DOI: </span>
-            <app-doi-badge *ngIf="doiInfo.value.versionDoi" [doi]="doiInfo.value.versionDoi" [displayInitiator]="false"></app-doi-badge>
-            <span *ngIf="!doiInfo.value.versionDoi">n/a</span>
-          </span>
-          <span>
-            <span>Concept DOI: </span>
-            <app-doi-badge *ngIf="doiInfo.value.conceptDoi" [doi]="doiInfo.value.conceptDoi" [displayInitiator]="false"></app-doi-badge>
-          </span>
+  <mat-radio-group [(ngModel)]="selectedOption" aria-label="Select an option" fxLayout="column" fxLayoutGap="1rem">
+    <mat-card *ngFor="let doiInfo of doiInfoMap | keyvalue: originalOrder" [class]="doiInfo.key === selectedOption ? 'selected-card' : ''">
+      <mat-radio-button [value]="doiInfo.key" class="w-100">
+        <div>
+          <app-doi-badge [doi]="doiInfo.value.conceptDoi" [displayDoi]="false" class="mr-2"></app-doi-badge>
+          <strong>{{ doiInfo.key | titlecase }}</strong>
         </div>
-      </mat-card>
-    </div>
+      </mat-radio-button>
+      <div class="ml-5">
+        <div class="size-small gray-caption">
+          <span *ngIf="doiInfo.key === DoiInitiatorEnum.USER"> Manually created by a user in the Dockstore UI. </span>
+          <span *ngIf="doiInfo.key === DoiInitiatorEnum.DOCKSTORE">
+            Automatically created by Dockstore for valid tags belonging to published {{ entryTypeMetadata.termPlural }}.
+          </span>
+          <span *ngIf="doiInfo.key === DoiInitiatorEnum.GITHUB"> Created by Zenodo's integration with GitHub. </span>
+        </div>
+        <span class="mr-4">
+          <span>Version DOI: </span>
+          <app-doi-badge *ngIf="doiInfo.value.versionDoi" [doi]="doiInfo.value.versionDoi" [displayInitiator]="false"></app-doi-badge>
+          <span *ngIf="!doiInfo.value.versionDoi">n/a</span>
+        </span>
+        <span>
+          <span>Concept DOI: </span>
+          <app-doi-badge *ngIf="doiInfo.value.conceptDoi" [doi]="doiInfo.value.conceptDoi" [displayInitiator]="false"></app-doi-badge>
+        </span>
+      </div>
+    </mat-card>
   </mat-radio-group>
 </mat-dialog-content>
 <div mat-dialog-actions class="pull-right">

--- a/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.scss
+++ b/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.scss
@@ -1,9 +1,0 @@
-// This style ensures that the mat radio content text fills up the whole mat-card
-:host ::ng-deep .mat-radio-label-content {
-  width: 100%;
-}
-
-// Wraps the text because by default, mat-radio-label doesn't wrap
-:host ::ng-deep .mat-radio-label {
-  white-space: normal;
-}

--- a/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.ts
+++ b/src/app/shared/entry/doi/manage-dois/manage-dois-dialog.component.ts
@@ -25,7 +25,7 @@ export interface DoiInfo {
 @Component({
   selector: 'app-manage-dois-dialog',
   templateUrl: './manage-dois-dialog.component.html',
-  styleUrls: ['./manage-dois-dialog.component.scss'],
+  styleUrls: ['../../../styles/radio-button-cards.scss'],
   standalone: true,
   imports: [
     MatLegacyDialogModule,

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -75,7 +75,7 @@
           {{ topicOption.value || 'Not Available' }}
           <button
             mat-icon-button
-            *ngIf="topicOption.type === TopicSelectionEnum.AI"
+            *ngIf="topicOption.type === TopicSelectionEnum.AI && topicOption.value"
             [cdkCopyToClipboard]="topicOption.value"
             matTooltip="Copy AI topic"
             appSnackbar

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -90,12 +90,14 @@
             class="w-100 pb-0"
             matTooltip="Edit the manual topic for this {{ entryTypeMetadata.term }}"
           >
-            <input
+            <textarea
               matInput
               [(ngModel)]="editedTopicManual"
               placeholder="Short description of the {{ entryTypeMetadata.term }}"
               data-cy="topicInput"
-            />
+              cdkTextareaAutosize
+            >
+            </textarea>
           </mat-form-field>
         </ng-template>
       </div>

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -13,7 +13,7 @@
     fxLayoutAlign="start stretch"
     fxLayoutGap="1rem"
   >
-    <mat-card *ngFor="let topicOption of topicOptions">
+    <mat-card *ngFor="let topicOption of topicOptions" [class]="topicOption.type === selectedOption ? 'selected-card' : ''">
       <mat-radio-button [value]="topicOption.type" class="w-100">
         <div fxLayoutAlign="space-between">
           <div>
@@ -41,6 +41,8 @@
             ><mat-icon class="mat-icon-sm">checkmark</mat-icon> Approved</span
           >
         </div>
+      </mat-radio-button>
+      <div class="ml-5">
         <div class="size-small gray-caption">
           {{ topicOption.description }}
           <a
@@ -51,6 +53,7 @@
             }}.html#full-template-with-explanation-of-all-available-fields"
             target="_blank"
             rel="noopener noreferrer"
+            matTooltip="View more information about the topic field"
             ><mat-icon>info</mat-icon></a
           >
         </div>
@@ -70,12 +73,21 @@
           [class]="topicOption.value ? '' : 'gray-caption'"
         >
           {{ topicOption.value || 'Not Available' }}
+          <button
+            mat-icon-button
+            *ngIf="topicOption.type === TopicSelectionEnum.AI"
+            [cdkCopyToClipboard]="topicOption.value"
+            matTooltip="Copy AI topic"
+            appSnackbar
+          >
+            <mat-icon>file_copy</mat-icon>
+          </button>
         </div>
         <ng-template #editableManualField>
           <mat-form-field
             color="accent"
             appearance="outline"
-            class="w-100"
+            class="w-100 pb-0"
             matTooltip="Edit the manual topic for this {{ entryTypeMetadata.term }}"
           >
             <input
@@ -86,7 +98,7 @@
             />
           </mat-form-field>
         </ng-template>
-      </mat-radio-button>
+      </div>
     </mat-card>
   </mat-radio-group>
 </mat-dialog-content>

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -87,7 +87,7 @@
           <mat-form-field
             color="accent"
             appearance="outline"
-            class="w-100 pb-0"
+            class="w-100"
             matTooltip="Edit the manual topic for this {{ entryTypeMetadata.term }}"
           >
             <textarea

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.html
@@ -5,80 +5,90 @@
     {{ topicOptions.length }} type{{ topicOptions.length === 1 ? '' : 's' }} of topic{{ topicOptions.length === 1 ? '' : 's' }} that you can
     choose from:
   </p>
-  <div fxLayout="column">
-    <mat-radio-group
-      [(ngModel)]="selectedOption"
-      (change)="radioButtonChange($event)"
-      aria-label="Select an option"
-      fxLayout="column"
-      fxLayoutAlign="start stretch"
-      fxLayoutGap="1rem"
-    >
-      <mat-card *ngFor="let topicOption of topicOptions">
-        <mat-radio-button [value]="topicOption.type" class="w-100">
-          <div fxLayoutAlign="space-between">
-            <div>
-              <span class="bubble mr-2">
-                <mat-icon *ngIf="topicOption.type === TopicSelectionEnum.MANUAL" class="mat-icon-sm">edit</mat-icon>
-                <img
-                  *ngIf="topicOption.type === TopicSelectionEnum.AUTOMATIC"
-                  class="site-icons-small"
-                  src="../assets/images/thirdparty/github.svg"
-                  alt="GitHub icon"
-                />
-                <img
-                  *ngIf="topicOption.type === TopicSelectionEnum.AI"
-                  class="site-icons-small"
-                  src="../../../assets/svg/ai-icon.svg"
-                  alt="AI generation icon"
-                />
-              </span>
-              <strong>{{ topicOption.label }}</strong>
-            </div>
-            <span
-              *ngIf="topicOption.type === TopicSelectionEnum.AI && entry.approvedAITopic"
-              class="bubble approved"
-              matTooltip="This AI topic was reviewed and selected by a {{ entryTypeMetadata.term }} owner"
-              ><mat-icon class="mat-icon-sm">checkmark</mat-icon> Approved</span
-            >
-          </div>
-          <div class="size-small gray-caption">{{ topicOption.description }}</div>
-
-          <!-- Display an info card if the AI topic was automatically set as the topic selection but it hasn't been approved by the user -->
-          <mat-card
-            *ngIf="topicOption.type === TopicSelectionEnum.AI && !entry.approvedAITopic && entry.topicSelection === TopicSelectionEnum.AI"
-            class="alert-info mat-elevation-z size-small py-1 my-3"
-            data-cy="unapprovedAITopicCard"
-          >
-            <mat-icon class="mat-icon-sm">info</mat-icon> You have not approved this topic. Click <strong>Save</strong> to confirm that you
-            have reviewed and approved the topic. Otherwise, select another topic.
-          </mat-card>
-
-          <div
-            *ngIf="topicOption.type !== TopicSelectionEnum.MANUAL || isGitHubAppEntry; else editableManualField"
-            [class]="topicOption.value ? '' : 'gray-caption'"
-          >
-            {{ topicOption.value || 'Not Available' }}
-          </div>
-          <ng-template #editableManualField>
-            <mat-form-field
-              color="accent"
-              appearance="outline"
-              class="w-100"
-              matTooltip="Edit the manual topic for this {{ entryTypeMetadata.term }}"
-            >
-              <input
-                matInput
-                [(ngModel)]="editedTopicManual"
-                placeholder="Short description of the {{ entryTypeMetadata.term }}"
-                data-cy="topicInput"
+  <mat-radio-group
+    [(ngModel)]="selectedOption"
+    (change)="radioButtonChange($event)"
+    aria-label="Select an option"
+    fxLayout="column"
+    fxLayoutAlign="start stretch"
+    fxLayoutGap="1rem"
+  >
+    <mat-card *ngFor="let topicOption of topicOptions">
+      <mat-radio-button [value]="topicOption.type" class="w-100">
+        <div fxLayoutAlign="space-between">
+          <div>
+            <span class="bubble mr-2">
+              <mat-icon *ngIf="topicOption.type === TopicSelectionEnum.MANUAL" class="mat-icon-sm">edit</mat-icon>
+              <img
+                *ngIf="topicOption.type === TopicSelectionEnum.AUTOMATIC"
+                class="site-icons-small"
+                src="../assets/images/thirdparty/github.svg"
+                alt="GitHub icon"
               />
-            </mat-form-field>
-          </ng-template>
-        </mat-radio-button>
-      </mat-card>
-    </mat-radio-group>
-  </div>
+              <img
+                *ngIf="topicOption.type === TopicSelectionEnum.AI"
+                class="site-icons-small"
+                src="../../../assets/svg/ai-icon.svg"
+                alt="AI generation icon"
+              />
+            </span>
+            <strong>{{ topicOption.label }}</strong>
+          </div>
+          <span
+            *ngIf="topicOption.type === TopicSelectionEnum.AI && entry.approvedAITopic"
+            class="bubble approved"
+            matTooltip="This AI topic was reviewed and selected by a {{ entryTypeMetadata.term }} owner"
+            ><mat-icon class="mat-icon-sm">checkmark</mat-icon> Approved</span
+          >
+        </div>
+        <div class="size-small gray-caption">
+          {{ topicOption.description }}
+          <a
+            *ngIf="topicOption.type === TopicSelectionEnum.MANUAL && isGitHubAppEntry"
+            class="ds-green"
+            href="{{ Dockstore.DOCUMENTATION_URL }}/assets/templates/{{ entryTypeMetadata.termPlural }}/{{
+              entryTypeMetadata.termPlural
+            }}.html#full-template-with-explanation-of-all-available-fields"
+            target="_blank"
+            rel="noopener noreferrer"
+            ><mat-icon>info</mat-icon></a
+          >
+        </div>
+
+        <!-- Display an info card if the AI topic was automatically set as the topic selection but it hasn't been approved by the user -->
+        <mat-card
+          *ngIf="topicOption.type === TopicSelectionEnum.AI && !entry.approvedAITopic && entry.topicSelection === TopicSelectionEnum.AI"
+          class="alert-info mat-elevation-z size-small py-1 my-3"
+          data-cy="unapprovedAITopicCard"
+        >
+          <mat-icon class="mat-icon-sm">info</mat-icon> You have not approved this topic. Click <strong>Save</strong> to confirm that you
+          have reviewed and approved the topic. Otherwise, select another topic.
+        </mat-card>
+
+        <div
+          *ngIf="topicOption.type !== TopicSelectionEnum.MANUAL || isGitHubAppEntry; else editableManualField"
+          [class]="topicOption.value ? '' : 'gray-caption'"
+        >
+          {{ topicOption.value || 'Not Available' }}
+        </div>
+        <ng-template #editableManualField>
+          <mat-form-field
+            color="accent"
+            appearance="outline"
+            class="w-100"
+            matTooltip="Edit the manual topic for this {{ entryTypeMetadata.term }}"
+          >
+            <input
+              matInput
+              [(ngModel)]="editedTopicManual"
+              placeholder="Short description of the {{ entryTypeMetadata.term }}"
+              data-cy="topicInput"
+            />
+          </mat-form-field>
+        </ng-template>
+      </mat-radio-button>
+    </mat-card>
+  </mat-radio-group>
 </mat-dialog-content>
 <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end">
   <div *ngIf="promptToConfirmAISelection" fxLayout="row" fxLayoutAlign="end" class="mb-3">

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
@@ -2,27 +2,7 @@
 
 @import 'materialColorScheme.scss';
 
-// This style ensures that the mat radio content text fills up the whole mat-card
-:host ::ng-deep .mat-radio-label-content {
-  width: 100%;
-}
-
-// Wraps the text because by default, mat-radio-label doesn't wrap
-:host ::ng-deep .mat-radio-label {
-  white-space: normal;
-}
-
 .approved {
   color: white !important;
   background-color: $accent-3-dark;
-}
-
-.selected-card {
-  border-width: 0.15rem;
-  border-color: mat.get-color-from-palette($kim-secondary, 2);
-}
-
-:host ::ng-deep .mat-form-field-wrapper {
-  // Removing the padding because we don't need hint
-  padding-bottom: 0;
 }

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
@@ -16,3 +16,13 @@
   color: white !important;
   background-color: $accent-3-dark;
 }
+
+.selected-card {
+  border-width: 0.25rem;
+  border-color: mat.get-color-from-palette($kim-secondary, 2);
+}
+
+:host ::ng-deep .mat-form-field-wrapper {
+  // Removing the padding because we don't need hint
+  padding-bottom: 0;
+}

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.scss
@@ -18,7 +18,7 @@
 }
 
 .selected-card {
-  border-width: 0.25rem;
+  border-width: 0.15rem;
   border-color: mat.get-color-from-palette($kim-secondary, 2);
 }
 

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -33,6 +33,7 @@ import { MatLegacyCardModule } from '@angular/material/legacy-card';
 import { EditTopicDialogService } from './edit-topic-dialog.service';
 import { EntryActionsService } from 'app/shared/entry-actions/entry-actions.service';
 import { MatRadioChange } from '@angular/material/radio';
+import { Dockstore } from 'app/shared/dockstore.model';
 
 export interface EditTopicDialogData {
   entry: DockstoreTool | Workflow;
@@ -69,6 +70,7 @@ export interface TopicOption {
   ],
 })
 export class EditTopicDialogComponent {
+  Dockstore = Dockstore;
   TopicSelectionEnum = Entry.TopicSelectionEnum;
   entry: Workflow | DockstoreTool;
   entryType: EntryType;

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -103,9 +103,9 @@ export class EditTopicDialogComponent {
     const manualTopicOption: TopicOption = {
       type: this.TopicSelectionEnum.MANUAL,
       label: 'Manual',
-      description: `Entered manually by the user.${
-        this.isGitHubAppEntry ? ` Edit the topic field in the .dockstore.yml file on GitHub.` : ''
-      }`,
+      description: this.isGitHubAppEntry
+        ? 'Specified in the .dockstore.yml file on GitHub. Edit the topic field in the .dockstore.yml to change the topic.'
+        : 'Entered manually by the user.',
       value: this.entry.topicManual,
     };
     const automaticTopicOption: TopicOption = {

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -97,7 +97,9 @@ export class EditTopicDialogComponent {
     const manualTopicOption: TopicOption = {
       type: this.TopicSelectionEnum.MANUAL,
       label: 'Manual',
-      description: `Entered manually by the user${this.isGitHubAppEntry ? 'in the .dockstore.yml.' : '.'}`,
+      description: `Entered manually by the user.${
+        this.isGitHubAppEntry ? ` Edit the topic field in the .dockstore.yml file on GitHub.` : ''
+      }`,
       value: this.entry.topicManual,
     };
     const automaticTopicOption: TopicOption = {

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -34,6 +34,8 @@ import { EditTopicDialogService } from './edit-topic-dialog.service';
 import { EntryActionsService } from 'app/shared/entry-actions/entry-actions.service';
 import { MatRadioChange } from '@angular/material/radio';
 import { Dockstore } from 'app/shared/dockstore.model';
+import { ClipboardModule } from '@angular/cdk/clipboard';
+import { SnackbarDirective } from 'app/shared/snackbar.directive';
 
 export interface EditTopicDialogData {
   entry: DockstoreTool | Workflow;
@@ -67,6 +69,8 @@ export interface TopicOption {
     MatIconModule,
     MatLegacyCardModule,
     NgFor,
+    ClipboardModule,
+    SnackbarDirective,
   ],
 })
 export class EditTopicDialogComponent {

--- a/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
+++ b/src/app/shared/entry/info-tab-topic/edit-topic/edit-topic-dialog.component.ts
@@ -51,7 +51,7 @@ export interface TopicOption {
 @Component({
   selector: 'app-edit-topic-dialog',
   templateUrl: './edit-topic-dialog.component.html',
-  styleUrls: ['./edit-topic-dialog.component.scss'],
+  styleUrls: ['./edit-topic-dialog.component.scss', '../../../styles/radio-button-cards.scss'],
   standalone: true,
   imports: [
     MatLegacyDialogModule,

--- a/src/app/shared/styles/radio-button-cards.scss
+++ b/src/app/shared/styles/radio-button-cards.scss
@@ -29,13 +29,13 @@
   white-space: normal;
 }
 
+:host ::ng-deep .mat-form-field-wrapper {
+  // Removing the padding because we don't need hint
+  padding-bottom: 0;
+}
+
 // Highlights the card with the selected radio button
 .selected-card {
   border-width: 0.15rem;
   border-color: mat.get-color-from-palette($kim-secondary, 2);
-}
-
-:host ::ng-deep .mat-form-field-wrapper {
-  // Removing the padding because we don't need hint
-  padding-bottom: 0;
 }

--- a/src/app/shared/styles/radio-button-cards.scss
+++ b/src/app/shared/styles/radio-button-cards.scss
@@ -1,0 +1,41 @@
+/*
+ *     Copyright 2024 OICR
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License")
+ *     you may not use this file except in compliance with the License
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+@import 'materialColorScheme.scss';
+
+// This file contains styles for mat-cards with radio buttons
+
+// This style ensures that the mat radio content text fills up the whole mat-card
+:host ::ng-deep .mat-radio-label-content {
+  width: 100%;
+}
+
+// Wraps the text because by default, mat-radio-label doesn't wrap
+:host ::ng-deep .mat-radio-label {
+  white-space: normal;
+}
+
+// Highlights the card with the selected radio button
+.selected-card {
+  border-width: 0.15rem;
+  border-color: mat.get-color-from-palette($kim-secondary, 2);
+}
+
+:host ::ng-deep .mat-form-field-wrapper {
+  // Removing the padding because we don't need hint
+  padding-bottom: 0;
+}


### PR DESCRIPTION
**Description**
FYI, I recommend hiding whitespace when reviewing because I removed some divs that didn't need to be there.

This PR improves the Edit Topic dialog by:
- Making the AI topic copyable with a copy button
  - Previously, clicking any area of the mat card selected the radio button. This prevented the topic content from being selectable. This PR changes it so only the top part of the card with the label is selectable. This allows for better interaction with the rest of the card content that may contain buttons or links. 
- Improving the manual topic description for GitHub App entries by using active voice and including an info button to the documentation

There are also miscellaneous improvements while I was testing the changes:
- The card with the selected radio button has a different border color so that it's more obvious that it's the selected option. Applied this change to the Manage DOIs dialog as well.
- The form field for manual topics autosizes to the size of its content. Before, it introduced a horizontal scroll bar if the length exceeded the form field box, which makes it difficult to read the whole topic.

<details open>
<summary>Screenshots</summary>

**Making the AI topic copyable:** There is now a copy button for AI topics.
- Before

  [Screencast from 2024-09-05 10:43:38 AM.webm](https://github.com/user-attachments/assets/8cb0b4e7-f4ce-4807-bddf-77ae78b797f4)

- After
  
  [Screencast from 2024-09-05 10:46:33 AM.webm](https://github.com/user-attachments/assets/6830a03b-2115-4ccc-aafc-3b16aa10c55a)

  

**Improving the manual topic description for GitHub App entries:** There is now an info button that links to documentation and the description says to edit the .dockstore.yml file.
- Before
  ![image](https://github.com/user-attachments/assets/ed06ec5f-8cea-400a-baf1-95fb344c5555)
- After
  ![Screenshot 2024-09-05 at 13-37-12 Dockstore My Notebooks](https://github.com/user-attachments/assets/c09c7daf-e047-4822-9aa1-c3416cd22b31)


</details>

**Review Instructions**
On QA:
- Navigate to the My Workflows page of a workflow with an AI topic. If your workflow has no AI topic, you can use this [endpoint](https://qa.dockstore.org/api/static/swagger-ui/index.html#/extendedGA4GH/updateAITopic) to submit an AI topic for your workflow (requires curator or admin token).
- Click the Edit button for Topic. Verify that you can copy the AI topic content. Paste the content somewhere to check that it was copied successfully.
- Verify that the card for the selected topic has a different border color than the unselected options.
- Navigate to the My Workflows page of a GitHub app entry. 
- Click the Edit button for Topic. Verify that the description for the Manual topic says to edit the .dockstore.yml file and that there is an info button that links to the full template for .dockstore.yml entries.

**Issue**
- https://github.com/dockstore/dockstore/issues/5959 / [DOCK-2562](https://ucsc-cgl.atlassian.net/browse/DOCK-2562)
- https://github.com/dockstore/dockstore/issues/5942 / [DOCK-2552](https://ucsc-cgl.atlassian.net/browse/DOCK-2552)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2562]: https://ucsc-cgl.atlassian.net/browse/DOCK-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ