### PR TITLE
DOCK-2591: Use webservice-defined sort ordering in workflow versions table by default

### DIFF
--- a/cypress/e2e/group1/checkerWorkflowFromWorkflow.ts
+++ b/cypress/e2e/group1/checkerWorkflowFromWorkflow.ts
@@ -123,9 +123,6 @@ describe('Checker workflow test from my-workflows', () => {
       cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
 
       goToTab('Versions');
-      // Need to press this twice to get the sort into "last modified last" order
-      cy.get('[data-cy=date-modified-header]').should('be.visible').click();
-      cy.get('[data-cy=date-modified-header]').should('be.visible').click();
       cy.wait(1000); //waits for the sorting to finish to ensure Actions button is clicked for the right version (was encountering flakiness)
 
       cy.contains('button', 'Actions').click();

--- a/cypress/e2e/group1/checkerWorkflowFromWorkflow.ts
+++ b/cypress/e2e/group1/checkerWorkflowFromWorkflow.ts
@@ -123,6 +123,8 @@ describe('Checker workflow test from my-workflows', () => {
       cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
 
       goToTab('Versions');
+      // Need to press this twice to get the sort into "last modified last" order
+      cy.get('[data-cy=date-modified-header]').should('be.visible').click();
       cy.get('[data-cy=date-modified-header]').should('be.visible').click();
       cy.wait(1000); //waits for the sorting to finish to ensure Actions button is clicked for the right version (was encountering flakiness)
 

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -431,7 +431,6 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=dockstore-request-doi-button]').click();
       cy.get('[data-cy=export-button').should('be.enabled');
       cy.get('[data-cy=export-button').click();
-
       cy.fixture('versionWithDoi.json').then((json) => {
         cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortOrder=desc', {
           body: json,
@@ -457,8 +456,7 @@ describe('Dockstore my workflows part 2', () => {
           statusCode: 200,
         }).as('getVersionAfterOrcidExport');
       });
-      goToTab('Versions');
-      cy.get('td').contains('Actions').click();
+      gotoVersionsAndClickActions();
       cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
     });
   });

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -433,7 +433,7 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=export-button').click();
 
       cy.fixture('versionWithDoi.json').then((json) => {
-        cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortCol=lastModified&sortOrder=asc', {
+        cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortOrder=desc', {
           body: json,
           statusCode: 200,
         }).as('getVersionWithDoi');
@@ -452,7 +452,7 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=export-button').should('be.enabled');
       cy.get('[data-cy=export-button').click();
       cy.fixture('versionAfterOrcidExport.json').then((json) => {
-        cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortCol=lastModified&sortOrder=asc', {
+        cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortOrder=desc', {
           body: json,
           statusCode: 200,
         }).as('getVersionAfterOrcidExport');

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -444,7 +444,6 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=concept-DOI-badge]').should('be.visible');
       cy.get('[data-cy=version-DOI-badge]').should('be.visible');
       goToTab('Versions');
-      cy.wait(1000);
       cy.get('td').contains('Actions').click();
       cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
 

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -337,7 +337,6 @@ describe('Dockstore my workflows part 2', () => {
     cy.visit('/my-workflows/github.com/A/l');
     cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
     goToTab('Versions');
-    cy.get('[data-cy=date-modified-header]').should('be.visible').click();
     cy.wait(1000);
 
     cy.get('td').contains('Actions').click();
@@ -504,7 +503,6 @@ describe('Dockstore my workflows part 2', () => {
     cy.visit('/my-workflows/github.com/A/l');
     cy.url().should('eq', Cypress.config().baseUrl + '/my-workflows/github.com/A/l');
     goToTab('Versions');
-    cy.get('[data-cy=date-modified-header]').should('be.visible').click();
     cy.wait(1000);
     cy.contains('button', 'Actions').click();
     cy.contains('button', 'Refresh Version').should('not.be.disabled');
@@ -661,7 +659,6 @@ describe('Dockstore my workflows part 3', () => {
       cy.get('#publishButton').should('contain', 'Publish').should('be.visible');
 
       goToTab('Versions');
-      cy.get('[data-cy=date-modified-header]').should('be.visible').click();
       cy.wait(1000);
       cy.contains('button', 'Actions').click();
       cy.get('[data-cy=set-default-version-button]').should('be.visible').click();

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -444,6 +444,7 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=concept-DOI-badge]').should('be.visible');
       cy.get('[data-cy=version-DOI-badge]').should('be.visible');
       goToTab('Versions');
+      cy.wait(1000);
       cy.get('td').contains('Actions').click();
       cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
 

--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -428,15 +428,15 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=version-DOI-badge]').should('not.exist');
       gotoVersionsAndClickActions();
       // Request DOI
-      cy.get('[data-cy=dockstore-request-doi-button]').click();
-      cy.get('[data-cy=export-button').should('be.enabled');
-      cy.get('[data-cy=export-button').click();
       cy.fixture('versionWithDoi.json').then((json) => {
         cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortOrder=desc', {
           body: json,
           statusCode: 200,
         }).as('getVersionWithDoi');
       });
+      cy.get('[data-cy=dockstore-request-doi-button]').click();
+      cy.get('[data-cy=export-button').should('be.enabled');
+      cy.get('[data-cy=export-button').click();
 
       // Should have DOI badges now
       cy.get('[data-cy=user-DOI-icon]').should('be.visible');
@@ -447,15 +447,15 @@ describe('Dockstore my workflows part 2', () => {
       cy.get('[data-cy=dockstore-request-doi-button').should('not.exist'); // Should not be able to request another DOI
 
       // Export to ORCID
-      cy.get('[data-cy=dockstore-export-orcid-button]').click();
-      cy.get('[data-cy=export-button').should('be.enabled');
-      cy.get('[data-cy=export-button').click();
       cy.fixture('versionAfterOrcidExport.json').then((json) => {
         cy.intercept('GET', '/api/workflows/11/workflowVersions?limit=10&offset=0&sortOrder=desc', {
           body: json,
           statusCode: 200,
         }).as('getVersionAfterOrcidExport');
       });
+      cy.get('[data-cy=dockstore-export-orcid-button]').click();
+      cy.get('[data-cy=export-button').should('be.enabled');
+      cy.get('[data-cy=export-button').click();
       gotoVersionsAndClickActions();
       cy.get('[data-cy=dockstore-export-orcid-button]').should('not.exist'); // Should not be able to export to ORCID again
     });

--- a/cypress/fixtures/getWorkflowWithDoi.json
+++ b/cypress/fixtures/getWorkflowWithDoi.json
@@ -105,6 +105,7 @@
         "doiURL": null,
         "dois": {
             "USER": {
+                "id": 1234,
                 "type": "VERSION",
                 "name": "10.5072/zenodo.841014",
                 "initiator": "USER"
@@ -137,7 +138,14 @@
         "versionEditor": null,
         "versionMetadata": {
           "descriptorTypeVersions": [],
-          "dois": {},
+          "dois": {
+             "USER": {
+              "id": 1234,
+              "type": "VERSION",
+              "name": "10.5072/zenodo.841014",
+              "initiator": "USER"
+            }
+          },
           "engineVersions": [],
           "id": 13,
           "parsedInformationSet": [],

--- a/cypress/fixtures/versionWithDoi.json
+++ b/cypress/fixtures/versionWithDoi.json
@@ -19,6 +19,7 @@
     "doiURL": null,
     "dois": {
       "USER": {
+        "id": 1234,
         "type": "VERSION",
         "name": "10.5072/zenodo.841014",
         "initiator": "USER"
@@ -53,6 +54,7 @@
       "descriptorTypeVersions": [],
       "dois": {
         "USER": {
+          "id": 1234,
           "type": "VERSION",
           "name": "10.5072/zenodo.841014",
           "initiator": "USER"

--- a/cypress/fixtures/versionWithDoi.json
+++ b/cypress/fixtures/versionWithDoi.json
@@ -51,7 +51,13 @@
     "versionEditor": null,
     "versionMetadata": {
       "descriptorTypeVersions": [],
-      "dois": {},
+      "dois": {
+        "USER": {
+          "type": "VERSION",
+          "name": "10.5072/zenodo.841014",
+          "initiator": "USER"
+        }
+      },
       "engineVersions": [],
       "id": 13,
       "parsedInformationSet": [],

--- a/src/app/workflow/versions/versions.component.html
+++ b/src/app/workflow/versions/versions.component.html
@@ -21,9 +21,7 @@
     [dataSource]="dataSource"
     class="w-100"
     matSort
-    matSortActive="last_modified"
-    matSortDisableClear
-    matSortDirection="desc"
+    matSortStart="asc"
     [trackBy]="trackBy"
   >
     <ng-container matColumnDef="name">
@@ -85,7 +83,7 @@
         mat-header-cell
         *matHeaderCellDef
         mat-sort-header
-        disableClear
+        start="desc"
         matTooltip="Date of last update to Git reference"
         matTooltipPosition="above"
         data-cy="date-modified-header"


### PR DESCRIPTION
**Description**
As it turns out, the UI was already using the webservice-defined sort order when the versions table was loaded.  I confirmed this by observing that the request to the webservice did not include a `sortCol` parameter, and that initially, the default version always appeared at the top, no matter when it was last updated.  However, the UI was incorrectly indicating that it was sorting by "Last Modified" in descending order (the black arrow appeared next to the "Last Modified" header).
 
This PR changes the UI so that the version table sort controls now have three states ("none", "ascending", and "descending"), they start off set to "none". and they display their state correctly.

This is similar to how the search table works: the controls initially don't specify any sort ordering. In that case, we supply a default sort order in the ES query.

For the workflow versions table, we let the webservice decide the order, because it has access to all of the versions and we can code whatever ordering logic we like, allowing us the freedom to implement whatever default order is appropriate.  Currently, we implement the "default version at top" rule, but later, we could do other things, like bubble release tags towards the top, `main` and `develop`, etc... This could be rule-based: for example, `main`, then `develop`, then release tags, then other versions.  Or, the sort query could calculate a numerical "importance" for each version, based on whether it was the default branch, a release tag, a mainline branch, feature branch, creation/modification date, etc., and sort on it.

**Review Instructions**
Find a workflow that has a default version that's not the last modified version.  Make sure that when the workflow's versions table is first displayed, the default version appears first, and then is followed by other versions in descending "Last Modified" order.  Confirm that the sort controls are in "none" state.  Then, toggle them and confirm that the versions sort correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2591
dockstore/dockstore#6019

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
