### PR TITLE
SEAB-7086: Add some colons

### DIFF
--- a/src/app/container/container.component.html
+++ b/src/app/container/container.component.html
@@ -111,14 +111,14 @@
   <div class="row m-1">
     <div *ngIf="tool">
       <span *ngIf="(categories$ | async).length > 0" class="mr-5 mt-1 mb-1">
-        <span class="size-small mr-2">Categories</span>
+        <span class="size-small mr-2">Categories:</span>
         <mat-chip-set>
           <app-category-button *ngFor="let category of categories$ | async" [category]="category" entryType="tool"></app-category-button>
         </mat-chip-set>
       </span>
       <span *ngIf="!labelsEditMode && !starGazersClicked" class="mt-1 mb-1">
         <span *ngIf="containerEditData?.labels.length > 0" class="size-small mr-3">
-          Labels
+          Labels:
           <mat-chip-set class="ml-2">
             <mat-chip
               class="tool-background pointer"

--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -191,7 +191,7 @@
         </button>
       </div>
       <span *ngIf="(categories$ | async)?.length > 0" class="inline-block mr-5 mt-1 mb-1">
-        <span class="size-small mr-2">Categories</span>
+        <span class="size-small mr-2">Categories:</span>
         <mat-chip-set>
           <app-category-button
             *ngFor="let category of categories$ | async"


### PR DESCRIPTION
**Description**
This PR modifies the tool/workflow pages so that colons appear at the end of the "Categories" and "Labels" text that precede the corresponding bubbles.  I went with colons (rather than "no colons") because there was some adjacent "coloned" text, and it looked weird otherwise.

**Review Instructions**
Bask in the glow of the colons.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7086

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
