### PR TITLE
disable bitbucket registration of workflows, tools and accounts link

### DIFF
--- a/cypress/e2e/immutableDatabaseTests/dropdown.ts
+++ b/cypress/e2e/immutableDatabaseTests/dropdown.ts
@@ -87,7 +87,7 @@ describe('Dropdown test', () => {
       cy.get('#dropdown-accounts').click();
     });
 
-    it('Should show all accounts as linked (except GitLab and Bitbucket)', () => {
+    it('Should show all accounts as linked (except GitLab)', () => {
       everythingOk();
     });
     setTokenUserViewPort();
@@ -368,7 +368,6 @@ describe('Dropdown test', () => {
   const everythingOk = () => {
     cy.get('#unlink-GitHub').should('be.visible');
     cy.get('#unlink-Quay').should('be.visible');
-    cy.get('#link-Bitbucket').should('be.visible');
     cy.get('#link-GitLab').should('be.visible');
   };
 
@@ -390,7 +389,7 @@ describe('Dropdown test', () => {
       cy.get('#updateUsername').should('be.disabled');
     });
 
-    it('Should show all accounts as linked (except GitLab and Bitbucket)', () => {
+    it('Should show all accounts as linked (except GitLab)', () => {
       // everythingOk();
       // goToAccountsOnboarding();
       // cy.visit( '/auth/gitlab.com?code=somefakeid', {'failOnStatusCode': false}).then((resp) => {
@@ -402,10 +401,6 @@ describe('Dropdown test', () => {
 
       goToAccountsOnboarding();
       everythingOk();
-      goToAccountsOnboarding();
-      cy.visit('/auth/bitbucket.org?code=somefakeid', { failOnStatusCode: false }).then((resp) => {
-        expect(resp.status).to.eq('');
-      });
       goToAccountsOnboarding();
       everythingOk();
       goToAccountsOnboarding();

--- a/src/app/container/register-tool/register-tool.service.ts
+++ b/src/app/container/register-tool/register-tool.service.ts
@@ -318,7 +318,7 @@ export class RegisterToolService {
 
   friendlyRepositoryKeys(): Array<string> {
     if (this.sourceControlMap) {
-      return this.sourceControlMap.map((a) => a.friendlyName);
+      return this.sourceControlMap.filter((a) => a.value !== 'bitbucket.org').map((a) => a.friendlyName);
     }
   }
 }

--- a/src/app/loginComponents/accounts/external/accounts.component.ts
+++ b/src/app/loginComponents/accounts/external/accounts.component.ts
@@ -91,7 +91,7 @@ export class AccountsExternalComponent implements OnInit, OnDestroy {
   public TokenSource = TokenSource;
   public username$: Observable<string>;
   Dockstore = Dockstore;
-  accountsInfo: Array<AccountInfo> = accountInfo;
+  accountsInfo: Array<AccountInfo> = accountInfo.filter((item) => item.name !== 'Bitbucket');
 
   public tokens: TokenUser[];
   private ngUnsubscribe: Subject<{}> = new Subject();

--- a/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
+++ b/src/app/workflow/register-workflow-modal/register-workflow-modal.component.ts
@@ -111,12 +111,12 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
   private baseOptions = [
     {
       label: 'Quickly register remote workflows',
-      extendedLabel: 'Toggle repositories from GitHub, Bitbucket, and GitLab to quickly create workflows on Dockstore.',
+      extendedLabel: 'Toggle repositories from GitHub and GitLab to quickly create workflows on Dockstore.',
       value: 1,
     },
     {
       label: 'Register custom remote workflows',
-      extendedLabel: 'Manually add individual workflows at custom file paths from repositories on GitHub, Bitbucket, and GitLab.',
+      extendedLabel: 'Manually add individual workflows at custom file paths from repositories on GitHub and GitLab.',
       value: 2,
     },
     {
@@ -153,7 +153,7 @@ export class RegisterWorkflowModalComponent implements OnInit, AfterViewChecked,
   ) {}
 
   friendlyRepositoryKeys(): Array<string> {
-    return this.registerWorkflowModalService.friendlyRepositoryKeys().filter((key) => key !== 'Dockstore');
+    return this.registerWorkflowModalService.friendlyRepositoryKeys().filter((key) => key !== 'Dockstore' && key !== 'BitBucket');
   }
 
   clearWorkflowRegisterError(): void {


### PR DESCRIPTION
**Description**
Disable registration of bitbucket workflows and tools. 
Also hide account linking for Bitbucket

**Review Instructions**
Try to register a bitbucket workflow

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7686

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that your code compiles by running `npm run build`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If this is the first time you're submitting a PR or even if you just need a refresher, consider reviewing our [style guide](https://github.com/dockstore/dockstore/wiki/Dockstore-Frontend-Opinionated-Style-Guide#pr-checklist)
- [x] Do not bypass Angular sanitization (bypassSecurityTrustHtml, etc.), or justify why you need to do so
- [x] If displaying markdown, use the `markdown-wrapper` component, which does extra sanitization
- [x] Do not use cookies, although this may change in the future
- [x] Run `npm audit` and ensure you are not introducing new vulnerabilities
- [x] Do due diligence on new 3rd party libraries, checking for CVEs
- [x] Don't allow user-uploaded images to be served from the Dockstore domain
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
- [x] Check whether this PR disables tests. If it legitimately needs to disable a test, create a new ticket to re-enable it in a specific milestone. 
