### PR TITLE
add check for topic length

### DIFF
--- a/src/app/organizations/registerOrganization/register-organization.component.html
+++ b/src/app/organizations/registerOrganization/register-organization.component.html
@@ -47,6 +47,7 @@
       <mat-label>Topic</mat-label>
       <input type="text" matInput formControlName="topic" required data-cy="topic-input" />
       <mat-error *ngIf="topic.hasError('required')">Topic is required</mat-error>
+      <mat-error *ngIf="topic.hasError('maxlength')">Topic should be at most 255 characters long</mat-error>
       <mat-hint>A short description of the organization</mat-hint>
     </mat-form-field>
     <mat-form-field>

--- a/src/app/organizations/state/register-organization.service.ts
+++ b/src/app/organizations/state/register-organization.service.ts
@@ -121,7 +121,7 @@ export class RegisterOrganizationService {
         { value: displayName, disabled: organization?.status === Organization.StatusEnum.APPROVED },
         [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(this.organizationDisplayNameRegex)],
       ],
-      topic: [topic, Validators.required],
+      topic: [topic, Validators.required, Validators.maxLength(255)],
       link: [link, Validators.pattern(this.urlRegex)],
       location: [location],
       contactEmail: [contactEmail, [Validators.email, Validators.required]],

--- a/src/app/organizations/state/register-organization.service.ts
+++ b/src/app/organizations/state/register-organization.service.ts
@@ -121,7 +121,7 @@ export class RegisterOrganizationService {
         { value: displayName, disabled: organization?.status === Organization.StatusEnum.APPROVED },
         [Validators.required, Validators.maxLength(50), Validators.minLength(3), Validators.pattern(this.organizationDisplayNameRegex)],
       ],
-      topic: [topic, Validators.required, Validators.maxLength(255)],
+      topic: [topic, [Validators.required, Validators.maxLength(255)]],
       link: [link, Validators.pattern(this.urlRegex)],
       location: [location],
       contactEmail: [contactEmail, [Validators.email, Validators.required]],


### PR DESCRIPTION
**Description**
Add ui guard for excessive topic length

**Review Instructions**
Can try to add organization with excessive topic length

**Issue**
https://github.com/dockstore/dockstore/issues/6234
https://ucsc-cgl.atlassian.net/browse/DOCK-2631

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
