### PR TITLE
SEAB-7545: Display category display names ("titles") in the search facets

### DIFF
--- a/cypress/e2e/group2/categories.ts
+++ b/cypress/e2e/group2/categories.ts
@@ -85,13 +85,13 @@ describe('Dockstore Categories', () => {
     it('appear in search sidebar', () => {
       cy.visit('/search?entryType=tools');
       cy.get('.search-container').get('mat-accordion').contains('Category');
-      cy.get('.search-container').get('mat-accordion').contains(categoryName);
+      cy.get('.search-container').get('mat-accordion').contains(categoryDisplayName);
     });
     it('appear exclusively in search results if Category checkbox is clicked', () => {
       cy.visit('/search?entryType=tools');
       cy.get('app-search-results').contains(toolSnippet);
       cy.get('app-search-results').contains('A2/a');
-      cy.contains('mat-checkbox', categoryName).click();
+      cy.contains('mat-checkbox', categoryDisplayName).click();
       cy.get('app-search-results').contains(toolSnippet);
       cy.get('app-search-results').contains('A2/a').should('not.exist');
     });
@@ -124,7 +124,7 @@ describe('Dockstore Categories', () => {
       cy.visit('/organizations/dockstore/collections/' + categoryName);
       cy.get('app-category-button').contains(categoryDisplayName).click();
       cy.url().should('include', '/search');
-      cy.url().should('include', categoryName);
+      cy.url().should('include', categoryDisplayName);
     });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -134,7 +134,7 @@ export function resetDB() {
     cy.exec('java -jar dockstore-webservice.jar db drop-all --confirm-delete-everything test/web.yml');
     cy.exec(psqlInvocation + ' -h localhost webservice_test -U dockstore < test/db_dump.sql');
     cy.exec(
-      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0 test/web.yml'
+      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0,1.20.0 test/web.yml'
     );
   });
 }
@@ -144,7 +144,7 @@ export function resetDBWithService() {
     cy.exec('java -jar dockstore-webservice.jar db drop-all --confirm-delete-everything test/web.yml');
     cy.exec(psqlInvocation + ' -h localhost webservice_test -U dockstore < test/db_dump.sql');
     cy.exec(
-      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0 test/web.yml'
+      'java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0,1.20.0 test/web.yml'
     );
   });
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version_prefix": "1.20.0",
-    "webservice_version": "1.20.0-alpha.0",
+    "webservice_version": "1.20.0-alpha.3",
     "use_snapshot": false
   },
   "scripts": {

--- a/scripts/run-webservice-script.sh
+++ b/scripts/run-webservice-script.sh
@@ -20,4 +20,4 @@ psql -h localhost -c "create user dockstore with password 'dockstore' createdb;"
 psql -h localhost -c "ALTER USER dockstore WITH superuser;" -U postgres
 psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
 psql -h localhost -f test/${DB_DUMP:-db_dump.sql} webservice_test -U postgres
-java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,add_notebook_1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0 test/web.yml
+java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,1.8.0,1.9.0,1.10.0,alter_test_user_1.10.2,1.11.0,1.12.0,1.13.0,1.14.0,add_notebook_1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0,1.20.0 test/web.yml

--- a/src/app/categories/button/category-button.component.ts
+++ b/src/app/categories/button/category-button.component.ts
@@ -39,7 +39,7 @@ export class CategoryButtonComponent implements OnChanges {
     this.className = isWorkflow ? 'workflow-background' : 'tool-background';
     this.routerLink = ['/search'];
     this.queryParams = {
-      'categories.name.keyword': this.category.name,
+      'categories.displayName.keyword': this.category.displayName,
       entryType: isWorkflow ? 'workflows' : 'tools',
       searchMode: 'files',
     };

--- a/src/app/search/facet-search/facet-search.pipe.ts
+++ b/src/app/search/facet-search/facet-search.pipe.ts
@@ -22,7 +22,7 @@ export class GetFacetSearchResultsPipe implements PipeTransform {
         facet !== 'organization' &&
         facet !== 'labels.value.keyword' &&
         facet !== 'namespace' &&
-        facet !== 'categories.name.keyword')
+        facet !== 'categories.displayName.keyword')
     ) {
       return items;
     }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -111,7 +111,7 @@
               key === 'labels.value.keyword' ||
               key === 'namespace' ||
               key === 'organization' ||
-              key === 'categories.name.keyword'
+              key === 'categories.displayName.keyword'
             "
           >
             <mat-form-field>
@@ -204,7 +204,7 @@
                       key !== 'labels.value.keyword' &&
                       key !== 'namespace' &&
                       key !== 'organization' &&
-                      key !== 'categories.name.keyword';
+                      key !== 'categories.displayName.keyword';
                     else facetLoading
                   "
                   >{{ fullyExpandMap.get(key) ? 'Hide' : orderedBuckets.get(key).Items.size - 5 + ' more' }}</span

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -684,7 +684,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       ['labels.value.keyword', ''],
       ['namespace', ''],
       ['organization', ''],
-      ['categories.name.keyword', ''],
+      ['categories.displayName.keyword', ''],
     ]);
   }
 

--- a/src/app/search/state/search.service.ts
+++ b/src/app/search/state/search.service.ts
@@ -88,7 +88,7 @@ export class SearchService {
 
   private getOrderedFacetInfos(tabIndex: number): Array<FacetInfo> {
     const facetInfos = [
-      { friendlyName: 'Category', esName: 'categories.name.keyword', initiallyExpanded: true },
+      { friendlyName: 'Category', esName: 'categories.displayName.keyword', initiallyExpanded: true },
       {
         friendlyName: tabIndex === SearchService.NOTEBOOKS_TAB_INDEX ? 'Format' : 'Language',
         esName: 'descriptorType',

--- a/src/app/test/service-stubs.ts
+++ b/src/app/test/service-stubs.ts
@@ -288,7 +288,7 @@ export class SearchStubService {
         ['has_checker', false],
         ['organization', true],
         ['verified_platforms.keyword', false],
-        ['categories.name.keyword', true],
+        ['categories.displayName.keyword', true],
         ['descriptor_type_versions.keyword', false],
         ['openData', false],
       ]);


### PR DESCRIPTION
**Description**
Currently, for each category listed in the Category search facet, the category's "name" is displayed.  A category "name" is similar to a "slug", for example "bobs-category'.

This PR changes the Category facet so that it displays the category "display name" is displayed.  A category "display name" is similar to a "title", for example "Bob's Awesome Category".

To do so, we modify the UI's search facet and query generation code to use the ES field `categories.displayName.keyword`, instead of `categories.name.keyword`.

This approach will require that each category within the facet has a unique display name.  This constraint should be easy to satisfy, because we're planning on having a separate facet for each subontology.  If there _does_ happen to be two categories with the display name, they'll both map to the same facet entry, which isn't ideal, but also isn't the end of the world, and kinda actually might make sense. 

Drawback to this approach is that old saved links that include a category facet selection will no longer work properly.  Also, new saved links will probably be less reliable, as a category's "display name" (title) changes more often than its "name" (slug).

There are some different approaches, but they all appear to be much more complicated, fragile, or slow:
1. "Retrieve displayName alongside name in ES query": requires special sub-aggregation, bloats responses, may cause ES performance issues.  Requires more extensive changes to search facet code.
2. "Download full category name -> displayName mapping ahead of time and use in category facet rendering code": Mapping will be large if we have thousands of categories.  Fiddly, lots of additional code.
3. "Retrieve displayName for each category on demand": Create a webservice endpoint that allows us to map a category name to its displayName.  Hit this endpoint to map the facet values.  Lots of hits if there's lots of categories, lots of additional code.

**Review Instructions**
Confirm that the category "display names" are being displayed in the Category search facet.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7545

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
