### PR TITLE
bump versions for github actions

### DIFF
--- a/.github/workflows/accessibility_test.yml
+++ b/.github/workflows/accessibility_test.yml
@@ -110,7 +110,7 @@ jobs:
 
   compare_accessibility_results:
     needs: run-accessibility-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/accessibility_test.yml
+++ b/.github/workflows/accessibility_test.yml
@@ -13,7 +13,7 @@ jobs:
     # 'matrix.branch == github.base_ref' is the condition, 'base' is the true value and 'current' is the false value
     name: Accessibility test (${{ matrix.branch == github.base_ref && 'base' || 'current' }} branch)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:16.1

--- a/.github/workflows/npm_audit_test.yml
+++ b/.github/workflows/npm_audit_test.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   npm-audit-test:
     name: npm audit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/update_license.yml
+++ b/.github/workflows/update_license.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   update_license_file:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Description**
Bumps three workflows
npm audit test - akita legitimately shows a broken signature, will need to unblock https://github.com/dockstore/dockstore-ui2/pull/2047 think this is broken for everyone
accessibility: seems to work
update license file: seems to work

**Review Instructions**
Look at these builds in github actions

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6965

**Security**
None

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
