### PR TITLE
SEAB-7086: Fix sequera launch-with button

### DIFF
--- a/src/app/workflow/launch-third-party/launch-third-party.component.scss
+++ b/src/app/workflow/launch-third-party/launch-third-party.component.scss
@@ -26,7 +26,7 @@
 
 img.partner-launch,
 img.galaxy-launch {
-  width: 100%;
+  width: 8.3rem;
   height: auto;
   max-width: 8.3rem;
   max-height: 2.7rem;


### PR DESCRIPTION
**Description**
This PR tweaks the CSS so that the Sequera launch-with button appears in all browsers.  The previous fix worked in Chrome, but  not in Firefox, the button did not appear.

I am not a CSS expert, so I do not fully understand why this works and the previous solution did not.

**Review Instructions**
See https://github.com/dockstore/dockstore-ui2/pull/2082

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7086

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
