### PR TITLE
SEAB-6840: remove redundant "More" dropdown

### DIFF
--- a/cypress/e2e/group2/myworkflows.ts
+++ b/cypress/e2e/group2/myworkflows.ts
@@ -53,7 +53,6 @@ describe('Dockstore my workflows', () => {
     });
 
     cy.visit('/my-workflows');
-    cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
     cy.fixture('myWorkflows.json').then((json) => {
       cy.intercept('GET', '/api/users/1/workflows', {
         body: json,

--- a/cypress/e2e/group2/notebooks.ts
+++ b/cypress/e2e/group2/notebooks.ts
@@ -141,7 +141,6 @@ describe('Dockstore notebooks', () => {
     });
 
     cy.visit('/my-notebooks');
-    cy.get('[data-cy=myWorkflowsMoreActionButtons]').should('be.visible').click();
     cy.fixture('myNotebooks.json').then((json) => {
       cy.intercept('GET', '/api/users/1/notebooks', {
         body: json,

--- a/cypress/e2e/group2/notebooks.ts
+++ b/cypress/e2e/group2/notebooks.ts
@@ -148,6 +148,7 @@ describe('Dockstore notebooks', () => {
       }).as('getNotebooks');
     });
     cy.get('[data-cy=addToExistingWorkflows]').should('be.visible').click();
+    cy.visit('/my-notebooks/' + name);
 
     cy.wait('@getNotebooks');
     cy.contains('addedthisnotebookviasync');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -50,12 +50,17 @@ describe('Dockstore my tools', () => {
   });
 
   it('Should have discover existing tools button', () => {
+    cy.intercept('api/containers/*?include=validations').as('getTool');
+    cy.visit('/my-tools');
+    cy.wait('@getTool');
+
     cy.fixture('myWorkflows.json').then((json) => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,
         statusCode: 200,
       });
     });
+
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
         body: json,
@@ -66,7 +71,7 @@ describe('Dockstore my tools', () => {
       body: {},
       statusCode: 200,
     }).as('getAppTools');
-    cy.wait(1000);
+
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
 
     cy.wait('@getContainers');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -50,11 +50,12 @@ describe('Dockstore my tools', () => {
   });
 
   it('Should have discover existing tools button', () => {
+    cy.visit('/my-tools');
     cy.fixture('myWorkflows.json').then((json) => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,
         statusCode: 200,
-      }).as('getWorkflows');
+      });
     });
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
@@ -67,11 +68,10 @@ describe('Dockstore my tools', () => {
       statusCode: 200,
     }).as('getAppTools');
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
-    cy.visit('/my-tools/github.com/A2/addedthistoolviasync');
+    cy.visit('/my-tools');
 
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
-    cy.wait('@getWorkflows');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -60,7 +60,6 @@ describe('Dockstore my tools', () => {
         statusCode: 200,
       });
     });
-
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
         body: json,
@@ -73,7 +72,6 @@ describe('Dockstore my tools', () => {
     }).as('getAppTools');
 
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
-
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
     cy.contains('addedthistoolviasync');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -71,6 +71,7 @@ describe('Dockstore my tools', () => {
     cy.visit('/my-tools');
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
+    selectUnpublishedTab('A2');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -56,8 +56,6 @@ describe('Dockstore my tools', () => {
         statusCode: 200,
       });
     });
-
-    cy.get('[data-cy=myToolsMoreActionButtons]').should('be.visible').click();
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
         body: json,

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -66,6 +66,7 @@ describe('Dockstore my tools', () => {
       body: {},
       statusCode: 200,
     }).as('getAppTools');
+    cy.wait(1000);
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
 
     cy.wait('@getContainers');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -67,6 +67,7 @@ describe('Dockstore my tools', () => {
       statusCode: 200,
     }).as('getAppTools');
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
+    cy.visit('/my-tools');
 
     cy.wait('@getContainers');
     cy.wait('@getAppTools');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -54,7 +54,7 @@ describe('Dockstore my tools', () => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,
         statusCode: 200,
-      }).as('getWorkflows');
+      });
     });
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
@@ -67,11 +67,10 @@ describe('Dockstore my tools', () => {
       statusCode: 200,
     }).as('getAppTools');
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
-    cy.visit('/my-tools');
+    cy.visit('/my-tools/github.com/A2/addedthistoolviasync');
 
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
-    cy.wait('@getWorkflows');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -36,7 +36,6 @@ describe('Dockstore my tools', () => {
   }
 
   function selectPublishedTab(org: string) {
-    cy.get('#tool-path').should('be.visible');
     cy.get('mat-expansion-panel-header')
       .contains(org)
       .parentsUntil('mat-accordion')

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -50,7 +50,6 @@ describe('Dockstore my tools', () => {
   });
 
   it('Should have discover existing tools button', () => {
-    cy.visit('/my-tools');
     cy.fixture('myWorkflows.json').then((json) => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,
@@ -68,8 +67,8 @@ describe('Dockstore my tools', () => {
       statusCode: 200,
     }).as('getAppTools');
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
-    cy.visit('/my-tools');
 
+    cy.visit('/my-tools');
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
     cy.contains('addedthistoolviasync');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -68,7 +68,6 @@ describe('Dockstore my tools', () => {
     }).as('getAppTools');
     cy.get('[data-cy=addToExistingTools]').should('be.visible').click();
 
-    cy.visit('/my-tools');
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
     cy.contains('addedthistoolviasync');

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -35,16 +35,6 @@ describe('Dockstore my tools', () => {
       .click();
   }
 
-  function selectPublishedTab(org: string) {
-    cy.get('mat-expansion-panel-header')
-      .contains(org)
-      .parentsUntil('mat-accordion')
-      .should('be.visible')
-      .contains('.mat-tab-label', 'Published')
-      .should('be.visible')
-      .click();
-  }
-
   function selectTool(tool: string) {
     cy.get('#tool-path').should('be.visible');
     cy.contains('div .no-wrap', tool).should('be.visible').click();
@@ -81,7 +71,6 @@ describe('Dockstore my tools', () => {
     cy.visit('/my-tools');
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
-    selectPublishedTab('A2');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -54,7 +54,7 @@ describe('Dockstore my tools', () => {
       cy.intercept('PATCH', '/api/users/1/workflows', {
         body: json,
         statusCode: 200,
-      });
+      }).as('getWorkflows');
     });
     cy.fixture('myTools.json').then((json) => {
       cy.intercept('GET', '/api/users/1/containers', {
@@ -71,6 +71,7 @@ describe('Dockstore my tools', () => {
 
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
+    cy.wait('@getWorkflows');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/e2e/group3/mytools.ts
+++ b/cypress/e2e/group3/mytools.ts
@@ -35,6 +35,17 @@ describe('Dockstore my tools', () => {
       .click();
   }
 
+  function selectPublishedTab(org: string) {
+    cy.get('#tool-path').should('be.visible');
+    cy.get('mat-expansion-panel-header')
+      .contains(org)
+      .parentsUntil('mat-accordion')
+      .should('be.visible')
+      .contains('.mat-tab-label', 'Published')
+      .should('be.visible')
+      .click();
+  }
+
   function selectTool(tool: string) {
     cy.get('#tool-path').should('be.visible');
     cy.contains('div .no-wrap', tool).should('be.visible').click();
@@ -71,7 +82,7 @@ describe('Dockstore my tools', () => {
     cy.visit('/my-tools');
     cy.wait('@getContainers');
     cy.wait('@getAppTools');
-    selectUnpublishedTab('A2');
+    selectPublishedTab('A2');
     cy.contains('addedthistoolviasync');
   });
 

--- a/cypress/fixtures/myTools.json
+++ b/cypress/fixtures/myTools.json
@@ -18,6 +18,7 @@
     "descriptorType": ["CWL"],
     "entryType": "TOOL",
     "email": null,
+    "full_workflow_path": "github.com/A2/addedthistoolviasync",
     "gitUrl": "git@github.com:A2/addedthistoolviasync.git",
     "has_checker": false,
     "id": 18,

--- a/cypress/fixtures/myTools.json
+++ b/cypress/fixtures/myTools.json
@@ -18,7 +18,6 @@
     "descriptorType": ["CWL"],
     "entryType": "TOOL",
     "email": null,
-    "full_workflow_path": "github.com/A2/addedthistoolviasync",
     "gitUrl": "git@github.com:A2/addedthistoolviasync.git",
     "has_checker": false,
     "id": 18,

--- a/src/app/mytools/my-tool/my-tool.component.html
+++ b/src/app/mytools/my-tool/my-tool.component.html
@@ -56,33 +56,19 @@
                   <img src="../../../assets/svg/icons-plus.svg" alt="Register a tool" class="pr-2 pb-1" />
                   Register a Tool
                 </button>
+
                 <button
                   mat-button
                   class="private-btn small-btn-structure ml-3 mb-3"
-                  [matMenuTriggerFor]="myToolsActions"
-                  [disabled]="isRefreshing$ | async"
-                  id="myToolsMoreActionButtons"
-                  data-cy="myToolsMoreActionButtons"
+                  (click)="addToExistingTools()"
+                  [disabled]="(isRefreshing$ | async) || (userQuery.user$ | async) === null"
+                  matTooltip="Discover tools added by others using your linked source control accounts"
+                  matTooltipPosition="after"
+                  id="addToExistingTools"
+                  data-cy="addToExistingTools"
                 >
-                  <img src="../../../assets/svg/gear-icon.svg" alt="Gear icon" />
-                  More
-                  <img src="../../../assets/svg/drop-down-arrow.svg" alt="Drop down menu icon" />
+                  <span>Discover Tools</span>
                 </button>
-                <mat-menu #myToolsActions="matMenu">
-                  <button
-                    mat-menu-item
-                    color="primary"
-                    type="button"
-                    (click)="addToExistingTools()"
-                    [disabled]="(isRefreshing$ | async) || (userQuery.user$ | async) === null"
-                    matTooltip="Discover tools added by others using your linked source control accounts"
-                    matTooltipPosition="after"
-                    id="addToExistingTools"
-                    data-cy="addToExistingTools"
-                  >
-                    <span>Discover Existing Dockstore Tools</span>
-                  </button>
-                </mat-menu>
               </div>
               <p *ngIf="(hasGroupEntriesObject$ | async) === false && (hasGroupGitHubAppToolEntriesObjects$ | async) === false">
                 You have not registered any tools

--- a/src/app/myworkflows/my-workflow/my-workflow.component.html
+++ b/src/app/myworkflows/my-workflow/my-workflow.component.html
@@ -65,30 +65,15 @@
                   *ngIf="entryType === EntryType.BioWorkflow || entryType === EntryType.Notebook"
                   mat-button
                   class="private-btn small-btn-structure ml-3 mb-3"
-                  [matMenuTriggerFor]="myWorkflowsActions"
-                  [disabled]="isRefreshing$ | async"
-                  id="myWorkflowsMoreActionButtons"
-                  data-cy="myWorkflowsMoreActionButtons"
+                  (click)="addToExistingWorkflows()"
+                  [disabled]="(isRefreshing$ | async) || (user$ | async) === null"
+                  matTooltip="Discover {{ entryType$ | async }}s added by others using your linked source control accounts"
+                  matTooltipPosition="after"
+                  id="addToExistingWorkflows"
+                  data-cy="addToExistingWorkflows"
                 >
-                  <img src="../../../assets/svg/gear-icon.svg" alt="Gear icon" />
-                  More
-                  <img src="../../../assets/svg/drop-down-arrow.svg" alt="Drop down menu icon" />
+                  <span>Discover {{ entryType$ | async | titlecase }}s</span>
                 </button>
-                <mat-menu #myWorkflowsActions="matMenu">
-                  <button
-                    mat-menu-item
-                    color="primary"
-                    type="button"
-                    (click)="addToExistingWorkflows()"
-                    [disabled]="(isRefreshing$ | async) || (user$ | async) === null"
-                    matTooltip="Discover {{ entryType$ | async }}s added by others using your linked source control accounts"
-                    matTooltipPosition="after"
-                    id="addToExistingWorkflows"
-                    data-cy="addToExistingWorkflows"
-                  >
-                    <span>Discover Existing Dockstore {{ entryType$ | async | titlecase }}s</span>
-                  </button>
-                </mat-menu>
               </div>
               <p *ngIf="(hasGroupEntriesObject$ | async) === false">You have not registered any {{ entryType$ | async }}s</p>
               <app-workflow-sidebar-accordion


### PR DESCRIPTION
**Description**
This PR removes the redundant "More" dropdown in the My Workflows and My Tools pages. 

Before: 
![image](https://github.com/user-attachments/assets/f74b25c1-dcf7-408e-bebb-28c557cb0124)

After:
![image](https://github.com/user-attachments/assets/93e92ddb-42b7-48b0-af80-e2d27311c8cf)
![image](https://github.com/user-attachments/assets/f17a8fde-ea0d-4f52-a660-36f574928890)


**Review Instructions**
Verify that the dropdown is removed

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6840
**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [ ] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
