### PR TITLE
SEAB-6777: Improve formatting of workflow "Versions" table

### DIFF
--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -104,7 +104,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="The {{
           workflow.entryType === entryType.NOTEBOOK ? 'format' : 'language versions'
         }} used by the version's descriptor file(s)."
@@ -124,7 +123,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="The minimum required {{ workflow.descriptorType | descriptorLanguage }} engine version."
         matTooltipPosition="above"
       >
@@ -142,7 +140,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="A version is valid if the descriptor file(s) have been successfully validated."
         matTooltipPosition="above"
       >
@@ -158,7 +155,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="A hidden version is only visible here and not publicly."
         matTooltipPosition="above"
       >
@@ -174,7 +170,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="The version has a test parameter file with open data or requires no input files."
         matTooltipPosition="above"
       >
@@ -207,7 +202,6 @@
         scope="col"
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header
         matTooltip="The version has has execution and/or validation metrics."
         matTooltipPosition="above"
       >

--- a/src/app/workflow/versions/versions.component.scss
+++ b/src/app/workflow/versions/versions.component.scss
@@ -49,3 +49,14 @@ tr.mat-row.highlight {
 tr.highlight > .mat-cell:first-of-type > span {
   padding-left: 5px;
 }
+
+.mat-cell:not(:first-of-type),
+.mat-header-cell:not(:first-of-type) {
+  padding-left: 1rem;
+}
+
+.mat-cell:not(:last-of-type),
+.mat-header-cell:not(:last-of-type),
+table th {
+  padding-right: 1rem;
+}

--- a/src/app/workflow/versions/versions.component.scss
+++ b/src/app/workflow/versions/versions.component.scss
@@ -50,6 +50,8 @@ tr.highlight > .mat-cell:first-of-type > span {
   padding-left: 5px;
 }
 
+/* Narrow the version table columns by decreasing their padding. */
+/* See https://ucsc-cgl.atlassian.net/browse/SEAB-6777 */
 .mat-cell:not(:first-of-type),
 .mat-header-cell:not(:first-of-type) {
   padding-left: 1rem;


### PR DESCRIPTION
**Description**
This PR improves the workflow page's "Versions" table so that it fits horizontally into our UI when the browser window is wide.  Previously, the table was too wide for space afforded to it by our UI, causing the rightmost elements to be hidden behind other elements, wide content to be wrapped over multiple lines, and a scrollbar to appear at bottom.

Specifically, this PR:
1. removes the "sort" control from all but the "Git Reference" and "Date Modified" columns.
2. decreases the padding between adjacent columns.

These changes allow the column headers to fit within the available space, and provide extra horizontal space that columns containing wide content can scale into.

These changes make a big difference, improving the spacing and flow of the table for most workflows.  Arguably, the table is less useful because we now can't sort some columns, but IMHO, the readability improvement greatly outweighs any drawbacks.

Before (develop):
<img width="1393" alt="dump 2024-11-13 at 5 54 39 PM" src="https://github.com/user-attachments/assets/e8fd0701-f949-40ae-bef6-aaa777e70b50">

After (this PR):
<img width="1403" alt="dump 2024-11-13 at 5 53 46 PM" src="https://github.com/user-attachments/assets/7a431f01-46d8-4cac-a82f-bb14509ba518">

The tool table contains less information, and didn't need these changes.

At narrow browser widths, the table still gets mangled/hidden.   A possible next step might be to remove the "information circles" and instead directly link the table heading text to the documentation. 

**Review Instructions**
Scale your browser to maximum width, view a workflow's "Versions" table, and confirm that it fits horizontally and that there is no scroll bar.  Do the same for some other types of workflows.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6777

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
