### PR TITLE
fix github app notification paging

### DIFF
--- a/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
+++ b/src/app/myworkflows/sidebar-accordion/github-apps-logs/recommended-actions.component.ts
@@ -113,6 +113,6 @@ export class RecommendedActionsComponent extends Base implements OnInit, AfterVi
   }
 
   private loadEvents() {
-    this.dataSource.loadEvents(this.paginator.pageIndex, this.paginator.pageSize);
+    this.dataSource.loadEvents(this.paginator.pageIndex * this.paginator.pageSize, this.paginator.pageSize);
   }
 }


### PR DESCRIPTION
**Description**
Turns out we're just not taking into account pageSize when switching between pages, so there's overlap especially with relatively small numbers of notifications

**Review Instructions**
Get 6 of more notifications. They will overlap in production 1.19.X but should not overlap after this PR

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2635

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
