### PR TITLE
DOCK-2586: Remove "Jupyter" from workflow-related UI

### DIFF
--- a/src/app/shared/entry/descriptor-language.service.spec.ts
+++ b/src/app/shared/entry/descriptor-language.service.spec.ts
@@ -28,23 +28,24 @@ describe('Service: DescriptorLanguage', () => {
   it('should return the descriptor languages in an string array', () => {
     const stubValue: Array<DescriptorLanguageBean> = [{ value: 'cwl' }, { value: 'wdl' }, { value: 'nextflow' }];
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(stubValue));
+    workflowQuerySpy.entryType$ = observableOf('workflow');
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
     descriptorLanguageService.filteredDescriptorLanguages$.pipe(first()).subscribe((languages: Array<string>) => {
       expect(languages).toEqual(['cwl', 'wdl', 'nextflow'], 'service returned stub value');
     });
   });
-  it('should be able to filter service out', () => {
+  it('should be able to filter service and notebook out', () => {
     const descriptorLanguageBeans: DescriptorLanguageBean[] = [];
     descriptorLanguageBeans.push({ friendlyName: 'potato', value: 'potato' });
     descriptorLanguageBeans.push({ friendlyName: 'beef', value: 'beef' });
     descriptorLanguageBeans.push({ friendlyName: 'stew', value: 'stew' });
     descriptorLanguageBeans.push({ friendlyName: 'generic placeholder for services', value: 'service' });
+    descriptorLanguageBeans.push({ friendlyName: 'generic placeholder for notebooks', value: 'jupyter' });
     metadataServiceSpy.getDescriptorLanguages.and.returnValue(observableOf(descriptorLanguageBeans));
+    workflowQuerySpy.entryType$ = observableOf('workflow');
     const descriptorLanguageService = new DescriptorLanguageService(metadataServiceSpy, workflowQuerySpy);
-    const filteredDescriptorLanguageBeans = descriptorLanguageService.filterService(descriptorLanguageBeans);
-    expect(filteredDescriptorLanguageBeans.length).toEqual(3);
-    filteredDescriptorLanguageBeans.forEach((descriptorLanguageBean) => {
-      expect(descriptorLanguageBean.value).not.toEqual(descriptorLanguageService.knownServiceValue);
+    descriptorLanguageService.filteredDescriptorLanguages$.pipe(first()).subscribe((languages: Array<string>) => {
+      expect(languages).toEqual(['potato', 'beef', 'stew'], 'service returned stub value');
     });
   });
   it('should be able to get home page inner HTML', () => {

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -34,8 +34,6 @@ export class DescriptorLanguageService {
   readonly knownServiceValue = 'service';
 
   public descriptorLanguages$: Observable<Array<Workflow.DescriptorTypeEnum>>;
-  public descriptorLanguagesInnerHTML$: Observable<string>;
-  public noService$: Observable<DescriptorLanguageBean[]>;
   private descriptorLanguagesBean$ = new BehaviorSubject<DescriptorLanguageBean[]>([]);
   public filteredDescriptorLanguages$: Observable<Array<Workflow.DescriptorTypeEnum>>;
   constructor(private metadataService: MetadataService, private sessionQuery: SessionQuery) {
@@ -46,10 +44,6 @@ export class DescriptorLanguageService {
           return descriptorLanguageMap.map((descriptorLanguage) => <Workflow.DescriptorTypeEnum>descriptorLanguage.value.toString());
         }
       })
-    );
-    this.noService$ = this.descriptorLanguagesBean$.pipe(map((beans) => this.filterService(beans)));
-    this.descriptorLanguagesInnerHTML$ = this.noService$.pipe(
-      map((descriptorLanguageBeans: DescriptorLanguageBean[]) => this.getDescriptorLanguagesInnerHTML(descriptorLanguageBeans))
     );
     const combined$ = combineLatest([this.descriptorLanguages$, this.sessionQuery.entryType$]);
     this.filteredDescriptorLanguages$ = combined$.pipe(map((combined) => this.filterLanguages(combined[0], combined[1])));

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -251,8 +251,7 @@ export class DescriptorLanguageService {
       return descriptorTypes.filter(
         (descriptorType) => descriptorType !== Workflow.DescriptorTypeEnum.Service && descriptorType !== Workflow.DescriptorTypeEnum.Jupyter
       );
-    }
-    if (entryType === EntryType.Notebook) {
+    } else if (entryType === EntryType.Notebook) {
       return [Workflow.DescriptorTypeEnum.Jupyter];
     } else {
       return [Workflow.DescriptorTypeEnum.Service];

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -254,7 +254,12 @@ export class DescriptorLanguageService {
    */
   filterLanguages(descriptorTypes: Workflow.DescriptorTypeEnum[], entryType: EntryType): Workflow.DescriptorTypeEnum[] {
     if (entryType === EntryType.BioWorkflow || entryType === EntryType.Tool || !entryType) {
-      return descriptorTypes.filter((descriptorType) => descriptorType !== Workflow.DescriptorTypeEnum.Service);
+      return descriptorTypes.filter(
+        (descriptorType) => descriptorType !== Workflow.DescriptorTypeEnum.Service && descriptorType !== Workflow.DescriptorTypeEnum.Jupyter
+      );
+    }
+    if (entryType === EntryType.Notebook) {
+      return [Workflow.DescriptorTypeEnum.Jupyter];
     } else {
       return [Workflow.DescriptorTypeEnum.Service];
     }

--- a/src/app/shared/entry/descriptor-language.service.ts
+++ b/src/app/shared/entry/descriptor-language.service.ts
@@ -228,17 +228,6 @@ export class DescriptorLanguageService {
   }
 
   /**
-   * Certain pages ignore the 'service' descriptor language completely, this filters it out of the known languages
-   *
-   * @param {DescriptorLanguageBean[]} beans  Descriptor language bean returned from the metadata endpoint
-   * @returns {DescriptorLanguageBean[]}   Filtered list of languages that do not have 'service' in it
-   * @memberof DescriptorLanguageService
-   */
-  filterService(beans: DescriptorLanguageBean[]): DescriptorLanguageBean[] {
-    return beans.filter((bean) => bean.value !== this.knownServiceValue);
-  }
-
-  /**
    * Some entries are not meant to show all descriptor types
    *
    * @param {ToolDescriptor.TypeEnum[]} descriptorTypes


### PR DESCRIPTION
**Description**
As detailed in https://ucsc-cgl.atlassian.net/browse/DOCK-2586, "Jupyter" was appearing in several locations in our UI, all related to "manual" workflow registration, as a possible value for a workflow descriptor language.  This PR changes the UI so that "Jupyter" no longer appears in those locations.

The primary change is to modify the code that calculates the `filteredDescriptorLanguages$` observable of `DescriptorLanguageService`, which is used by the errant UI elements, so that "Jupyter" is not included in the returned list of workflow languages.

Turns out that the related unit tests were not working because the `entryType$` property of the mocked `WorkflowQuery` was not set, causing the tests to [effectively silently, except for some warnings on the console] not test anything.  This was fixed.

While I was in there, I deleted some unused code.  I'm not sure precisely what it was originally intended for, but it doesn't appear to be used any more.

**Review Instructions**
Confirm that "Jupyter" no longer appears as an option in the UI in the locations that were flagged by the ticket.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2586
dockstore/dockstore#6004

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
