### PR TITLE
DOCK-2594: Fix TRS ID "copy button" bug

### DIFF
--- a/src/app/workflow/info-tab/info-tab.component.ts
+++ b/src/app/workflow/info-tab/info-tab.component.ts
@@ -194,6 +194,7 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
       this.authors = null;
       this.description = null;
     }
+    this.displayTextForButton = this.infoTabService.getTRSId(this.workflow);
   }
 
   ngOnInit() {
@@ -208,9 +209,6 @@ export class InfoTabComponent extends EntryTab implements OnInit, OnChanges {
     this.infoTabService.defaultTestFilePathEditing$
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((editing) => (this.defaultTestFilePathEditing = editing));
-    this.entryType$
-      .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe((entryType) => (this.displayTextForButton = this.infoTabService.getTRSId(this.workflow, entryType)));
     this.infoTabService.forumUrlEditing$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((editing) => (this.forumUrlEditing = editing));
   }
   /**

--- a/src/app/workflow/info-tab/info-tab.service.spec.ts
+++ b/src/app/workflow/info-tab/info-tab.service.spec.ts
@@ -10,7 +10,7 @@ import { WorkflowsService } from 'app/shared/openapi';
 import { ExtendedWorkflowQuery } from 'app/shared/state/extended-workflow.query';
 import { WorkflowService } from 'app/shared/state/workflow.service';
 import { WorkflowsStubService, WorkflowStubService } from 'app/test/service-stubs';
-import { sampleWorkflow3 } from '../../test/mocked-objects';
+import { sampleWorkflow3, appToolEntryTypeMetadata, serviceEntryTypeMetadata, notebookEntryTypeMetadata } from '../../test/mocked-objects';
 import { InfoTabService } from './info-tab.service';
 
 describe('ValueService', () => {
@@ -54,10 +54,15 @@ describe('ValueService', () => {
   it(`getTRSId should work for tools and workflows`, () => {
     service = TestBed.inject(InfoTabService);
     const fullWorkflowPath = sampleWorkflow3.full_workflow_path;
-    expect(service.getTRSId(sampleWorkflow3, EntryType.BioWorkflow)).toBe(`#workflow/${fullWorkflowPath}`);
-    expect(service.getTRSId(sampleWorkflow3, EntryType.AppTool)).toBe(fullWorkflowPath);
-    expect(service.getTRSId(sampleWorkflow3, EntryType.Service)).toBe(`#service/${fullWorkflowPath}`);
-    expect(service.getTRSId(null, EntryType.BioWorkflow)).toBe('');
+    const clone = Object.assign({}, sampleWorkflow3);
+    expect(service.getTRSId(clone)).toBe(`#workflow/${fullWorkflowPath}`);
+    clone.entryTypeMetadata = appToolEntryTypeMetadata;
+    expect(service.getTRSId(clone)).toBe(fullWorkflowPath);
+    clone.entryTypeMetadata = serviceEntryTypeMetadata;
+    expect(service.getTRSId(clone)).toBe(`#service/${fullWorkflowPath}`);
+    clone.entryTypeMetadata = notebookEntryTypeMetadata;
+    expect(service.getTRSId(clone)).toBe(`#notebook/${fullWorkflowPath}`);
+    expect(service.getTRSId(null)).toBe('');
   });
 
   it(`getTRSPlainType should work for various descriptor types`, () => {

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -189,7 +189,7 @@ export class InfoTabService {
 
   getTRSId(workflow: Workflow | undefined): string {
     if (workflow) {
-      return workflow.trsId;
+      return workflow.entryTypeMetadata.trsPrefix + workflow.full_workflow_path;
     } else {
       return '';
     }

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -189,7 +189,7 @@ export class InfoTabService {
 
   getTRSId(workflow: Workflow | undefined): string {
     if (workflow) {
-      return workflow.entryTypeMetadata.trsId;
+      return workflow.trsId;
     } else {
       return '';
     }

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -187,11 +187,12 @@ export class InfoTabService {
     );
   }
 
-  getTRSId(workflow: Workflow | undefined, entryType: EntryType): string {
-    if (!workflow) {
+  getTRSId(workflow: Workflow | undefined): string {
+    if (workflow) {
+      return workflow.entryTypeMetadata.trsPrefix + workflow.full_workflow_path;
+    } else {
       return '';
     }
-    return this.getTRSIDFromPath(workflow.full_workflow_path, entryType);
   }
 
   private getTRSIDFromPath(fullWorkflowPath: string, entryType: EntryType): string {

--- a/src/app/workflow/info-tab/info-tab.service.ts
+++ b/src/app/workflow/info-tab/info-tab.service.ts
@@ -189,7 +189,7 @@ export class InfoTabService {
 
   getTRSId(workflow: Workflow | undefined): string {
     if (workflow) {
-      return workflow.entryTypeMetadata.trsPrefix + workflow.full_workflow_path;
+      return workflow.entryTypeMetadata.trsId;
     } else {
       return '';
     }


### PR DESCRIPTION
**Description**
This PR fixes the "copy" button (on the workflow page, in the "Workflow Information" section, at the right end of the "TRS" line) so that when two workflows are viewed successively, the copied value is correct.  Previously, if you visited the pages for two workflows A and B, if you used the button to copy the TRS ID on workflow B's page, the copied value was the TRS ID for workflow A.

The cause was that we were updating the TRS ID field of the component when an "entryType" observable issued forth a new value.  The assumption was probably that if we visited successive workflows, we'd see successive "workflow" entry type values on the line.  But, for whatever reason, that's not how it was working...

Editorial: this type of bug suggests that our UI code (and more specifically, the architecture and constructs typically employed within) is making it hard for us to do simple, straightforward things (such as, in this case, display the TRS ID corresponding to the current workflow).

The branch has the wrong issue number, woops.

**Review Instructions**
Go to search, reproduce the steps in the first paragraph of the "Description" section above, use the button to copy the TRS ID, and confirm it has the correct value.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2594
dockstore/dockstore#6024

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
