### PR TITLE
SEAB-6748: Fix "Flash Of Previous Entry" for some entry types

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -13,7 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<app-workflow *ngIf="displayAppTool" [isWorkflowPublic]="isToolPublic"></app-workflow>
+<app-workflow *ngIf="displayAppTool" [isWorkflowPublic]="isToolPublic" [shouldClear]="false"></app-workflow>
 <div *ngIf="tool && !displayAppTool">
   <div class="row m-1 mt-3 mb-0" *ngIf="tool?.archived">
     <mat-card class="alert alert-warning mat-elevation-z m-0">

--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -13,7 +13,7 @@
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
   -->
-<app-workflow *ngIf="displayAppTool" [isWorkflowPublic]="isToolPublic" [shouldClear]="false"></app-workflow>
+<app-workflow *ngIf="displayAppTool" [isWorkflowPublic]="isToolPublic" [shouldClearState]="false"></app-workflow>
 <div *ngIf="tool && !displayAppTool">
   <div class="row m-1 mt-3 mb-0" *ngIf="tool?.archived">
     <mat-card class="alert alert-warning mat-elevation-z m-0">

--- a/src/app/container/container.component.ts
+++ b/src/app/container/container.component.ts
@@ -197,7 +197,7 @@ export class ContainerComponent extends Entry<Tag> implements AfterViewInit, OnI
   }
 
   ngOnInit() {
-    this.init();
+    this.init(false);
   }
 
   ngAfterViewInit() {

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -62,6 +62,7 @@ export abstract class Entry<V extends WorkflowVersion | Tag> implements OnDestro
   location: Location;
   @Input() isWorkflowPublic = true;
   @Input() isToolPublic = true;
+  @Input() shouldClear = true;
   public publicPage: boolean;
   public versionsFileTypes: Array<SourceFile.TypeEnum> = [];
   public versionsWithVerifiedPlatforms: Array<VersionVerifiedPlatform> = [];
@@ -92,8 +93,9 @@ export abstract class Entry<V extends WorkflowVersion | Tag> implements OnDestro
   }
 
   init() {
-    // Getting rid of this line makes the linking work again and I didn't notice any weird behaviour, but I'm not sure.. Needs more testing
-    // this.clearState();
+    if (this.shouldClear) {
+      this.clearState();
+    }
     this.subscriptions();
     this.router.events
       .pipe(

--- a/src/app/shared/entry.ts
+++ b/src/app/shared/entry.ts
@@ -62,7 +62,6 @@ export abstract class Entry<V extends WorkflowVersion | Tag> implements OnDestro
   location: Location;
   @Input() isWorkflowPublic = true;
   @Input() isToolPublic = true;
-  @Input() shouldClear = true;
   public publicPage: boolean;
   public versionsFileTypes: Array<SourceFile.TypeEnum> = [];
   public versionsWithVerifiedPlatforms: Array<VersionVerifiedPlatform> = [];
@@ -92,8 +91,13 @@ export abstract class Entry<V extends WorkflowVersion | Tag> implements OnDestro
     this.gA4GHFilesService.clearFiles();
   }
 
-  init() {
-    if (this.shouldClear) {
+  init(shouldClearState: boolean) {
+    // In a PR that added support for displaying AppTools, this clearState call was commented out:
+    // https://github.com/dockstore/dockstore-ui2/pull/1388#discussion_r761229496
+    // It has been partially restored, for non-tool/AppTool entry types, to eliminate the
+    // Flash Of Previous Entry (FOPE) problem for those entry types:
+    // https://ucsc-cgl.atlassian.net/browse/SEAB-6748
+    if (shouldClearState) {
       this.clearState();
     }
     this.subscriptions();

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -267,7 +267,6 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   }
 
   ngOnInit(): void {
-    console.log(`INIT WORKFLOW ${this.workflow?.id} VERSION ${this.selectedVersion?.name}`);
     this.user$ = this.userQuery.user$;
     this.cloudInstanceService.getCloudInstances().subscribe((cloudInstances: Array<CloudInstance>) => {
       this.cloudInstances = cloudInstances;
@@ -281,7 +280,6 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    console.log(`CHANGES WORKFLOW ${this.workflow?.id} VERSION ${this.selectedVersion?.name}`);
     this.descriptorsQuery.clear();
     this.primaryDescriptorSubscription?.unsubscribe();
     this.secondaryDescriptorsSubscription?.unsubscribe();

--- a/src/app/workflow/launch-third-party/launch-third-party.component.ts
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.ts
@@ -267,6 +267,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   }
 
   ngOnInit(): void {
+    console.log(`INIT WORKFLOW ${this.workflow?.id} VERSION ${this.selectedVersion?.name}`);
     this.user$ = this.userQuery.user$;
     this.cloudInstanceService.getCloudInstances().subscribe((cloudInstances: Array<CloudInstance>) => {
       this.cloudInstances = cloudInstances;
@@ -280,6 +281,7 @@ export class LaunchThirdPartyComponent extends Base implements OnChanges, OnInit
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    console.log(`CHANGES WORKFLOW ${this.workflow?.id} VERSION ${this.selectedVersion?.name}`);
     this.descriptorsQuery.clear();
     this.primaryDescriptorSubscription?.unsubscribe();
     this.secondaryDescriptorsSubscription?.unsubscribe();

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -210,6 +210,7 @@ export class WorkflowComponent extends Entry<WorkflowVersion> implements AfterVi
 
   @Input() user;
   @Input() selectedVersion: WorkflowVersion;
+  @Input() shouldClearState: boolean = true;
 
   constructor(
     private dockstoreService: DockstoreService,
@@ -283,7 +284,7 @@ export class WorkflowComponent extends Entry<WorkflowVersion> implements AfterVi
   }
 
   ngOnInit() {
-    this.init();
+    this.init(this.shouldClearState);
     //watch for changes in search
     this.versionFilterCtrl.valueChanges.pipe(takeUntil(this.ngUnsubscribe)).subscribe(() => {
       this.filterVersions();


### PR DESCRIPTION
**Description**
This PR fixes the "Flash Of Previous Entry" (FOPE) bug for non-tool/AppTool entry types, by restoring an `Entry.clearState` call for those entry types, which is called at component initialization time.  This call was commented out in a PR that added support for AppTools: https://github.com/dockstore/dockstore-ui2/pull/1388#discussion_r761229496

Indeed, consistent with the accompanying comment that was added in that PR, if you simply restore the `clearState` call for all entry types, the tool pages get messed up (nothing is displayed).  There might be a smallish fix for tools/AppTools which mostly works, but it would be very risky, there's lots of looping information and hard-to-quantify data dependencies in this part of the code.

Fixing the problem for all entry types might best be done if/when we refactor our entry state storage model, hopefully simplifying the web of observables and gathering together the little bits of state that are spread out everywhere.

IMHO, this PR improves the appearance/feel of page loads for the affected entry types.  I think it's relatively safe, and I would support putting it into the 1.16 release, with the caveat that there is some risk: the current entry state architecture is very hard to reason about and modify, and easy to change in a way that inadvertently breaks something.

**Review Instructions**
Try to reproduce the FOPE per the ticket and confirm that you cannot for workflows and notebooks.  Go to the "my entries" section of the dashboard, flip between successive tools, and confirm that their pages display correctly.  Repeat this step for AppTools, workflows, and notebooks.  Go to the search page, select a tool, go back to the search page, select a different tool, and confirm that their pages display correctly.  Repeat this step for AppTools.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6748

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
