### PR TITLE
Add slack alerts for nightly develop snapshot test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ workflows:
           matrix:
             parameters: 
               stack: [ "qa", "staging", "prod" ]
-              test-name: "no-auth"
+              test-name: [ "no-auth" ]
           name: no_auth_smoke_tests_<< matrix.stack >>
           context:
             - dockerhub
@@ -357,8 +357,8 @@ workflows:
       - smoke_tests:
           matrix:
             parameters: 
-              stack: ["qa", "staging", "prod"]
-              test-name: "auth"
+              stack: [ "qa", "staging", "prod" ]
+              test-name: [ "auth" ]
           name: auth_smoke_tests_<< matrix.stack >>
           context:
             - dockerhub


### PR DESCRIPTION
**Description**
See https://ucsc-cgl.atlassian.net/browse/SEAB-7198?focusedCommentId=49257 for why we weren't receiving slack alerts for the nightly QA smoke tests. The fix to receive slack alerts for the nightly QA smoke tests required no code (just needed to add an environment variable to CircleCI). The nightly QA smoke test alerts now go to dockstore-dev-info.

This PR adds slack alerts if our nightly develop snapshot tests fail, which we didn't have before. These alerts also go to dockstore-dev-info. While I was in there, I did some refactoring to reduce duplication (mainly, taking advantage of [matrix parameters](https://circleci.com/docs/configuration-reference/#matrix)).

**Review Instructions**
Nightly QA smoke test alerts should go to dockstore-dev-info every night regardless of pass or fail. Night snapshot tests should go to dockstore-dev-info only if there are failed tests

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7198

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
