### PR TITLE
Add newline to "EDAM" text in category mouseover

### DIFF
--- a/src/app/categories/button/category-button.component.spec.ts
+++ b/src/app/categories/button/category-button.component.spec.ts
@@ -22,8 +22,9 @@ describe('CategoryButtonComponent tooltip', () => {
 
   describe('source attribution', () => {
     it('reports EDAM URL when metadata.source is an edamontology.org URL', () => {
+      expect(tooltip({ metadata: { source: 'http://edamontology.org/operation_3802' } })).toContain('Derived from EDAM:');
       expect(tooltip({ metadata: { source: 'http://edamontology.org/operation_3802' } })).toContain(
-        'Derived from EDAM: http://edamontology.org/operation_3802'
+        'http://edamontology.org/operation_3802'
       );
     });
 

--- a/src/app/categories/button/category-button.component.ts
+++ b/src/app/categories/button/category-button.component.ts
@@ -66,7 +66,8 @@ export class CategoryButtonComponent implements OnChanges {
     if (source === 'ai') {
       parts.push('Category created by AI.');
     } else if (source?.startsWith(EDAM_PREFIX)) {
-      parts.push(`Derived from EDAM: ${source}`);
+      parts.push('Derived from EDAM:');
+      parts.push(source);
     } else {
       parts.push('Category created by Dockstore.');
     }


### PR DESCRIPTION
**Description**
This PR adds a newline after the "Derived from EDAM:" text in the category mouseover, thus placing the EDAM URL on the next line.  The URL currently appears on the same line, and the line is too long to fit into the width of the mouseover box, causing the URL to be split into two pieces that are displayed on different lines.

**Review Instructions**
Confirm that the EDAM URL appears on its own line and is no longer broken apart.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7621

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
