### PR TITLE
Fix search smoke tests in staging and prod

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -10,7 +10,7 @@ describe('run stochastic smoke test', () => {
 });
 
 // TODO: set to only 'entryColumn' when search cards are deployed to staging and prod
-function getSearchDataCy(tab: string = 'Workflow') {
+function getSearchDataCy(tab: string = 'Workflows') {
   return isStagingOrProd() ? getLinkName(tab) : 'entryColumn';
 }
 

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -1,6 +1,6 @@
 import { ga4ghPath } from '../../../../src/app/shared/constants';
 import { ToolDescriptor } from '../../../../src/app/shared/openapi';
-import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeed } from '../../../support/commands';
+import { goToTab, checkFeaturedContent, checkNewsAndUpdates, checkMastodonFeed, isStagingOrProd } from '../../../support/commands';
 
 // Test an entry, these should be ambiguous between tools, workflows, and notebooks.
 describe('run stochastic smoke test', () => {
@@ -8,14 +8,33 @@ describe('run stochastic smoke test', () => {
   testEntry('Workflows');
   testEntry('Notebooks');
 });
+
+// TODO: set to only 'entryColumn' when search cards are deployed to staging and prod
+function getSearchDataCy(tab: string = 'Workflow') {
+  return isStagingOrProd() ? getLinkName(tab) : 'entryColumn';
+}
+
+function getLinkName(tab: string): string {
+  switch (tab) {
+    case 'Tools':
+      return 'toolNames';
+    case 'Workflows':
+      return 'workflowColumn';
+    case 'Notebooks':
+      return 'notebookColumn';
+    default:
+      throw new Error('unknown tab');
+  }
+}
+
 function testEntry(tab: string) {
   function goToRandomEntry() {
     cy.visit('/search');
-    cy.get('[data-cy=entryColumn] a');
+    cy.get(`[data-cy=${getSearchDataCy(tab)}] a`);
     goToTab(tab);
     // select a random entry on the first page and navigate to it
     let chosen_index = 0;
-    cy.get('[data-cy=entryColumn]')
+    cy.get(`[data-cy=${getSearchDataCy(tab)}]`)
       .then(($list) => {
         chosen_index = Math.floor(Math.random() * $list.length);
       })
@@ -54,11 +73,6 @@ function testEntry(tab: string) {
   });
 }
 
-function isStagingOrProd() {
-  const baseUrl = Cypress.config('baseUrl');
-  return baseUrl === 'https://staging.dockstore.org' || baseUrl === 'https://dockstore.org';
-}
-
 describe('Check organizations page', () => {
   it('has multiple organizations and org with content', () => {
     cy.visit('/');
@@ -90,7 +104,7 @@ describe('Test logged out home page', () => {
 describe('Test search page functionality', () => {
   it('displays tools', () => {
     cy.visit('/search');
-    cy.get('[data-cy=entryColumn]').should('have.length.of.at.least', 1);
+    cy.get(`[data-cy=${getSearchDataCy()}]`).should('have.length.of.at.least', 1);
   });
   it('has working tag cloud', () => {
     cy.visit('/search');
@@ -109,7 +123,7 @@ describe('Test search page functionality', () => {
     cy.visit('/search');
     cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow').click();
-    cy.get('[data-cy=entryColumn] a');
+    cy.get(`[data-cy=${getSearchDataCy()}] a`);
     cy.wait(2500); // Wait less than ideal, facets keep getting rerendered is the problem
     cy.contains('mat-checkbox', 'Nextflow'); // wait for the checkbox to reappear, indicating the filtering is almost complete
     cy.get('[data-cy=descriptorType]').each(($el, index, $list) => {
@@ -125,7 +139,7 @@ describe('Test search page functionality', () => {
     cy.visit('/search');
     cy.contains('mat-checkbox', /^[ ]*verified/).click();
     cy.url().should('contain', 'verified=1');
-    cy.get('[data-cy=entryColumn] a');
+    cy.get(`[data-cy=${getSearchDataCy()}] a`);
     cy.contains('mat-checkbox', /^[ ]*verified/);
   });
 });
@@ -134,11 +148,11 @@ describe('Test workflow page functionality', () => {
   it('find a WDL workflow', () => {
     cy.visit('/search');
     cy.contains('.mat-tab-label', 'Workflows');
-    cy.get('[data-cy=entryColumn]').should('have.length.of.at.least', 1);
+    cy.get(`[data-cy=${getSearchDataCy()}]`).should('have.length.of.at.least', 1);
 
     // Use facet to find WDL workflow
     cy.contains('mat-checkbox', 'WDL').click();
-    cy.get('[data-cy=entryColumn] a').first().click();
+    cy.get(`[data-cy=${getSearchDataCy()}] a`).first().click();
   });
 });
 

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -30,7 +30,8 @@ function getLinkName(tab: string): string {
 function testEntry(tab: string) {
   function goToRandomEntry() {
     cy.visit('/search');
-    cy.get(`[data-cy=${getSearchDataCy(tab)}] a`);
+    // Get a workflow in the table results to make sure things are loaded.
+    cy.get(`[data-cy=${getSearchDataCy()}] a`);
     goToTab(tab);
     // select a random entry on the first page and navigate to it
     let chosen_index = 0;

--- a/cypress/e2e/smokeTests/sharedTests/search.ts
+++ b/cypress/e2e/smokeTests/sharedTests/search.ts
@@ -1,3 +1,5 @@
+import { isStagingOrProd } from '../../../support/commands';
+
 describe('Admin UI', () => {
   before(() => {
     cy.visit('');
@@ -25,15 +27,19 @@ describe('Admin UI', () => {
       cy.url().should('not.include', 'search=dhockstore');
 
       cy.contains('Items per page');
-      cy.get('[data-cy=search-entry-table-paginator]').within(() => {
+      // TODO: set to '[data-cy=search-entry-table-paginator]' when search cards are in staging and prod
+      const searchPaginatorDataCy = isStagingOrProd()
+        ? '[data-cy=search-workflow-table-paginator]'
+        : '[data-cy=search-entry-table-paginator]';
+      cy.get(searchPaginatorDataCy).within(() => {
         cy.get('.mat-paginator-range-label').contains('10 of');
       });
-      cy.get('[data-cy=search-entry-table-paginator]').contains(10).should('be.visible').click();
+      cy.get(searchPaginatorDataCy).contains(10).should('be.visible').click();
       cy.get('mat-option').contains(20).click();
-      cy.get('[data-cy=search-entry-table-paginator]').contains(20);
+      cy.get(searchPaginatorDataCy).contains(20);
       cy.get('a').contains('Organizations').click();
       cy.go('back');
-      cy.get('[data-cy=search-entry-table-paginator]').contains(20);
+      cy.get(searchPaginatorDataCy).contains(20);
 
       cy.get('[data-cy=basic-search]').type('dockstore_{enter}');
       cy.contains('Open Advanced Search').click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,6 +18,11 @@
 // const psqlInvocation: string = 'PASSWORD=dockstore docker exec -i postgres1 psql';
 const psqlInvocation: string = 'PASSWORD=dockstore psql';
 
+export function isStagingOrProd() {
+  const baseUrl = Cypress.config('baseUrl');
+  return baseUrl === 'https://staging.dockstore.org' || baseUrl === 'https://dockstore.org';
+}
+
 export function goToTab(tabName: string): void {
   // cypress tests run asynchronously, so if the DOM changes and an element-of-interest becomes detached while we're manipulating it, the test will fail.
   // our current (admittedly primitive) go-to solution is to wait (sleep) for long enough that the DOM "settles", thus avoiding the "detached element" bug.


### PR DESCRIPTION
**Description**
This PR fixes the failed search page tests in staging and prod. PR https://github.com/dockstore/dockstore-ui2/pull/2055 added search cards in QA and modified the smoke tests, which caused the smoke tests to fail in staging and prod because those search card elements don't exist. I'll create a follow-up ticket to remove the staging/prod code when the search cards are deployed to staging and prod.

**Review Instructions**
Smoke tests should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
