### PR TITLE
SEAB-6966: add relevance sort in search

### DIFF
--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -53,7 +53,7 @@ export class AboutComponent implements OnInit {
     new Sponsor('galaxy.png', new URL('https://galaxyproject.org/')),
   ];
   public contributors: Sponsor[] = [
-    new Sponsor('collaboratory.svg', new URL('https://www.cancercollaboratory.org/')),
+    new Sponsor('collaboratory.svg', new URL('https://doi.org/10.1158/1538-7445.AM2017-378')),
     new Sponsor('oicr.svg', new URL('https://oicr.on.ca/')),
     new Sponsor('ucsc.png', new URL('https://ucscgenomics.soe.ucsc.edu/')),
     new Sponsor('broad.svg', new URL('https://www.broadinstitute.org/')),

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -50,7 +50,7 @@ export class FooterComponent extends Base implements OnInit {
   year: number;
   content: string;
   public sponsors: Sponsor[] = [
-    new Sponsor('collaboratory.svg', new URL('https://www.cancercollaboratory.org/')),
+    new Sponsor('collaboratory.svg', new URL('https://doi.org/10.1158/1538-7445.AM2017-378')),
     new Sponsor('oicr.svg', new URL('https://oicr.on.ca/')),
     new Sponsor('broad1.svg', new URL('https://www.broadinstitute.org/')),
     new Sponsor('ga.svg', new URL('https://genomicsandhealth.org/')),

--- a/src/app/search/search-entry-table.component.ts
+++ b/src/app/search/search-entry-table.component.ts
@@ -128,11 +128,15 @@ export class SearchEntryTableComponent extends Base implements OnInit {
     ['categories.displayName', 'Category'],
   ]);
   public defaultSortOption: SortOption = {
-    label: 'Most Stars',
-    sort: { active: 'starredUsers', direction: 'desc' },
+    label: 'Relevance',
+    sort: { active: null, direction: 'desc' },
   };
   public sortOptions: SortOption[] = [
     this.defaultSortOption,
+    {
+      label: 'Most Stars',
+      sort: { active: 'starredUsers', direction: 'desc' },
+    },
     {
       label: 'Recently Updated',
       sort: { active: 'last_modified_date', direction: 'desc' },


### PR DESCRIPTION
**Description**
This PR adds the relevance sort back to the search page and adds it as default.

Screenshot example when searched for "test"
![image](https://github.com/user-attachments/assets/9b3fc9d6-9b02-4347-9662-138825ede371)

When set back to Most stars
![image](https://github.com/user-attachments/assets/98b8bd24-ba4b-4dae-836a-6eed47acf755)


**Review Instructions**
Go to the search page on qa and verify the relevance sort works

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6966

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
