### PR TITLE
DOCK-2601: Fix flash of "may not be automatically updating" notice

### DIFF
--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -180,7 +180,7 @@ export class WorkflowComponent extends Entry<WorkflowVersion> implements AfterVi
   public sortedVersions: Array<WorkflowVersion> = [];
   private resourcePath: string;
   public showRedirect = false;
-  public gitHubAppInstalled: boolean | null;
+  public gitHubAppInstalled: boolean | undefined;
   public githubPath = 'github.com/';
   public gitlabPath = 'gitlab.com/';
   public bitbucketPath = 'bitbucket.org/';
@@ -377,6 +377,7 @@ export class WorkflowComponent extends Entry<WorkflowVersion> implements AfterVi
       }
       this.canRead = this.canWrite = this.isOwner = false;
       this.readers = this.writers = this.owners = [];
+      this.gitHubAppInstalled = undefined;
       if (!this.isPublic()) {
         const subclass: WorkflowSubClass = this.getWorkflowSubclass(this.entryType);
         this.showWorkflowActions = false;


### PR DESCRIPTION
**Description**
A while back, we added a feature wherein Dockstore displays a warning message on the private entry page when it detects that our GitHub app may have been uninstalled.  Intermittently, this warning was appearing erroneously, for a split second when a workflow was first displayed, when switching between workflows.

The solution was to unset the controlling flag upon a change of workflow.  Based on the declared type of the flag in the existing code, it appears that I probably intended the flag to be unset, but forgot to add the code to do it. 

To improve the type consistency, I changed the "unset" value from `null` to `undefined`.

**Review Instructions**
Switch between private workflows in the dashboard, being sure to include some  `.dockstore.yml`-based workflows, and confirm that you never see the warning message.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2601
dockstore/dockstore#6034

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
