### PR TITLE
SEAB-6308: Directly link "AI bubble" to AI policy in FAQ

### DIFF
--- a/src/app/shared/ai-bubble/ai-bubble.component.html
+++ b/src/app/shared/ai-bubble/ai-bubble.component.html
@@ -1,5 +1,5 @@
 <a
-  [href]="Dockstore.DOCUMENTATION_URL + '/faq.html'"
+  [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#in-plain-language-what-is-dockstore-s-approach-to-generative-ai'"
   target="_blank"
   rel="noopener noreferrer"
   data-cy="ai-bubble"


### PR DESCRIPTION
**Description**
This PR changes the "AI bubble" (that appears next to an AI topic in certain cases) so that it links directory to the AI policy section of the documentation FAQ.
 
**Review Instructions**
Click on an AI bubble and confirm that it points at the AI policy section of the FAQ.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6308

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
