### PR TITLE
SEAB-7439: Fix flash of stale search results

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -261,6 +261,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     });
 
     this.hits = [];
+    this.searchService.setHits([], [], []);
 
     this.aNDSplitFilterText$ = this.advancedSearchQuery.aNDSplitFilterText$;
     this.aNDNoSplitFilterText$ = this.advancedSearchQuery.aNDNoSplitFilterText$;

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -176,6 +176,7 @@ export class SearchStubService {
   joinComma(searchTerm: string): string {
     return searchTerm.trim().split(' ').join(', ');
   }
+  setHits() {}
   haveNoHits(object: Object[]): boolean {
     if (!object || object.length === 0) {
       return true;


### PR DESCRIPTION
**Description**
Previously, in certain situations, stale results briefly appear on the search page.  Typically, this was most noticeable when the user runs a search, navigates to another page, and then returns to the search page, in which case the previous results would appear for a split second before being replaced.  For example, if the user ran a "covid" search, then left and returned again via the navbar, the "covid" results would appear briefly.

This PR partially addresses the problem by more completely clearing the state when the search component initializes.

I also tried a different solution, which was to simply not display the results when `isLoading` was true.  However, it felt too jolty for parts of the search UI to completely blink out and then back in again.  I kinda like the way the search results lazily update...

**Review Instructions**
On qa, try the triggering navigation sequence as detailed above, and confirm that stale results do not briefly appear when you return to the search page.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7439

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
