### PR TITLE
SEAB-7086: Center card headers vertically

### DIFF
--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -28,7 +28,7 @@
       </mat-card-title>
       <button
         mat-stroked-button
-        class="private-btn ml-3"
+        class="private-btn ml-3 mt-1 white-space-no-wrap"
         id="register{{ entryTypeLowerCase | titlecase }}Button"
         matTooltip="Register {{ entryTypeLowerCase | titlecase }}"
         matTooltipPosition="after"

--- a/src/app/home-page/widget/entry-box/entry-box.component.html
+++ b/src/app/home-page/widget/entry-box/entry-box.component.html
@@ -28,7 +28,7 @@
       </mat-card-title>
       <button
         mat-stroked-button
-        class="private-btn ml-3 mb-3"
+        class="private-btn ml-3"
         id="register{{ entryTypeLowerCase | titlecase }}Button"
         matTooltip="Register {{ entryTypeLowerCase | titlecase }}"
         matTooltipPosition="after"

--- a/src/app/home-page/widget/organization-box/organization-box.component.html
+++ b/src/app/home-page/widget/organization-box/organization-box.component.html
@@ -34,7 +34,7 @@
       </div>
       <button
         mat-stroked-button
-        class="private-btn"
+        class="private-btn mt-1 white-space-no-wrap"
         matTooltip="Request Organization"
         matTooltipPosition="after"
         (click)="requireAccounts()"

--- a/src/app/home-page/widget/organization-box/organization-box.component.html
+++ b/src/app/home-page/widget/organization-box/organization-box.component.html
@@ -8,7 +8,7 @@
     </mat-card-title>
 
     <div fxLayout="row wrap" fxLayoutGap="1rem">
-      <div id="pending-requests" fxLayout="row" fxLayoutAlign="center center" class="mb-3">
+      <div id="pending-requests" fxLayout="row" fxLayoutAlign="center center">
         <mat-icon [class.disabled]="(pendingRequests$ | async)?.length === 0" class="pending-requests mr-1">pending_icon</mat-icon>
         <a
           routerLink="/accounts"
@@ -20,7 +20,7 @@
           {{ (pendingRequests$ | async)?.length }} Pending Request<span *ngIf="(pendingRequests$ | async)?.length !== 1">s</span>
         </a>
       </div>
-      <div id="pending-invites" fxLayout="row" fxLayoutAlign="center center" class="mb-3">
+      <div id="pending-invites" fxLayout="row" fxLayoutAlign="center center">
         <mat-icon [class.disabled]="(pendingInvites$ | async)?.length === 0" class="pending-invites mr-1">error</mat-icon>
         <a
           routerLink="/accounts"
@@ -34,7 +34,7 @@
       </div>
       <button
         mat-stroked-button
-        class="private-btn mb-3"
+        class="private-btn"
         matTooltip="Request Organization"
         matTooltipPosition="after"
         (click)="requireAccounts()"

--- a/src/app/home-page/widget/starred-box/starred-box.component.html
+++ b/src/app/home-page/widget/starred-box/starred-box.component.html
@@ -1,7 +1,7 @@
 <mat-card class="h-100">
   <mat-card-header fxLayout="row" fxLayoutAlign="space-between">
     <mat-card-title>Starred</mat-card-title>
-    <div fxLayout="row wrap" fxLayoutGap="2rem" class="size-small pb-3">
+    <div fxLayout="row wrap" fxLayoutGap="2rem" class="size-small">
       <div fxLayout fxLayoutAlign="center center">
         <mat-icon class="mat-icon-sm">{{ totalStarredWorkflows ? 'star' : 'star_border' }}</mat-icon>
         <a [routerLink]="['/starred']" [queryParams]="{ tab: 'workflows' }">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1267,6 +1267,7 @@ mat-toolbar.files-toolbar {
   --mat-card-title-text-size: 1.7rem;
 }
 
-mat-card-header {
-  margin-bottom: 12px;
+// Add spacing above horizontal dividers that follow mat card headers
+mat-card-header + .mat-divider-horizontal {
+  margin-top: 12px;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -603,6 +603,7 @@ h5.mat-mdc-card-title,
   font-size: 16px;
   color: $header-color;
   font-weight: normal;
+  line-height: 1.1;
 }
 
 // Used by container and workflow's last build/modified "subtitle"
@@ -1264,4 +1265,8 @@ mat-toolbar.files-toolbar {
 // Smaller text size for mat-card-titles
 .small-card-title {
   --mat-card-title-text-size: 1.7rem;
+}
+
+mat-card-header {
+  margin-bottom: 12px;
 }


### PR DESCRIPTION
**Description**
This PR changes the UI so that the card headers are now centered vertically in the available space.  Essentially, this is a couple of style changes pulled from the pre-migration UI.

**Review Instructions**
Mouse around the UI and confirm the above.  Try to find card headers that were missed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7086

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
