### PR TITLE
SEAB-6696: Improve search result presentation

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -141,9 +141,6 @@ describe('Test search page functionality', () => {
     cy.url().should('contain', 'verified=1');
     cy.get('[data-cy=workflowColumn] a');
     cy.contains('mat-checkbox', /^[ ]*verified/);
-    cy.get('[data-cy=verificationStatus] a').each(($el, index, $list) => {
-      cy.wrap($el).contains('done');
-    });
   });
 });
 

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -32,7 +32,7 @@ export abstract class SearchEntryTable extends Base implements OnInit {
   protected verifiedLink: string;
   protected ngUnsubscribe: Subject<{}> = new Subject();
 
-  public readonly displayedColumns = ['name', 'all_authors', 'descriptorType', 'projectLinks', 'starredUsers'];
+  public readonly displayedColumns = ['name', 'all_authors', 'descriptorType', 'starredUsers'];
   public readonly columnsToDisplayWithExpand = [...this.displayedColumns, 'expand'];
   public readonly searchEverythingFriendlyNames = new Map([
     ['full_workflow_path', 'Path'],

--- a/src/app/search/search-entry-table.ts
+++ b/src/app/search/search-entry-table.ts
@@ -32,7 +32,7 @@ export abstract class SearchEntryTable extends Base implements OnInit {
   protected verifiedLink: string;
   protected ngUnsubscribe: Subject<{}> = new Subject();
 
-  public readonly displayedColumns = ['name', 'verified', 'all_authors', 'descriptorType', 'projectLinks', 'starredUsers'];
+  public readonly displayedColumns = ['name', 'all_authors', 'descriptorType', 'projectLinks', 'starredUsers'];
   public readonly columnsToDisplayWithExpand = [...this.displayedColumns, 'expand'];
   public readonly searchEverythingFriendlyNames = new Map([
     ['full_workflow_path', 'Path'],

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -54,7 +54,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="starred-cell weight-bold" *matCellDef="let notebook"
         ><mat-icon class="star-icon" *ngIf="notebook?.source.starredUsers?.length > 0">star_rate</mat-icon>
-        {{ !notebook?.source.starredUsers || notebook?.source.starredUsers.length === 0 ? '' : notebook?.source.starredUsers?.length }}
+        {{ !notebook?.source.starredUsers || notebook?.source.starredUsers.length === 0 ? '' : notebook?.source.starredUsers.length }}
       </mat-cell>
     </ng-container>
     <!-- Search highlighting column - this row is made up of this one column that spans across all columns -->

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -25,14 +25,11 @@
     </ng-container>
     <ng-container matColumnDef="all_authors">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
-      <mat-cell
-        fxShow
-        fxHide.lt-sm
-        class="duration-cell truncate-text-2"
-        *matCellDef="let notebook"
-        [matTooltip]="notebook?.source.all_authors | getSearchAuthorsHtml: false"
-        [innerHTML]="notebook?.source.all_authors | getSearchAuthorsHtml"
-      ></mat-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let notebook" [matTooltip]="notebook?.source.all_authors | getSearchAuthorsHtml: false">
+        <div class="truncate-text-3 size-small">
+          <span [innerHTML]="notebook?.source?.all_authors | getSearchAuthorsHtml"></span>
+        </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
       <mat-header-cell fxShow fxHide.lt-sm data-cy="descriptorTypeHeader" *matHeaderCellDef mat-sort-header>Format</mat-header-cell>
@@ -54,9 +51,9 @@
     </ng-container>
     <ng-container matColumnDef="starredUsers">
       <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
-      <mat-cell class="description-cell" *matCellDef="let notebook"
-        >{{ !notebook?.source.starredUsers || notebook?.source.starredUsers.length === 0 ? '' : notebook?.source.starredUsers?.length }}
-        <mat-icon class="star-icon" *ngIf="notebook?.source.starredUsers?.length > 0">star_rate</mat-icon>
+      <mat-cell class="starred-cell weight-bold" *matCellDef="let notebook"
+        ><mat-icon class="star-icon" *ngIf="notebook?.source.starredUsers?.length > 0">star_rate</mat-icon>
+        {{ !notebook?.source.starredUsers || notebook?.source.starredUsers.length === 0 ? '' : notebook?.source.starredUsers?.length }}
       </mat-cell>
     </ng-container>
     <!-- Search highlighting column - this row is made up of this one column that spans across all columns -->

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -4,9 +4,10 @@
   </div>
   <mat-table [hidden]="!dataSource" [dataSource]="dataSource" matSort data-cy="search-notebook-results-table" multiTemplateDataRows>
     <ng-container matColumnDef="name">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="notebookColumn" *matCellDef="let notebook">
         <div>
+          <img src="../../../../assets/svg/notebook-circle.svg" class="mr-2_5 site-icons-small" />
           <a [matTooltip]="notebook?.source.full_workflow_path" [routerLink]="'/notebooks/' + notebook?.source.full_workflow_path">{{
             notebook?.source.organization +
               '/' +

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -52,14 +52,6 @@
         </div>
       </mat-cell>
     </ng-container>
-    <ng-container matColumnDef="projectLinks">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Links</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let entry">
-        <a [href]="entry?.source.providerUrl" *ngIf="entry?.source.providerUrl">
-          <fa-icon class="fa-lg" [icon]="entry.source.providerIcon" [matTooltip]="entry?.source.provider"></fa-icon>
-        </a>
-      </mat-cell>
-    </ng-container>
     <ng-container matColumnDef="starredUsers">
       <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="description-cell" *matCellDef="let notebook"

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -7,7 +7,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="notebookColumn" *matCellDef="let notebook">
         <div>
-          <img src="../../../../assets/svg/notebook-circle.svg" class="mr-2_5 site-icons-small" />
+          <img src="../../../../assets/svg/notebook-circle.svg" class="mr-2_5 site-icons-small" alt="notebook icon" />
           <a [matTooltip]="notebook?.source.full_workflow_path" [routerLink]="'/notebooks/' + notebook?.source.full_workflow_path">{{
             notebook?.source.organization +
               '/' +

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -14,7 +14,7 @@
               notebook?.source.repository +
               (notebook?.source.workflowName ? '/' + notebook?.source.workflowName : '')
           }}</a>
-          <div class="truncate-text-2">
+          <div class="truncate-text-3">
             <app-ai-bubble
               *ngIf="notebook?.source.topicSelection === TopicSelectionEnum.AI && !notebook?.source.approvedAITopic"
               [isPublic]="true"

--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -18,9 +18,7 @@
               *ngIf="notebook?.source.topicSelection === TopicSelectionEnum.AI && !notebook?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span class="size-small" [matTooltip]="notebook?.source.topicAutomatic" matTooltipPosition="left">{{
-              notebook?.source.topicAutomatic
-            }}</span>
+            <span [matTooltip]="notebook?.source.topicAutomatic" matTooltipPosition="left">{{ notebook?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-notebook-table/search-notebook-table.component.scss
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.scss
@@ -1,9 +1,9 @@
 .mat-column-descriptorType {
-  max-width: 90px;
+  max-width: 10rem;
 }
 
-.mat-column-projectLinks {
-  max-width: 80px;
+.mat-column-descriptorTypeSubclass {
+  max-width: 10rem;
 }
 
 td.mat-cell {

--- a/src/app/search/search-notebook-table/search-notebook-table.component.ts
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.ts
@@ -65,7 +65,7 @@ import TopicSelectionEnum = Workflow.TopicSelectionEnum;
   ],
 })
 export class SearchNotebookTableComponent extends SearchEntryTable implements OnInit {
-  public readonly displayedColumns = ['name', 'all_authors', 'descriptorType', 'descriptorTypeSubclass', 'projectLinks', 'starredUsers'];
+  public readonly displayedColumns = ['name', 'all_authors', 'descriptorType', 'descriptorTypeSubclass', 'starredUsers'];
   readonly entryType = 'notebook';
   public dataSource: MatTableDataSource<SearchResult<Notebook>>;
   constructor(dateService: DateService, searchQuery: SearchQuery, searchService: SearchService) {

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -49,9 +49,7 @@
               *ngIf="tool?.source.topicSelection === TopicSelectionEnum.AI && !tool?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span class="size-small" [matTooltip]="tool?.source.topicAutomatic" matTooltipPosition="left">{{
-              tool?.source.topicAutomatic
-            }}</span>
+            <span [matTooltip]="tool?.source.topicAutomatic" matTooltipPosition="left">{{ tool?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -45,7 +45,7 @@
               tool?.source.namespace + '/' + tool?.source.name + (tool?.source.toolname ? '/' + tool?.source.toolname : '')
             }}</a>
           </ng-template>
-          <div class="truncate-text-2">
+          <div class="truncate-text-3">
             <app-ai-bubble
               *ngIf="tool?.source.topicSelection === TopicSelectionEnum.AI && !tool?.source.approvedAITopic"
               [isPublic]="true"

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -23,7 +23,7 @@
       <!-- the wrap causes slightly odd behavior with the mat-icon but is needed for the topic -->
       <mat-cell data-cy="toolNames" *matCellDef="let tool">
         <div>
-          <img src="../../../../assets/svg/tool-circle.svg" class="mr-2_5 site-icons-small" />
+          <img src="../../../../assets/svg/tool-circle.svg" class="mr-2_5 site-icons-small" alt="tool icon" />
           <span *ngIf="tool?.source.private_access">
             <app-private-icon></app-private-icon>
           </span>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -27,7 +27,7 @@
           <span *ngIf="tool?.source.private_access">
             <app-private-icon></app-private-icon>
           </span>
-          <div *ngIf="tool.source | isAppTool; else docktoreToolName">
+          <span *ngIf="tool.source | isAppTool; else docktoreToolName">
             <a
               [matTooltip]="tool?.source.full_workflow_path"
               matTooltipPosition="left"
@@ -39,7 +39,7 @@
                   (tool?.source.workflowName ? '/' + tool?.source.workflowName : '')
               }}</a
             >
-          </div>
+          </span>
           <ng-template #docktoreToolName>
             <a [matTooltip]="tool?.source.tool_path" matTooltipPosition="left" [routerLink]="'/containers/' + tool.source.tool_path">{{
               tool?.source.namespace + '/' + tool?.source.name + (tool?.source.toolname ? '/' + tool?.source.toolname : '')

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -23,6 +23,7 @@
       <!-- the wrap causes slightly odd behavior with the mat-icon but is needed for the topic -->
       <mat-cell data-cy="toolNames" *matCellDef="let tool">
         <div>
+          <img src="../../../../assets/svg/tool-circle.svg" class="mr-2_5 site-icons-small" />
           <span *ngIf="tool?.source.private_access">
             <app-private-icon></app-private-icon>
           </span>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -54,24 +54,13 @@
         </div>
       </mat-cell>
     </ng-container>
-    <ng-container matColumnDef="verified">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
-        <a *ngIf="tool.source.verified" [href]="verifiedLink">
-          <mat-icon matTooltip="Verified">check</mat-icon>
-        </a>
-      </mat-cell>
-    </ng-container>
     <ng-container matColumnDef="all_authors">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
-      <mat-cell
-        fxShow
-        fxHide.lt-sm
-        class="duration-cell truncate-text-2"
-        *matCellDef="let tool"
-        [matTooltip]="tool?.source.all_authors | getSearchAuthorsHtml: false"
-        [innerHTML]="tool?.source.all_authors | getSearchAuthorsHtml"
-      ></mat-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let tool" [matTooltip]="tool?.source.all_authors | getSearchAuthorsHtml: false">
+        <div class="truncate-text-3 size-small">
+          <span [innerHTML]="tool?.source.all_authors | getSearchAuthorsHtml"></span>
+        </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType" style="width: fit-content">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header fxFlex="15%">Format</mat-header-cell>
@@ -88,18 +77,6 @@
             </span>
           </div>
         </ng-template>
-      </mat-cell>
-    </ng-container>
-    <ng-container matColumnDef="projectLinks">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Links</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let tool">
-        <a [href]="tool?.source.providerUrl" *ngIf="tool?.source.providerUrl">
-          <fa-icon class="fa-lg" [icon]="tool.source.providerIcon" [matTooltip]="tool?.source.provider"></fa-icon>
-        </a>
-        &nbsp; &nbsp;
-        <a [href]="tool?.source.imgProviderUrl" *ngIf="tool?.source.imgProviderUrl">
-          <fa-icon class="fa-lg" [icon]="tool.source.imgProviderIcon" [matTooltip]="tool?.source.imgProvider"></fa-icon>
-        </a>
       </mat-cell>
     </ng-container>
     <ng-container matColumnDef="starredUsers">

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -23,9 +23,7 @@
               *ngIf="workflow?.source.topicSelection === TopicSelectionEnum.AI && !workflow?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span class="size-small" [matTooltip]="workflow?.source.topicAutomatic" matTooltipPosition="left">{{
-              workflow?.source.topicAutomatic
-            }}</span>
+            <span [matTooltip]="workflow?.source.topicAutomatic" matTooltipPosition="left">{{ workflow?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -7,7 +7,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
         <div>
-          <img src="../../../../assets/svg/workflow-circle.svg" class="mr-2_5 site-icons-small" />
+          <img src="../../../../assets/svg/workflow-circle.svg" class="mr-2_5 site-icons-small" alt="workflow icon" />
           <a
             [matTooltip]="workflow?.source.full_workflow_path"
             matTooltipPosition="left"

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -18,7 +18,7 @@
                 (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
             }}</a
           >
-          <div class="truncate-text-2">
+          <div class="truncate-text-3">
             <app-ai-bubble
               *ngIf="workflow?.source.topicSelection === TopicSelectionEnum.AI && !workflow?.source.approvedAITopic"
               [isPublic]="true"

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -49,7 +49,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="starred-cell weight-bold" *matCellDef="let workflow"
         ><mat-icon class="star-icon" *ngIf="workflow?.source.starredUsers?.length > 0">star_rate</mat-icon>
-        {{ !workflow?.source.starredUsers || workflow?.source.starredUsers.length === 0 ? '' : workflow?.source.starredUsers?.length }}
+        {{ !workflow?.source.starredUsers || workflow?.source.starredUsers.length === 0 ? '' : workflow?.source.starredUsers.length }}
       </mat-cell>
     </ng-container>
 

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -31,7 +31,7 @@
     <ng-container matColumnDef="all_authors">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
       <mat-cell fxShow fxHide.lt-sm *matCellDef="let workflow" [matTooltip]="workflow?.source?.all_authors | getSearchAuthorsHtml: false">
-        <div class="truncate-text-3">
+        <div class="truncate-text-3 size-small">
           <span [innerHTML]="workflow?.source?.all_authors | getSearchAuthorsHtml"></span>
         </div>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -7,6 +7,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
         <div>
+          <img src="../../../../assets/svg/workflow-circle.svg" class="mr-2" width="16" height="16" />
           <a
             [matTooltip]="workflow?.source.full_workflow_path"
             matTooltipPosition="left"

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -30,14 +30,11 @@
     </ng-container>
     <ng-container matColumnDef="all_authors">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
-      <mat-cell
-        fxShow
-        fxHide.lt-sm
-        class="duration-cell truncate-text-2"
-        *matCellDef="let workflow"
-        [matTooltip]="workflow?.source?.all_authors | getSearchAuthorsHtml: false"
-        [innerHTML]="workflow?.source?.all_authors | getSearchAuthorsHtml"
-      ></mat-cell>
+      <mat-cell fxShow fxHide.lt-sm *matCellDef="let workflow" [matTooltip]="workflow?.source?.all_authors | getSearchAuthorsHtml: false">
+        <div class="truncate-text-3">
+          <span [innerHTML]="workflow?.source?.all_authors | getSearchAuthorsHtml"></span>
+        </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="descriptorType">
       <mat-header-cell fxShow fxHide.lt-sm data-cy="descriptorTypeHeader" *matHeaderCellDef mat-sort-header>Format</mat-header-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -45,14 +45,6 @@
         </div>
       </mat-cell>
     </ng-container>
-    <ng-container matColumnDef="projectLinks">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Links</mat-header-cell>
-      <mat-cell fxShow fxHide.lt-md *matCellDef="let entry">
-        <a [href]="entry?.source.providerUrl" *ngIf="entry?.source.providerUrl">
-          <fa-icon class="fa-lg" [icon]="entry.source.providerIcon" [matTooltip]="entry?.source.provider"></fa-icon>
-        </a>
-      </mat-cell>
-    </ng-container>
     <ng-container matColumnDef="starredUsers">
       <mat-header-cell *matHeaderCellDef mat-sort-header start="desc">Stars</mat-header-cell>
       <mat-cell class="starred-cell weight-bold" *matCellDef="let workflow"

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -28,14 +28,6 @@
         </div>
       </mat-cell>
     </ng-container>
-    <ng-container matColumnDef="verified">
-      <mat-header-cell fxShow fxHide.lt-md *matHeaderCellDef>Verified</mat-header-cell>
-      <mat-cell data-cy="verificationStatus" fxShow fxHide.lt-md *matCellDef="let workflow">
-        <a *ngIf="workflow.source.verified" [href]="verifiedLink">
-          <mat-icon matTooltip="Verified">done</mat-icon>
-        </a>
-      </mat-cell>
-    </ng-container>
     <ng-container matColumnDef="all_authors">
       <mat-header-cell fxShow fxHide.lt-sm *matHeaderCellDef mat-sort-header>Author</mat-header-cell>
       <mat-cell

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -7,7 +7,7 @@
       <mat-header-cell *matHeaderCellDef mat-sort-header>Name and Description</mat-header-cell>
       <mat-cell data-cy="workflowColumn" *matCellDef="let workflow">
         <div>
-          <img src="../../../../assets/svg/workflow-circle.svg" class="mr-2" width="16" height="16" />
+          <img src="../../../../assets/svg/workflow-circle.svg" class="mr-2_5 site-icons-small" />
           <a
             [matTooltip]="workflow?.source.full_workflow_path"
             matTooltipPosition="left"

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -24,6 +24,10 @@ mat-tab-group.homeComponent {
   color: $header-color;
 }
 
+.hits {
+  line-height: 1.7;
+}
+
 .sidebar {
   position: fixed;
   top: 0;

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -25,7 +25,7 @@ mat-tab-group.homeComponent {
 }
 
 .hits {
-  line-height: 1.7;
+  line-height: 1.8;
 }
 
 .sidebar {

--- a/src/app/shared/styles/entry-table.scss
+++ b/src/app/shared/styles/entry-table.scss
@@ -9,7 +9,7 @@
 }
 
 .mat-column-all_authors {
-  max-width: 20rem;
+  max-width: 16rem;
 }
 
 .mat-column-descriptorType,

--- a/src/app/shared/styles/entry-table.scss
+++ b/src/app/shared/styles/entry-table.scss
@@ -5,7 +5,6 @@
 .mat-column-starredUsers,
 .mat-column-stars {
   max-width: 6rem;
-  justify-content: flex-end;
   color: mat.get-color-from-palette($dockstore-app-accent-1, darker);
 }
 
@@ -14,6 +13,7 @@
 }
 
 .mat-column-descriptorType,
+.mat-column-descriptorTypeSubclass,
 .mat-column-format {
   min-width: min-content;
   max-width: 14rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1436,3 +1436,7 @@ app-ai-bubble {
 .gray-caption {
   color: mat.get-color-from-palette($kim-gray, 2);
 }
+
+.mr-2_5 {
+  margin-right: 0.75rem;
+}


### PR DESCRIPTION
**Description**
This PR makes some relatively-minor changes to the presentation of Dockstore's Search page results, with the overarching goal of making each hit's topic sentence more prominent. readable, and completely-displayed.

This Slack thread contains some of the related discussion:
https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1727899641002089

Specifically, this PR:

* increases topic font size
* removes "Verified" and "Links" columns
* decreases "Author" value font size and column width
* tightens line height
* fixes vertical alignment of authors block and horizontal alignment of star counts
* increases truncation limit of topic and authors values to three lines
* adds a small "entry" icon in front of each hit
* fixes a smattering of inconsistencies

The net effect is to widen the column that contains the topic sentence, thus allowing more of it to be displayed, in a larger font. 

Screenshots of non-keyword results, before PR ([dockstore.org](http://dockstore.org/)) and after (localhost):
<img width="1729" alt="dump 2024-10-03 at 9 41 05 AM" src="https://github.com/user-attachments/assets/bc1407be-6999-4bd0-88b4-67d000ec1024">
<img width="1729" alt="dump 2024-10-03 at 9 43 23 AM" src="https://github.com/user-attachments/assets/75d4fd6f-40d8-48f1-8d25-b6bf216ffbf8">

Screenshots of keyword results, before PR ([dockstore.org](http://dockstore.org/)) and after (localhost):
<img width="1729" alt="dump 2024-10-03 at 9 41 35 AM" src="https://github.com/user-attachments/assets/57e44088-634b-4983-b74b-b5dc0b86df83">
<img width="1685" alt="dump 2024-10-03 at 9 42 46 AM" src="https://github.com/user-attachments/assets/38b7d663-1bcb-4486-a8b9-b4382227cb28">

There's another set of pages that list all of the workflows/tools/notebooks (for example: https://dockstore.org/workflows), which this PR doesn't currently change.  Although these pages are public, we generally don't point at or advertise them.  Should we update them with the same changes as we made above?  Not sure.  It could be useful to leave them the way they are, to have more info to aid with debugging, for example...

Longer term, IMHO, we should probably format the search results as "cards", in a style that's unified with the current collection entry scheme.  After this PR merges, I will write a ticket which describes that work.
 
**Review Instructions**
Go to the search page on qa, click on each of the "Workflows", "Tools", and "Notebooks" tabs, and confirm that the changes appear and look fine.  Inspect similarly after clicking a facet, and searching for a keyword.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6696

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
