### PR TITLE
Fix ChromeDriver syntax error on install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   aws-s3: circleci/aws-s3@3.0.0
   aws-cli: circleci/aws-cli@3.1.1
   slack: circleci/slack@4.4.4
-  browser-tools: circleci/browser-tools@1.4.7
+  browser-tools: circleci/browser-tools@1.4.8
 executors:
   integration_test_exec: # declares a reusable executor
     docker:

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "test-staging-no-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/monitor.ts,cypress/e2e/smokeTests/stagingOnly/basic-enduser.ts,cypress/e2e/smokeTests/stagingOnly/search.ts,cypress/e2e/smokeTests/sharedTests/monitor.ts,cypress/e2e/smokeTests/sharedTests/basic-enduser.ts,cypress/e2e/smokeTests/sharedTests/search.ts,cypress/e2e/smokeTests/sharedTests/secheaders.ts\"",
     "test-prod-no-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/monitor.ts,cypress/e2e/smokeTests/prodOnly/basic-enduser.ts,cypress/e2e/smokeTests/prodOnly/search.ts,cypress/e2e/smokeTests/prodOnly/basic-enduser-prod-only.ts,cypress/e2e/smokeTests/sharedTests/monitor.ts,cypress/e2e/smokeTests/sharedTests/basic-enduser.ts,cypress/e2e/smokeTests/sharedTests/search.ts,cypress/e2e/smokeTests/sharedTests/secheaders.ts\"",
     "test-local-auth": "npx cypress run --headed -c baseUrl=http://localhost:4200 -s \"cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-qa-auth": "npx cypress run -c baseUrl=https://qa.dockstore.org -s \"cypress/e2e/smokeTests/qaOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-staging-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-prod-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-qa-auth": "npx cypress run --browser chrome -c baseUrl=https://qa.dockstore.org -s \"cypress/e2e/smokeTests/qaOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-staging-auth": "npx cypress run --browser chrome -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-prod-auth": "npx cypress run --browser chrome -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
     "prepare": "husky install",
     "compare-audits": "scripts/npm-audit-comparison.sh",
     "accessibility-test": "scripts/run-pa11y-ci.sh"

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "test-staging-no-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/monitor.ts,cypress/e2e/smokeTests/stagingOnly/basic-enduser.ts,cypress/e2e/smokeTests/stagingOnly/search.ts,cypress/e2e/smokeTests/sharedTests/monitor.ts,cypress/e2e/smokeTests/sharedTests/basic-enduser.ts,cypress/e2e/smokeTests/sharedTests/search.ts,cypress/e2e/smokeTests/sharedTests/secheaders.ts\"",
     "test-prod-no-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/monitor.ts,cypress/e2e/smokeTests/prodOnly/basic-enduser.ts,cypress/e2e/smokeTests/prodOnly/search.ts,cypress/e2e/smokeTests/prodOnly/basic-enduser-prod-only.ts,cypress/e2e/smokeTests/sharedTests/monitor.ts,cypress/e2e/smokeTests/sharedTests/basic-enduser.ts,cypress/e2e/smokeTests/sharedTests/search.ts,cypress/e2e/smokeTests/sharedTests/secheaders.ts\"",
     "test-local-auth": "npx cypress run --headed -c baseUrl=http://localhost:4200 -s \"cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-qa-auth": "npx cypress run --browser chrome -c baseUrl=https://qa.dockstore.org -s \"cypress/e2e/smokeTests/qaOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-staging-auth": "npx cypress run --browser chrome -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
-    "test-prod-auth": "npx cypress run --browser chrome -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-qa-auth": "npx cypress run -c baseUrl=https://qa.dockstore.org -s \"cypress/e2e/smokeTests/qaOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-staging-auth": "npx cypress run -c baseUrl=https://staging.dockstore.org -s \"cypress/e2e/smokeTests/stagingOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
+    "test-prod-auth": "npx cypress run -c baseUrl=https://dockstore.org -s \"cypress/e2e/smokeTests/prodOnly/auth-tests.ts,cypress/e2e/smokeTests/sharedTests/auth-tests.ts\"",
     "prepare": "husky install",
     "compare-audits": "scripts/npm-audit-comparison.sh",
     "accessibility-test": "scripts/run-pa11y-ci.sh"


### PR DESCRIPTION
**Description**
Noticed error https://github.com/CircleCI-Public/browser-tools-orb/pull/109 in the CircleCI logs. 
Seems unlikely to fix qa (affects all environments), but may as well fix

**Review Instructions**
See "Install ChromeDriver" step in Circle CI and see that linked syntax error no longer shows up.

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
