### PR TITLE
Update prod smoke tests for search cards

### DIFF
--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -23,7 +23,6 @@ describe('run stochastic smoke test', () => {
   testEntry('Notebooks');
 });
 
-// TODO: set to only 'entryColumn' when search cards are deployed to staging and prod
 function getSearchDataCy() {
   return 'entryColumn';
 }

--- a/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
+++ b/cypress/e2e/smokeTests/sharedTests/basic-enduser.ts
@@ -14,7 +14,6 @@ import {
   goToTestParameterFilesTab,
   goToToolsTab,
   goToTab,
-  isProd,
 } from '../../../support/commands';
 
 // Test an entry, these should be ambiguous between tools, workflows, and notebooks.
@@ -25,21 +24,8 @@ describe('run stochastic smoke test', () => {
 });
 
 // TODO: set to only 'entryColumn' when search cards are deployed to staging and prod
-function getSearchDataCy(tab: string = 'Workflows') {
-  return isProd() ? getLinkName(tab) : 'entryColumn';
-}
-
-function getLinkName(tab: string): string {
-  switch (tab) {
-    case 'Tools':
-      return 'toolNames';
-    case 'Workflows':
-      return 'workflowColumn';
-    case 'Notebooks':
-      return 'notebookColumn';
-    default:
-      throw new Error('unknown tab');
-  }
+function getSearchDataCy() {
+  return 'entryColumn';
 }
 
 function testEntry(tab: 'Tools' | 'Workflows' | 'Notebooks') {
@@ -50,7 +36,7 @@ function testEntry(tab: 'Tools' | 'Workflows' | 'Notebooks') {
     goToTab(tab);
     // select a random entry on the first page and navigate to it
     let chosen_index = 0;
-    cy.get(`[data-cy=${getSearchDataCy(tab)}]`)
+    cy.get(`[data-cy=${getSearchDataCy()}]`)
       .then(($list) => {
         chosen_index = Math.floor(Math.random() * $list.length);
       })

--- a/cypress/e2e/smokeTests/sharedTests/search.ts
+++ b/cypress/e2e/smokeTests/sharedTests/search.ts
@@ -1,4 +1,4 @@
-import { isProd, typeInInput } from '../../../support/commands';
+import { typeInInput } from '../../../support/commands';
 
 describe('Admin UI', () => {
   before(() => {
@@ -27,8 +27,7 @@ describe('Admin UI', () => {
       cy.url().should('not.include', 'search=dhockstore');
 
       cy.contains('Items per page');
-      // TODO: set to '[data-cy=search-entry-table-paginator]' when search cards are in staging and prod
-      const searchPaginatorDataCy = isProd() ? '[data-cy=search-workflow-table-paginator]' : '[data-cy=search-entry-table-paginator]';
+      const searchPaginatorDataCy = '[data-cy=search-entry-table-paginator]';
       cy.get(searchPaginatorDataCy).contains(10).should('be.visible').click();
       cy.get('mat-option').contains(20).click();
       cy.get(searchPaginatorDataCy).contains(20);


### PR DESCRIPTION
**Description**
Similar to https://github.com/dockstore/dockstore-ui2/pull/2089, now that the search cards are in prod, we need to update the smoke tests which will fix the failing prod no auth tests.

**Review Instructions**
No auth smoke tests on prod should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
