### PR TITLE
SEAB-7113: Sort "not available" values last in search results

### DIFF
--- a/src/app/search/search-authors-html.pipe.spec.ts
+++ b/src/app/search/search-authors-html.pipe.spec.ts
@@ -1,4 +1,5 @@
 import { SearchAuthorsHtmlPipe } from './search-authors-html.pipe';
+import { SearchService } from 'app/search/state/search.service';
 
 describe('Pipe: SearchAuthorsHtmlPipe', () => {
   it('create an instance and return search authors HTML', () => {
@@ -13,6 +14,6 @@ describe('Pipe: SearchAuthorsHtmlPipe', () => {
     );
 
     // The list of authors may contain a dummy Author where the name is null for the purposes of ES indexing
-    expect(pipe.transform([{ name: null }], false)).toBe('n/a');
+    expect(pipe.transform([{ name: null }], false)).toBe(SearchService.NOT_AVAILABLE);
   });
 });

--- a/src/app/search/search-authors-html.pipe.ts
+++ b/src/app/search/search-authors-html.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Author, OrcidAuthorInformation } from 'app/shared/openapi';
+import { SearchService } from 'app/search/state/search.service';
 
 @Pipe({
   name: 'getSearchAuthorsHtml',
@@ -19,7 +20,7 @@ export class SearchAuthorsHtmlPipe implements PipeTransform {
     // Filter for authors with names
     const nonNullAuthors = authors.filter((author) => author.name);
     if (nonNullAuthors.length === 0) {
-      return 'n/a';
+      return SearchService.NOT_AVAILABLE;
     }
 
     const authorNames: Array<string> = [];

--- a/src/app/search/state/search.service.spec.ts
+++ b/src/app/search/state/search.service.spec.ts
@@ -151,7 +151,8 @@ describe('SearchService', () => {
     expect(searchService.compareAttributes(a, b, 'all_authors', 'asc', EntryType.WORKFLOW)).toEqual(-1);
     expect(searchService.compareAttributes(a, b, 'all_authors', 'desc', EntryType.WORKFLOW)).toEqual(1);
     expect(searchService.compareAttributes(b, c, 'all_authors', 'asc', EntryType.WORKFLOW)).toEqual(-1);
-    expect(searchService.compareAttributes(b, c, 'all_authors', 'desc', EntryType.WORKFLOW)).toEqual(1);
+    // when all_authors is [], compareAttributes converts the value to 'n/a', which should be sorted last
+    expect(searchService.compareAttributes(b, c, 'all_authors', 'desc', EntryType.WORKFLOW)).toEqual(-1);
     expect(searchService.compareAttributes(a, c, 'descriptorType', 'asc', EntryType.WORKFLOW)).toEqual(-1);
     expect(searchService.compareAttributes(a, b, 'descriptorType', 'desc', EntryType.WORKFLOW)).toEqual(-0);
     expect(searchService.compareAttributes(a, b, 'starredUsers', 'asc', EntryType.WORKFLOW)).toEqual(-1);

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -71,6 +71,7 @@ export class SearchService {
   private static readonly WORKFLOWS_TAB_INDEX = 0;
   private static readonly TOOLS_TAB_INDEX = 1;
   private static readonly NOTEBOOKS_TAB_INDEX = 2;
+  private static readonly NOT_AVAILABLE = 'n/a';
   private searchInfoSource = new BehaviorSubject<any>(null);
   public toSaveSearch$ = new BehaviorSubject<boolean>(false);
   public searchTerm$ = new BehaviorSubject<boolean>(false);
@@ -260,11 +261,11 @@ export class SearchService {
         bVal = [];
       }
     } else {
-      // otherwise, regardless of sort direction, null or empty values go at the end
-      if (!aVal) {
+      // otherwise, regardless of sort direction, null, empty, or "not available" values go at the end
+      if (!aVal || aVal === SearchService.NOT_AVAILABLE) {
         return 1;
       }
-      if (!bVal) {
+      if (!bVal || bVal === SearchService.NOT_AVAILABLE) {
         return -1;
       }
     }

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -71,7 +71,7 @@ export class SearchService {
   private static readonly WORKFLOWS_TAB_INDEX = 0;
   private static readonly TOOLS_TAB_INDEX = 1;
   private static readonly NOTEBOOKS_TAB_INDEX = 2;
-  private static readonly NOT_AVAILABLE = 'n/a';
+  public static readonly NOT_AVAILABLE = 'n/a';
   private searchInfoSource = new BehaviorSubject<any>(null);
   public toSaveSearch$ = new BehaviorSubject<boolean>(false);
   public searchTerm$ = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
**Description**
This PR changes the UI so that in the search results table, results corresponding to values that are not available, denoted by "n/a", appear last, when said "n/a" values are used as the sort key.  At present, the main [only?] case where this applies is the "by 'Author'" sorting option.

**Review Instructions**
View the search results for a keyword that has lots of, but less than 200, matches, and sort by "Author, A-Z" and "Author, Z-A".  Confirm that "n/a" values always appear last in the list.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7113

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
