### PR TITLE
SEAB-7164: Fix thumbnail metrics graph when maxValue is zero

### DIFF
--- a/src/app/shared/graphs/thumbnail-time-series-graph.component.ts
+++ b/src/app/shared/graphs/thumbnail-time-series-graph.component.ts
@@ -38,7 +38,7 @@ export class ThumbnailTimeSeriesGraphComponent implements OnChanges {
   ngOnChanges(): void {
     this.datasets = undefined;
     this.options = undefined;
-    if (this.timeSeries && this.now && this.binCount && this.maxValue) {
+    if (this.timeSeries != undefined && this.now != undefined && this.binCount != undefined && this.maxValue != undefined) {
       const adjusted = this.timeSeriesService.adjustTimeSeries(this.timeSeries, this.now, this.binCount);
       const values = adjusted.values;
       const labels = new Array(values.length).fill('');
@@ -61,7 +61,7 @@ export class ThumbnailTimeSeriesGraphComponent implements OnChanges {
           },
           y: {
             min: 0,
-            max: this.maxValue,
+            max: Math.max(this.maxValue, 1),
             ticks: {
               display: false,
             },


### PR DESCRIPTION
**Description**
This PR makes the version table's thumbnail metrics timeseries graph display an empty graph, rather than nothing, when `maxValue` is set to zero.  `maxValue` might be set to zero when no version of a workflow has a recent run, as is the current situation on staging because we haven't copied the prod S3 metrics data back to it yet.

This code uses `x != undefined` to check if x is `null` or `undefined`, rather than `x !== undefined || x !== null`.  The latter, IMHO, is inferior, it takes longer to read, is easier to corrupt, and is more difficult to combine with neighboring clauses.

**Review Instructions**
Confirm that thumbnail metrics graphs appear as expected, if the version has metrics, even if there are no recent runs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7194

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
