### PR TITLE
SEAB-7395: Fix blank metrics charts

### DIFF
--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -189,7 +189,7 @@ At this point, you now have the Dockstore CLI set up for interacting with the Do
 
 #### Part 6 - Install cwltool (Optional)
 Dockstore relies on [cwltool](https://github.com/common-workflow-language/cwltool) - a reference implementation of CWL - for local execution of tools and workflows described with CWL.
-You'll need to have Python 3.10+ and [pipx](https://pipx.pypa.io/latest/installation/) to be installed on your machine.
+You'll need to have Python 3.10+ and [pipx](https://pipx.pypa.io/latest/how-to/install-pipx/) to be installed on your machine.
 
 **Note:** cwltool must be available on your PATH for the Dockstore CLI to find it.
 

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { AfterViewInit, Component, Input, OnChanges, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { EntryTab } from '../../shared/entry/entry-tab';
 import {
   CloudInstance,
@@ -93,7 +93,7 @@ interface ExecutionMetricsTableObject {
     BaseChartDirective,
   ],
 })
-export class ExecutionsTabComponent extends EntryTab implements OnInit, OnChanges {
+export class ExecutionsTabComponent extends EntryTab implements OnInit, OnChanges, AfterViewInit {
   readonly SUCCESSFUL_LABEL = 'Successful';
   readonly FAILED_LABEL = 'Failed';
   readonly ABORTED_LABEL = 'Aborted';
@@ -170,6 +170,7 @@ export class ExecutionsTabComponent extends EntryTab implements OnInit, OnChange
 
   @Input() entry: BioWorkflow | Service | Notebook;
   @Input() version: WorkflowVersion;
+  @ViewChildren(BaseChartDirective) charts: QueryList<BaseChartDirective>;
 
   constructor(
     private extendedGA4GHService: ExtendedGA4GHService,
@@ -220,6 +221,12 @@ export class ExecutionsTabComponent extends EntryTab implements OnInit, OnChange
           this.alertService.detailedError(error);
         }
       );
+  }
+
+  ngAfterViewInit() {
+    this.charts.forEach((chart) => {
+      chart.update();
+    });
   }
 
   getMetrics(): Observable<{ [key: string]: Metrics }> {

--- a/src/app/workflow/executions/executions-tab.component.ts
+++ b/src/app/workflow/executions/executions-tab.component.ts
@@ -224,6 +224,10 @@ export class ExecutionsTabComponent extends EntryTab implements OnInit, OnChange
   }
 
   ngAfterViewInit() {
+    // Re-render each of the charts, hopefully fixing the "blank chart" bug
+    // (https://ucsc-cgl.atlassian.net/browse/SEAB-7395)
+    // if the root cause is that the chart data arrives before the canvas
+    // is ready for rendering.
     this.charts.forEach((chart) => {
       chart.update();
     });


### PR DESCRIPTION
**Description**
This PR attempts to fix the "blank charts" bug by refreshing each chart in the metrics tab, by calling the `update()` method for each chart, after the Angular view is initialized.  This PR also fixes a broken link to the `pipx` install instructions on the quick start page.

I have only been able to reproduce the "blank charts" bug twice: once, a few months ago, and again, more recently.  Both times, it appeared for a day or two, and then went away.  I have always observed the bug in Firefox on Windows 11, and in no other configuration.  Currently, I cannot reproduce the bug.  Could be timing related, or somehow dependent upon the current state of my Windows box.

The bug manifests as metrics charts that appear blank, until the user mouses over a portion of the chart that triggers a refresh, after which the full chart appears, correctly.  This suggests that the data is making it to the charts, and that possibly, upon chart creation, either the initial render is not happening, or perhaps the render is happening, but the results are not "sticking".  In the latter case, for example, maybe the chart canvas is created but not yet ready to be rendered to, and so all of the drawing operations end up in the "bit bucket". 

If the above theory is correct, this PR might fix the problem.  However, until I can reproduce the bug, there's no way to confirm.  This PR is pretty minimal, and IMHO, the probability of it backfiring is low, so I suggest we merge.

**Review Instructions**
View some metrics charts in the UI, and confirm that they appear correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7395

**Security**
No security concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
