### PR TITLE
SEAB-7286:  Update bell when notification is deleted or user logs in

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2.15.0",
   "license": "Apache License 2.0",
   "config": {
-    "webservice_version_prefix": "1.18.0",
-    "webservice_version": "1.18.0",
-    "use_snapshot": false
+    "webservice_version_prefix": "1.18.1",
+    "webservice_version": "1.18.1",
+    "use_snapshot": true
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "config": {
     "webservice_version_prefix": "1.18.1",
     "webservice_version": "1.18.1",
-    "use_snapshot": true
+    "use_snapshot": false
   },
   "scripts": {
     "ng": "npx ng",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version_prefix": "1.18.1",
-    "webservice_version": "1.18.1",
+    "webservice_version": "1.18.1-alpha.0",
     "use_snapshot": false
   },
   "scripts": {

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
@@ -106,7 +106,7 @@ export class RecommendedActionsComponent extends Base implements OnInit, AfterVi
   }
 
   deleteGitHubAppNotification(notificationId: number) {
-    this.curationService.deleteUserNotification(notificationId).subscribe(() => {
+    this.curationService.hideUserNotification(notificationId).subscribe(() => {
       this.alertService.detailedSuccess(`Successfully deleted notification`);
       this.loadGitHubAppNotifications();
     });

--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
@@ -109,6 +109,7 @@ export class RecommendedActionsComponent extends Base implements OnInit, AfterVi
     this.curationService.hideUserNotification(notificationId).subscribe(() => {
       this.alertService.detailedSuccess(`Successfully deleted notification`);
       this.loadGitHubAppNotifications();
+      this.notificationsService.loadUserNotificationsCount();
     });
   }
 

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -133,7 +133,7 @@
           <button mat-menu-item [routerLink]="['/accounts']" [queryParams]="{ tab: 'recommended actions' }">
             <mat-icon
               matBadge="{{ userNotificationsCount$ | async }}"
-              matBadgeHidden="{{ (userNotificationsCount$ | async) == false }}"
+              matBadgeHidden="{{ (userNotificationsCount$ | async) <= 0 }}"
               matBadgeColor="warn"
               matBadgeSize="small"
               matBadgeOverlap="true"

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -132,8 +132,8 @@
           </button>
           <button mat-menu-item [routerLink]="['/accounts']" [queryParams]="{ tab: 'recommended actions' }">
             <mat-icon
-              matBadge="{{ userNotificationsCount }}"
-              matBadgeHidden="{{ userNotificationsCount === 0 }}"
+              matBadge="{{ userNotificationsCount$ | async }}"
+              matBadgeHidden="{{ !(userNotificationsCount$ | async) }}"
               matBadgeColor="warn"
               matBadgeSize="small"
               matBadgeOverlap="true"

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -133,7 +133,7 @@
           <button mat-menu-item [routerLink]="['/accounts']" [queryParams]="{ tab: 'recommended actions' }">
             <mat-icon
               matBadge="{{ userNotificationsCount$ | async }}"
-              matBadgeHidden="{{ !(userNotificationsCount$ | async) }}"
+              matBadgeHidden="{{ (userNotificationsCount$ | async) == false }}"
               matBadgeColor="warn"
               matBadgeSize="small"
               matBadgeOverlap="true"


### PR DESCRIPTION
**Description**
This PR updates the UI to hide a user notification when the user "deletes" it.  It also addresses a pair of bugs in the user notification code:

* The notification count (displayed on the bell) is now updated on user login and when the user "deletes" a notification.
* The bell no longer briefly flashes a "0" count, ever.

**Review Instructions**
On staging, create a github app notification.  Hide the notification via the UI, and confirm that the notification count on the bell is correct.  Load the UI on various browsers and confirm that the "0" flash is fixed. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7286
https://ucsc-cgl.atlassian.net/browse/SEAB-7288

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
