### PR TITLE
SEAB-6535: Fix auth-smoke-test-triggered 500s

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/auth-tests.ts
+++ b/cypress/e2e/smokeTests/sharedTests/auth-tests.ts
@@ -267,7 +267,13 @@ function testWorkflow(registry: string, repo: string, name: string) {
       cy.get('#publishButton').contains('Unpublish').click({ force: true });
 
       goToTab('Info');
+      cy.intercept('**/restub').as('restub');
       cy.contains('button', 'Restub').click();
+      // Wait for the restub request to complete, so that it does not overlap
+      // with the subsequent refresh and occasionally trigger a db error on
+      // the webservice.
+      // See https://ucsc-cgl.atlassian.net/browse/SEAB-6535
+      cy.wait('@restub');
       // This fails because DOI is auto issued when published, and restub fails.
       // See https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1718128426265779
       // cy.contains('button', 'Publish').should('be.disabled');


### PR DESCRIPTION
**Description**
Per these slack threads https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1723669795506039 https://app.slack.com/client/T09P9H91S/C05EZH3RVNY, in June 2024, the prod auth smoke tests began causing the webservice to sporadically 500 and produce corresponding Slack alerts.  After adding some logging, we determined that the webservice was occasionally throwing a database-consistency-related exception, which was triggered by overlapping restub and refresh requests.

This PR adds a bit of code to the auth smoke tests to delay the responsible refresh until after the preceding restub is complete, thus avoiding any overlap and preventing the database inconsistency and resulting exception.

Since the exceptions/500s happened only occasionally, and were sometimes separated by weeks of uneventful tests, we can't be 100% sure that this PR fixes the problem.  However, the "fixed" auth tests did run successfully against prod, which is encouraging.  We'll have to keep an eye on the Slacks for a while...

**Review Instructions**
Confirm that the 500-triggered Slack alerts due to the described problem are no longer occurring.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6535

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
