### PR TITLE
Display same DOI icon on public Versions tab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - setup_integration_test
       - run:
           name: Test
-          command: bash -i -c 'npx cypress run --browser chrome --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/e2e/<< parameters.integration_test_name >>/**/*'
+          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/e2e/<< parameters.integration_test_name >>/**/*'
           no_output_timeout: 30m
           environment:
             MOCHA_FILE: integration-tests/test-results/junit/test-results-[hash].xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - setup_integration_test
       - run:
           name: Test
-          command: bash -i -c 'npx cypress run --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/e2e/<< parameters.integration_test_name >>/**/*'
+          command: bash -i -c 'npx cypress run --browser chrome --record --config numTestsKeptInMemory=1 --reporter junit --spec cypress/e2e/<< parameters.integration_test_name >>/**/*'
           no_output_timeout: 30m
           environment:
             MOCHA_FILE: integration-tests/test-results/junit/test-results-[hash].xml

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -252,7 +252,11 @@
         DOI
       </th>
       <td mat-cell *matCellDef="let version">
-        <mat-icon *ngIf="this.publicPage && version.dois[workflow.doiSelection]">check</mat-icon>
+        <app-doi-badge
+          *ngIf="this.publicPage && version.dois[workflow.doiSelection]"
+          [doi]="version.dois[workflow.doiSelection]"
+          [displayDoi]="false"
+        ></app-doi-badge>
         <span *ngIf="!this.publicPage" fxLayout="row" fxLayoutGap="0.5rem">
           <span *ngFor="let doiEntry of version.dois | keyvalue: originalOrder">
             <app-doi-badge [doi]="doiEntry.value" [displayDoi]="false"></app-doi-badge>


### PR DESCRIPTION
**Description**
This PR updates the public Versions table so that it uses the same DOI icon as the private Versions table. The public Version previously had a check mark to indicate if it has a DOI. Now it has a DOI initiator icon which also indicates the source of the DOI.

Before:
![Screenshot 2024-10-25 at 14-41-29 Dockstore Workflow github com_kathy-t_ghapps-single-workflow github com_kathy-t_ghapps-single-workflow](https://github.com/user-attachments/assets/16c0e602-6ba4-4a1a-bfd3-a360a3dcc23f)

After:
![Screenshot 2024-10-25 at 14-40-33 Dockstore Workflow github com_kathy-t_ghapps-single-workflow github com_kathy-t_ghapps-single-workflow](https://github.com/user-attachments/assets/07c463c3-5d40-4728-b444-149672ac2d3a)


**Review Instructions**
Go to a public workflow with DOIs, navigate to the Versions tab, and verify that the DOI column uses the same icon as the private Versions page. Note that the public page will only show 1 DOI icon for each version because it only displays information about the DOIs with the selected DOI initiator.

**Issue**
dockstore/dockstore#6026
[DOCK-2595](https://ucsc-cgl.atlassian.net/browse/DOCK-2595)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 


[DOCK-2595]: https://ucsc-cgl.atlassian.net/browse/DOCK-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ