### PR TITLE
DOCK-2610: Include Toil launch instructions

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -64,7 +64,7 @@
             Dockstore never requires a user to log in to search and inspect contents for workflows and tools. Links to source repositories
             are provided. Once found, analyses can be moved from environment-to-environment (e.g.
             <a target="_blank" rel="noopener noreferrer" href="https://terra.bio/">Terra</a>,
-            <a target="_blank" rel="noopener noreferrer" href="https://www.dnastack.com/">DNAstack</a>, and
+            <a target="_blank" rel="noopener noreferrer" href="https://dnastack.com/">DNAstack</a>, and
             <a target="_blank" rel="noopener noreferrer" href="https://www.dnanexus.com/">DNAnexus</a>) and yet be guaranteed to run on
             anything that supports Docker.
           </p>

--- a/src/app/home-page/home-logged-out/home.component.html
+++ b/src/app/home-page/home-logged-out/home.component.html
@@ -112,7 +112,7 @@
                 </li>
                 <li>
                   Try out the workflow by running it on a variety of launch partners including
-                  <a target="_blank" rel="noopener noreferrer" href="https://www.dnastack.com/">DNAstack</a>,
+                  <a target="_blank" rel="noopener noreferrer" href="https://dnastack.com/">DNAstack</a>,
                   <a target="_blank" rel="noopener noreferrer" href="https://terra.bio">Terra</a>,
                   <a target="_blank" rel="noopener noreferrer" href="https://www.dnanexus.com/">DNAnexus</a>, and
                   <a target="_blank" rel="noopener noreferrer" href="https://www.sevenbridges.com">SevenBridges</a>.

--- a/src/app/shared/launch.service.ts
+++ b/src/app/shared/launch.service.ts
@@ -27,7 +27,7 @@ export abstract class LaunchService {
   public readonly cwlrunnerTooltip = 'Commands for launching tools/workflows through cwl-runner. ' + this.nonStrict;
   public readonly cwltoolTooltip =
     'Commands for launching tools/workflows through CWLtool: the CWL reference implementation. ' + this.nonStrict;
-  public readonly wesTooltip = 'Commands for provisioning files and launching a workflow against AWS AGC infrastructure.';
+  public readonly toilTooltip = "Commands for running using UCSC's Toil workflow engine.";
   private readonly galaxyParamFileName = 'galaxy_job.yml';
 
   constructor(protected descriptorTypeCompatService: DescriptorTypeCompatService) {}

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -170,7 +170,6 @@
             <pre>{{ dockstoreSupportedCwlMakeTemplate }}</pre>
           </div>
         </mat-card>
-        <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
 
         <mat-card
           *ngIf="
@@ -191,6 +190,8 @@
             information.
           </div>
         </mat-card>
+
+        <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
       </div>
     </div>
   </div>

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -179,11 +179,16 @@
           "
         >
           <div [matTooltip]="toilTooltip">
-            Run this workflow using UCSC's Toil workflow engine
+            Use the <a href="https://toil.ucsc-cgl.org/">Toil</a> workflow engine to run on private compute such as AWS, Kubernetes, Mesos,
+            and Slurm HPC clusters.
             <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="toilLaunchCommand" appSnackbar>
               <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
             </button>
             <pre>{{ toilLaunchCommand }}</pre>
+            See the Toil "<a href="https://toil.readthedocs.io/en/latest/{{ descriptorType$ | async | lowercase }}/running.html"
+              >Running {{ descriptorType$ | async }} Workflows</a
+            >" and "<a href="https://toil.readthedocs.io/en/latest/running/cliOptions.html">Commandline Options</a>" documentation for more
+            information.
           </div>
         </mat-card>
       </div>

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -172,10 +172,17 @@
         </mat-card>
         <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
 
-        <mat-card *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && (published$ | async)">
+        <mat-card
+          *ngIf="
+            ((descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL || (descriptorType$ | async) === ToolDescriptor.TypeEnum.CWL) &&
+            (published$ | async)
+          "
+        >
           <div [matTooltip]="toilTooltip">
-            To run this workflow using UCSC's Toil workflow engine, download and install Toil, and then use the following invocation to
-            start the workflow run:
+            Run this workflow using UCSC's Toil workflow engine
+            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="toilLaunchCommand" appSnackbar>
+              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
+            </button>
             <pre>{{ toilLaunchCommand }}</pre>
           </div>
         </mat-card>

--- a/src/app/workflow/launch/launch.component.html
+++ b/src/app/workflow/launch/launch.component.html
@@ -171,42 +171,15 @@
           </div>
         </mat-card>
         <app-launch-checker-workflow [versionName]="_selectedVersion?.name" [command]="checkEntryCommand"></app-launch-checker-workflow>
-      </div>
 
-      <mat-card *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && (published$ | async)">
-        <div [matTooltip]="wesTooltip">
-          <p>Launch this workflow on Amazon Web Services' (AWS) Amazon Genomics CLI (AGC) cloud infrastructure.</p>
-
-          <!--TODO: replace with actual documentation link after https://github.com/dockstore/dockstore-documentation/pull/173-->
-          <p>
-            Learn how to configure the Dockstore CLI to communicate with AWS AGC infrastructure by reading the
-            <a [href]="Dockstore.DOCUMENTATION_URL + '/advanced-topics/wes/cli-wes-tutorial.html'">Dockstore documentation</a>. For an
-            introduction to AWS AGC, see their official
-            <a href="https://aws.github.io/amazon-genomics-cli/docs/getting-started/">quick start guide</a>.
-          </p>
-
-          <div>
-            Make a runtime JSON template and fill in desired inputs, outputs, and other parameters
-            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="params" appSnackbar>
-              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
-            </button>
-            <pre>{{ params }}</pre>
-
-            Create a wrapper JSON file, which is used by AWS AGC.
-            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="wesWrapperJson" appSnackbar>
-              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
-            </button>
-            <pre>{{ wesWrapperJson }}</pre>
-
-            Launch the workflow. (Note: Any input files required to run this workflow must be specified using the `--attach` or `-a` command
-            line switch.)
-            <button mat-icon-button color="secondary" matTooltip="Copy command" [cdkCopyToClipboard]="wesLaunchCommand" appSnackbar>
-              <mat-icon class="mat-icon-copy-button">file_copy</mat-icon>
-            </button>
-            <pre>{{ wesLaunchCommand }}</pre>
+        <mat-card *ngIf="(descriptorType$ | async) === ToolDescriptor.TypeEnum.WDL && (published$ | async)">
+          <div [matTooltip]="toilTooltip">
+            To run this workflow using UCSC's Toil workflow engine, download and install Toil, and then use the following invocation to
+            start the workflow run:
+            <pre>{{ toilLaunchCommand }}</pre>
           </div>
-        </div>
-      </mat-card>
+        </mat-card>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -37,7 +37,7 @@ import { MatLegacyTooltipModule } from '@angular/material/legacy-tooltip';
 import { FlexModule } from '@ngbracket/ngx-layout/flex';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyCardModule } from '@angular/material/legacy-card';
-import { NgIf, AsyncPipe } from '@angular/common';
+import { NgIf, AsyncPipe, LowerCasePipe } from '@angular/common';
 
 @Component({
   selector: 'app-launch',
@@ -55,6 +55,7 @@ import { NgIf, AsyncPipe } from '@angular/common';
     ClipboardModule,
     LaunchCheckerWorkflowComponent,
     AsyncPipe,
+    LowerCasePipe,
   ],
 })
 export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChanges {

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -58,6 +58,7 @@ import { NgIf, AsyncPipe } from '@angular/common';
   ],
 })
 export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChanges {
+  @Input() workflow;
   @Input() basePath;
   @Input() path;
   currentDescriptor: ToolDescriptor.TypeEnum;
@@ -97,9 +98,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   EntryType = EntryType;
   protected published$: Observable<boolean>;
   protected ngUnsubscribe: Subject<{}> = new Subject();
-  wesWrapperJson: string;
-  wesLaunchCommand: string;
-  wesTooltip = this.launchService.wesTooltip;
+  toilTooltip = this.launchService.toilTooltip;
 
   constructor(
     private launchService: WorkflowLaunchService,
@@ -148,8 +147,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
     this.nextflowLocalLaunchDescription = this.launchService.getNextflowLocalLaunchString();
     this.nextflowDownloadFileDescription = this.launchService.getNextflowDownload(basePath, versionName);
     this.updateWgetTestJsonString(workflowPath, versionName, descriptorType);
-    this.wesLaunchCommand = this.launchService.getWesLaunch(workflowPath, versionName);
-    this.wesWrapperJson = this.launchService.getAgcFileWrapper();
+    this.toilLaunchCommand = this.launchService.getToilLaunch(workflow, versionName);
   }
 
   /**

--- a/src/app/workflow/launch/launch.component.ts
+++ b/src/app/workflow/launch/launch.component.ts
@@ -98,6 +98,7 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   EntryType = EntryType;
   protected published$: Observable<boolean>;
   protected ngUnsubscribe: Subject<{}> = new Subject();
+  toilLaunchCommand: string;
   toilTooltip = this.launchService.toilTooltip;
 
   constructor(
@@ -126,9 +127,15 @@ export class LaunchWorkflowComponent extends EntryTab implements OnInit, OnChang
   }
 
   reactToDescriptor(): void {
-    this.changeMessages(this.basePath, this.path, this._selectedVersion.name, this.currentDescriptor);
+    this.changeMessages(this.workflow, this.basePath, this.path, this._selectedVersion.name, this.currentDescriptor);
   }
-  private changeMessages(basePath: string, workflowPath: string, versionName: string, descriptorType: ToolDescriptor.TypeEnum) {
+  private changeMessages(
+    workflow: Workflow,
+    basePath: string,
+    workflowPath: string,
+    versionName: string,
+    descriptorType: ToolDescriptor.TypeEnum
+  ) {
     if (descriptorType === undefined) {
       return;
     }

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -74,7 +74,10 @@ export class WorkflowLaunchService extends LaunchService {
   }
 
   getToilLaunch(workflow: Workflow, versionName: string) {
-    return `toil '${workflow.trsId}:${versionName}'`;
+    const language = String(workflow.descriptorType).toLowerCase();
+    const inputFile = 'Dockstore.json';
+    const inputArguments = language === 'wdl' ? `--input ${inputFile}` : inputFile;
+    return `toil-${language}-runner '${workflow.trsId}:${versionName}' ${inputArguments}`;
   }
 
   getAgcFileWrapper() {

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -20,6 +20,7 @@ import { Dockstore } from '../../shared/dockstore.model';
 import { LaunchService } from '../../shared/launch.service';
 import { ToolDescriptor } from '../../shared/openapi';
 import { EntryType } from '../../shared/enum/entry-type';
+import { Workflow } from '../../shared/openapi/model/workflow';
 
 @Injectable()
 export class WorkflowLaunchService extends LaunchService {
@@ -73,7 +74,7 @@ export class WorkflowLaunchService extends LaunchService {
   }
 
   getToilLaunch(workflow: Workflow, versionName: string) {
-    return `toil command {workflow.trsId}:{versionName}`;
+    return `toil '${workflow.trsId}:${versionName}'`;
   }
 
   getAgcFileWrapper() {

--- a/src/app/workflow/launch/workflow-launch.service.ts
+++ b/src/app/workflow/launch/workflow-launch.service.ts
@@ -72,6 +72,10 @@ export class WorkflowLaunchService extends LaunchService {
     return `dockstore workflow wes launch --entry ${workflowPath}:${versionName} --json ${this.agcWrapperFile} -a ${this.wesInputFile}`;
   }
 
+  getToilLaunch(workflow: Workflow, versionName: string) {
+    return `toil command {workflow.trsId}:{versionName}`;
+  }
+
   getAgcFileWrapper() {
     return `echo '{\"workflowInputs\": \"${this.wesInputFile}\"}' > ${this.agcWrapperFile}`;
   }

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -311,7 +311,8 @@
               </div>
               <ng-template #launchSupported>
                 <app-launch
-                  *ngIf="workflow?.workflowVersions.length > 0; else noVersions"
+                  *ngIf="workflow?.workflowVersions?.length > 0; else noVersions"
+                  [workflow]="workflow"
                   [selectedVersion]="selectedVersion"
                   [basePath]="workflow?.path"
                   [path]="workflow?.full_workflow_path"


### PR DESCRIPTION
**Description**
Ticket https://ucsc-cgl.atlassian.net/browse/DOCK-2610 prescribes that we append the version to the TRS ID in our UI, so that when it's copied into a Toil command, there's enough information to download the correct version and run it.  However, a TRS ID containing the version is not spec compliant, and we determined that it would break Galaxy's import page, and perhaps other software.

So, instead, as agreed upon, this PR adds Toil launch instructions to the workflow page "Launch" tab for published CWL and WDL workflows.

Also, this PR:
* Removes AGC instructions from the "Launch" tab.
* Changes "www.dnastack.com" to "dnastack.com"  in links, because the former was hanging and causing the tests to fail.

The new Toil instructions are an abbreviated form of what Adam suggested to me in a Slack exchange.  In the spirit of the other example commands, the Toil command is a basic, non-intimidating incantation that will successfully run the workflow, is short enough to fit entirely within the available space (typically), and is easy to read, understand, and copy.  As a nod to more advanced uses, I included a couple of Toil documentation links below it.

In the Toil command, we reference the workflow via its TRS ID because that's what we tend to prefer.

Please fire this up and click around to make sure the links point at the right pages.

**Screenshot**
Snippet of the bottom of a workflow page, after change:
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/b34251cf-3225-4c6d-9ee8-cdc9f2bdd0af" />

**Review Instructions**
For a published CWL workflow, view the "Launch" tab and confirm that the Toil launch instructions appear, and that the example command and links within are correct.  Do the same for a published WDL workflow.  View the "Launch" tab for a Galaxy workflow, and confirm that Toil launch instructions do not appear.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2610
dockstore/dockstore#6067

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
