### PR TITLE
Don't truncate topics on search page, move AI bubble to the end of topic

### DIFF
--- a/src/app/search/search-notebook-table/search-notebook-table.component.html
+++ b/src/app/search/search-notebook-table/search-notebook-table.component.html
@@ -14,12 +14,12 @@
               notebook?.source.repository +
               (notebook?.source.workflowName ? '/' + notebook?.source.workflowName : '')
           }}</a>
-          <div class="truncate-text-3">
+          <div>
+            <span>{{ notebook?.source.topicAutomatic }}</span>
             <app-ai-bubble
               *ngIf="notebook?.source.topicSelection === TopicSelectionEnum.AI && !notebook?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span>{{ notebook?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-tool-table/search-tool-table.component.html
+++ b/src/app/search/search-tool-table/search-tool-table.component.html
@@ -45,12 +45,12 @@
               tool?.source.namespace + '/' + tool?.source.name + (tool?.source.toolname ? '/' + tool?.source.toolname : '')
             }}</a>
           </ng-template>
-          <div class="truncate-text-3">
+          <div>
+            <span>{{ tool?.source.topicAutomatic }}</span>
             <app-ai-bubble
               *ngIf="tool?.source.topicSelection === TopicSelectionEnum.AI && !tool?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span>{{ tool?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/search/search-workflow-table/search-workflow-table.component.html
+++ b/src/app/search/search-workflow-table/search-workflow-table.component.html
@@ -19,12 +19,12 @@
                 (workflow?.source.workflowName ? '/' + workflow?.source.workflowName : '')
             }}</a
           >
-          <div class="truncate-text-3">
+          <div>
+            <span>{{ workflow?.source.topicAutomatic }}</span>
             <app-ai-bubble
               *ngIf="workflow?.source.topicSelection === TopicSelectionEnum.AI && !workflow?.source.approvedAITopic"
               [isPublic]="true"
             ></app-ai-bubble>
-            <span>{{ workflow?.source.topicAutomatic }}</span>
           </div>
         </div>
       </mat-cell>

--- a/src/app/shared/styles/entry-table.scss
+++ b/src/app/shared/styles/entry-table.scss
@@ -48,8 +48,3 @@ th {
   white-space: nowrap;
   vertical-align: top;
 }
-
-// Align AI bubble all the way to the left
-app-ai-bubble {
-  margin-left: 0;
-}


### PR DESCRIPTION
**Description**
This PR addresses the first usability feedback point in this [document](https://docs.google.com/document/d/1nKpw3D-BajzwgpSWipUGgDWCv9YRUXt4BQHfPTtj8iE/edit?tab=t.0):

> In each hit on the search page, the "AI bubble" (displayed prior to the topic) and the new "entry bullet" icon are very close to each other, and both lead their respective lines, causing readability issues, because the confluence of the two elements is very busy, and they cause the apparent indentation of the first word on each line to be different, and neither first word to align with the left margin.
Possible alternative: display "AI bubble" at the end of the topic. 

Following https://github.com/dockstore/dockstore-ui2/pull/2036, we no longer display the tooltip for the topics on the search page because there is no truncation happening since we set the truncation to 3 lines. I don't think it makes sense to keep the truncation since our topics are limited to 250 characters which fit within the 3 lines. When we eventually move to a card-style display for the search page, the truncation will be even less relevant since there's more space.

By removing the truncation, this allows us to move the AI bubble to the end of the sentence, addressing Steve's usability comment. We initially put it at the beginning of the topic because the truncation would also remove the AI bubble.

Before:
![Screenshot 2024-10-25 at 14-05-02 Dockstore Search](https://github.com/user-attachments/assets/c3b1c107-ff91-4c8c-9943-90cddf790faa)


After:
![Screenshot 2024-10-25 at 14-04-46 Dockstore Search](https://github.com/user-attachments/assets/cf401e06-33c9-452e-a311-a562e7db8b94)


**Review Instructions**
On staging, go to the search page and verify that the AI bubble is at the end of the AI topic.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6727

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
