### PR TITLE
SEAB-6767: Fix launch-with button "has no content" bug

### DIFF
--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -889,6 +889,12 @@ export class WorkflowsStubService {
   updateWorkflowDefaultVersion(workflowId: number, tag: string) {
     return observableOf([]);
   }
+  primaryDescriptor1(workflowId, descriptorType, versionName) {
+    return observableOf({});
+  }
+  secondaryDescriptors1(workflowId, descriptorType, versionName) {
+    return observableOf([]);
+  }
 }
 
 export class ContainersStubService {

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/cor
 import { MatLegacyDialog as MatDialog, MatLegacyDialogModule } from '@angular/material/legacy-dialog';
 import { DescriptorLanguageService } from 'app/shared/entry/descriptor-language.service';
 import { combineLatest, Observable, Subscription } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
+import { map, shareReplay, takeUntil } from 'rxjs/operators';
 import { Base } from '../../shared/base';
 import { Dockstore } from '../../shared/dockstore.model';
 import { CloudInstance, CloudInstancesService, User, Workflow, WorkflowVersion } from '../../shared/openapi';
@@ -297,11 +297,13 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
         this.descriptorLanguageService.workflowDescriptorTypeEnumToExtendedDescriptorLanguageBean(descriptorType).descriptorLanguageEnum;
       this.primaryDescriptorSubscription = this.workflowsService
         .primaryDescriptor1(this.workflow.id, descriptorType, this.selectedVersion.name)
+        .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe((sourceFile) => {
           this.descriptorsService.updatePrimaryDescriptor(sourceFile);
         });
       this.secondaryDescriptorsSubscription = this.workflowsService
         .secondaryDescriptors1(this.workflow.id, descriptorLanguageEnum, this.selectedVersion.name)
+        .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe((sourceFiles: Array<SourceFile>) => {
           this.descriptorsService.updateSecondaryDescriptors(sourceFiles);
         });

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -164,7 +164,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     ]).subscribe(
       ([toolFiles, descriptorFiles]) => {
         // test parameter file is optional ...
-        if (toolFiles !== undefined) {
+        if (toolFiles != undefined) {
           if (toolFiles.length > 0) {
             this.testParameterPath = toolFiles[0].path;
           } else {

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -164,7 +164,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     ]).subscribe(
       ([toolFiles, descriptorFiles]) => {
         // test parameter file is optional ...
-        if (toolFiles != undefined) {
+        if (toolFiles) {
           if (toolFiles.length > 0) {
             this.testParameterPath = toolFiles[0].path;
           } else {


### PR DESCRIPTION
**Description**
This PR fixes the "has no content" launch-with button bug, which is described in https://ucsc-cgl.atlassian.net/browse/SEAB-6767.

The bug is caused by the complicated, asynchronous information flow through our UI, due to the web of Observables and Subscriptions that we have woven.  We have discussed removing Akita, and if/when we do, we should consider reevaluating this part of our UI's information management model. 

Because our UI code sets the workflow and version name at different clicks, `ngOnChanges` is called twice when the launch-with component is initialized, and the second call has consistent/correct values.  We move the primary/secondary descriptor retrieval code to `ngOnChanges` to more closely couple it to the final `ngOnChanges` call.

**Review Instructions**
Confirm that you cannot reproduce the bug, using the steps detailed in the Slack thread which is linked in the ticket.  Then, view successive entry pages (by navigating our UI, without reloading the page) and confirm that it does not feel laggier.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6767

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
