### PR TITLE
DOCK-2617: Fix workflow versions dropdown

### DIFF
--- a/src/app/workflow/workflow.component.html
+++ b/src/app/workflow/workflow.component.html
@@ -107,6 +107,7 @@
           <mat-select
             (selectionChange)="onSelectedVersionChange(selectedVersion)"
             [(value)]="selectedVersion"
+            [compareWith]="equalIds"
             [formControl]="workflowVersionsCtrl"
           >
             <mat-option>

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -654,4 +654,8 @@ export class WorkflowComponent extends Entry<WorkflowVersion> implements AfterVi
       data: { entry: this.workflow, version: this.selectedVersion },
     });
   }
+
+  equalIds(a: WorkflowVersion, b: WorkflowVersion): boolean {
+    return a.id == b.id;
+  }
 }


### PR DESCRIPTION
**Description**
This PR fixes the "versions" dropdown on the private workflows page, so that the selection changes when a version in the list below is clicked.  The problem was that `WorkflowVersion`s were being compared for equality, but at some point (the "paged version" implementation), our code changed so that the compared versions were sometimes different objects, and thus "not equal", even though their contents were the same.

The fix is to add a `compareWith` function to the `mat-select` that compares by version ID.

There are about 26 `mat-select`s in the current UI code, one wonders how many are similarly afflicted.

One proactive defense against future problems would be to create a `compareWith` function that would compare by ID and, if not possible, fall back to normal equality.  Something like:

```
    equivalent(a: any, b: any): boolean {
        return (a.id !== undefined || b.id !== undefined) ? a.id === b.id ? a === b;
    }
```
And add it to all of the mat-select`s.  Or maybe there's a way to specify it as the default, without having to change each one.

Might be too risky/late in the release cycle to do it for 1.17, though.

**Review Instructions**
Follow the steps in https://ucsc-cgl.atlassian.net/browse/DOCK-2617 that detail how to reproduce the bug, and confirm that it no longer happens.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2617
https://github.com/dockstore/dockstore/issues/6102

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
