### PR TITLE
SEAB-7086: Fix nextflow/Sequera launch-with button image

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.html
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.html
@@ -63,7 +63,7 @@
               [disabled]="disableTerraPlatform$ | async"
               [attr.href]="config.TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
               data-cy="terraLaunchWith"
-              ><img class="partner-launch" src="../assets/images/thirdparty/terra.png" alt="Terra launch with logo" />Terra</a
+              ><img class="partner-icon" src="../assets/images/thirdparty/terra.png" alt="Terra launch with logo" />Terra</a
             >
             <a
               mat-stroked-button
@@ -139,7 +139,7 @@
                 [disabled]="disableTerraPlatform$ | async"
                 [attr.href]="config.TERRA_IMPORT_URL + '/' + workflow?.full_workflow_path + ':' + selectedVersion?.name"
                 data-cy="terraLaunchWith"
-                ><img class="partner-launch mr-2" src="../assets/images/thirdparty/terra.png" alt="Terra launch with logo" />Terra</a
+                ><img class="partner-icon mr-2" src="../assets/images/thirdparty/terra.png" alt="Terra launch with logo" />Terra</a
               >
               <a
                 mat-stroked-button

--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -26,6 +26,8 @@
 
 img.partner-launch,
 img.galaxy-launch {
+  width: 100%;
+  height: auto;
   max-width: 8.3rem;
   max-height: 2.7rem;
 }


### PR DESCRIPTION
**Description**
This PR tweaks the `img.partner-launch` style so that svgs are displayed correctly, thus making the Sequera icon appear in its launch-with button appear, and corrects the style used on a couple of Terra icons.

**Review Instructions**
Confirm that the "launch-with" buttons look right, for all workflow types (Nextflow, WDL, etc), in a couple of different browser (to make sure they handle the styling the same way).  

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7086

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
