### PR TITLE
allow publishing of wdl 1.1+

### DIFF
--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -97,11 +97,11 @@ export class EntryActionsService {
   }
 
   private isWorkflow(entry: Entry): entry is Workflow {
-    return entry.entryType === 'WORKFLOW';
+    return entry.entryType === OpenApiEntryType.WORKFLOW;
   }
 
   private isTool(entry: Entry): entry is DockstoreTool {
-    return entry.entryType === 'TOOL' || entry.entryType === 'APPTOOL';
+    return entry.entryType === OpenApiEntryType.TOOL || entry.entryType === OpenApiEntryType.APPTOOL;
   }
 
   private isEntryValid(entry: Entry | null): boolean {

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -108,11 +108,12 @@ export class EntryActionsService {
     }
     // WDL 1.1 special case (version is not blank and doesn't start with draft and is 1.1 or higher)
     if (
-      entry.workflowVersions.some(
-        (version) =>
-          version.versionMetadata.descriptorTypeVersions?.length > 0 &&
-          version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'))
-      )
+      entry.workflowVersions.some((version) => {
+        if (version.versionMetadata && version.versionMetadata.descriptorTypeVersions) {
+          return version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'));
+        }
+        return false;
+      })
     ) {
       return true;
     }

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -97,11 +97,11 @@ export class EntryActionsService {
   }
 
   private isWorkflow(entry: Entry): entry is Workflow {
-    return 'descriptorType' in entry;
+    return entry.entryType === 'WORKFLOW';
   }
 
   private isTool(entry: Entry): entry is DockstoreTool {
-    return 'descriptorType' in entry;
+    return entry.entryType === 'TOOL' || entry.entryType === 'APPTOOL';
   }
 
   private isEntryValid(entry: Entry | null): boolean {

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -108,8 +108,10 @@ export class EntryActionsService {
     }
     // WDL 1.1 special case (version is not blank and doesn't start with draft and is 1.1 or higher)
     if (
-      entry.workflowVersions.some((version) =>
-        version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'))
+      entry.workflowVersions.some(
+        (version) =>
+          version.versionMetadata.descriptorTypeVersions?.length > 0 &&
+          version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'))
       )
     ) {
       return true;

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -106,6 +106,14 @@ export class EntryActionsService {
     if (!versionTags) {
       return false;
     }
+    // WDL 1.1 special case (version is not blank and doesn't start with draft and is 1.1 or higher)
+    if (
+      entry.workflowVersions.some((version) =>
+        version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'))
+      )
+    ) {
+      return true;
+    }
     return versionTags.some((version) => version.valid);
   }
 

--- a/src/app/shared/entry-actions/entry-actions.service.ts
+++ b/src/app/shared/entry-actions/entry-actions.service.ts
@@ -12,6 +12,7 @@ import { InformationDialogData } from '../../information-dialog/information-dial
 import { InformationDialogService } from '../../information-dialog/information-dialog.service';
 import { ArchiveEntryDialogComponent } from '../../entry/archive/dialog/archive-entry-dialog.component';
 import { bootstrap4mediumModalSize, bootstrap4largeModalSize } from '../../shared/constants';
+import DescriptorTypeEnum = Workflow.DescriptorTypeEnum;
 
 @Injectable()
 export class EntryActionsService {
@@ -95,6 +96,14 @@ export class EntryActionsService {
     }
   }
 
+  private isWorkflow(entry: Entry): entry is Workflow {
+    return 'descriptorType' in entry;
+  }
+
+  private isTool(entry: Entry): entry is DockstoreTool {
+    return 'descriptorType' in entry;
+  }
+
   private isEntryValid(entry: Entry | null): boolean {
     if (!entry) {
       return false;
@@ -107,15 +116,18 @@ export class EntryActionsService {
       return false;
     }
     // WDL 1.1 special case (version is not blank and doesn't start with draft and is 1.1 or higher)
-    if (
-      entry.workflowVersions.some((version) => {
-        if (version.versionMetadata && version.versionMetadata.descriptorTypeVersions) {
-          return version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'));
-        }
-        return false;
-      })
-    ) {
-      return true;
+    if (this.isWorkflow(entry) || this.isTool(entry)) {
+      if (
+        entry.descriptorType === DescriptorTypeEnum.WDL &&
+        entry.workflowVersions.some((version) => {
+          if (version.versionMetadata?.descriptorTypeVersions) {
+            return version.versionMetadata.descriptorTypeVersions.some((dtv) => dtv && !dtv.startsWith('draft') && !dtv.startsWith('1.0'));
+          }
+          return false;
+        })
+      ) {
+        return true;
+      }
     }
     return versionTags.some((version) => version.valid);
   }


### PR DESCRIPTION
**Description**
Temporary workaround to allow publishing of workflows detected as WDL 1.1 and above. 
Pending a proper update to our cromwell code for parsing 
 On merge, I will also cherry-pick this to a hotfix branch

**Review Instructions**
Can test with https://github.com/DockstoreTestUser2/TestEntryValidation/blob/master/valid_1_1_Workflow.wdl 
Register and publish with only a WDL 1.1 version registered and visible on the versions page

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1700
https://github.com/dockstore/dockstore/issues/4021

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
