### PR TITLE
Fix ui2 integration tests

### DIFF
--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -202,6 +202,7 @@ describe('GitHub App Tools', () => {
       cy.contains('/.dockstore.yml');
 
       selectUnpublishedGitHubAppTab('C');
+      cy.wait(1000);
       selectGitHubAppTool('test-github-app-tools/md5sum');
       cy.get('#publishButton').should('not.be.disabled');
       cy.get('[data-cy=viewPublicWorkflowButton]').should('not.exist');

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -102,16 +102,16 @@ describe('GitHub App Tools', () => {
       // GitHub App Logs
       cy.contains('Apps Logs').click();
       cy.wait('@lambdaEvents1');
-      cy.wait(1000);
       cy.contains('There were problems retrieving the GitHub App logs for this organization.');
+      cy.wait(1000);
       cy.contains('Close').click();
       cy.intercept('GET', '/api/lambdaEvents/**', {
         body: [],
       }).as('lambdaEvents2');
       cy.contains('Apps Logs').click();
       cy.wait('@lambdaEvents2');
-      cy.wait(1000);
       cy.contains('There are no GitHub App logs for this organization.');
+      cy.wait(1000);
       cy.contains('Close').click();
 
       const realResponse: LambdaEvent[] = [
@@ -212,7 +212,7 @@ describe('GitHub App Tools', () => {
       cy.contains('Default Version Required');
       cy.get('[data-cy=close-dialog-button]').click();
       goToTab('Versions');
-      cy.contains('button', 'Actions').click();
+      cy.contains('tr', 'invalidTool').contains('button', 'Actions').click();
       cy.contains('button', 'Set as Default Version').should('be.visible').click();
       cy.wait(500);
       cy.get('#publishButton').should('not.be.disabled');

--- a/cypress/e2e/group3/githubAppTools.ts
+++ b/cypress/e2e/group3/githubAppTools.ts
@@ -102,6 +102,7 @@ describe('GitHub App Tools', () => {
       // GitHub App Logs
       cy.contains('Apps Logs').click();
       cy.wait('@lambdaEvents1');
+      cy.wait(1000);
       cy.contains('There were problems retrieving the GitHub App logs for this organization.');
       cy.contains('Close').click();
       cy.intercept('GET', '/api/lambdaEvents/**', {
@@ -109,6 +110,7 @@ describe('GitHub App Tools', () => {
       }).as('lambdaEvents2');
       cy.contains('Apps Logs').click();
       cy.wait('@lambdaEvents2');
+      cy.wait(1000);
       cy.contains('There are no GitHub App logs for this organization.');
       cy.contains('Close').click();
 

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -36,7 +36,11 @@ describe('Find broken anchor links', () => {
               url: href,
               failOnStatusCode: false,
             }).then((result) => {
-              if (result.status != 200) {
+              const isOk = result.status === 200;
+              // Is the response a cloudflare challenge?
+              // https://developers.cloudflare.com/waf/reference/cloudflare-challenges/
+              const isChallenge = result.status === 403 && result.headers['cf-mitigated'] === 'challenge';
+              if (!isOk && !isChallenge) {
                 brokenUrls.push(href);
                 cy.log(`${result.status}: ${href}`);
               } else {

--- a/cypress/e2e/immutableDatabaseTests/linkCheck.ts
+++ b/cypress/e2e/immutableDatabaseTests/linkCheck.ts
@@ -40,11 +40,11 @@ describe('Find broken anchor links', () => {
               // Is the response a cloudflare challenge?
               // https://developers.cloudflare.com/waf/reference/cloudflare-challenges/
               const isChallenge = result.status === 403 && result.headers['cf-mitigated'] === 'challenge';
-              if (!isOk && !isChallenge) {
+              if (isOk || isChallenge) {
+                visitedUrls.push(href); // Add successful links to visitedUrls so that they won't be visited again
+              } else {
                 brokenUrls.push(href);
                 cy.log(`${result.status}: ${href}`);
-              } else {
-                visitedUrls.push(href); // Add successful links to visitedUrls so that they won't be visited again
               }
             });
           }


### PR DESCRIPTION
**Description**
Recently, the ui2 integration tests have been flaking a lot in `cypress/e2e/group3/githubAppTools.ts`, and in the linkcheck, when checking the URL https://doi.org/10.1093/nar/gkab346, which was consistently responding with a Cloudflare challenge.

And, as it turns out, beyond the flake sites, the tests were actually broken due to commit https://github.com/dockstore/dockstore/commit/4786a289a70a7eceb7e3b069572f75a54a455663 on Dec 9, which changed the default ordering of workflow versions.  The UI was coded so that the new search order was used by default, which violated an assumption in one of the tests.

This PR:
1. adds some `cy.wait`s to avoid race conditions.
2. changes the linkcheck so that it does not "fail" a url that responds with a cloudflare challenge.
3. fixes a `cy.contains` to more specifically target the desired row in the versions table.

After this PR, the tests are flaking much less, although they still do sometimes flake.

**Review Instructions**
Confirm that the ui2 circleci tests on the develop branch are passing, more than half of the time.

**Issue**
None.

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
