### PR TITLE
Typo in landing page

### DIFF
--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -174,7 +174,7 @@
                 <span class="code primary-3">## or grab one that the workflow author has provided (if applicable)</span>
                 <span class="code"><span style="color: #3f51b5">wget --header=</span><span style="color: #0277bd">'Accept: text/plain' </span><span class="warn-1">https://dockstore.org/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fdockstore%2Fbcc2020-training%2FHelloWorld/versions/master/PLAIN_WDL/descriptor/..%2F..%2Ftest.json -O Dockstore.json</span></span>
                 <span class="code primary-3">## Run locally with the Dockstore CLI</span>
-                <span class="code"><span style="color: #3f51b5">dockstore</span><span style="color: #0277bd">' workflow launch --entry </span><span class="warn-1">github.com/dockstore/bcc2020-training/HelloWorld:master --json Dockstore.json</span></span>
+                <span class="code"><span style="color: #3f51b5">dockstore</span> <span style="color: #0277bd">workflow launch --entry </span><span class="warn-1">github.com/dockstore/bcc2020-training/HelloWorld:master --json Dockstore.json</span></span>
               </pre>
             </div>
           </div>


### PR DESCRIPTION
**Description**
Typo, notice the apostrophe

<img width="361" alt="image" src="https://github.com/user-attachments/assets/f0c0d037-2182-4072-96b6-7a9f7e742419">


**Review Instructions**

I fear no one ever tried this

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
