### PR TITLE
DOCK-2618: Fix empty version list after viewing stargazers

### DIFF
--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -895,6 +895,9 @@ export class WorkflowsStubService {
   secondaryDescriptors1(workflowId, descriptorType, versionName) {
     return observableOf([]);
   }
+  getPublicWorkflowVersions(workflowId, limit, offset, sortCol, sortOrder, include, observe) {
+    return observableOf([]);
+  }
 }
 
 export class ContainersStubService {

--- a/src/app/workflow/versions/versions-datasource.ts
+++ b/src/app/workflow/versions/versions-datasource.ts
@@ -49,7 +49,8 @@ export class VersionsDataSource implements DataSource<WorkflowVersion> {
     sortCol: string
   ) {
     // Check to see if the arguments are the same as the last call, and if so, don't load again.
-    if (JSON.stringify(previousArguments) == JSON.stringify(this.arguments)) {
+    // "arguments" is a built-in Javascript variable that contains the method arguments.
+    if (JSON.stringify(this.previousArguments) == JSON.stringify(arguments)) {
       return;
     }
     this.previousArguments = arguments;

--- a/src/app/workflow/versions/versions-datasource.ts
+++ b/src/app/workflow/versions/versions-datasource.ts
@@ -24,6 +24,7 @@ import { HttpResponse } from '@angular/common/http';
 export class VersionsDataSource implements DataSource<WorkflowVersion> {
   private versionsSubject$ = new BehaviorSubject<WorkflowVersion[]>([]);
   private loadingSubject$ = new BehaviorSubject<boolean>(false);
+  private previousArguments;
   public versionsLengthSubject$ = new BehaviorSubject<number>(0);
   public loading$ = this.loadingSubject$.asObservable();
 
@@ -47,6 +48,12 @@ export class VersionsDataSource implements DataSource<WorkflowVersion> {
     pageSize: number,
     sortCol: string
   ) {
+    // Check to see if the arguments are the same as the last call, and if so, don't load again.
+    if (JSON.stringify(previousArguments) == JSON.stringify(this.arguments)) {
+      return;
+    }
+    this.previousArguments = arguments;
+
     this.loadingSubject$.next(true);
     let workflowVersions: Observable<HttpResponse<WorkflowVersion[]>>;
 

--- a/src/app/workflow/versions/versions.component.ts
+++ b/src/app/workflow/versions/versions.component.ts
@@ -181,6 +181,7 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
         )
         .subscribe();
     });
+    this.loadVersions(this.publicPage);
   }
 
   ngOnChanges() {
@@ -200,6 +201,9 @@ export class VersionsWorkflowComponent extends Versions implements OnInit, OnCha
   }
 
   loadVersions(publicPage: boolean) {
+    if (!this.dataSource) {
+      return;
+    }
     let direction: 'asc' | 'desc';
     switch (this.sort.direction) {
       case 'asc': {


### PR DESCRIPTION
**Description**
This PR fixes the bug wherein the workflow "Versions" tab would appear empty (no versions listed), after first visiting the "Versions" tab, then clicking and viewing the "stargazers" list, then clicking "Back to details" to return to the "Versions" tab.

The cause related to the order in which various parts of `VersionsWorkflowComponent` are initialized and called.

Per the Angular component lifecycle docs https://v17.angular.io/guide/lifecycle-hooks, `ngOnChange` is called before `ngoOnInit`.  So, due to way that our UI is coded, on the first display of  `VersionsWorkflowComponent`, the invocations happen in the following order:

```
ngOnChange
ngOnInit
ngOnChange
```
The first `ngOnChange` tries to use the uninitialized data source, and fails, and the second `ngOnChange` succeeds and loads the versions.

Then, after viewing the stargazers and returning, the component appears to be reconstructed, and the invocations are:
```
ngOnChange
ngOnInit
```
There is no second `ngOnChange`, so the versions are never loaded.

To fix this, we add a `loadVersions` call to `ngAfterViewInit`, which is invoked after the paginator and all other information sources are initialized.

Alas, when the versions list is first visited, this change causes duplicate version requests, so we add a little logic to `VersionsDataSource` to filter them out.

There is probably a [conceptually] cleaner way to fix this, by rejiggering all of the initializations, only loading when the pagination/sorting controls are initialized or change, etc.  However, something like that would probably take much more time to code, and is risky, so probably not something we should be doing a few days before the release. 

**Review Instructions**
On staging, try to reproduce the bug as described in the ticket, and confirm that you cannot.  Then, fiddle with the versions list and how they are paged and ordered, and make sure that everything still works right.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2618
https://github.com/dockstore/dockstore-ui2/pull/2097

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
