### PR TITLE
DOCK-2592: Fix faceted search for complex queries involving ORs

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -180,19 +180,18 @@ export class QueryBuilderService {
         values.forEach((value) => {
           body = body.notFilter('term', 'some garbage term that hopefully never gets matched', value);
         });
-      } else if (values.size > 1) {
-        // Add a filter that matches one or more of multiple values
+      } else if (values.size == 1) {
+        // Add a filter that matches a single value
+        const [value] = values;
+        const convertedValue = isExclusiveFilter ? this.convertIntStringToBoolString(value) : value;
+        body = body.filter('term', key, convertedValue);
+      } else {
+        // Add a filter that matches at least one of multiple values
         body = body.filter('bool', (b) => {
           for (const value of values) {
             b = b.orFilter('term', key, value);
           }
           return b;
-        });
-      } else {
-        // Add a filter that matches a single value
-        values.forEach((value) => {
-          const esValue = isExclusiveFilter ? this.convertIntStringToBoolString(value) : value;
-          body = body.filter('term', key, esValue);
         });
       }
     });

--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -173,26 +173,28 @@ export class QueryBuilderService {
    * @memberof SearchComponent
    */
   appendFilter(body: any, aggKey: string | null, filters: Map<string, Set<string>>, exclusiveFilters: Array<string>): Bodybuilder {
-    filters.forEach((value: Set<string>, key: string) => {
-      value.forEach((insideFilter) => {
-        const isExclusiveFilter = exclusiveFilters.includes(key);
-        if (aggKey === key && !isExclusiveFilter) {
-          // Return some garbage filter because we've decided to append a filter, there's no turning back
-          // return body;  // <--- this does not work
-          body = body.notFilter('term', 'some garbage term that hopefully never gets matched', insideFilter);
-        } else {
-          // value refers to the buckets selected
-          if (value.size > 1) {
-            body = body.orFilter('term', key, insideFilter);
-          } else {
-            if (isExclusiveFilter) {
-              body = body.filter('term', key, this.convertIntStringToBoolString(insideFilter));
-            } else {
-              body = body.filter('term', key, insideFilter);
-            }
+    filters.forEach((values: Set<string>, key: string) => {
+      const isExclusiveFilter = exclusiveFilters.includes(key);
+      if (aggKey === key && !isExclusiveFilter) {
+        // Return some garbage filter because we've decided to append a filter, there's no turning back
+        values.forEach((value) => {
+          body = body.notFilter('term', 'some garbage term that hopefully never gets matched', value);
+        });
+      } else if (values.size > 1) {
+        // Add a filter that matches one or more of multiple values
+        body = body.filter('bool', (b) => {
+          for (const value of values) {
+            b = b.orFilter('term', key, value);
           }
-        }
-      });
+          return b;
+        });
+      } else {
+        // Add a filter that matches a single value
+        values.forEach((value) => {
+          const esValue = isExclusiveFilter ? this.convertIntStringToBoolString(value) : value;
+          body = body.filter('term', key, esValue);
+        });
+      }
     });
     return body;
   }

--- a/src/app/shared/ai-bubble/ai-bubble.component.html
+++ b/src/app/shared/ai-bubble/ai-bubble.component.html
@@ -1,5 +1,5 @@
 <a
-  [href]="Dockstore.DOCUMENTATION_URL + '/faq.html'"
+  [href]="Dockstore.DOCUMENTATION_URL + '/faq.html#in-plain-language-what-is-dockstore-s-approach-to-generative-ai'"
   target="_blank"
   rel="noopener noreferrer"
   data-cy="ai-bubble"


### PR DESCRIPTION
**Description**
This PR changes the UI's Elasticsearch query-construction code to add OR subqueries in such a way that they produce correct results when included in complex queries.

In an ES query, `must` clauses corresponds to ANDs, and `should` clauses correspond to ORs.  We assemble a query as a collection of `musts` and `shoulds`, the `musts` corresponding to a facet with a single value selected, and the `shoulds` to a facet with multiple values selected.

Things work more or less as you'd expect, except for a quirk: if a query contains both `musts` and `shoulds`, the `shoulds` are effectively ignored for hit selection purposes (used only for ranking), and the query returns all hits that match the `musts`.  For example, in the case of the bug reported in the ticket, the query returned all Nextflow workflows, because there were multiple organization values selected in the facet, so the organizations were effectively ignored.

So, essentially, prior to this PR, all complex queries involving a combination of singly and multiply-selected facets were broken, and such queries returned all hits matching the singly-selected facets.  Probably affected keyword searches in combination with a multiply-selected facet, too.

The solution was to nest the OR (`should`) subqueries in their own `bool` filter, requiring a rewrite of the query construction logic.

In a nutshell: `musts` at the same level of `shoulds` override the `shoulds`, so we nest the `shoulds` in their own subfilter to avoid that.

I didn't totally grok the "Return some garbage filter" code, so I left it in there, functionally unchanged. 

We might be able to use a lightly-massaged version of the "OR" (multiple-value) query construction code to handle the "AND" (single-value) case, too.  But, that'd be a big enough change that I'd worry about unforeseen performance/functional gotchas, so for safety sake, we'll leave it the olde way for now...

This PR is targetted to the release branch.  It also contains the "AI Bubble FAQ link" change, which didn't get merged to develop in time to make it into the release.

**Review Instructions**
On staging, try the search in the ticket, and confirm that the results look good.  Play with the facets in similar ways and confirm the behavior is correct.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2592
dockstore/dockstore#6020
https://ucsc-cgl.atlassian.net/browse/SEAB-6308

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
