### PR TITLE
SEAB-7440: Add "relevance" as a secondary search criteria

### DIFF
--- a/src/app/search/query-builder.service.ts
+++ b/src/app/search/query-builder.service.ts
@@ -138,7 +138,7 @@ export class QueryBuilderService {
     // otherwise, sort hits by ES-calculated score
     // if we're sorting by ES-calculated score, sort archived entries last
     if (sortValue?.active && sortValue?.direction) {
-      tableBody = tableBody.sort([{ [sortValue?.active]: { order: sortValue?.direction, missing: '_last' } }]);
+      tableBody = tableBody.sort([{ [sortValue?.active]: { order: sortValue?.direction, missing: '_last' } }, { relevance: 'desc' }]);
     } else if (this.isEmpty(values) && !this.hasInclusiveSettings(advancedSearchObject)) {
       tableBody = tableBody.sort([{ relevance: 'desc' }]);
     } else {


### PR DESCRIPTION
**Description**
Currently, in Dockstore search, when the user selects a non-relevance "Sort by" order, there's no secondary search criteria being used, so results that are tied appear in random order.

This PR adds "relevance" as secondary search criteria.  This change is visible when sorting by star count or author name, wherein the results can sometimes include a good number of ties.

**Review Instructions**
On qa, sort search results by stars or author name and confirm that ties appear in most-to-least "relevant" order.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7440

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
