### PR TITLE
Adjust integration tests for new AI org

### DIFF
--- a/cypress/e2e/group2/organizations.ts
+++ b/cypress/e2e/group2/organizations.ts
@@ -184,7 +184,7 @@ describe('Dockstore Organizations', () => {
           id: 1,
           role: 'MAINTAINER',
           status: 'ACCEPTED',
-          organization: { id: 2, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe' },
+          organization: { id: 3, status: 'APPROVED', name: 'Potatoe', displayName: 'Potatoe' },
         },
       ];
       cy.intercept('GET', '*/users/user/memberships', {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -250,11 +250,11 @@ export function createPotatoMembership() {
 }
 
 export function approvePotatoMembership() {
-  invokeSql("update organization_user set status='ACCEPTED' where userid=2 and organizationid=2");
+  invokeSql("update organization_user set status='ACCEPTED' where userid=2 and organizationid=3");
 }
 
 export function rejectPotatoMembership() {
-  invokeSql("update organization_user set status='REJECTED' where userid=2 and organizationid=2");
+  invokeSql("update organization_user set status='REJECTED' where userid=2 and organizationid=3");
 }
 
 export function approvePotatoOrganization() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version_prefix": "1.20.0",
-    "webservice_version": "1.20.0-alpha.3",
+    "webservice_version": "1.20.0-alpha.7",
     "use_snapshot": false
   },
   "scripts": {


### PR DESCRIPTION
**Description**
This PR adjusts the UI2 integration tests so that they use the correct organization ID for the potatoe organization.  The IDs changed because we added the "dockstoreai" categorizer organization, which, together with the existing "dockstore" categorizer organization", is added to the test db during the migrations.
 
**Review Instructions**
Confirm that the integration tests pass.

**Issue**
none

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
