### PR TITLE
cpu units tooltip and null check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dockstore-ui2",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/app/workflow/executions/executions-tab.component.html
+++ b/src/app/workflow/executions/executions-tab.component.html
@@ -329,8 +329,8 @@
         matTooltip="{{ (num | number: '1.2-2') + ' ' + executionMetric.unit }}"
         >{{ num | number: '1.2-2' }} {{ executionMetric.unit }}</span
       >
-      <span *ngIf="executionMetric.metric === 'CPU'" matTooltip="{{ num + ' ' + (executionMetric.unit ?? 'cores') }}"
-        >{{ num }} {{ executionMetric.unit ?? 'cores' }}</span
+      <span *ngIf="executionMetric.metric === 'CPU'" matTooltip="{{ num + ' ' + (executionMetric.unit ?? (num > 1 ? 'cores' : 'core')) }}"
+        >{{ num }} {{ executionMetric.unit ?? (num > 1 ? 'cores' : 'core') }}</span
       >
       <span
         *ngIf="executionMetric.metric !== 'Run Time' && executionMetric.metric !== 'Cost' && executionMetric.metric !== 'CPU'"

--- a/src/app/workflow/executions/executions-tab.component.html
+++ b/src/app/workflow/executions/executions-tab.component.html
@@ -329,8 +329,11 @@
         matTooltip="{{ (num | number: '1.2-2') + ' ' + executionMetric.unit }}"
         >{{ num | number: '1.2-2' }} {{ executionMetric.unit }}</span
       >
+      <span *ngIf="executionMetric.metric === 'CPU'" matTooltip="{{ num + ' ' + (executionMetric.unit ?? 'cores') }}"
+        >{{ num }} {{ executionMetric.unit ?? 'cores' }}</span
+      >
       <span
-        *ngIf="executionMetric.metric !== 'Run Time' && executionMetric.metric !== 'Cost'"
+        *ngIf="executionMetric.metric !== 'Run Time' && executionMetric.metric !== 'Cost' && executionMetric.metric !== 'CPU'"
         matTooltip="{{ (num | number: '1.0-2') + ' ' + executionMetric.unit }}"
         >{{ num | number: '1.0-2' }} {{ executionMetric.unit }}</span
       >


### PR DESCRIPTION
**Description**
Existing cores row lacks detail, turns out it's a little broken. If a platform partner does not specify a CPU unit (which is cores), that null shows up as blank in the row and null in the tooltip. This defaults it to "cores". 

Before
<img width="1003" height="337" alt="Screenshot from 2026-06-02 14-25-03" src="https://github.com/user-attachments/assets/bc3f1906-848b-494a-acd7-2c7aa4d21935" />

After
<img width="1003" height="337" alt="Screenshot from 2026-06-02 15-01-37" src="https://github.com/user-attachments/assets/c4ec9f47-c058-4b6a-b24a-c1b4f8aa1486" />

<img width="1003" height="337" alt="Screenshot from 2026-06-02 14-53-42" src="https://github.com/user-attachments/assets/36782c3f-4731-4797-b4ca-e9c9c6994f8f" />


**Review Instructions**
Take a look at the relevant row in https://dockstore.org/workflows/github.com/broadinstitute/warp/ReblockGVCF:develop?tab=metrics (or in qa, staging) 
Also https://dockstore.org/workflows/github.com/broadinstitute/warp/Optimus:Optimus_v5.4.3?tab=metrics for plural

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7466

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
