### PR TITLE
DOCK-2469: Display "Warnings" indicator in lambda logs

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -133,7 +133,7 @@ describe('Dockstore my workflows', () => {
       }).as('Default sort');
       cy.contains('Apps Logs').click();
       // Check that app logs contain the correct columns
-      const appLogColumns = ['Date', 'GitHub Username', 'Entry Name', 'Delivery ID', 'Repository', 'Reference', 'Success', 'Type'];
+      const appLogColumns = ['Date', 'GitHub Username', 'Entry Name', 'Delivery ID', 'Repository', 'Reference', 'Status', 'Type'];
       appLogColumns.forEach((column) => cy.contains(column));
       // These next 2 values work on Circle CI (UTC?) I would have thought East Coast time, but there's an 8 hour diff with West Coast time. Confused
       cy.contains('2020-02-20T02:20');

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -142,7 +142,7 @@ describe('GitHub App Tools', () => {
         'Organization',
         'Repository',
         'Reference',
-        'Success',
+        'Status',
         'Type',
       ];
       appLogColumns.forEach((column) => cy.contains(column));

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -62,7 +62,7 @@
             </td>
           </div>
           <div *ngSwitchCase="'success'">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>Success</th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
             <td mat-cell *matCellDef="let element">
               {{
                 element.ignored ? 'Ignored' : element.success && element.message ? 'Warnings' : (column | mapFriendlyValue: element[column])

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/github-apps-logs.component.html
@@ -63,7 +63,11 @@
           </div>
           <div *ngSwitchCase="'success'">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Success</th>
-            <td mat-cell *matCellDef="let element">{{ element.ignored ? 'Ignored' : (column | mapFriendlyValue: element[column]) }}</td>
+            <td mat-cell *matCellDef="let element">
+              {{
+                element.ignored ? 'Ignored' : element.success && element.message ? 'Warnings' : (column | mapFriendlyValue: element[column])
+              }}
+            </td>
           </div>
           <div *ngSwitchDefault>
             <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column | titlecase }}</th>


### PR DESCRIPTION
**Description**
This PR changes the UI to display the text "Warnings" in the "Success" column of the lambda logs, when the event is successful (`success` == true) and a message is included.  This approach works because currently, lambda log messages are composed solely of warnings and errors.

In the longer term, we might want to implement a more "correct"/robust solution, which might involve collapsing the four existing "outcomes" of a lambda event ("Success", "Failed", "Warnings", and "Ignored") into a single enum/column.

But the latter is a lot more work than what's implemented here, which works fine in the meantime and helps us to hit our 1.16 release date.

**Review Instructions**
View the lambda logs, and confirm that for events that were successful but have a message, "Warnings" is displayed in the "Success" column.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2469

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
