### PR TITLE
SEAB-7598: Rename Collection.displayname to title

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version_prefix": "1.20.0",
-    "webservice_version": "feature/seab-7598/change-collection-displayname-to-title",
+    "webservice_version": "1.20.0-beta.4",
     "use_snapshot": false
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache License 2.0",
   "config": {
     "webservice_version_prefix": "1.20.0",
-    "webservice_version": "1.20.0-beta.2",
+    "webservice_version": "feature/seab-7598/change-collection-displayname-to-title",
     "use_snapshot": false
   },
   "scripts": {

--- a/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
+++ b/src/app/loginComponents/onboarding/downloadcliclient/downloadcliclient.component.ts
@@ -189,7 +189,7 @@ At this point, you now have the Dockstore CLI set up for interacting with the Do
 
 #### Part 6 - Install cwltool (Optional)
 Dockstore relies on [cwltool](https://github.com/common-workflow-language/cwltool) - a reference implementation of CWL - for local execution of tools and workflows described with CWL.
-You'll need to have Python 3.10+ and [pipx](https://pipx.pypa.io/latest/how-to/install-pipx/) to be installed on your machine.
+You'll need to have Python 3.10+ and [pipx](https://pipx.pypa.io/latest/how-to/install-pipx.html) to be installed on your machine.
 
 **Note:** cwltool must be available on your PATH for the Dockstore CLI to find it.
 

--- a/test/edam_categories_db_dump.sql
+++ b/test/edam_categories_db_dump.sql
@@ -20,7 +20,7 @@
 --   workflow id=11 github.com/A/l                                    (published)
 -- Both have entry_metadata rows inserted by the 1.20.0 Liquibase migration.
 
-INSERT INTO collection (name, displayname, topic, organizationid, dtype, deleted, dbcreatedate, dbupdatedate, metadata)
+INSERT INTO collection (name, title, topic, organizationid, dtype, deleted, dbcreatedate, dbupdatedate, metadata)
 VALUES
   ('operation-sort',           'Sort',            'Sorting of sequences',            (SELECT id FROM organization WHERE name = 'dockstoreai'), 'Category', false, LOCALTIMESTAMP, LOCALTIMESTAMP, '{"source":"http://edamontology.org/operation_3802"}'),
   ('topic-genomics',           'Genomics',        'Genomics and genome biology',     (SELECT id FROM organization WHERE name = 'dockstoreai'), 'Category', false, LOCALTIMESTAMP, LOCALTIMESTAMP, '{"source":"http://edamontology.org/topic_0622"}'),


### PR DESCRIPTION
**Description**
This PR adjust one of the "mini" test db dumps so that in the inserts to the `collection` table, the `displayname` column is renamed to `title`.  This is necessary because these "mini" dumps aren't migrated.

This PR also fixes a broken pipx " how to install" link.

**Review Instructions**
Verify that the tests pass.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7598

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
